### PR TITLE
Re-expose KHR_xcb_surface from nulldrv

### DIFF
--- a/icd/nulldrv/nulldrv.c
+++ b/icd/nulldrv/nulldrv.c
@@ -730,6 +730,20 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
 {
     NULLDRV_LOG_FUNC;
 
+    pSurfaceCapabilities->minImageCount = 1;
+    pSurfaceCapabilities->maxImageCount = 0;  /* any number of images! */
+    pSurfaceCapabilities->currentExtent.width = -1;
+    pSurfaceCapabilities->currentExtent.height = -1;
+    pSurfaceCapabilities->minImageExtent.width = 1;
+    pSurfaceCapabilities->minImageExtent.height = 1;
+    pSurfaceCapabilities->maxImageExtent.width = 1024;
+    pSurfaceCapabilities->maxImageExtent.height = 1024;
+    pSurfaceCapabilities->maxImageArrayLayers = 1;
+    pSurfaceCapabilities->supportedTransforms = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    pSurfaceCapabilities->currentTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    pSurfaceCapabilities->supportedCompositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    pSurfaceCapabilities->supportedUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
     return VK_SUCCESS;
 }
 

--- a/icd/nulldrv/nulldrv.c
+++ b/icd/nulldrv/nulldrv.c
@@ -43,14 +43,14 @@
     #define NULLDRV_LOG_FUNC do { } while (0)
 #endif
 
