### PR TITLE
Updating VulkanTools build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
 # Build Instructions
-This project fully supports Linux today.
-Support for Windows is for the layers, tests and the VkTrace trace/replay tools.
+This project fully supports Linux today.<br/>
+Support for Windows is for the layers, tests and the VkTrace trace/replay tools.<br/>
 Support for Android is TBD.
 
 ## Git the Bits
@@ -10,8 +10,9 @@ preferred work flow is to clone the repo, create a branch, push branch to github
 issue a merge request to integrate that work back into the repo.
 
 ## Dependencies
-  - You must have a LoaderAndValidationLayers (LoaderAndValidationLayers) repository from Khronos,
-    and a glslang, LunarGlass repository that are file system peers to VulkanTools,.
+  - You must have a Vulkan-LoaderAndValidationLayers (Vulkan-LoaderAndValidationLayers) repository from Khronos,
+    and a glslang, LunarGlass repository that are file system peers to VulkanTools. You'll do this in 'Cloning
+	the Repository(ies)', after installing other build requirements below.
 
 ## Linux System Requirements
 Ubuntu 14.04.3 LTS, 14.10, 15.04 and 15.10 have been used with the sample driver.
@@ -243,21 +244,24 @@ xdpyinfo | grep DRI
 ## Clone the repository(ies)
 
 To create your local git repository of VulkanTools:
+(It is recommended to use an "MSBuild Command Prompt for VS2012" or for another version of Visual Studio)
 ```
 mkdir YOUR_DEV_PARENT_DIRECTORY  # this will hold several repositories
 cd YOUR_DEV_PARENT_DIRECTORY
-mkdir YOUR_DEV_DIRECTORY     # it is called VulkanTools  on Github but name can be anything
+
+mkdir YOUR_DEV_DIRECTORY     # it is called VulkanTools on Github but can be anything
 git clone -o LunarG git@github.com:LunarG/VulkanTools.git <YOUR_DEV_DIRECTORY>
 # Or substitute the URL from your forked repo for git@github.com:LunarG/VulkanTools.git above.
-# if you need the LoaderAndValidationLayers repo as a sibling
+
+# You need the Vulkan-LoaderAndValidationLayers repo as a sibling
 cd YOUR_DEV_PARENT_DIRECTORY
-git clone -o khronos git@gitlab.khronos.org:vulkan/LoaderAndValidationLayers.git .
-# Or substitute the URL from your forked repo for git@gitlab.khronos.org:vulkan/LoaderAndValidationLayers.git above.
-cd LoaderAndValidationLayers
-# this will fetch glslang, llvm, SPIR-V and LunarGlass as sibling repositories
-export KHRONOS_ACCOUNT_NAME= <subversion login name for svn checkout of SPIR-V>
+git clone -o khronos git@gitlab.khronos.org:vulkan/Vulkan-LoaderAndValidationLayers.git
+# Or substitute the URL from your forked repo for git@gitlab.khronos.org:vulkan/Vulkan-LoaderAndValidationLayers.git above.
+
+cd Vulkan-LoaderAndValidationLayers
+# this will fetch and build glslang, llvm, SPIR-V and LunarGlass as sibling repositories
 ./update_external_sources.sh   # linux
-./update_external_sources.bat  # windows
+./update_external_sources.bat --all # windows
 ```
 
 ## Linux Build
@@ -266,7 +270,7 @@ The sample driver uses cmake and should work with the usual cmake options and ut
 The standard build process builds the icd, vktrace and all the tests.
 
 Example debug build:
