### PR TITLE
build: set GLSLANG_VALIDATOR when building demos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ option(BUILD_DEMOS "Build demos" ON)
 option(BUILD_VKTRACE "Build VkTrace" ON)
 option(BUILD_VKJSON "Build vkjson" ON)
 
-if (BUILD_ICD OR BUILD_TESTS)
+if (BUILD_ICD OR BUILD_TESTS OR BUILD_DEMOS)
     find_program(GLSLANG_VALIDATOR NAMES glslangValidator
                  HINTS "${CMAKE_SOURCE_DIR}/../glslang/${BUILDTGT_DIR}/install/bin"
                        "${PROJECT_SOURCE_DIR}/../${BINDATA_DIR}" )


### PR DESCRIPTION
GLSLANG_VALIDATOR is used in demos/CMakeLists.txt
for building the demos. It gets evaluated to the empty
string and fails the build when the master CMakeLists.txt
file does not determine the path to glslangValidator.

Otherwise the build fails when doing:
$  cd VulkanTools
$  ./update_external_sources.sh
$  cmake \
    -DCMAKE_BUILD_TYPE=Release \
    -DBUILD_VKTRACE=ON \
    -DBUILD_DEMOS=ON \
    -DBUILD_ICD=OFF \
    -DBUILD_TESTS=OFF \
    -DBUILD_LAYERS=OFF \
    .
$  make