### PR TITLE
Fix Building vktrace on ARM Linux

### DIFF
--- a/vktrace/src/build_options.cmake
+++ b/vktrace/src/build_options.cmake
@@ -177,7 +177,6 @@ endfunction()
 ### TODO: see if sse is generated with these instructions and clang:
 ## -march=corei7 -msse -mfpmath=sse
 
-set(MARCH_STR "-march=corei7")
 if (${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
    if ( NOT BUILD_X64 )
       # Fix startup crash in dlopen_notify_callback (called indirectly from our dlopen() function) when tracing glxspheres on my AMD dev box (x86 release only)

--- a/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
@@ -77,10 +77,7 @@ BOOL vktrace_init_time()
 
 uint64_t vktrace_get_time()
 {
-#if defined(VKTRACE_USE_LINUX_API)
-    extern int g_reliable_rdtsc;
-    if (g_reliable_rdtsc == -1)
-        init_rdtsc();
+#if defined(PLATFORM_LINUX)
     if (g_reliable_rdtsc == 0)
     {
         //$ TODO: Should just use SDL_GetPerformanceCounter?


### PR DESCRIPTION
Below are two fixes:
- Remove hardcoding "corei7" in cmake files
- Fix vktrace_get_time()