-NOTE: The loader repository (LoaderAndValidationLayers) must be a sibling directory of VulkanTools.
+NOTE: The loader repository (Vulkan-LoaderAndValidationLayers) must be a sibling directory of VulkanTools.
 The loader repository should be built first prior to this repository. Follow
 the directions in BUILD.md in the loader repository.
 ```
@@ -278,7 +282,7 @@ make
 
 ## Linux Test
 
-The test executibles can be found in the dbuild/tests directory. The tests use the Google
+The test executables can be found in the dbuild/tests directory. The tests use the Google
 gtest infrastructure. Tests available so far:
 - vkbase: Test basic entry points
 - vk_blit_tests: Test VK Blits (copy, clear, and resolve)
@@ -351,19 +355,17 @@ Optional software packages:
 Cygwin is used in order to obtain a local copy of the Git repository, and to run the CMake command that creates Visual Studio files.  Visual Studio is used to build the software, and will re-run CMake as appropriate.
 
 Example debug x64 build (e.g. in a "Developer Command Prompt for VS2013" window):
-NOTE: The loader repository (LoaderAndValidationLayers) must be a sibling directory of VulkanTools.
+NOTE: The loader repository (Vulkan-LoaderAndValidationLayers) must be a sibling directory of VulkanTools.
 The loader repository should be built first prior to this repository. Follow
 the directions in BUILD.md in the loader repository.
 ```
 cd VulkanTools  # cd to the root of the VulkanTools git repository
