### PR TITLE
vkreplay: Loop on vkGetQueryPoolResults return value.

### DIFF
--- a/vktrace/vktrace_generate.py
+++ b/vktrace/vktrace_generate.py
@@ -1656,7 +1656,7 @@ class Subcommand(object):
         # Functions to treat as "Create' that don't have 'Create' in the name
         special_create_list = ['LoadPipeline', 'LoadPipelineDerivative', 'AllocateMemory', 'GetDeviceQueue', 'PinSystemMemory', 'AllocateDescriptorSets']
         # A couple funcs use do while loops
-        do_while_dict = {'GetFenceStatus': 'replayResult != pPacket->result  && pPacket->result == VK_SUCCESS', 'GetEventStatus': '(pPacket->result == VK_EVENT_SET || pPacket->result == VK_EVENT_RESET) && replayResult != pPacket->result'}
+        do_while_dict = {'GetFenceStatus': 'replayResult != pPacket->result  && pPacket->result == VK_SUCCESS', 'GetEventStatus': '(pPacket->result == VK_EVENT_SET || pPacket->result == VK_EVENT_RESET) && replayResult != pPacket->result', 'GetQueryPoolResults': 'pPacket->result == VK_SUCCESS && replayResult != pPacket->result'}
         rbody = []
         rbody.append('%s' % self.lineinfo.get())
         rbody.append('vktrace_replay::VKTRACE_REPLAY_RESULT vkReplay::replay(vktrace_trace_packet_header *packet)')


### PR DESCRIPTION
* If the trace file recorded VK_SUCCESS as a result, then loop on the call to vkGetQueryPoolResults until it also has a successful return value. It can validly happen that the replay will return VK_NOT_READY, and the replay simply needs to wait a bit longer for the result to come back. This fix puts a do-while loop around vkGetQueryPoolResults and loops as needed.