### PR TITLE
nulldrv: Claim support for all features

### DIFF
--- a/icd/nulldrv/nulldrv.c
+++ b/icd/nulldrv/nulldrv.c
@@ -1379,8 +1379,8 @@ VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures(
 {
     NULLDRV_LOG_FUNC;
 
-    /* TODO: fill out features */
-    memset(pFeatures, 0, sizeof(*pFeatures));
+    /* nulldrv "implements" all vulkan features -- by doing nothing */
+    memset(pFeatures, VK_TRUE, sizeof(*pFeatures));
 }
 
 VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFormatProperties(


### PR DESCRIPTION
Previously we supported no features. SC will shortly start checking for
capabilities matching enabled device features, so we need to expose
at least the features the tests and demos use.

It's safe to just expose everything, so do.