-mkdir build
-cd build
-cmake -G "Visual Studio 12 Win64" ..
+cmake -H. -Bbuild -G "Visual Studio 12 Win64"
 ```
 
-At this point, you can use Windows Explorer to launch Visual Studio by double-clicking on the "VULKAN.sln" file in the \build folder.  Once Visual Studio comes up, you can select "Debug" or "Release" from a drop-down list.  You can start a build with either the menu (Build->Build Solution), or a keyboard shortcut (Ctrl+Shift+B).  As part of the build process, Python scripts will create additional Visual Studio files and projects, along with additional source files.  All of these auto-generated files are under the "build" folder.
+At this point, you can use Windows Explorer to launch Visual Studio by double-clicking on the "VULKANTOOLS.sln" file in the \build folder.  Once Visual Studio comes up, you can select "Debug" or "Release" from a drop-down list.  You can start a build with either the menu (Build->Build Solution), or a keyboard shortcut (Ctrl+Shift+B).  As part of the build process, Python scripts will create additional Visual Studio files and projects, along with additional source files.  All of these auto-generated files are under the "build" folder.
 
-VK programs must be able to find and use the VK.dll libary. Make sure it is either installed in the C:\Windows\System32 folder, or the PATH enviroment variable includes the folder that it is located in.
+Vulkan programs must be able to find and use the Vulkan-1.dll libary. Make sure it is either installed in the C:\Windows\System32 folder, or the PATH environment variable includes the folder that it is located in.
 
 ### Windows 64-bit Installation Notes
 If you plan on creating a Windows Install file (done in the windowsRuntimeInstaller sub-directory) you will need to build for both 32-bit and 64-bit Windows since both versions of EXEs and DLLs exist simultaneously on Windows 64.

--- a/BUILD.md
+++ b/BUILD.md
@@ -255,8 +255,8 @@ git clone -o LunarG git@github.com:LunarG/VulkanTools.git <YOUR_DEV_DIRECTORY>
 
 # You need the Vulkan-LoaderAndValidationLayers repo as a sibling
 cd YOUR_DEV_PARENT_DIRECTORY
-git clone -o khronos git@gitlab.khronos.org:vulkan/Vulkan-LoaderAndValidationLayers.git
-# Or substitute the URL from your forked repo for git@gitlab.khronos.org:vulkan/Vulkan-LoaderAndValidationLayers.git above.
+git clone -o khronos https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers.git
+# Or substitute the URL from your forked repo for https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers.git above.
 
 cd Vulkan-LoaderAndValidationLayers
 # this will fetch and build glslang, llvm, SPIR-V and LunarGlass as sibling repositories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 # Header file for CMake settings
 #hacky use layer include directory from loader repo
-set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/include)
+set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/include)
 include_directories(${PROJECT_SOURCE_DIR}/include ${LOADER_UNCLUDE_DIR})
 
 if(NOT WIN32)
@@ -109,7 +109,7 @@ else()
     set(PYTHON_CMD "py")
 endif()
 
-set(LOADER_PY_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers)
+set(LOADER_PY_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers)
 
 # icd: Device dependent (DD) VULKAN components
 # tests: VULKAN tests

--- a/buildAndroid/android-generate.sh
+++ b/buildAndroid/android-generate.sh
@@ -19,8 +19,8 @@ rm -rf generated
 mkdir -p generated
 python ../vk-generate.py dispatch-table-ops layer > generated/vk_dispatch_table_helper.h
 
-python ../vk_helper.py --gen_enum_string_helper ../../LoaderAndValidationLayers/include/vulkan/vulkan.h --abs_out_dir generated
-python ../vk_helper.py --gen_struct_wrappers ../../LoaderAndValidationLayers/include/vulkan/vulkan.h --abs_out_dir generated
+python ../vk_helper.py --gen_enum_string_helper ../../Vulkan-LoaderAndValidationLayers/include/vulkan/vulkan.h --abs_out_dir generated
+python ../vk_helper.py --gen_struct_wrappers ../../Vulkan-LoaderAndValidationLayers/include/vulkan/vulkan.h --abs_out_dir generated
 
 python ../vk-layer-generate.py generic ../include/vulkan/vulkan.h > generated/generic_layer.cpp
 python ../vk-layer-generate.py api_dump ../include/vulkan/vulkan.h > generated/api_dump.cpp

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 endif()
   
 #hacky get include files from loader repo
-set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/include)
+set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/include)
 include_directories( ${LOADER_INCLUDE_DIR} )
 
 add_subdirectory(common)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 2.8.11)
 
-set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/include)
+set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/include)
 macro(run_vk_helper subcmd)
 	add_custom_command(OUTPUT ${ARGN}
 		COMMAND ${PYTHON_CMD} ${LOADER_PY_DIR}/vk_helper.py --${subcmd} ${LOADER_INCLUDE_DIR}/vulkan/vulkan.h --abs_out_dir ${CMAKE_CURRENT_BINARY_DIR}
@@ -72,8 +72,8 @@ else()
 endif()
 
 #hacky use layer include directory from loader repo
-set (LOADER_LAYER_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/layers)
-set (LOADER_LOADER_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/loader)
+set (LOADER_LAYER_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/layers)
+set (LOADER_LOADER_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/loader)
 include_directories(
         ${LOADER_LAYER_DIR}
         ${LOADER_LOADER_DIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,7 +88,7 @@ else ()
 endif()
 
 #hacky get include files from loader repo
-set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/include)
+set (LOADER_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/include)
 include_directories(
      ${LOADER_INCLUDE_DIR}
     "${PROJECT_SOURCE_DIR}/tests/gtest-1.7.0/include"
@@ -131,13 +131,13 @@ endif()
 set (LIBVK "vulkan-${MAJOR}")
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(LIBVK
-        ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/${BUILDTGT_DIR}/loader/${CMAKE_CFG_INTDIR}/vulkan-${MAJOR}.lib
+        ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/${BUILDTGT_DIR}/loader/${CMAKE_CFG_INTDIR}/vulkan-${MAJOR}.lib
     )
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(LIBVK
-        ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/build/loader/${CMAKE_CFG_INTDIR}/libvulkan.so
+        ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/build/loader/${CMAKE_CFG_INTDIR}/libvulkan.so
     )
 endif()
 add_executable(vkbase init.cpp ${COMMON_CPP})

--- a/tests/_run_all_tests.ps1
+++ b/tests/_run_all_tests.ps1
@@ -8,7 +8,7 @@ if ($Debug) {
     $dPath = "Release"
 }
 
-Set-Item -path env:Path -value ($env:Path + ";..\..\LoaderAndValidationLayers\build\loader\$dPath")
+Set-Item -path env:Path -value ($env:Path + ";..\..\Vulkan-LoaderAndValidationLayers\build\loader\$dPath")
 Set-Item -path env:Path -value ($env:Path + ";gtest-1.7.0\$dPath")
 $env:VK_LAYER_PATH = "..\layers\$dPath"
 

--- a/tests/_run_all_tests_with_layers.ps1
+++ b/tests/_run_all_tests_with_layers.ps1
@@ -9,7 +9,7 @@ if ($Debug) {
 $ErrorActionPreference = "Stop"
 echo $dPath
 
-Set-Item -path env:Path -value ($env:Path + ";..\..\LoaderAndValidationLayers\build\loader\$dPath")
+Set-Item -path env:Path -value ($env:Path + ";..\..\Vulkan-LoaderAndValidationLayers\build\loader\$dPath")
 Set-Item -path env:Path -value ($env:Path + ";gtest-1.7.0\$dPath")
 $env:VK_LAYER_PATH = "..\layers\$dPath"
 

--- a/tests/_vktracereplay.ps1
+++ b/tests/_vktracereplay.ps1
@@ -1,7 +1,7 @@
 # Powershell script for running the vktrace trace/replay auto test
 # To run this test:
 #    cd <this-dir>
-#    powershell C:\src\LoaderAndValidationLayers\vktracereplay.ps1 [-Debug]
+#    powershell C:\src\Vulkan-LoaderAndValidationLayers\vktracereplay.ps1 [-Debug]
 $exitstatus = 0
 
 if ($args[0] -eq "-Debug") {
@@ -22,10 +22,10 @@ new-item vktracereplay_tmp -itemtype directory > $null 2> $null
 cd vktracereplay_tmp
 cp ..\..\vktrace\$dPath\vkreplay.exe .
 cp ..\..\vktrace\$dPath\vktrace.exe .
-cp ..\..\..\..\LoaderAndValidationLayers\build\demos\$dPath\cube.exe .
-cp ..\..\..\..\LoaderAndValidationLayers\demos\*.ppm .
-cp ..\..\..\..\LoaderAndValidationLayers\build\demos\*.spv .
-cp ..\..\..\..\LoaderAndValidationLayers\build\loader\$dPath\vulkan-1.dll .
+cp ..\..\..\..\Vulkan-LoaderAndValidationLayers\build\demos\$dPath\cube.exe .
+cp ..\..\..\..\Vulkan-LoaderAndValidationLayers\demos\*.ppm .
+cp ..\..\..\..\Vulkan-LoaderAndValidationLayers\build\demos\*.spv .
+cp ..\..\..\..\Vulkan-LoaderAndValidationLayers\build\loader\$dPath\vulkan-1.dll .
 cp ..\..\layers\$dPath\VkLayer_screenshot.dll .
 cp ..\..\layers\$dPath\VkLayer_screenshot.json .
 cp ..\..\layers\$dPath\VkLayer_vktrace_layer.dll .

--- a/tests/vktracereplay.sh
+++ b/tests/vktracereplay.sh
@@ -19,10 +19,10 @@ cd vktracereplay_tmp
 cp ../../vktrace/vkreplay .
 cp ../../vktrace/vktrace .
 cp ../../vktrace/libVkLayer_vktrace_layer.so .
-cp ../../../../LoaderAndValidationLayers/build/demos/cube .
-cp ../../../../LoaderAndValidationLayers/demos/*ppm .
-cp ../../../../LoaderAndValidationLayers/build/demos/*spv .
-export LD_LIBRARY_PATH=`pwd`/../../../../LoaderAndValidationLayers/build/loader:$LD_LIBRARY_PATH
+cp ../../../../Vulkan-LoaderAndValidationLayers/build/demos/cube .
+cp ../../../../Vulkan-LoaderAndValidationLayers/demos/*ppm .
+cp ../../../../Vulkan-LoaderAndValidationLayers/build/demos/*spv .
+export LD_LIBRARY_PATH=`pwd`/../../../../Vulkan-LoaderAndValidationLayers/build/loader:$LD_LIBRARY_PATH
 export VK_LAYER_PATH=`pwd`/../../layers
 
 (

--- a/vk-generate.py
+++ b/vk-generate.py
@@ -27,7 +27,7 @@
 
 import sys
 import imp
-vulkan = imp.load_source('vulkan', '../../../../LoaderAndValidationLayers/vulkan.py')
+vulkan = imp.load_source('vulkan', '../../../../Vulkan-LoaderAndValidationLayers/vulkan.py')
 
 
 def generate_get_proc_addr_check(name):

--- a/vk-layer-generate.py
+++ b/vk-layer-generate.py
@@ -37,8 +37,8 @@ import os
 import re
 
 import imp
-vulkan = imp.load_source('vulkan', '../../../LoaderAndValidationLayers/vulkan.py')
-vk_helper = imp.load_source('vulkan', '../../../LoaderAndValidationLayers/vk_helper.py')
+vulkan = imp.load_source('vulkan', '../../../Vulkan-LoaderAndValidationLayers/vulkan.py')
+vk_helper = imp.load_source('vulkan', '../../../Vulkan-LoaderAndValidationLayers/vk_helper.py')
 from source_line_info import sourcelineinfo
 from collections import defaultdict
 

--- a/vktrace/CMakeLists.txt
+++ b/vktrace/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT PYTHONINTERP_FOUND)
 endif()
 
 #hacky get include files from loader repo
-set (VKTRACE_VULKAN_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/include)
+set (VKTRACE_VULKAN_INCLUDE_DIR ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/include)
 include_directories( ${VKTRACE_VULKAN_INCLUDE_DIR} )
 
 message("")

--- a/vktrace/README.md
+++ b/vktrace/README.md
@@ -15,16 +15,16 @@ Vktrace as a server one should omit the "-p" option.
 cd <vktrace build directory>
 ./vktrace <options>
 Example to trace spinning cube demo.
-export VK_ICD_FILENAMES=/home/jon/LoaderAndValidationLayers/main_icd.json
-export LD_LIBRARY_PATH=/home/jon/LoaderAndValidationLayers/dbuild/loader
+export VK_ICD_FILENAMES=/home/jon/Vulkan-LoaderAndValidationLayers/main_icd.json
+export LD_LIBRARY_PATH=/home/jon/Vulkan-LoaderAndValidationLayers/dbuild/loader
 ./vktrace -o vktrace_cube.vktrace
 ```
 
 In a separate terminal run your app, the cube demo in this example:
 ```
 cd /home/jon/LoaderAndValidationLayers/dbuild/demos
-export VK_ICD_FILENAMES=/home/jon/LoaderAndValidationLayers/dbuild/icd/intel/intel_icd.json
-export LD_LIBRARY_PATH=/home/jon/LoaderAndValidationLayers/dbuild/loader
+export VK_ICD_FILENAMES=/home/jon/Vulkan-LoaderAndValidationLayers/dbuild/icd/intel/intel_icd.json
+export LD_LIBRARY_PATH=/home/jon/Vulkan-LoaderAndValidationLayers/dbuild/loader
 VK_INSTANCE_LAYERS=Vktrace VK_DEVICE_LAYERS=Vktrace ./cube
 ```
 
