### PR TITLE
vkreplay: fix frame loop bug of -lsf and -lef.

### DIFF
--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay.cpp
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay.cpp
@@ -147,6 +147,7 @@ void VKTRACER_CDECL VkReplayDeinitialize()
 vktrace_trace_packet_header* VKTRACER_CDECL VkReplayInterpret(vktrace_trace_packet_header* pPacket)
 {
     // Attempt to interpret the packet as a Vulkan packet
+    g_pReplayer->set_is_end_of_frame(false);
     vktrace_trace_packet_header* pInterpretedHeader = interpret_trace_packet_vk(pPacket);
     if (pInterpretedHeader == NULL)
     {
@@ -188,10 +189,19 @@ int VKTRACER_CDECL VkReplayGetFrameNumber()
     return -1;
 }
 
-void VKTRACER_CDECL VkReplayResetFrameNumber()
+void VKTRACER_CDECL VkReplaySetFrameNumber(int frameNumber)
 {
     if (g_pReplayer != NULL)
     {
-        g_pReplayer->reset_frame_number();
+        g_pReplayer->set_frame_number(frameNumber);
     }
+}
+
+bool VKTRACER_CDECL VkIsEndOfFrame()
+{
+    if (g_pReplayer != NULL)
+    {
+        return g_pReplayer->is_end_of_frame();
+    }
+    return false;
 }

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay.h
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay.h
@@ -42,6 +42,7 @@ extern vktrace_trace_packet_header* VKTRACER_CDECL VkReplayInterpret(vktrace_tra
 extern vktrace_replay::VKTRACE_REPLAY_RESULT VKTRACER_CDECL VkReplayReplay(vktrace_trace_packet_header* pPacket);
 extern int VKTRACER_CDECL VkReplayDump();
 extern int VKTRACER_CDECL VkReplayGetFrameNumber();
-extern void VKTRACER_CDECL VkReplayResetFrameNumber();
+extern void VKTRACER_CDECL VkReplaySetFrameNumber(int frameNumber);
+extern bool VKTRACER_CDECL VkIsEndOfFrame();
 
 extern PFN_vkDebugReportCallbackEXT g_fpDbgMsgCallback;

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
@@ -52,6 +52,7 @@ vkReplay::vkReplay(vkreplayer_settings *pReplaySettings)
     m_objMapper.m_adjustForGPU = false;
 
     m_frameNumber = 0;
+    m_isEndOfFrame = false;
 }
 
 vkReplay::~vkReplay()
@@ -1915,6 +1916,7 @@ VkResult vkReplay::manually_replay_vkQueuePresentKHR(packet_vkQueuePresentKHR* p
         replayResult = m_vkFuncs.real_vkQueuePresentKHR(remappedQueue, &present);
 
         m_frameNumber++;
+        m_isEndOfFrame = true;
 
         // Compare the results from the trace file with those just received from the replay.  Report any differences.
         if (present.pResults != NULL) {

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.h
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.h
@@ -70,7 +70,9 @@ public:
     vktrace_replay::VKTRACE_REPLAY_RESULT pop_validation_msgs();
     int dump_validation_data();
     int get_frame_number() { return m_frameNumber; }
-    void reset_frame_number() { m_frameNumber = 0; }
+    void set_frame_number(int frameNumber) { m_frameNumber = frameNumber; }
+    bool is_end_of_frame() { return m_isEndOfFrame; }
+    void set_is_end_of_frame(bool is) { m_isEndOfFrame = is; }
 private:
     struct vkFuncs m_vkFuncs;
     vkReplayObjMapper m_objMapper;
@@ -80,6 +82,7 @@ private:
     vkDisplay *m_display;
 
     int m_frameNumber;
+    bool m_isEndOfFrame;
 
     struct ValidationMsg {
         VkFlags msgFlags;

--- a/vktrace/src/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/src/vktrace_replay/vkreplay_main.cpp
@@ -38,7 +38,7 @@
 #include "vkreplay_window.h"
 #include "vkreplay.h"
 
-vkreplayer_settings replaySettings = { NULL, 1, -1, -1, NULL, NULL };
+vkreplayer_settings replaySettings = { NULL, 1, 0, -1, NULL, NULL };
 
 vktrace_SettingInfo g_settings_info[] =
 {
@@ -71,9 +71,8 @@ int main_loop(Sequencer &seq, vkreplayer_settings settings)
     struct seqBookmark startingPacket;
 
     bool trace_running = true;
-    int prevFrameNumber = -1;
 
-    // record the location of looping start packet
+    // record the location of default looping start packet
     seq.record_bookmark();
     seq.get_bookmark(startingPacket);
     while (settings.numLoops > 0)
@@ -116,10 +115,8 @@ int main_loop(Sequencer &seq, vkreplayer_settings settings)
 
                         // frame control logic
                         int frameNumber = VkReplayGetFrameNumber();
-                        if (prevFrameNumber != frameNumber)
+                        if (VkIsEndOfFrame())
                         {
-                            prevFrameNumber = frameNumber;
-
                             if (frameNumber == settings.loopStartFrame)
                             {
                                 // record the location of looping start packet
@@ -143,7 +140,7 @@ int main_loop(Sequencer &seq, vkreplayer_settings settings)
         settings.numLoops--;
         seq.set_bookmark(startingPacket);
         trace_running = true;
-        VkReplayResetFrameNumber();
+        VkReplaySetFrameNumber(replaySettings.loopStartFrame);
     }
     return err;
 }

--- a/vktrace/vktrace_generate.py
+++ b/vktrace/vktrace_generate.py
@@ -535,6 +535,7 @@ class Subcommand(object):
         interp_func_body.append('    {')
         interp_func_body.append('        return NULL;')
         interp_func_body.append('    }')
+        interp_func_body.append('    m_isEndOfFrame = false;')
         interp_func_body.append('    switch (pHeader->packet_id)')
         interp_func_body.append('    {')
         interp_func_body.append('        case VKTRACE_TPI_VK_vkApiVersion:')


### PR DESCRIPTION
Add VkIsEndOfFrame to mark the end of a frame.
Replace VkReplayResetFrameNumber with VkReplaySetFrameNumber.
Stable frame loop confirmed on SDK samples: cube and tri.