-static const VkExtensionProperties nulldrv_instance_extensions[NULLDRV_EXT_COUNT] = {
+static const VkExtensionProperties nulldrv_instance_extensions[NULLDRV_INST_EXT_COUNT] = {
     {
         .extensionName = VK_KHR_SURFACE_EXTENSION_NAME,
         .specVersion = VK_KHR_SURFACE_SPEC_VERSION,
     }
 };
 
-const VkExtensionProperties nulldrv_device_exts[1] = {
+const VkExtensionProperties nulldrv_device_exts[NULLDRV_DEV_EXT_COUNT] = {
     {
         .extensionName = VK_KHR_SWAPCHAIN_EXTENSION_NAME,
         .specVersion = VK_KHR_SWAPCHAIN_SPEC_VERSION,
@@ -156,18 +156,18 @@ static VkResult dev_create_queues(struct nulldrv_dev *dev,
     return VK_SUCCESS;
 }
 
-static enum nulldrv_ext_type nulldrv_gpu_lookup_extension(
+static enum nulldrv_dev_ext_type nulldrv_gpu_lookup_extension(
         const struct nulldrv_gpu *gpu,
         const char* extensionName)
 {
-    enum nulldrv_ext_type type;
+    enum nulldrv_dev_ext_type type;
 
     for (type = 0; type < ARRAY_SIZE(nulldrv_device_exts); type++) {
         if (strcmp(nulldrv_device_exts[type].extensionName, extensionName) == 0)
             break;
     }
 
-    assert(type < NULLDRV_EXT_COUNT || type == NULLDRV_EXT_INVALID);
+    assert(type < NULLDRV_DEV_EXT_COUNT || type == NULLDRV_DEV_EXT_INVALID);
 
     return type;
 }
@@ -205,11 +205,10 @@ static VkResult nulldrv_dev_create(struct nulldrv_gpu *gpu,
         return VK_ERROR_OUT_OF_HOST_MEMORY;
 
     for (i = 0; i < info->enabledExtensionCount; i++) {
-        const enum nulldrv_ext_type ext = nulldrv_gpu_lookup_extension(
-                    gpu,
-                    info->ppEnabledExtensionNames[i]);
+        const enum nulldrv_dev_ext_type ext = nulldrv_gpu_lookup_extension(
+                    gpu, info->ppEnabledExtensionNames[i]);
 
-        if (ext == NULLDRV_EXT_INVALID)
+        if (ext == NULLDRV_DEV_EXT_INVALID)
             return VK_ERROR_EXTENSION_NOT_PRESENT;
 
         dev->exts[ext] = true;
@@ -1458,14 +1457,14 @@ VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(
     uint32_t copy_size;
 
     if (pProperties == NULL) {
-        *pPropertyCount = NULLDRV_EXT_COUNT;
+        *pPropertyCount = NULLDRV_INST_EXT_COUNT;
         return VK_SUCCESS;
     }
 
-    copy_size = *pPropertyCount < NULLDRV_EXT_COUNT ? *pPropertyCount : NULLDRV_EXT_COUNT;
+    copy_size = *pPropertyCount < NULLDRV_INST_EXT_COUNT ? *pPropertyCount : NULLDRV_INST_EXT_COUNT;
     memcpy(pProperties, nulldrv_instance_extensions, copy_size * sizeof(VkExtensionProperties));
     *pPropertyCount = copy_size;
-    if (copy_size < NULLDRV_EXT_COUNT) {
+    if (copy_size < NULLDRV_INST_EXT_COUNT) {
         return VK_INCOMPLETE;
     }
     return VK_SUCCESS;

--- a/icd/nulldrv/nulldrv.c
+++ b/icd/nulldrv/nulldrv.c
@@ -47,7 +47,11 @@ static const VkExtensionProperties nulldrv_instance_extensions[NULLDRV_INST_EXT_
     {
         .extensionName = VK_KHR_SURFACE_EXTENSION_NAME,
         .specVersion = VK_KHR_SURFACE_SPEC_VERSION,
-    }
+    },
+    {
+        .extensionName = VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+        .specVersion = VK_KHR_XCB_SURFACE_SPEC_VERSION,
+    },
 };
 
 const VkExtensionProperties nulldrv_device_exts[NULLDRV_DEV_EXT_COUNT] = {
@@ -1469,6 +1473,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(
     }
     return VK_SUCCESS;
 }
+
 VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
         uint32_t*                                   pPropertyCount,
         VkLayerProperties*                          pProperties)

--- a/icd/nulldrv/nulldrv.c
+++ b/icd/nulldrv/nulldrv.c
@@ -1445,7 +1445,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(
         uint32_t*                                   pPropertyCount,
         VkLayerProperties*                          pProperties)
 {
-    // TODO: Fill in with real data
+    *pPropertyCount = 0;
     return VK_SUCCESS;
 }
 
@@ -1473,7 +1473,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
         uint32_t*                                   pPropertyCount,
         VkLayerProperties*                          pProperties)
 {
-    // TODO: Fill in with real data
+    *pPropertyCount = 0;
     return VK_SUCCESS;
 }
 

--- a/icd/nulldrv/nulldrv.h
+++ b/icd/nulldrv/nulldrv.h
@@ -51,10 +51,17 @@ struct nulldrv_obj {
     struct nulldrv_base base;
 };
 
-enum nulldrv_ext_type {
-   NULLDRV_EXT_KHR_SWAPCHAIN,
-   NULLDRV_EXT_COUNT,
-   NULLDRV_EXT_INVALID = NULLDRV_EXT_COUNT,
+enum nulldrv_dev_ext_type {
+   NULLDRV_DEV_EXT_KHR_SWAPCHAIN,
+   NULLDRV_DEV_EXT_COUNT,
+   NULLDRV_DEV_EXT_INVALID = NULLDRV_DEV_EXT_COUNT,
+};
+
+
+enum nulldrv_inst_ext_type {
+   NULLDRV_INST_EXT_KHR_SURFACE,
+   NULLDRV_INST_EXT_COUNT,
+   NULLDRV_INST_EXT_INVALID = NULLDRV_INST_EXT_COUNT,
 };
 
 
@@ -68,7 +75,7 @@ struct nulldrv_gpu {
 
 struct nulldrv_dev {
      struct nulldrv_base base;
-     bool exts[NULLDRV_EXT_COUNT];
+     bool exts[NULLDRV_DEV_EXT_COUNT];
      struct nulldrv_desc_ooxx *desc_ooxx;
      struct nulldrv_queue *queues[1];
 };

--- a/icd/nulldrv/nulldrv.h
+++ b/icd/nulldrv/nulldrv.h
@@ -60,6 +60,7 @@ enum nulldrv_dev_ext_type {
 
 enum nulldrv_inst_ext_type {
    NULLDRV_INST_EXT_KHR_SURFACE,
+   NULLDRV_INST_EXT_KHR_XCB_SURFACE,
    NULLDRV_INST_EXT_COUNT,
    NULLDRV_INST_EXT_INVALID = NULLDRV_INST_EXT_COUNT,
 };


### PR DESCRIPTION
This series untangles some of the extension handling in nulldrv, and has it claim to support KHR_xcb_surface. The entrypoints associated are not implemented, as they are never called when nulldrv is used with the loader.

Also assorted fixes to queries to avoid confusing the app with junk.

(Is just enough to get demos/tri working again)