@@ -46,9 +46,9 @@ cd <vktrace build dir>
 ```
 Example to trace the spinning cube demo from sample implementation
 ```
-export VK_ICD_FILENAMES=/home/jon/LoaderAndValidationLayers/main_icd.json
-export LD_LIBRARY_PATH=/home/jon/LoaderAndValidationLayers/dbuild/loader
-./vktrace -p /home/jon/LoaderAndValidationLayers/dbuild/demos/cube -o vktrace_cube.vktrace -w /home/jon/LoaderAndValidationLayers/dbuild/demos
+export VK_ICD_FILENAMES=/home/jon/Vulkan-LoaderAndValidationLayers/main_icd.json
+export LD_LIBRARY_PATH=/home/jon/Vulkan-LoaderAndValidationLayers/dbuild/loader
+./vktrace -p /home/jon/Vulkan-LoaderAndValidationLayers/dbuild/demos/cube -o vktrace_cube.vktrace -w /home/jon/Vulkan-LoaderAndValidationLayers/dbuild/demos
 ```
 Trace file is in "vktrace_cube.vktrace".
 
@@ -62,8 +62,8 @@ export LD_LIBRARY_PATH=<path to libvulkan.so>
 ```
 Example to replay trace file captured above
 ```
-export VK_ICD_FILENAMES=/home/jon/LoaderAndValidationLayers/main_icd.json
-export LD_LIBRARY_PATH=/home/jon/LoaderAndValidationLayers/dbuild:/home/jon/LoaderAndValidationLayers/dbuild/loader
+export VK_ICD_FILENAMES=/home/jon/Vulkan-LoaderAndValidationLayers/main_icd.json
+export LD_LIBRARY_PATH=/home/jon/Vulkan-LoaderAndValidationLayers/dbuild:/home/jon/Vulkan-LoaderAndValidationLayers/dbuild/loader
 ./vkreplay -t vktrace_cube.vktrace
 ```
 
