### PR TITLE
Update VK_LAYER_LUNARG_{basic,multi*,screenshot}

### DIFF
--- a/layersvt/basic.cpp
+++ b/layersvt/basic.cpp
@@ -122,16 +122,12 @@ basic_GetPhysicalDeviceFormatProperties(VkPhysicalDevice gpu, VkFormat format, V
     printf("Completed wrapped vkGetPhysicalDeviceFormatProperties() call w/ gpu: %p\n", (void *)gpu);
 }
 
-static const VkLayerProperties globalLayerProps[] = {{
+static const VkLayerProperties basic_LayerProps = {
     "VK_LAYER_LUNARG_basic",
     VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), // specVersion
     1,              // implementationVersion
     "LunarG Sample Layer",
-}};
-
-static const VkLayerProperties basic_physicaldevice_layers[] = {{
-    "VK_LAYER_LUNARG_basic", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "Sample layer: basic, implements vkLayerBasicEXT",
-}};
+};
 
 static const VkExtensionProperties basic_physicaldevice_extensions[] = {{
     "vkLayerBasicEXT", 1,
@@ -139,12 +135,12 @@ static const VkExtensionProperties basic_physicaldevice_extensions[] = {{
 
 VKAPI_ATTR VkResult VKAPI_CALL
 basic_EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
-    return util_GetLayerProperties(ARRAY_SIZE(globalLayerProps), globalLayerProps, pCount, pProperties);
+    return util_GetLayerProperties(1, &basic_LayerProps, pCount, pProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL
 basic_EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
-    return util_GetLayerProperties(ARRAY_SIZE(basic_physicaldevice_layers), basic_physicaldevice_layers, pCount, pProperties);
+    return util_GetLayerProperties(1, &basic_LayerProps, pCount, pProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL

--- a/layersvt/basic.cpp
+++ b/layersvt/basic.cpp
@@ -201,6 +201,10 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL basic_GetInstanceProcAddr(VkInstance in
     if (!strcmp("vkEnumeratePhysicalDevices", pName))
         return (PFN_vkVoidFunction)basic_EnumeratePhysicalDevices;
 
+    PFN_vkVoidFunction proc = basic_GetDeviceProcAddr(VK_NULL_HANDLE, pName);
+    if (proc)
+        return proc;
+
     if (instance == NULL)
         return NULL;
 

--- a/layersvt/basic.cpp
+++ b/layersvt/basic.cpp
@@ -221,12 +221,11 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL basic_GetInstanceProcAddr(VkInstance in
     if (!strcmp("vkEnumeratePhysicalDevices", pName))
         return (PFN_vkVoidFunction)basic_EnumeratePhysicalDevices;
 
+    assert(instance);
+
     PFN_vkVoidFunction proc = basic_GetDeviceProcAddr(VK_NULL_HANDLE, pName);
     if (proc)
         return proc;
-
-    if (instance == NULL)
-        return NULL;
 
     if (instance_dispatch_table(instance)->GetInstanceProcAddr == NULL)
         return NULL;

--- a/layersvt/basic.cpp
+++ b/layersvt/basic.cpp
@@ -183,12 +183,16 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkD
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *pName) {
-    if (!strcmp("vkGetInstanceProcAddr", pName))
-        return (PFN_vkVoidFunction)vkGetInstanceProcAddr;
+    if (!strcmp("vkEnumerateInstanceLayerProperties", pName))
+        return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
     if (!strcmp("vkEnumerateDeviceLayerProperties", pName))
         return (PFN_vkVoidFunction)vkEnumerateDeviceLayerProperties;
+    if (!strcmp("vkEnumerateInstanceExtensionProperties", pName))
+        return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
     if (!strcmp("vkEnumerateDeviceExtensionProperties", pName))
         return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
+    if (!strcmp("vkGetInstanceProcAddr", pName))
+        return (PFN_vkVoidFunction)vkGetInstanceProcAddr;
     if (!strcmp("vkGetPhysicalDeviceFormatProperties", pName))
         return (PFN_vkVoidFunction)basic_GetPhysicalDeviceFormatProperties;
     if (!strcmp("vkCreateInstance", pName))

--- a/layersvt/basic.cpp
+++ b/layersvt/basic.cpp
@@ -30,7 +30,7 @@
 typedef VkResult(VKAPI_PTR *PFN_vkLayerBasicEXT)(VkDevice device);
 static PFN_vkLayerBasicEXT pfn_layer_extension;
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkLayerBasicEXT(VkDevice device) {
+VKAPI_ATTR VkResult VKAPI_CALL basic_LayerBasicEXT(VkDevice device) {
     printf("In vkLayerBasicEXT() call w/ device: %p\n", (void *)device);
     if (pfn_layer_extension) {
         printf("In vkLayerBasicEXT() call down chain\n");
@@ -40,7 +40,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkLayerBasicEXT(VkDevice device) 
     return VK_SUCCESS;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 basic_CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
     VkLayerInstanceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
@@ -63,7 +63,7 @@ basic_CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocation
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 basic_EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, VkPhysicalDevice *pPhysicalDevices) {
     printf("At start of wrapped vkEnumeratePhysicalDevices() call w/ inst: %p\n", (void *)instance);
     VkResult result = instance_dispatch_table(instance)->EnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
@@ -71,9 +71,9 @@ basic_EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCou
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL basic_CreateDevice(VkPhysicalDevice physicalDevice,
-                                                                  const VkDeviceCreateInfo *pCreateInfo,
-                                                                  const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
+VKAPI_ATTR VkResult VKAPI_CALL basic_CreateDevice(VkPhysicalDevice physicalDevice,
+                                                  const VkDeviceCreateInfo *pCreateInfo,
+                                                  const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
     printf("VK_LAYER_LUNARG_Basic: At start of vkCreateDevice() call w/ gpu: %p\n", (void *)physicalDevice);
 
     VkLayerDeviceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
@@ -102,20 +102,20 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL basic_CreateDevice(VkPhysicalDevi
 }
 
 /* hook DestroyDevice to remove tableMap entry */
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL basic_DestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL basic_DestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
     dispatch_key key = get_dispatch_key(device);
     device_dispatch_table(device)->DestroyDevice(device, pAllocator);
     destroy_device_dispatch_table(key);
 }
 
 /* hook DestroyInstance to remove tableInstanceMap entry */
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL basic_DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL basic_DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
     dispatch_key key = get_dispatch_key(instance);
     instance_dispatch_table(instance)->DestroyInstance(instance, pAllocator);
     destroy_instance_dispatch_table(key);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL
+VKAPI_ATTR void VKAPI_CALL
 basic_GetPhysicalDeviceFormatProperties(VkPhysicalDevice gpu, VkFormat format, VkFormatProperties *pFormatInfo) {
     printf("At start of wrapped vkGetPhysicalDeviceFormatProperties() call w/ gpu: %p\n", (void *)gpu);
     instance_dispatch_table(gpu)->GetPhysicalDeviceFormatProperties(gpu, format, pFormatInfo);
@@ -137,26 +137,24 @@ static const VkExtensionProperties basic_physicaldevice_extensions[] = {{
     "vkLayerBasicEXT", 1,
 }};
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL
+basic_EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
     return util_GetLayerProperties(ARRAY_SIZE(globalLayerProps), globalLayerProps, pCount, pProperties);
 }
 
-/* Must use Vulkan name so that loader finds it */
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
-    /* Mem tracker's physical device layers are the same as global */
+VKAPI_ATTR VkResult VKAPI_CALL
+basic_EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
     return util_GetLayerProperties(ARRAY_SIZE(basic_physicaldevice_layers), basic_physicaldevice_layers, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL
+basic_EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
     return util_GetExtensionProperties(0, NULL, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
-                                                                                    const char *pLayerName, uint32_t *pCount,
-                                                                                    VkExtensionProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL basic_EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                        const char *pLayerName, uint32_t *pCount,
+                                                                        VkExtensionProperties *pProperties) {
     if (pLayerName == NULL) {
         return instance_dispatch_table(physicalDevice)
             ->EnumerateDeviceExtensionProperties(physicalDevice, NULL, pCount, pProperties);
@@ -166,13 +164,13 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
     }
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char *pName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL basic_GetDeviceProcAddr(VkDevice device, const char *pName) {
     if (!strcmp("vkGetDeviceProcAddr", pName))
-        return (PFN_vkVoidFunction)vkGetDeviceProcAddr;
+        return (PFN_vkVoidFunction)basic_GetDeviceProcAddr;
     if (!strcmp("vkDestroyDevice", pName))
         return (PFN_vkVoidFunction)basic_DestroyDevice;
     if (!strcmp("vkLayerBasicEXT", pName))
-        return (PFN_vkVoidFunction)vkLayerBasicEXT;
+        return (PFN_vkVoidFunction)basic_LayerBasicEXT;
 
     if (device == NULL)
         return NULL;
@@ -182,17 +180,17 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkD
     return device_dispatch_table(device)->GetDeviceProcAddr(device, pName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *pName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL basic_GetInstanceProcAddr(VkInstance instance, const char *pName) {
     if (!strcmp("vkEnumerateInstanceLayerProperties", pName))
-        return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
+        return (PFN_vkVoidFunction)basic_EnumerateInstanceLayerProperties;
     if (!strcmp("vkEnumerateDeviceLayerProperties", pName))
-        return (PFN_vkVoidFunction)vkEnumerateDeviceLayerProperties;
+        return (PFN_vkVoidFunction)basic_EnumerateDeviceLayerProperties;
     if (!strcmp("vkEnumerateInstanceExtensionProperties", pName))
-        return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
+        return (PFN_vkVoidFunction)basic_EnumerateInstanceExtensionProperties;
     if (!strcmp("vkEnumerateDeviceExtensionProperties", pName))
-        return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
+        return (PFN_vkVoidFunction)basic_EnumerateDeviceExtensionProperties;
     if (!strcmp("vkGetInstanceProcAddr", pName))
-        return (PFN_vkVoidFunction)vkGetInstanceProcAddr;
+        return (PFN_vkVoidFunction)basic_GetInstanceProcAddr;
     if (!strcmp("vkGetPhysicalDeviceFormatProperties", pName))
         return (PFN_vkVoidFunction)basic_GetPhysicalDeviceFormatProperties;
     if (!strcmp("vkCreateInstance", pName))
@@ -210,4 +208,39 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(V
     if (instance_dispatch_table(instance)->GetInstanceProcAddr == NULL)
         return NULL;
     return instance_dispatch_table(instance)->GetInstanceProcAddr(instance, pName);
+}
+
+// loader-layer interface v0, just wrappers since there is only a layer
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+    return basic_EnumerateInstanceLayerProperties(pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
+    // the layer command handles VK_NULL_HANDLE just fine internally
+    assert(physicalDevice == VK_NULL_HANDLE);
+    return basic_EnumerateDeviceLayerProperties(VK_NULL_HANDLE, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
+    return basic_EnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                                    const char *pLayerName, uint32_t *pCount,
+                                                                                    VkExtensionProperties *pProperties) {
+    // the layer command handles VK_NULL_HANDLE just fine internally
+    assert(physicalDevice == VK_NULL_HANDLE);
+    return basic_EnumerateDeviceExtensionProperties(VK_NULL_HANDLE, pLayerName, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
+    return basic_GetDeviceProcAddr(dev, funcName);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
+    return basic_GetInstanceProcAddr(instance, funcName);
 }

--- a/layersvt/basic.cpp
+++ b/layersvt/basic.cpp
@@ -145,19 +145,22 @@ basic_EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *
 
 VKAPI_ATTR VkResult VKAPI_CALL
 basic_EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
-    return util_GetExtensionProperties(0, NULL, pCount, pProperties);
+    if (pLayerName && !strcmp(pLayerName, basic_LayerProps.layerName))
+        return util_GetExtensionProperties(0, NULL, pCount, pProperties);
+
+    return VK_ERROR_LAYER_NOT_PRESENT;
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL basic_EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
                                                                         const char *pLayerName, uint32_t *pCount,
                                                                         VkExtensionProperties *pProperties) {
-    if (pLayerName == NULL) {
-        return instance_dispatch_table(physicalDevice)
-            ->EnumerateDeviceExtensionProperties(physicalDevice, NULL, pCount, pProperties);
-    } else {
-        return util_GetExtensionProperties(ARRAY_SIZE(basic_physicaldevice_extensions), basic_physicaldevice_extensions, pCount,
-                                           pProperties);
+    if (pLayerName && !strcmp(pLayerName, basic_LayerProps.layerName)) {
+        return util_GetExtensionProperties(ARRAY_SIZE(basic_physicaldevice_extensions),
+                basic_physicaldevice_extensions, pCount, pProperties);
     }
+
+    return instance_dispatch_table(physicalDevice)
+        ->EnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pCount, pProperties);
 }
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL basic_GetDeviceProcAddr(VkDevice device, const char *pName) {

--- a/layersvt/basic.cpp
+++ b/layersvt/basic.cpp
@@ -27,13 +27,6 @@
 #include "vk_layer_table.h"
 #include "vk_layer_extension_utils.h"
 
-static const VkLayerProperties globalLayerProps[] = {{
-    "VK_LAYER_LUNARG_basic",
-    VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), // specVersion
-    1,              // implementationVersion
-    "LunarG Sample Layer",
-}};
-
 typedef VkResult(VKAPI_PTR *PFN_vkLayerBasicEXT)(VkDevice device);
 static PFN_vkLayerBasicEXT pfn_layer_extension;
 
@@ -45,33 +38,6 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkLayerBasicEXT(VkDevice device) 
     }
     printf("vkLayerBasicEXT returning SUCCESS\n");
     return VK_SUCCESS;
-}
-
-static const VkLayerProperties basic_physicaldevice_layers[] = {{
-    "VK_LAYER_LUNARG_basic", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "Sample layer: basic, implements vkLayerBasicEXT",
-}};
-
-/* Must use Vulkan name so that loader finds it */
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
-    /* Mem tracker's physical device layers are the same as global */
-    return util_GetLayerProperties(ARRAY_SIZE(basic_physicaldevice_layers), basic_physicaldevice_layers, pCount, pProperties);
-}
-
-static const VkExtensionProperties basic_physicaldevice_extensions[] = {{
-    "vkLayerBasicEXT", 1,
-}};
-
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
-                                                                                    const char *pLayerName, uint32_t *pCount,
-                                                                                    VkExtensionProperties *pProperties) {
-    if (pLayerName == NULL) {
-        return instance_dispatch_table(physicalDevice)
-            ->EnumerateDeviceExtensionProperties(physicalDevice, NULL, pCount, pProperties);
-    } else {
-        return util_GetExtensionProperties(ARRAY_SIZE(basic_physicaldevice_extensions), basic_physicaldevice_extensions, pCount,
-                                           pProperties);
-    }
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
@@ -156,6 +122,50 @@ basic_GetPhysicalDeviceFormatProperties(VkPhysicalDevice gpu, VkFormat format, V
     printf("Completed wrapped vkGetPhysicalDeviceFormatProperties() call w/ gpu: %p\n", (void *)gpu);
 }
 
+static const VkLayerProperties globalLayerProps[] = {{
+    "VK_LAYER_LUNARG_basic",
+    VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), // specVersion
+    1,              // implementationVersion
+    "LunarG Sample Layer",
+}};
+
+static const VkLayerProperties basic_physicaldevice_layers[] = {{
+    "VK_LAYER_LUNARG_basic", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "Sample layer: basic, implements vkLayerBasicEXT",
+}};
+
+static const VkExtensionProperties basic_physicaldevice_extensions[] = {{
+    "vkLayerBasicEXT", 1,
+}};
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+    return util_GetLayerProperties(ARRAY_SIZE(globalLayerProps), globalLayerProps, pCount, pProperties);
+}
+
+/* Must use Vulkan name so that loader finds it */
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
+    /* Mem tracker's physical device layers are the same as global */
+    return util_GetLayerProperties(ARRAY_SIZE(basic_physicaldevice_layers), basic_physicaldevice_layers, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
+    return util_GetExtensionProperties(0, NULL, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                                    const char *pLayerName, uint32_t *pCount,
+                                                                                    VkExtensionProperties *pProperties) {
+    if (pLayerName == NULL) {
+        return instance_dispatch_table(physicalDevice)
+            ->EnumerateDeviceExtensionProperties(physicalDevice, NULL, pCount, pProperties);
+    } else {
+        return util_GetExtensionProperties(ARRAY_SIZE(basic_physicaldevice_extensions), basic_physicaldevice_extensions, pCount,
+                                           pProperties);
+    }
+}
+
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char *pName) {
     if (!strcmp("vkGetDeviceProcAddr", pName))
         return (PFN_vkVoidFunction)vkGetDeviceProcAddr;
@@ -196,14 +206,4 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(V
     if (instance_dispatch_table(instance)->GetInstanceProcAddr == NULL)
         return NULL;
     return instance_dispatch_table(instance)->GetInstanceProcAddr(instance, pName);
-}
-
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
-    return util_GetExtensionProperties(0, NULL, pCount, pProperties);
-}
-
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
-    return util_GetLayerProperties(ARRAY_SIZE(globalLayerProps), globalLayerProps, pCount, pProperties);
 }

--- a/layersvt/linux/VkLayer_multi.json
+++ b/layersvt/linux/VkLayer_multi.json
@@ -8,8 +8,8 @@
         "implementation_version": "1",
         "description": "LunarG Sample multiple layer per library",
         "functions" : {
-          "vkGetInstanceProcAddr" : "multi1GetInstanceProcAddr",
-          "vkGetDeviceProcAddr" : "multi1GetDeviceProcAddr"
+          "vkGetInstanceProcAddr" : "VK_LAYER_LUNARG_multi1GetInstanceProcAddr",
+          "vkGetDeviceProcAddr" : "VK_LAYER_LUNARG_multi1GetDeviceProcAddr"
         }
     },
     "layer" : {
@@ -20,7 +20,7 @@
         "implementation_version": "1",
         "description": "LunarG Sample multiple layer per library",
         "functions" : {
-          "vkGetInstanceProcAddr" : "multi2GetInstanceProcAddr"
+          "vkGetInstanceProcAddr" : "VK_LAYER_LUNARG_multi2GetInstanceProcAddr"
         }
     }
 }

--- a/layersvt/multi.cpp
+++ b/layersvt/multi.cpp
@@ -244,27 +244,18 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetInstanceProcAddr(VkInstance in
         return (PFN_vkVoidFunction)multi1EnumerateDeviceExtensionProperties;
     if (!strcmp(pName, "multi1GetInstanceProcAddr") || !strcmp(pName, "vkGetInsatnceProcAddr"))
         return (PFN_vkVoidFunction)multi1GetInstanceProcAddr;
-    if (!strcmp(pName, "multi1GetDeviceProcAddr") || !strcmp(pName, "vkGetDeviceProcAddr"))
-        return (PFN_vkVoidFunction)multi1GetDeviceProcAddr;
     if (!strcmp("vkCreateInstance", pName))
         return (PFN_vkVoidFunction)multi1CreateInstance;
     if (!strcmp("vkCreateDevice", pName))
         return (PFN_vkVoidFunction)multi1CreateDevice;
-    if (!strcmp("vkDestroyDevice", pName))
-        return (PFN_vkVoidFunction)multi1DestroyDevice;
-    if (!strcmp("vkCreateSampler", pName))
-        return (PFN_vkVoidFunction)multi1CreateSampler;
-    if (!strcmp("vkCreateGraphicsPipelines", pName))
-        return (PFN_vkVoidFunction)multi1CreateGraphicsPipelines;
     if (!strcmp("vkDestroyInstance", pName))
         return (PFN_vkVoidFunction)multi1DestroyInstance;
+
+    assert(instance);
 
     PFN_vkVoidFunction proc = multi1GetDeviceProcAddr(VK_NULL_HANDLE, pName);
     if (proc)
         return proc;
-
-    if (instance == NULL)
-        return NULL;
 
     VkLayerInstanceDispatchTable *pTable = get_dispatch_table(multi1_instance_table_map, instance);
     if (pTable->GetInstanceProcAddr == NULL)

--- a/layersvt/multi.cpp
+++ b/layersvt/multi.cpp
@@ -26,10 +26,40 @@
 #include "vk_loader_platform.h"
 #include "vulkan/vk_layer.h"
 #include "vk_layer_table.h"
+#include "vk_layer_extension_utils.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+enum {
+    LAYER_MULTI1,
+    LAYER_MULTI2,
+    LAYER_COUNT,
+};
+
+static const VkLayerProperties all_layer_props[LAYER_COUNT] = {
+    {
+        "VK_LAYER_LUNARG_multi1",
+        VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), // specVersion
+        1,              // implementationVersion
+        "LunarG Sample multiple layer per library",
+    },
+    {
+        "VK_LAYER_LUNARG_multi2",
+        VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), // specVersion
+        1,              // implementationVersion
+        "LunarG Sample multiple layer per library",
+    },
+};
+
+static const struct {
+    uint32_t count;
+    const VkExtensionProperties* extensions;
+} all_extension_props[LAYER_COUNT] = {
+    { 0, NULL, },
+    { 0, NULL, },
+};
 
 static device_table_map multi1_device_table_map;
 static instance_table_map multi1_instance_table_map;
@@ -134,6 +164,43 @@ multi1CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, ui
     return result;
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL
+multi1EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties)
+{
+    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI1], pCount, pProperties);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+multi1EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties)
+{
+    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI1], pCount, pProperties);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+multi1EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties)
+{
+    if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI1].layerName)) {
+        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI1].count,
+                all_extension_props[LAYER_MULTI1].extensions, pCount, pProperties);
+    }
+
+    return VK_ERROR_LAYER_NOT_PRESENT;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+multi1EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                         const char *pLayerName, uint32_t *pCount,
+                                         VkExtensionProperties *pProperties)
+{
+    if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI1].layerName)) {
+        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI1].count,
+                all_extension_props[LAYER_MULTI1].extensions, pCount, pProperties);
+    }
+
+    VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(multi1_instance_table_map, physicalDevice);
+    return pDisp->EnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pCount, pProperties);
+}
+
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetDeviceProcAddr(VkDevice device, const char *pName) {
     if (!strcmp(pName, "multi1GetDeviceProcAddr") || !strcmp(pName, "vkGetDeviceProcAddr"))
         return (PFN_vkVoidFunction)multi1GetDeviceProcAddr;
@@ -154,6 +221,14 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetDeviceProcAddr(VkDevice device
 }
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetInstanceProcAddr(VkInstance instance, const char *pName) {
+    if (!strcmp("vkEnumerateInstanceLayerProperties", pName))
+        return (PFN_vkVoidFunction)multi1EnumerateInstanceLayerProperties;
+    if (!strcmp("vkEnumerateDeviceLayerProperties", pName))
+        return (PFN_vkVoidFunction)multi1EnumerateDeviceLayerProperties;
+    if (!strcmp("vkEnumerateInstanceExtensionProperties", pName))
+        return (PFN_vkVoidFunction)multi1EnumerateInstanceExtensionProperties;
+    if (!strcmp("vkEnumerateDeviceExtensionProperties", pName))
+        return (PFN_vkVoidFunction)multi1EnumerateDeviceExtensionProperties;
     if (!strcmp(pName, "multi1GetInstanceProcAddr") || !strcmp(pName, "vkGetInsatnceProcAddr"))
         return (PFN_vkVoidFunction)multi1GetInstanceProcAddr;
     if (!strcmp(pName, "multi1GetDeviceProcAddr") || !strcmp(pName, "vkGetDeviceProcAddr"))
@@ -247,7 +322,52 @@ VKAPI_ATTR void VKAPI_CALL multi2DestroyInstance(VkInstance instance, const VkAl
     printf("Completed multi2 layer vkDestroyInstance()\n");
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL
+multi2EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties)
+{
+    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI2], pCount, pProperties);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+multi2EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties)
+{
+    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI2], pCount, pProperties);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+multi2EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties)
+{
+    if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI2].layerName)) {
+        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI2].count,
+                all_extension_props[LAYER_MULTI2].extensions, pCount, pProperties);
+    }
+
+    return VK_ERROR_LAYER_NOT_PRESENT;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+multi2EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                         const char *pLayerName, uint32_t *pCount,
+                                         VkExtensionProperties *pProperties)
+{
+    if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI2].layerName)) {
+        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI2].count,
+                all_extension_props[LAYER_MULTI2].extensions, pCount, pProperties);
+    }
+
+    VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(multi2_instance_table_map, physicalDevice);
+    return pDisp->EnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pCount, pProperties);
+}
+
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi2GetInstanceProcAddr(VkInstance inst, const char *pName) {
+    if (!strcmp("vkEnumerateInstanceLayerProperties", pName))
+        return (PFN_vkVoidFunction)multi2EnumerateInstanceLayerProperties;
+    if (!strcmp("vkEnumerateDeviceLayerProperties", pName))
+        return (PFN_vkVoidFunction)multi2EnumerateDeviceLayerProperties;
+    if (!strcmp("vkEnumerateInstanceExtensionProperties", pName))
+        return (PFN_vkVoidFunction)multi2EnumerateInstanceExtensionProperties;
+    if (!strcmp("vkEnumerateDeviceExtensionProperties", pName))
+        return (PFN_vkVoidFunction)multi2EnumerateDeviceExtensionProperties;
     if (!strcmp("vkCreateInstance", pName))
         return (PFN_vkVoidFunction)multi2CreateInstance;
     if (!strcmp(pName, "multi2GetInstanceProcAddr") || !strcmp(pName, "vkGetInstanceProcAddr"))
@@ -272,15 +392,82 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi2GetInstanceProcAddr(VkInstance in
 
 // loader-layer interface v0
 
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties)
+{
+    return util_GetLayerProperties(LAYER_COUNT, all_layer_props, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties)
+{
+    // multi2 does not intercept any device-level command
+    return multi1EnumerateDeviceLayerProperties(physicalDevice, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties)
+{
+    assert(pLayerName);
+
+    for (int i = 0; i < LAYER_COUNT; i++) {
+        if (!strcmp(pLayerName, all_layer_props[i].layerName)) {
+            return util_GetExtensionProperties(all_extension_props[i].count,
+                    all_extension_props[i].extensions, pCount, pProperties);
+        }
+    }
+
+    assert(!"unreachable");
+    *pCount = 0;
+    return VK_SUCCESS;
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                     const char *pLayerName, uint32_t *pCount,
+                                     VkExtensionProperties *pProperties)
+{
+    assert(physicalDevice == VK_NULL_HANDLE && pLayerName);
+
+    for (int i = 0; i < LAYER_COUNT; i++) {
+        if (!strcmp(pLayerName, all_layer_props[i].layerName)) {
+            return util_GetExtensionProperties(all_extension_props[i].count,
+                    all_extension_props[i].extensions, pCount, pProperties);
+        }
+    }
+
+    assert(!"unreachable");
+    *pCount = 0;
+    return VK_SUCCESS;
+}
+
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_multi1GetDeviceProcAddr(VkDevice device, const char *pName) {
     return multi1GetDeviceProcAddr(device, pName);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_multi1GetInstanceProcAddr(VkInstance instance, const char *pName) {
+    if (!strcmp(pName, "vkEnumerateInstanceLayerProperties"))
+        return reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceLayerProperties);
+    if (!strcmp(pName, "vkEnumerateDeviceLayerProperties"))
+        return reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateDeviceLayerProperties);
+    if (!strcmp(pName, "vkEnumerateInstanceExtensionProperties"))
+        return reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceExtensionProperties);
+    if (!strcmp(pName, "vkGetInstanceProcAddr"))
+        return reinterpret_cast<PFN_vkVoidFunction>(VK_LAYER_LUNARG_multi1GetInstanceProcAddr);
+
     return multi1GetInstanceProcAddr(instance, pName);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_multi2GetInstanceProcAddr(VkInstance instance, const char *pName) {
+    if (!strcmp(pName, "vkEnumerateInstanceLayerProperties"))
+        return reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceLayerProperties);
+    if (!strcmp(pName, "vkEnumerateDeviceLayerProperties"))
+        return reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateDeviceLayerProperties);
+    if (!strcmp(pName, "vkEnumerateInstanceExtensionProperties"))
+        return reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceExtensionProperties);
+    if (!strcmp(pName, "vkGetInstanceProcAddr"))
+        return reinterpret_cast<PFN_vkVoidFunction>(VK_LAYER_LUNARG_multi2GetInstanceProcAddr);
+
     return multi2GetInstanceProcAddr(instance, pName);
 }
 

