### PR TITLE
fix rangeoffset problem

### DIFF
--- a/vktrace/src/vktrace_layer/vktrace_lib_helpers.h
+++ b/vktrace/src/vktrace_layer/vktrace_lib_helpers.h
@@ -224,7 +224,7 @@ static void add_data_to_mem_info(const VkDeviceMemory handle, VkDeviceSize range
             entry->rangeSize = entry->totalSize - rangeOffset;
         else
             entry->rangeSize = rangeSize;
-        entry->rangeOffset = entry->rangeOffset;
+        entry->rangeOffset = rangeOffset;
         assert(entry->totalSize >= rangeSize + rangeOffset);
     }
     g_memInfo.pLastMapped = entry;


### PR DESCRIPTION
rangeoffset is not correctly set, so vktrace capture not correct for range offset not equal 0 in vkFlushMappedMemoryRanges.