@@ -85,8 +85,8 @@ Example to trace the spinning cube demo (Note: see other files for how to config
 ```
 cd C:\\Users\developer\\Vktrace\\_out64\\Debug
 
-vktrace -p C:\\Users\developer\\LoaderAndValidationLayers\\_out64\\demos\\cube.exe
-        -w C:\\Users\developer\\LoaderAndValidationLayers\\_out64\\demos
+vktrace -p C:\\Users\developer\\Vulkan-LoaderAndValidationLayers\\_out64\\demos\\cube.exe
+        -w C:\\Users\developer\\Vulkan-LoaderAndValidationLayers\\_out64\\demos
         -o vktrace_cube.vktrace
 ```
 Trace file is in "vktrace_cube.vktrace".

--- a/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
@@ -30,14 +30,14 @@ set(VKTRACE_VULKAN_LUNARG_DEBUG_MARKER_HEADER ${VKTRACE_VULKAN_INCLUDE_DIR}/vulk
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(VKTRACE_VULKAN_LIB
-        ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/${BUILDTGT_DIR}/loader/${CMAKE_CFG_INTDIR}/vulkan-${MAJOR}.lib
+        ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/${BUILDTGT_DIR}/loader/${CMAKE_CFG_INTDIR}/vulkan-${MAJOR}.lib
     )
 endif()
 
  
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(VKTRACE_VULKAN_LIB
-        ${VULKANTOOLS_SOURCE_DIR}/../LoaderAndValidationLayers/build/loader/libvulkan.so
+        ${VULKANTOOLS_SOURCE_DIR}/../Vulkan-LoaderAndValidationLayers/build/loader/libvulkan.so
      )
 endif()
 

--- a/vktrace/vktrace_generate.py
+++ b/vktrace/vktrace_generate.py
@@ -37,7 +37,7 @@ main_path = os.path.abspath(vktrace_scripts_path + "/../")
 sys.path.append(main_path)
 from source_line_info import sourcelineinfo
 import imp
-vulkan = imp.load_source('vulkan', '%s/../LoaderAndValidationLayers/vulkan.py' % main_path)
+vulkan = imp.load_source('vulkan', '%s/../Vulkan-LoaderAndValidationLayers/vulkan.py' % main_path)
 
 # vulkan.py doesn't include all the extensions (debug_report missing)
 headers = []


### PR DESCRIPTION
This also included changing all references to the
"LoaderAndValidationLayers" repo to the newly named
"Vulkan-LoaderAndValidationLayers"

One tricky reference that is now updated is in vktrace\vktrace_generate.py