--- a/layersvt/multi.cpp
+++ b/layersvt/multi.cpp
@@ -34,7 +34,7 @@ extern "C" {
 static device_table_map multi1_device_table_map;
 static instance_table_map multi1_instance_table_map;
 /******************************** Layer multi1 functions **************************/
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 multi1CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
     VkLayerInstanceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
@@ -58,7 +58,7 @@ multi1CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocation
 }
 
 /* hook DestroyInstance to remove tableInstanceMap entry */
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL multi1DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL multi1DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
     VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(multi1_instance_table_map, instance);
     dispatch_key key = get_dispatch_key(instance);
 
@@ -68,7 +68,7 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL multi1DestroyInstance(VkInstance inst
     printf("Completed multi1 layer vkDestroyInstance()\n");
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL multi1CreateDevice(VkPhysicalDevice physicalDevice,
+VKAPI_ATTR VkResult VKAPI_CALL multi1CreateDevice(VkPhysicalDevice physicalDevice,
                                                                   const VkDeviceCreateInfo *pCreateInfo,
                                                                   const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
     printf("At start of multi1 layer vkCreateDevice()\n");
@@ -98,7 +98,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL multi1CreateDevice(VkPhysicalDevi
 }
 
 /* hook DestroyDevice to remove tableMap entry */
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL multi1DestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL multi1DestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
     VkLayerDispatchTable *pDisp = get_dispatch_table(multi1_device_table_map, device);
     dispatch_key key = get_dispatch_key(device);
 
@@ -108,7 +108,7 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL multi1DestroyDevice(VkDevice device, 
     printf("Completed multi1 layer vkDestroyDevice()\n");
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL multi1CreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
+VKAPI_ATTR VkResult VKAPI_CALL multi1CreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
                                                                    const VkAllocationCallbacks *pAllocator, VkSampler *pSampler) {
     VkLayerDispatchTable *pDisp = get_dispatch_table(multi1_device_table_map, device);
 
@@ -118,7 +118,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL multi1CreateSampler(VkDevice devi
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 multi1CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                               const VkGraphicsPipelineCreateInfo *pCreateInfos, const VkAllocationCallbacks *pAllocator,
                               VkPipeline *pPipelines) {
@@ -130,7 +130,7 @@ multi1CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, ui
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetDeviceProcAddr(VkDevice device, const char *pName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetDeviceProcAddr(VkDevice device, const char *pName) {
     if (!strcmp(pName, "multi1GetDeviceProcAddr") || !strcmp(pName, "vkGetDeviceProcAddr"))
         return (PFN_vkVoidFunction)multi1GetDeviceProcAddr;
     if (!strcmp("vkDestroyDevice", pName))
@@ -149,7 +149,7 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetDeviceProcAddr
     return pTable->GetDeviceProcAddr(device, pName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetInstanceProcAddr(VkInstance instance, const char *pName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetInstanceProcAddr(VkInstance instance, const char *pName) {
     if (!strcmp(pName, "multi1GetInstanceProcAddr") || !strcmp(pName, "vkGetInsatnceProcAddr"))
         return (PFN_vkVoidFunction)multi1GetInstanceProcAddr;
     if (!strcmp(pName, "multi1GetDeviceProcAddr") || !strcmp(pName, "vkGetDeviceProcAddr"))
@@ -179,7 +179,7 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetInstanceProcAd
 
 static instance_table_map multi2_instance_table_map;
 /******************************** Layer multi2 functions **************************/
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 multi2CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
     VkLayerInstanceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
@@ -202,7 +202,7 @@ multi2CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocation
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 multi2EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, VkPhysicalDevice *pPhysicalDevices) {
     VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(multi2_instance_table_map, instance);
 
@@ -212,7 +212,7 @@ multi2EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCou
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL
+VKAPI_ATTR void VKAPI_CALL
 multi2GetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties *pProperties) {
     VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(multi2_instance_table_map, physicalDevice);
     printf("At start of wrapped multi2 vkGetPhysicalDeviceProperties()\n");
@@ -220,7 +220,7 @@ multi2GetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, VkPhysicalDev
     printf("Completed multi2 layer vkGetPhysicalDeviceProperties()\n");
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL
+VKAPI_ATTR void VKAPI_CALL
 multi2GetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures *pFeatures) {
     VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(multi2_instance_table_map, physicalDevice);
     printf("At start of wrapped multi2 vkGetPhysicalDeviceFeatures()\n");
@@ -229,7 +229,7 @@ multi2GetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDevic
 }
 
 /* hook DestroyInstance to remove tableInstanceMap entry */
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL multi2DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL multi2DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
     VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(multi2_instance_table_map, instance);
     dispatch_key key = get_dispatch_key(instance);
 
@@ -239,7 +239,7 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL multi2DestroyInstance(VkInstance inst
     printf("Completed multi2 layer vkDestroyInstance()\n");
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi2GetInstanceProcAddr(VkInstance inst, const char *pName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi2GetInstanceProcAddr(VkInstance inst, const char *pName) {
     if (!strcmp("vkCreateInstance", pName))
         return (PFN_vkVoidFunction)multi2CreateInstance;
     if (!strcmp(pName, "multi2GetInstanceProcAddr") || !strcmp(pName, "vkGetInstanceProcAddr"))
@@ -260,6 +260,20 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi2GetInstanceProcAd
     if (pTable->GetInstanceProcAddr == NULL)
         return NULL;
     return pTable->GetInstanceProcAddr(inst, pName);
+}
+
+// loader-layer interface v0
+
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_multi1GetDeviceProcAddr(VkDevice device, const char *pName) {
+    return multi1GetDeviceProcAddr(device, pName);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_multi1GetInstanceProcAddr(VkInstance instance, const char *pName) {
+    return multi1GetInstanceProcAddr(instance, pName);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_multi2GetInstanceProcAddr(VkInstance instance, const char *pName) {
+    return multi2GetInstanceProcAddr(instance, pName);
 }
 
 #ifdef __cplusplus

--- a/layersvt/multi.cpp
+++ b/layersvt/multi.cpp
@@ -167,6 +167,10 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi1GetInstanceProcAddr(VkInstance in
     if (!strcmp("vkDestroyInstance", pName))
         return (PFN_vkVoidFunction)multi1DestroyInstance;
 
+    PFN_vkVoidFunction proc = multi1GetDeviceProcAddr(VK_NULL_HANDLE, pName);
+    if (proc)
+        return proc;
+
     if (instance == NULL)
         return NULL;
 

--- a/layersvt/multi.cpp
+++ b/layersvt/multi.cpp
@@ -26,7 +26,20 @@
 #include "vk_loader_platform.h"
 #include "vulkan/vk_layer.h"
 #include "vk_layer_table.h"
-#include "vk_layer_extension_utils.h"
+
+template<typename T>
+VkResult EnumerateProperties(uint32_t src_count, const T *src_props, uint32_t *dst_count, T *dst_props) {
+    if (!dst_props || !src_props) {
+        *dst_count = src_count;
+        return VK_SUCCESS;
+    }
+
+    uint32_t copy_count = (*dst_count < src_count) ? *dst_count : src_count;
+    memcpy(dst_props, src_props, sizeof(T) * copy_count);
+    *dst_count = copy_count;
+
+    return (copy_count == src_count) ? VK_SUCCESS : VK_INCOMPLETE;
+}
 
 #ifdef __cplusplus
 extern "C" {
@@ -167,20 +180,20 @@ multi1CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, ui
 VKAPI_ATTR VkResult VKAPI_CALL
 multi1EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties)
 {
-    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI1], pCount, pProperties);
+    return EnumerateProperties(1, &all_layer_props[LAYER_MULTI1], pCount, pProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL
 multi1EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties)
 {
-    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI1], pCount, pProperties);
+    return EnumerateProperties(1, &all_layer_props[LAYER_MULTI1], pCount, pProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL
 multi1EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties)
 {
     if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI1].layerName)) {
-        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI1].count,
+        return EnumerateProperties(all_extension_props[LAYER_MULTI1].count,
                 all_extension_props[LAYER_MULTI1].extensions, pCount, pProperties);
     }
 
@@ -193,7 +206,7 @@ multi1EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
                                          VkExtensionProperties *pProperties)
 {
     if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI1].layerName)) {
-        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI1].count,
+        return EnumerateProperties(all_extension_props[LAYER_MULTI1].count,
                 all_extension_props[LAYER_MULTI1].extensions, pCount, pProperties);
     }
 
@@ -325,20 +338,20 @@ VKAPI_ATTR void VKAPI_CALL multi2DestroyInstance(VkInstance instance, const VkAl
 VKAPI_ATTR VkResult VKAPI_CALL
 multi2EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties)
 {
-    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI2], pCount, pProperties);
+    return EnumerateProperties(1, &all_layer_props[LAYER_MULTI2], pCount, pProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL
 multi2EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties)
 {
-    return util_GetLayerProperties(1, &all_layer_props[LAYER_MULTI2], pCount, pProperties);
+    return EnumerateProperties(1, &all_layer_props[LAYER_MULTI2], pCount, pProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL
 multi2EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties)
 {
     if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI2].layerName)) {
-        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI2].count,
+        return EnumerateProperties(all_extension_props[LAYER_MULTI2].count,
                 all_extension_props[LAYER_MULTI2].extensions, pCount, pProperties);
     }
 
@@ -351,7 +364,7 @@ multi2EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
                                          VkExtensionProperties *pProperties)
 {
     if (pLayerName && !strcmp(pLayerName, all_layer_props[LAYER_MULTI2].layerName)) {
-        return util_GetExtensionProperties(all_extension_props[LAYER_MULTI2].count,
+        return EnumerateProperties(all_extension_props[LAYER_MULTI2].count,
                 all_extension_props[LAYER_MULTI2].extensions, pCount, pProperties);
     }
 
@@ -395,7 +408,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL multi2GetInstanceProcAddr(VkInstance in
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties)
 {
-    return util_GetLayerProperties(LAYER_COUNT, all_layer_props, pCount, pProperties);
+    return EnumerateProperties(LAYER_COUNT, all_layer_props, pCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
@@ -412,7 +425,7 @@ vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
 
     for (int i = 0; i < LAYER_COUNT; i++) {
         if (!strcmp(pLayerName, all_layer_props[i].layerName)) {
-            return util_GetExtensionProperties(all_extension_props[i].count,
+            return EnumerateProperties(all_extension_props[i].count,
                     all_extension_props[i].extensions, pCount, pProperties);
         }
     }
@@ -431,7 +444,7 @@ vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
 
     for (int i = 0; i < LAYER_COUNT; i++) {
         if (!strcmp(pLayerName, all_layer_props[i].layerName)) {
-            return util_GetExtensionProperties(all_extension_props[i].count,
+            return EnumerateProperties(all_extension_props[i].count,
                     all_extension_props[i].extensions, pCount, pProperties);
         }
     }

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -358,7 +358,7 @@ CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallba
     assert(chain_info->u.pLayerInfo);
     PFN_vkGetInstanceProcAddr fpGetInstanceProcAddr = chain_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
     assert(fpGetInstanceProcAddr);
-    PFN_vkCreateInstance fpCreateInstance = (PFN_vkCreateInstance)fpGetInstanceProcAddr(*pInstance, "vkCreateInstance");
+    PFN_vkCreateInstance fpCreateInstance = (PFN_vkCreateInstance)fpGetInstanceProcAddr(VK_NULL_HANDLE, "vkCreateInstance");
     if (fpCreateInstance == NULL) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
@@ -402,7 +402,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     assert(chain_info->u.pLayerInfo);
     PFN_vkGetInstanceProcAddr fpGetInstanceProcAddr = chain_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
     PFN_vkGetDeviceProcAddr fpGetDeviceProcAddr = chain_info->u.pLayerInfo->pfnNextGetDeviceProcAddr;
-    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice)fpGetInstanceProcAddr(NULL, "vkCreateDevice");
+    VkInstance instance = physDeviceMap[gpu]->instance;
+    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice)fpGetInstanceProcAddr(instance, "vkCreateDevice");
     if (fpCreateDevice == NULL) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -743,16 +743,17 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice dev, const c
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char *funcName) {
     PFN_vkVoidFunction proc = intercept_core_instance_command(funcName);
-    if (!proc)
-        proc = intercept_core_device_command(funcName);
+    if (proc)
+        return proc;
+
+    assert(instance);
+
+    proc = intercept_core_device_command(funcName);
     if (!proc)
         proc = intercept_khr_swapchain_command(funcName, VK_NULL_HANDLE);
     if (proc)
         return proc;
 
-    if (instance == VK_NULL_HANDLE) {
-        return NULL;
-    }
     VkLayerInstanceDispatchTable *pTable = instance_dispatch_table(instance);
     if (pTable->GetInstanceProcAddr == NULL)
         return NULL;

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -351,8 +351,8 @@ static void writePPM(const char *filename, VkImage image1) {
     pTableDevice->FreeCommandBuffers(device, deviceMap[device]->commandPool, 1, &commandBuffer);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
+VKAPI_ATTR VkResult VKAPI_CALL
+CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
     VkLayerInstanceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
     assert(chain_info->u.pLayerInfo);
@@ -395,8 +395,8 @@ static void createDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo
     }
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo,
-                                                              const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
+VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo,
+                                            const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
     VkLayerDeviceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
     assert(chain_info->u.pLayerInfo);
@@ -437,8 +437,8 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice g
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, VkPhysicalDevice *pPhysicalDevices) {
+VKAPI_ATTR VkResult VKAPI_CALL
+EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, VkPhysicalDevice *pPhysicalDevices) {
     VkResult result;
 
     VkLayerInstanceDispatchTable *pTable = instance_dispatch_table(instance);
@@ -456,7 +456,7 @@ vkEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, 
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
+VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     DeviceMapStruct *devMap = get_dev_info(device);
     assert(devMap);
     VkLayerDispatchTable *pDisp = devMap->device_dispatch_table;
@@ -470,8 +470,8 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, cons
     loader_platform_thread_unlock_mutex(&globalLock);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL
-vkGetDeviceQueue(VkDevice device, uint32_t queueNodeIndex, uint32_t queueIndex, VkQueue *pQueue) {
+VKAPI_ATTR void VKAPI_CALL
+GetDeviceQueue(VkDevice device, uint32_t queueNodeIndex, uint32_t queueIndex, VkQueue *pQueue) {
     DeviceMapStruct *devMap = get_dev_info(device);
     assert(devMap);
     VkLayerDispatchTable *pDisp = devMap->device_dispatch_table;
@@ -492,9 +492,9 @@ vkGetDeviceQueue(VkDevice device, uint32_t queueNodeIndex, uint32_t queueIndex, 
     loader_platform_thread_unlock_mutex(&globalLock);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
-                                                                   const VkAllocationCallbacks *pAllocator,
-                                                                   VkCommandPool *pCommandPool) {
+VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
+                                                 const VkAllocationCallbacks *pAllocator,
+                                                 VkCommandPool *pCommandPool) {
     DeviceMapStruct *devMap = get_dev_info(device);
     assert(devMap);
     VkLayerDispatchTable *pDisp = devMap->device_dispatch_table;
@@ -514,9 +514,9 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateCommandPool(VkDevice devi
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
-                                                                    const VkAllocationCallbacks *pAllocator,
-                                                                    VkSwapchainKHR *pSwapchain) {
+VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
+                                                  const VkAllocationCallbacks *pAllocator,
+                                                  VkSwapchainKHR *pSwapchain) {
 
     DeviceMapStruct *devMap = get_dev_info(device);
     assert(devMap);
@@ -551,8 +551,8 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR(VkDevice dev
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pCount, VkImage *pSwapchainImages) {
+VKAPI_ATTR VkResult VKAPI_CALL
+GetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pCount, VkImage *pSwapchainImages) {
     DeviceMapStruct *devMap = get_dev_info(device);
     assert(devMap);
     VkLayerDispatchTable *pDisp = devMap->device_dispatch_table;
@@ -594,7 +594,7 @@ vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pCo
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
+VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
     static int frameNumber = 0;
     if (frameNumber == 10) {
         fflush(stdout); /* *((int*)0)=0; */
@@ -679,27 +679,27 @@ static const VkLayerProperties global_layer = {
     "VK_LAYER_LUNARG_screenshot", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "Layer: screenshot",
 };
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL
+EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
     return util_GetLayerProperties(1, &global_layer, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL
+EnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
     return util_GetLayerProperties(1, &global_layer, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL
+EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
     if (pLayerName && !strcmp(pLayerName, global_layer.layerName))
         return util_GetExtensionProperties(0, NULL, pCount, pProperties);
 
     return VK_ERROR_LAYER_NOT_PRESENT;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
-                                                                                    const char *pLayerName, uint32_t *pCount,
-                                                                                    VkExtensionProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                  const char *pLayerName, uint32_t *pCount,
+                                                                  VkExtensionProperties *pProperties) {
     if (pLayerName && !strcmp(pLayerName, global_layer.layerName))
         return util_GetExtensionProperties(0, NULL, pCount, pProperties);
 
@@ -718,7 +718,7 @@ intercept_core_device_command(const char *name);
 static PFN_vkVoidFunction
 intercept_khr_swapchain_command(const char *name, VkDevice dev);
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice dev, const char *funcName) {
     PFN_vkVoidFunction proc = intercept_core_device_command(funcName);
     if (proc)
         return proc;
@@ -740,7 +740,7 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkD
     return pDisp->GetDeviceProcAddr(dev, funcName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char *funcName) {
     PFN_vkVoidFunction proc = intercept_core_instance_command(funcName);
     if (!proc)
         proc = intercept_core_device_command(funcName);
@@ -765,14 +765,14 @@ intercept_core_instance_command(const char *name) {
         const char *name;
         PFN_vkVoidFunction proc;
     } core_instance_commands[] = {
-        { "vkGetInstanceProcAddr", reinterpret_cast<PFN_vkVoidFunction>(vkGetInstanceProcAddr) },
-        { "vkCreateInstance", reinterpret_cast<PFN_vkVoidFunction>(vkCreateInstance) },
-        { "vkCreateDevice", reinterpret_cast<PFN_vkVoidFunction>(vkCreateDevice) },
-        { "vkEnumeratePhysicalDevices", reinterpret_cast<PFN_vkVoidFunction>(vkEnumeratePhysicalDevices) },
-        { "vkEnumerateInstanceLayerProperties", reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceLayerProperties) },
-        { "vkEnumerateDeviceLayerProperties", reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateDeviceLayerProperties) },
-        { "vkEnumerateInstanceExtensionProperties", reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceExtensionProperties) },
-        { "vkEnumerateDeviceExtensionProperties", reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateDeviceExtensionProperties) }
+        { "vkGetInstanceProcAddr", reinterpret_cast<PFN_vkVoidFunction>(GetInstanceProcAddr) },
+        { "vkCreateInstance", reinterpret_cast<PFN_vkVoidFunction>(CreateInstance) },
+        { "vkCreateDevice", reinterpret_cast<PFN_vkVoidFunction>(CreateDevice) },
+        { "vkEnumeratePhysicalDevices", reinterpret_cast<PFN_vkVoidFunction>(EnumeratePhysicalDevices) },
+        { "vkEnumerateInstanceLayerProperties", reinterpret_cast<PFN_vkVoidFunction>(EnumerateInstanceLayerProperties) },
+        { "vkEnumerateDeviceLayerProperties", reinterpret_cast<PFN_vkVoidFunction>(EnumerateDeviceLayerProperties) },
+        { "vkEnumerateInstanceExtensionProperties", reinterpret_cast<PFN_vkVoidFunction>(EnumerateInstanceExtensionProperties) },
+        { "vkEnumerateDeviceExtensionProperties", reinterpret_cast<PFN_vkVoidFunction>(EnumerateDeviceExtensionProperties) }
     };
 
     for (size_t i = 0; i < ARRAY_SIZE(core_instance_commands); i++) {
@@ -789,10 +789,10 @@ intercept_core_device_command(const char *name) {
         const char *name;
         PFN_vkVoidFunction proc;
     } core_device_commands[] = {
-        { "vkGetDeviceProcAddr", reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceProcAddr) },
-        { "vkGetDeviceQueue", reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceQueue) },
-        { "vkCreateCommandPool", reinterpret_cast<PFN_vkVoidFunction>(vkCreateCommandPool) },
-        { "vkDestroyDevice", reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDevice) },
+        { "vkGetDeviceProcAddr", reinterpret_cast<PFN_vkVoidFunction>(GetDeviceProcAddr) },
+        { "vkGetDeviceQueue", reinterpret_cast<PFN_vkVoidFunction>(GetDeviceQueue) },
+        { "vkCreateCommandPool", reinterpret_cast<PFN_vkVoidFunction>(CreateCommandPool) },
+        { "vkDestroyDevice", reinterpret_cast<PFN_vkVoidFunction>(DestroyDevice) },
     };
 
     for (size_t i = 0; i < ARRAY_SIZE(core_device_commands); i++) {
@@ -809,9 +809,9 @@ intercept_khr_swapchain_command(const char *name, VkDevice dev) {
         const char *name;
         PFN_vkVoidFunction proc;
     } khr_swapchain_commands[] = {
-        { "vkCreateSwapchainKHR", reinterpret_cast<PFN_vkVoidFunction>(vkCreateSwapchainKHR) },
-        { "vkGetSwapchainImagesKHR", reinterpret_cast<PFN_vkVoidFunction>(vkGetSwapchainImagesKHR) },
-        { "vkQueuePresentKHR", reinterpret_cast<PFN_vkVoidFunction>(vkQueuePresentKHR) },
+        { "vkCreateSwapchainKHR", reinterpret_cast<PFN_vkVoidFunction>(CreateSwapchainKHR) },
+        { "vkGetSwapchainImagesKHR", reinterpret_cast<PFN_vkVoidFunction>(GetSwapchainImagesKHR) },
+        { "vkQueuePresentKHR", reinterpret_cast<PFN_vkVoidFunction>(QueuePresentKHR) },
     };
 
     if (dev) {
@@ -834,19 +834,19 @@ intercept_khr_swapchain_command(const char *name, VkDevice dev) {
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
-    return screenshot::vkEnumerateInstanceLayerProperties(pCount, pProperties);
+    return screenshot::EnumerateInstanceLayerProperties(pCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
     // the layer command handles VK_NULL_HANDLE just fine internally
     assert(physicalDevice == VK_NULL_HANDLE);
-    return screenshot::vkEnumerateDeviceLayerProperties(VK_NULL_HANDLE, pCount, pProperties);
+    return screenshot::EnumerateDeviceLayerProperties(VK_NULL_HANDLE, pCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
-    return screenshot::vkEnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
+    return screenshot::EnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
@@ -854,13 +854,13 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
                                                                                     VkExtensionProperties *pProperties) {
     // the layer command handles VK_NULL_HANDLE just fine internally
     assert(physicalDevice == VK_NULL_HANDLE);
-    return screenshot::vkEnumerateDeviceExtensionProperties(VK_NULL_HANDLE, pLayerName, pCount, pProperties);
+    return screenshot::EnumerateDeviceExtensionProperties(VK_NULL_HANDLE, pLayerName, pCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
-    return screenshot::vkGetDeviceProcAddr(dev, funcName);
+    return screenshot::GetDeviceProcAddr(dev, funcName);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
-    return screenshot::vkGetInstanceProcAddr(instance, funcName);
+    return screenshot::GetInstanceProcAddr(instance, funcName);
 }

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -42,6 +42,8 @@ using namespace std;
 #include "vk_layer_table.h"
 #include "vk_layer_extension_utils.h"
 
+namespace screenshot {
+
 static int globalLockInitialized = 0;
 static loader_platform_thread_mutex globalLock;
 
@@ -824,4 +826,41 @@ intercept_khr_swapchain_command(const char *name, VkDevice dev) {
     }
 
     return nullptr;
+}
+
+} // namespace screenshot
+
+// loader-layer interface v0, just wrappers since there is only a layer
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+    return screenshot::vkEnumerateInstanceLayerProperties(pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
+    // the layer command handles VK_NULL_HANDLE just fine internally
+    assert(physicalDevice == VK_NULL_HANDLE);
+    return screenshot::vkEnumerateDeviceLayerProperties(VK_NULL_HANDLE, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
+    return screenshot::vkEnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                                    const char *pLayerName, uint32_t *pCount,
+                                                                                    VkExtensionProperties *pProperties) {
+    // the layer command handles VK_NULL_HANDLE just fine internally
+    assert(physicalDevice == VK_NULL_HANDLE);
+    return screenshot::vkEnumerateDeviceExtensionProperties(VK_NULL_HANDLE, pLayerName, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
+    return screenshot::vkGetDeviceProcAddr(dev, funcName);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
+    return screenshot::vkGetInstanceProcAddr(instance, funcName);
 }

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -468,39 +468,6 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, cons
     loader_platform_thread_unlock_mutex(&globalLock);
 }
 
-static const VkLayerProperties ss_device_layers[] = {{
-    "VK_LAYER_LUNARG_screenshot", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "Layer: screenshot",
-}};
-
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
-    /* ScreenShot does not have any global extensions */
-    return util_GetExtensionProperties(0, NULL, pCount, pProperties);
-}
-
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
-    /* ScreenShot does not have any global layers */
-    return util_GetLayerProperties(0, NULL, pCount, pProperties);
-}
-
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
-                                                                                    const char *pLayerName, uint32_t *pCount,
-                                                                                    VkExtensionProperties *pProperties) {
-    /* ScreenShot does not have any physical device extensions */
-    if (pLayerName == NULL) {
-        VkLayerInstanceDispatchTable *pTable = instance_dispatch_table(physicalDevice);
-        return pTable->EnumerateDeviceExtensionProperties(physicalDevice, NULL, pCount, pProperties);
-    } else {
-        return util_GetExtensionProperties(0, NULL, pCount, pProperties);
-    }
-}
-
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
-vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
-    return util_GetLayerProperties(ARRAY_SIZE(ss_device_layers), ss_device_layers, pCount, pProperties);
-}
-
 VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL
 vkGetDeviceQueue(VkDevice device, uint32_t queueNodeIndex, uint32_t queueIndex, VkQueue *pQueue) {
     DeviceMapStruct *devMap = get_dev_info(device);
@@ -704,6 +671,39 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, 
     frameNumber++;
     loader_platform_thread_unlock_mutex(&globalLock);
     return result;
+}
+
+static const VkLayerProperties ss_device_layers[] = {{
+    "VK_LAYER_LUNARG_screenshot", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "Layer: screenshot",
+}};
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+    /* ScreenShot does not have any global layers */
+    return util_GetLayerProperties(0, NULL, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount, VkLayerProperties *pProperties) {
+    return util_GetLayerProperties(ARRAY_SIZE(ss_device_layers), ss_device_layers, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties) {
+    /* ScreenShot does not have any global extensions */
+    return util_GetExtensionProperties(0, NULL, pCount, pProperties);
+}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+                                                                                    const char *pLayerName, uint32_t *pCount,
+                                                                                    VkExtensionProperties *pProperties) {
+    /* ScreenShot does not have any physical device extensions */
+    if (pLayerName == NULL) {
+        VkLayerInstanceDispatchTable *pTable = instance_dispatch_table(physicalDevice);
+        return pTable->EnumerateDeviceExtensionProperties(physicalDevice, NULL, pCount, pProperties);
+    } else {
+        return util_GetExtensionProperties(0, NULL, pCount, pProperties);
+    }
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {

--- a/layersvt/windows/VkLayer_multi.json
+++ b/layersvt/windows/VkLayer_multi.json
@@ -8,8 +8,8 @@
         "implementation_version": "1",
         "description": "LunarG Sample multiple layer per library",
         "functions" : {
-          "vkGetInstanceProcAddr" : "multi1GetInstanceProcAddr",
-          "vkGetDeviceProcAddr" : "multi1GetDeviceProcAddr"
+          "vkGetInstanceProcAddr" : "VK_LAYER_LUNARG_multi1GetInstanceProcAddr",
+          "vkGetDeviceProcAddr" : "VK_LAYER_LUNARG_multi1GetDeviceProcAddr"
         }
     },
     "layer" : {
@@ -20,7 +20,7 @@
         "implementation_version": "1",
         "description": "LunarG Sample multiple layer per library",
         "functions" : {
-          "vkGetInstanceProcAddr" : "multi2GetInstanceProcAddr"
+          "vkGetInstanceProcAddr" : "VK_LAYER_LUNARG_multi2GetInstanceProcAddr"
         }
     }
 }


### PR DESCRIPTION
Update them such that

 - there is a clear separation between layer commands and layer library interface functions
 - GIPA handles device commands as well
 - avoid invalid GIPA calls
 - add/fix/improve introspection functions