### PR TITLE
Various improvements to enable trace/replay of DOOM.

### DIFF
--- a/vktrace/src/vktrace_common/CMakeLists.txt
+++ b/vktrace/src/vktrace_common/CMakeLists.txt
@@ -23,7 +23,12 @@ set(SRC_LIST
     vktrace_trace_packet_utils.c
 )
 
+set (CXX_SRC_LIST
+     optimization_function.cpp
+)
+
 set_source_files_properties( ${SRC_LIST} PROPERTIES LANGUAGE C)
+set_source_files_properties( ${CXX_SRC_LIST} PROPERTIES LANGUAGE CXX)
 
 file( GLOB_RECURSE HDRS *.[h|inl] )
 
@@ -31,7 +36,7 @@ if (NOT MSVC)
     add_compiler_flag("-fPIC")
 endif()
 
-add_library(${PROJECT_NAME} STATIC ${SRC_LIST} ${HDRS})
+add_library(${PROJECT_NAME} STATIC ${SRC_LIST} ${CXX_SRC_LIST} ${HDRS})
 
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/vktrace/src/vktrace_common/optimization_function.cpp
+++ b/vktrace/src/vktrace_common/optimization_function.cpp
@@ -1,55 +1,64 @@
+/*
+* Copyright (C) 2016 Advanced Micro Device, Inc.
+*/
+
 #include <stdio.h>
 #include <string.h>
-#include <ppl.h>
 #include <stdlib.h>
 
+#ifdef WIN32
+#include <ppl.h>
 using namespace concurrency;
-using namespace std;
-
-
 #define PARALLEL_INVOKE_NUM   10
 #define SIZE_LIMIT_TO_USE_OPTIMIZATION 67100000
+#endif
+
+using namespace std;
+
 extern "C" void *opt_memcpy(void * destination, const void * source, size_t size)
 {
-    void *pRet=NULL;
-		if (size < SIZE_LIMIT_TO_USE_OPTIMIZATION)
-		{
-			//memcpy(ptr_address, pBuffer, (size_t)size);
-			pRet=memcpy(destination, source, (size_t)size);
-		}
-		else
-		{
-		    pRet=destination;
-			void* ptr_parallel[PARALLEL_INVOKE_NUM];
-			void* pBuffer_parallel[PARALLEL_INVOKE_NUM];
-            size_t size_parallel[PARALLEL_INVOKE_NUM];
+    void *pRet = NULL;
+#ifndef WIN32
+    pRet = memcpy(destination, source, (size_t)size);
+#else
+    if (size < SIZE_LIMIT_TO_USE_OPTIMIZATION)
+    {
+        pRet = memcpy(destination, source, (size_t)size);
+    }
+    else
+    {
+        pRet = destination;
+        void* ptr_parallel[PARALLEL_INVOKE_NUM];
+        void* pBuffer_parallel[PARALLEL_INVOKE_NUM];
+        size_t size_parallel[PARALLEL_INVOKE_NUM];
 
-			int stepsize = size / PARALLEL_INVOKE_NUM;
-			for (int i = 0; i < PARALLEL_INVOKE_NUM; i++)
-			{
-				ptr_parallel[i] = (char *)destination + i*stepsize;
-				pBuffer_parallel[i] = (char *)source + i*stepsize;
-				if ((i + 1) == PARALLEL_INVOKE_NUM)
-				{
-					size_parallel[i] = size - (PARALLEL_INVOKE_NUM-1)*stepsize;
-				}
-				else
-				{
-                   size_parallel[i] = stepsize;
-				}
-			}
-			parallel_invoke(
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[9], pBuffer_parallel[9], (size_t)size_parallel[9]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[8], pBuffer_parallel[8], (size_t)size_parallel[8]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[7], pBuffer_parallel[7], (size_t)size_parallel[7]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[6], pBuffer_parallel[6], (size_t)size_parallel[6]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[5], pBuffer_parallel[5], (size_t)size_parallel[5]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[4], pBuffer_parallel[4], (size_t)size_parallel[4]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[3], pBuffer_parallel[3], (size_t)size_parallel[3]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[2], pBuffer_parallel[2], (size_t)size_parallel[2]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[1], pBuffer_parallel[1], (size_t)size_parallel[1]); },
-				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[0], pBuffer_parallel[0], (size_t)size_parallel[0]); }
-			);
-		}
-	return pRet;
+        int stepsize = size / PARALLEL_INVOKE_NUM;
+        for (int i = 0; i < PARALLEL_INVOKE_NUM; i++)
+        {
+            ptr_parallel[i] = (char *)destination + i*stepsize;
+            pBuffer_parallel[i] = (char *)source + i*stepsize;
+            if ((i + 1) == PARALLEL_INVOKE_NUM)
+            {
+                size_parallel[i] = size - (PARALLEL_INVOKE_NUM - 1)*stepsize;
+            }
+            else
+            {
+                size_parallel[i] = stepsize;
+            }
+        }
+        parallel_invoke(
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[9], pBuffer_parallel[9], (size_t)size_parallel[9]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[8], pBuffer_parallel[8], (size_t)size_parallel[8]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[7], pBuffer_parallel[7], (size_t)size_parallel[7]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[6], pBuffer_parallel[6], (size_t)size_parallel[6]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[5], pBuffer_parallel[5], (size_t)size_parallel[5]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[4], pBuffer_parallel[4], (size_t)size_parallel[4]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[3], pBuffer_parallel[3], (size_t)size_parallel[3]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[2], pBuffer_parallel[2], (size_t)size_parallel[2]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[1], pBuffer_parallel[1], (size_t)size_parallel[1]); },
+            [&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[0], pBuffer_parallel[0], (size_t)size_parallel[0]); }
+        );
+    }
+#endif
+    return pRet;
 }

--- a/vktrace/src/vktrace_common/optimization_function.cpp
+++ b/vktrace/src/vktrace_common/optimization_function.cpp
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <string.h>
+#include <ppl.h>
+#include <stdlib.h>
+
+using namespace concurrency;
+using namespace std;
+
+
+#define PARALLEL_INVOKE_NUM   10
+#define SIZE_LIMIT_TO_USE_OPTIMIZATION 67100000
+extern "C" void *opt_memcpy(void * destination, const void * source, size_t size)
+{
+    void *pRet=NULL;
+		if (size < SIZE_LIMIT_TO_USE_OPTIMIZATION)
+		{
+			//memcpy(ptr_address, pBuffer, (size_t)size);
+			pRet=memcpy(destination, source, (size_t)size);
+		}
+		else
+		{
+		    pRet=destination;
+			void* ptr_parallel[PARALLEL_INVOKE_NUM];
+			void* pBuffer_parallel[PARALLEL_INVOKE_NUM];
+            size_t size_parallel[PARALLEL_INVOKE_NUM];
+
+			int stepsize = size / PARALLEL_INVOKE_NUM;
+			for (int i = 0; i < PARALLEL_INVOKE_NUM; i++)
+			{
+				ptr_parallel[i] = (char *)destination + i*stepsize;
+				pBuffer_parallel[i] = (char *)source + i*stepsize;
+				if ((i + 1) == PARALLEL_INVOKE_NUM)
+				{
+					size_parallel[i] = size - (PARALLEL_INVOKE_NUM-1)*stepsize;
+				}
+				else
+				{
+                   size_parallel[i] = stepsize;
+				}
+			}
+			parallel_invoke(
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[9], pBuffer_parallel[9], (size_t)size_parallel[9]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[8], pBuffer_parallel[8], (size_t)size_parallel[8]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[7], pBuffer_parallel[7], (size_t)size_parallel[7]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[6], pBuffer_parallel[6], (size_t)size_parallel[6]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[5], pBuffer_parallel[5], (size_t)size_parallel[5]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[4], pBuffer_parallel[4], (size_t)size_parallel[4]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[3], pBuffer_parallel[3], (size_t)size_parallel[3]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[2], pBuffer_parallel[2], (size_t)size_parallel[2]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[1], pBuffer_parallel[1], (size_t)size_parallel[1]); },
+				[&ptr_parallel, &pBuffer_parallel, &size_parallel] { memcpy(ptr_parallel[0], pBuffer_parallel[0], (size_t)size_parallel[0]); }
+			);
+		}
+	return pRet;
+}

--- a/vktrace/src/vktrace_common/optimization_function.h
+++ b/vktrace/src/vktrace_common/optimization_function.h
@@ -1,4 +1,8 @@
-//#pragma once
+/*
+* Copyright (C) 2016 Advanced Micro Device, Inc.
+*/
+
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,5 +12,3 @@ extern "C" void *opt_memcpy(void * destination, const void * source, size_t num)
 #else
 void *opt_memcpy(void * destination, const void * source, size_t num);
 #endif
-
-	

--- a/vktrace/src/vktrace_common/optimization_function.h
+++ b/vktrace/src/vktrace_common/optimization_function.h
@@ -1,0 +1,12 @@
+//#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _cplusplus
+extern "C" void *opt_memcpy(void * destination, const void * source, size_t num);
+#else
+void *opt_memcpy(void * destination, const void * source, size_t num);
+#endif
+
+	

--- a/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
@@ -157,7 +157,7 @@ void* vktrace_trace_packet_get_new_buffer_address(vktrace_trace_packet_header* p
     pHeader->next_buffers_offset += byteCount;
     return pBufferStart;
 }
-
+#include "optimization_function.h"
 void vktrace_add_buffer_to_trace_packet(vktrace_trace_packet_header* pHeader, void** ptr_address, uint64_t size, const void* pBuffer)
 {
     assert(ptr_address != NULL);
@@ -171,7 +171,7 @@ void vktrace_add_buffer_to_trace_packet(vktrace_trace_packet_header* pHeader, vo
         *ptr_address = vktrace_trace_packet_get_new_buffer_address(pHeader, size);
 
         // copy buffer to the location
-        memcpy(*ptr_address, pBuffer, (size_t)size);
+        opt_memcpy(*ptr_address, pBuffer, (size_t)size);
     }
 }
 

--- a/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
@@ -2,6 +2,7 @@
  *
  * Copyright 2014-2016 Valve Corporation
  * Copyright (C) 2014-2016 LunarG, Inc.
+ * Copyright (C) 2016 Advanced Micro Device, Inc.
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +23,8 @@
 #include "vktrace_trace_packet_utils.h"
 #include "vktrace_interconnect.h"
 #include "vktrace_filelike.h"
+#include "optimization_function.h"
+
 #ifdef WIN32
 #include <rpc.h>
 #pragma comment (lib, "Rpcrt4.lib")
@@ -157,7 +160,7 @@ void* vktrace_trace_packet_get_new_buffer_address(vktrace_trace_packet_header* p
     pHeader->next_buffers_offset += byteCount;
     return pBufferStart;
 }
-#include "optimization_function.h"
+
 void vktrace_add_buffer_to_trace_packet(vktrace_trace_packet_header* pHeader, void** ptr_address, uint64_t size, const void* pBuffer)
 {
     assert(ptr_address != NULL);

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
@@ -1115,6 +1115,12 @@ void vkReplay::manually_replay_vkCmdBindDescriptorSets(packet_vkCmdBindDescripto
     for (uint32_t idx = 0; idx < pPacket->descriptorSetCount && pPacket->pDescriptorSets != NULL; idx++)
     {
         pRemappedSets[idx] = m_objMapper.remap_descriptorsets(pPacket->pDescriptorSets[idx]);
+        if (pRemappedSets[idx] == VK_NULL_HANDLE && pPacket->pDescriptorSets[idx] != VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkCmdBindDescriptorSets() due to invalid remapped VkDescriptorSet.");
+            vktrace_free(pRemappedSets);
+            return;
+        }
     }
 
     m_vkFuncs.real_vkCmdBindDescriptorSets(remappedCommandBuffer, pPacket->pipelineBindPoint, remappedLayout, pPacket->firstSet, pPacket->descriptorSetCount, pRemappedSets, pPacket->dynamicOffsetCount, pPacket->pDynamicOffsets);

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
@@ -245,6 +245,7 @@ VkResult vkReplay::manually_replay_vkCreateDevice(packet_vkCreateDevice* pPacket
         char **ppEnabledLayerNames = NULL, **saved_ppLayers;
         if (remappedPhysicalDevice == VK_NULL_HANDLE)
         {
+            vktrace_LogError("Skipping vkCreateDevice() due to invalid remapped VkPhysicalDevice.");
             return VK_ERROR_VALIDATION_FAILED_EXT;
         }
         const char strScreenShot[] = "VK_LAYER_LUNARG_screenshot";
@@ -315,7 +316,10 @@ VkResult vkReplay::manually_replay_vkEnumeratePhysicalDevices(packet_vkEnumerate
 
         VkInstance remappedInstance = m_objMapper.remap_instances(pPacket->instance);
         if (remappedInstance == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkEnumeratePhysicalDevices() due to invalid remapped VkInstance.");
             return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
         if (pPacket->pPhysicalDevices != NULL)
             pDevices = VKTRACE_NEW_ARRAY(VkPhysicalDevice, deviceCount);
         replayResult = m_vkFuncs.real_vkEnumeratePhysicalDevices(remappedInstance, &deviceCount, pDevices);
@@ -515,7 +519,10 @@ VkResult vkReplay::manually_replay_vkEnumeratePhysicalDevices(packet_vkEnumerate
 //    void* pData = vktrace_malloc(dataSize);
 //    VkSwapchainWSI remappedSwapchain = m_objMapper.remap_swapchainwsis(pPacket->swapchain);
 //    if (remappedSwapchain == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkGetSwapchainInfoWSI() due to invalid remapped VkSwapchainWSI.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //    replayResult = m_vkFuncs.real_vkGetSwapchainInfoWSI(remappedSwapchain, pPacket->infoType, &dataSize, pData);
 //    if (replayResult == VK_SUCCESS)
 //    {
@@ -551,11 +558,17 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit* pPacket)
 
     VkQueue remappedQueue = m_objMapper.remap_queues(pPacket->queue);
     if (remappedQueue == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkQueueSubmit() due to invalid remapped VkQueue.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkFence remappedFence = m_objMapper.remap_fences(pPacket->fence);
     if (pPacket->fence != VK_NULL_HANDLE && remappedFence == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkQueueSubmit() due to invalid remapped VkPhysicalDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkSubmitInfo *remappedSubmits = NULL;
     remappedSubmits = VKTRACE_NEW_ARRAY( VkSubmitInfo, pPacket->submitCount);
@@ -577,6 +590,7 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit* pPacket)
             for (i = 0; i < submit->commandBufferCount; i++) {
                 *(pRemappedBuffers + i) = m_objMapper.remap_commandbuffers(*(submit->pCommandBuffers + i));
                 if (*(pRemappedBuffers + i) == VK_NULL_HANDLE) {
+                    vktrace_LogError("Skipping vkQueueSubmit() due to invalid remapped VkCommandBuffer.");
                     VKTRACE_DELETE(remappedSubmits);
                     VKTRACE_DELETE(pRemappedBuffers);
                     return replayResult;
@@ -588,9 +602,9 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit* pPacket)
             remappedSubmit->pWaitSemaphores = pRemappedWaitSems;
             remappedSubmit->waitSemaphoreCount = submit->waitSemaphoreCount;
             for (i = 0; i < submit->waitSemaphoreCount; i++) {
-                //*(pRemappedWaitSems + i)->handle = m_objMapper.remap_semaphores(*(submit->pWaitSemaphores + i));
                 (*(pRemappedWaitSems + i)) = m_objMapper.remap_semaphores((*(submit->pWaitSemaphores + i)));
                 if (*(pRemappedWaitSems + i) == VK_NULL_HANDLE) {
+                    vktrace_LogError("Skipping vkQueueSubmit() due to invalid remapped wait VkSemaphore.");
                     VKTRACE_DELETE(remappedSubmits);
                     VKTRACE_DELETE(pRemappedWaitSems);
                     return replayResult;
@@ -604,6 +618,7 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit* pPacket)
             for (i = 0; i < submit->signalSemaphoreCount; i++) {
                 (*(pRemappedSignalSems + i)) = m_objMapper.remap_semaphores((*(submit->pSignalSemaphores + i)));
                 if (*(pRemappedSignalSems + i) == VK_NULL_HANDLE) {
+                    vktrace_LogError("Skipping vkQueueSubmit() due to invalid remapped signal VkSemaphore.");
                     VKTRACE_DELETE(remappedSubmits);
                     VKTRACE_DELETE(pRemappedSignalSems);
                     return replayResult;
@@ -628,11 +643,17 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit* pPacket)
 //
 //    VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
 //    if (remappedDevice == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkGetObjectInfo() due to invalid remapped VkDevice.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //
 //    VkObject remappedObject = m_objMapper.remap(pPacket->object, pPacket->objType);
 //    if (remappedObject == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkGetObjectInfo() due to invalid remapped VkObject.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //
 //    size_t size = 0;
 //    void* pData = NULL;
@@ -694,11 +715,17 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit* pPacket)
 //
 //    VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
 //    if (remappedDevice == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkGetImageSubresourceInfo() due to invalid remapped VkDevice.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //
 //    VkImage remappedImage = m_objMapper.remap(pPacket->image);
 //    if (remappedImage == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkGetImageSubresourceInfo() due to invalid remapped VkImage.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //
 //    size_t size = 0;
 //    void* pData = NULL;
@@ -895,7 +922,10 @@ VkResult vkReplay::manually_replay_vkCreateDescriptorSetLayout(packet_vkCreateDe
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateDescriptorSetLayout() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkDescriptorSetLayoutCreateInfo *pInfo = (VkDescriptorSetLayoutCreateInfo*) pPacket->pCreateInfo;
     if (pInfo != NULL)
@@ -911,6 +941,11 @@ VkResult vkReplay::manually_replay_vkCreateDescriptorSetLayout(packet_vkCreateDe
                     {
                         VkSampler* pSampler = (VkSampler*)&pBindings->pImmutableSamplers[j];
                         *pSampler = m_objMapper.remap_samplers(pBindings->pImmutableSamplers[j]);
+                        if (*pSampler == VK_NULL_HANDLE)
+                        {
+                            vktrace_LogError("Skipping vkCreateDescriptorSetLayout() due to invalid remapped VkSampler.");
+                            return VK_ERROR_VALIDATION_FAILED_EXT;
+                        }
                     }
                 }
             }
@@ -943,10 +978,37 @@ VkResult vkReplay::manually_replay_vkAllocateDescriptorSets(packet_vkAllocateDes
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkAllocateDescriptorSets() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
-    // VkDescriptorPool descriptorPool;
-    // descriptorPool.handle = remap_descriptorpools(pPacket->descriptorPool.handle);
+    VkDescriptorPool remappedPool = m_objMapper.remap_descriptorpools(pPacket->pAllocateInfo->descriptorPool);
+    if (remappedPool == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkAllocateDescriptorSets() due to invalid remapped VkDescriptorPool.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
+    VkDescriptorSetLayout* pRemappedSetLayouts = VKTRACE_NEW_ARRAY(VkDescriptorSetLayout, pPacket->pAllocateInfo->descriptorSetCount);
+
+    VkDescriptorSetAllocateInfo allocateInfo;
+    allocateInfo.pNext = NULL;
+    allocateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    allocateInfo.descriptorPool = remappedPool;
+    allocateInfo.descriptorSetCount = pPacket->pAllocateInfo->descriptorSetCount;
+    allocateInfo.pSetLayouts = pRemappedSetLayouts;
+
+    for (uint32_t i = 0; i < allocateInfo.descriptorSetCount; i++)
+    {
+        pRemappedSetLayouts[i] = m_objMapper.remap_descriptorsetlayouts(pPacket->pAllocateInfo->pSetLayouts[i]);
+        if (pRemappedSetLayouts[i] == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkAllocateDescriptorSets() due to invalid remapped VkDescriptorSetLayout.");
+            VKTRACE_DELETE(pRemappedSetLayouts);
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
+    }
 
     VkDescriptorSet* pDescriptorSets = NULL;
     replayResult = m_vkFuncs.real_vkAllocateDescriptorSets(
@@ -960,6 +1022,9 @@ VkResult vkReplay::manually_replay_vkAllocateDescriptorSets(packet_vkAllocateDes
            m_objMapper.add_to_descriptorsets_map(pPacket->pDescriptorSets[i], pDescriptorSets[i]);
         }
     }
+
+    VKTRACE_DELETE(pRemappedSetLayouts);
+
     return replayResult;
 }
 
@@ -969,21 +1034,31 @@ VkResult vkReplay::manually_replay_vkFreeDescriptorSets(packet_vkFreeDescriptorS
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkFreeDescriptorSets() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
-    VkDescriptorPool descriptorPool;
-    descriptorPool = m_objMapper.remap_descriptorpools(pPacket->descriptorPool);
+    VkDescriptorPool remappedDescriptorPool;
+    remappedDescriptorPool = m_objMapper.remap_descriptorpools(pPacket->descriptorPool);
+    if (remappedDescriptorPool == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkFreeDescriptorSets() due to invalid remapped VkDescriptorPool.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     VkDescriptorSet* localDSs = VKTRACE_NEW_ARRAY(VkDescriptorSet, pPacket->descriptorSetCount);
     uint32_t i;
     for (i = 0; i < pPacket->descriptorSetCount; ++i) {
        localDSs[i] = m_objMapper.remap_descriptorsets(pPacket->pDescriptorSets[i]);
        if (localDSs[i] == VK_NULL_HANDLE && pPacket->pDescriptorSets[i] != VK_NULL_HANDLE)
        {
+           vktrace_LogError("Skipping vkFreeDescriptorSets() due to invalid remapped VkDescriptorSet.");
            return VK_ERROR_VALIDATION_FAILED_EXT;
        }
     }
 
-    replayResult = m_vkFuncs.real_vkFreeDescriptorSets(remappedDevice, descriptorPool, pPacket->descriptorSetCount, localDSs);
+    replayResult = m_vkFuncs.real_vkFreeDescriptorSets(remappedDevice, remappedDescriptorPool, pPacket->descriptorSetCount, localDSs);
     if(replayResult == VK_SUCCESS)
     {
         for (i = 0; i < pPacket->descriptorSetCount; ++i) {
@@ -1073,6 +1148,7 @@ void vkReplay::manually_replay_vkCmdBindVertexBuffers(packet_vkCmdBindVertexBuff
 //    VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
 //    if (remappedDevice == VK_NULL_HANDLE)
 //    {
+//        vktrace_LogError("Skipping vkCreateGraphicsPipeline() due to invalid remapped VkDevice.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
 //    }
 //
@@ -1082,6 +1158,11 @@ void vkReplay::manually_replay_vkCmdBindVertexBuffers(packet_vkCmdBindVertexBuff
 //    for (uint32_t i = 0; i < pPacket->pCreateInfo->stageCount; i++)
 //    {
 //        pRemappedStages[i].shader = m_objMapper.remap(pRemappedStages[i].shader);
+//        if (pRemappedStages[i].shader == VK_NULL_HANDLE)
+//        {
+//            vktrace_LogError("Skipping vkCreateGraphicsPipeline() due to invalid remapped VkShader.");
+//            return VK_ERROR_VALIDATION_FAILED_EXT;
+//        }
 //    }
 //
 //    VkGraphicsPipelineCreateInfo createInfo = {
@@ -1118,14 +1199,16 @@ VkResult vkReplay::manually_replay_vkGetPipelineCacheData(packet_vkGetPipelineCa
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
     size_t dataSize;
     VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
-    if (pPacket->device != VK_NULL_HANDLE && remappeddevice == VK_NULL_HANDLE)
+    if (remappeddevice == VK_NULL_HANDLE)
     {
+        vktrace_LogError("Skipping vkGetPipelineCacheData() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
     VkPipelineCache remappedpipelineCache = m_objMapper.remap_pipelinecaches(pPacket->pipelineCache);
     if (pPacket->pipelineCache != VK_NULL_HANDLE && remappedpipelineCache == VK_NULL_HANDLE)
     {
+        vktrace_LogError("Skipping vkGetPipelineCacheData() due to invalid remapped VkPipelineCache.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
@@ -1209,13 +1292,9 @@ VkResult vkReplay::manually_replay_vkCreateGraphicsPipelines(packet_vkCreateGrap
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
     {
+        vktrace_LogError("Skipping vkCreateGraphicsPipelines() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
-
-    // TODO : This is hacky, just correlating these remap values to 0,1,2 in array for now
-//    VkPipelineLayout local_layout;
-//    VkRenderPass     local_renderPass;
-//    VkPipeline       local_basePipelineHandle;
 
     // remap shaders from each stage
     VkPipelineShaderStageCreateInfo* pRemappedStages = VKTRACE_NEW_ARRAY(VkPipelineShaderStageCreateInfo, pPacket->pCreateInfos->stageCount);
@@ -1228,15 +1307,43 @@ VkResult vkReplay::manually_replay_vkCreateGraphicsPipelines(packet_vkCreateGrap
         for (j=0; j < pPacket->pCreateInfos[i].stageCount; j++)
         {
             pRemappedStages[j].module = m_objMapper.remap_shadermodules(pRemappedStages[j].module);
+            if (pRemappedStages[j].module == VK_NULL_HANDLE)
+            {
+                vktrace_LogError("Skipping vkCreateGraphicsPipelines() due to invalid remapped VkShaderModule.");
+                VKTRACE_DELETE(pRemappedStages);
+                VKTRACE_DELETE(pLocalCIs);
+                return VK_ERROR_VALIDATION_FAILED_EXT;
+            }
         }
         VkPipelineShaderStageCreateInfo** ppSSCI = (VkPipelineShaderStageCreateInfo**)&(pLocalCIs[i].pStages);
         *ppSSCI = pRemappedStages;
 
         pLocalCIs[i].layout = m_objMapper.remap_pipelinelayouts(pPacket->pCreateInfos[i].layout);
+        if (pLocalCIs[i].layout == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkCreateGraphicsPipelines() due to invalid remapped VkPipelineLayout.");
+            VKTRACE_DELETE(pRemappedStages);
+            VKTRACE_DELETE(pLocalCIs);
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
 
         pLocalCIs[i].renderPass = m_objMapper.remap_renderpasss(pPacket->pCreateInfos[i].renderPass);
+        if (pLocalCIs[i].renderPass == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkCreateGraphicsPipelines() due to invalid remapped VkRenderPass.");
+            VKTRACE_DELETE(pRemappedStages);
+            VKTRACE_DELETE(pLocalCIs);
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
 
         pLocalCIs[i].basePipelineHandle = m_objMapper.remap_pipelines(pPacket->pCreateInfos[i].basePipelineHandle);
+        if (pLocalCIs[i].basePipelineHandle == VK_NULL_HANDLE && pPacket->pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkCreateGraphicsPipelines() due to invalid remapped VkPipeline.");
+            VKTRACE_DELETE(pRemappedStages);
+            VKTRACE_DELETE(pLocalCIs);
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
 
         ((VkPipelineViewportStateCreateInfo*)pLocalCIs[i].pViewportState)->pViewports =
                 (VkViewport*)vktrace_trace_packet_interpret_buffer_pointer(pPacket->header, (intptr_t)pPacket->pCreateInfos[i].pViewportState->pViewports);
@@ -1247,13 +1354,20 @@ VkResult vkReplay::manually_replay_vkCreateGraphicsPipelines(packet_vkCreateGrap
                 (VkSampleMask*)vktrace_trace_packet_interpret_buffer_pointer(pPacket->header, (intptr_t)pPacket->pCreateInfos[i].pMultisampleState->pSampleMask);
     }
 
-    VkPipelineCache pipelineCache;
-    pipelineCache = m_objMapper.remap_pipelinecaches(pPacket->pipelineCache);
-    uint32_t createInfoCount = pPacket->createInfoCount;
+    VkPipelineCache remappedPipelineCache;
+    remappedPipelineCache = m_objMapper.remap_pipelinecaches(pPacket->pipelineCache);
+    if (remappedPipelineCache == VK_NULL_HANDLE && pPacket->pipelineCache != VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateGraphicsPipelines() due to invalid remapped VkPipelineCache.");
+        VKTRACE_DELETE(pRemappedStages);
+        VKTRACE_DELETE(pLocalCIs);
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
+    uint32_t createInfoCount = pPacket->createInfoCount;
     VkPipeline *local_pPipelines = VKTRACE_NEW_ARRAY(VkPipeline, pPacket->createInfoCount);
 
-    replayResult = m_vkFuncs.real_vkCreateGraphicsPipelines(remappedDevice, pipelineCache, createInfoCount, pLocalCIs, NULL, local_pPipelines);
+    replayResult = m_vkFuncs.real_vkCreateGraphicsPipelines(remappedDevice, remappedPipelineCache, createInfoCount, pLocalCIs, NULL, local_pPipelines);
 
     if (replayResult == VK_SUCCESS)
     {
@@ -1327,6 +1441,12 @@ void vkReplay::manually_replay_vkCmdWaitEvents(packet_vkCmdWaitEvents* pPacket)
         VkEvent *pEvent = (VkEvent *) &(pPacket->pEvents[idx]);
         saveEvent[idx] = pPacket->pEvents[idx];
         *pEvent = m_objMapper.remap_events(pPacket->pEvents[idx]);
+        if (*pEvent == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkCmdWaitEvents() due to invalid remapped VkEvent.");
+            VKTRACE_DELETE(saveEvent);
+            return;
+        }
     }
 
     VkBuffer* saveBuf = VKTRACE_NEW_ARRAY(VkBuffer, pPacket->bufferMemoryBarrierCount);
@@ -1335,6 +1455,13 @@ void vkReplay::manually_replay_vkCmdWaitEvents(packet_vkCmdWaitEvents* pPacket)
         VkBufferMemoryBarrier *pNextBuf = (VkBufferMemoryBarrier *)& (pPacket->pBufferMemoryBarriers[idx]);
         saveBuf[numRemapBuf++] = pNextBuf->buffer;
         pNextBuf->buffer = m_objMapper.remap_buffers(pNextBuf->buffer);
+        if (pNextBuf->buffer == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkCmdWaitEvents() due to invalid remapped VkBuffer.");
+            VKTRACE_DELETE(saveEvent);
+            VKTRACE_DELETE(saveBuf);
+            return;
+        }
     }
     VkImage* saveImg = VKTRACE_NEW_ARRAY(VkImage, pPacket->imageMemoryBarrierCount);
     for (idx = 0; idx < pPacket->imageMemoryBarrierCount; idx++)
@@ -1342,6 +1469,14 @@ void vkReplay::manually_replay_vkCmdWaitEvents(packet_vkCmdWaitEvents* pPacket)
         VkImageMemoryBarrier *pNextImg = (VkImageMemoryBarrier *) &(pPacket->pImageMemoryBarriers[idx]);
         saveImg[numRemapImg++] = pNextImg->image;
         pNextImg->image = m_objMapper.remap_images(pNextImg->image);
+        if (pNextImg->image == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkCmdWaitEvents() due to invalid remapped VkImage.");
+            VKTRACE_DELETE(saveEvent);
+            VKTRACE_DELETE(saveBuf);
+            VKTRACE_DELETE(saveImg);
+            return;
+        }
     }
     m_vkFuncs.real_vkCmdWaitEvents(remappedCommandBuffer, pPacket->eventCount, pPacket->pEvents, pPacket->srcStageMask, pPacket->dstStageMask, pPacket->memoryBarrierCount, pPacket->pMemoryBarriers, pPacket->bufferMemoryBarrierCount, pPacket->pBufferMemoryBarriers, pPacket->imageMemoryBarrierCount, pPacket->pImageMemoryBarriers);
 
@@ -1482,7 +1617,10 @@ VkResult vkReplay::manually_replay_vkCreateRenderPass(packet_vkCreateRenderPass*
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateRenderPass() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkRenderPass local_renderpass;
     replayResult = m_vkFuncs.real_vkCreateRenderPass(remappedDevice, pPacket->pCreateInfo, NULL, &local_renderpass);
@@ -1505,7 +1643,17 @@ void vkReplay::manually_replay_vkCmdBeginRenderPass(packet_vkCmdBeginRenderPass*
     memcpy((void*)&local_renderPassBeginInfo, (void*)pPacket->pRenderPassBegin, sizeof(VkRenderPassBeginInfo));
     local_renderPassBeginInfo.pClearValues = (const VkClearValue*)pPacket->pRenderPassBegin->pClearValues;
     local_renderPassBeginInfo.framebuffer = m_objMapper.remap_framebuffers(pPacket->pRenderPassBegin->framebuffer);
+    if (local_renderPassBeginInfo.framebuffer == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCmdBeginRenderPass() due to invalid remapped VkFramebuffer.");
+        return;
+    }
     local_renderPassBeginInfo.renderPass = m_objMapper.remap_renderpasss(pPacket->pRenderPassBegin->renderPass);
+    if (local_renderPassBeginInfo.renderPass == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCmdBeginRenderPass() due to invalid remapped VkRenderPass.");
+        return;
+    }
     m_vkFuncs.real_vkCmdBeginRenderPass(remappedCommandBuffer, &local_renderPassBeginInfo, pPacket->contents);
     return;
 }
@@ -1516,7 +1664,10 @@ VkResult vkReplay::manually_replay_vkBeginCommandBuffer(packet_vkBeginCommandBuf
 
     VkCommandBuffer remappedCommandBuffer = m_objMapper.remap_commandbuffers(pPacket->commandBuffer);
     if (remappedCommandBuffer == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkBeginCommandBuffer() due to invalid remapped VkCommandBuffer.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkCommandBufferBeginInfo* pInfo = (VkCommandBufferBeginInfo*)pPacket->pBeginInfo;
     VkCommandBufferInheritanceInfo *pHinfo = (VkCommandBufferInheritanceInfo *) ((pInfo) ? pInfo->pInheritanceInfo : NULL);
@@ -1547,11 +1698,17 @@ VkResult vkReplay::manually_replay_vkBeginCommandBuffer(packet_vkBeginCommandBuf
 //
 //    VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
 //    if (remappedDevice == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkStorePipeline() due to invalid remapped VkDevice.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //
 //    VkPipeline remappedPipeline = m_objMapper.remap(pPacket->pipeline);
 //    if (remappedPipeline == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkStorePipeline() due to invalid remapped VkPipeline.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //
 //    size_t size = 0;
 //    void* pData = NULL;
@@ -1583,7 +1740,10 @@ VkResult vkReplay::manually_replay_vkBeginCommandBuffer(packet_vkBeginCommandBuf
 //
 //    VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
 //    if (remappedDevice == VK_NULL_HANDLE)
+//    {
+//        vktrace_LogError("Skipping vkDestroy() due to invalid remapped VkDevice.");
 //        return VK_ERROR_VALIDATION_FAILED_EXT;
+//    }
 //
 //    uint64_t remapHandle = m_objMapper.remap_<OBJECT_TYPE_HERE>(pPacket->object, pPacket->objType);
 //    <VkObject> object;
@@ -1602,12 +1762,21 @@ VkResult vkReplay::manually_replay_vkWaitForFences(packet_vkWaitForFences* pPack
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkWaitForFences() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkFence *pFence = VKTRACE_NEW_ARRAY(VkFence, pPacket->fenceCount);
     for (i = 0; i < pPacket->fenceCount; i++)
     {
         (*(pFence + i)) = m_objMapper.remap_fences((*(pPacket->pFences + i)));
+        if (*(pFence + i) == VK_NULL_HANDLE)
+        {
+            vktrace_LogError("Skipping vkWaitForFences() due to invalid remapped VkFence.");
+            VKTRACE_DELETE(pFence);
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
     }
 	if (pPacket->result == VK_SUCCESS)
 	{
@@ -1634,7 +1803,10 @@ VkResult vkReplay::manually_replay_vkAllocateMemory(packet_vkAllocateMemory* pPa
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkAllocateMemory() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     gpuMemObj local_mem;
 
@@ -1653,7 +1825,8 @@ VkResult vkReplay::manually_replay_vkAllocateMemory(packet_vkAllocateMemory* pPa
 void vkReplay::manually_replay_vkFreeMemory(packet_vkFreeMemory* pPacket)
 {
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
-    if (remappedDevice == VK_NULL_HANDLE) {
+    if (remappedDevice == VK_NULL_HANDLE)
+    {
         vktrace_LogError("Skipping vkFreeMemory() due to invalid remapped VkDevice.");
         return;
     }
@@ -1672,7 +1845,10 @@ VkResult vkReplay::manually_replay_vkMapMemory(packet_vkMapMemory* pPacket)
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkMapMemory() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     gpuMemObj local_mem = m_objMapper.m_devicememorys.find(pPacket->memory)->second;
     void* pData;
@@ -1736,7 +1912,10 @@ VkResult vkReplay::manually_replay_vkFlushMappedMemoryRanges(packet_vkFlushMappe
 
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkFlushMappedMemoryRanges() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkMappedMemoryRange* localRanges = VKTRACE_NEW_ARRAY(VkMappedMemoryRange, pPacket->memoryRangeCount);
     memcpy(localRanges, pPacket->pMemoryRanges, sizeof(VkMappedMemoryRange) * (pPacket->memoryRangeCount));
@@ -1748,6 +1927,7 @@ VkResult vkReplay::manually_replay_vkFlushMappedMemoryRanges(packet_vkFlushMappe
         localRanges[i].memory = m_objMapper.remap_devicememorys(pPacket->pMemoryRanges[i].memory);
         if (localRanges[i].memory == VK_NULL_HANDLE || pLocalMems[i].pGpuMem == NULL)
         {
+            vktrace_LogError("Skipping vkFlushMappedMemoryRanges() due to invalid remapped VkDeviceMemory.");
             VKTRACE_DELETE(localRanges);
             VKTRACE_DELETE(pLocalMems);
             return VK_ERROR_VALIDATION_FAILED_EXT;
@@ -1785,28 +1965,21 @@ VkResult vkReplay::manually_replay_vkGetPhysicalDeviceSurfaceSupportKHR(packet_v
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
 
     VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
+    if (remappedphysicalDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfaceSupportKHR() due to invalid remapped VkPhysicalDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     VkSurfaceKHR remappedSurfaceKHR = m_objMapper.remap_surfacekhrs(pPacket->surface);
-//    if (pPacket->physicalDevice != VK_NULL_HANDLE && remappedphysicalDevice == VK_NULL_HANDLE)
-//    {
-//        return vktrace_replay::VKTRACE_REPLAY_ERROR;
-//    }
+    if (remappedSurfaceKHR == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfaceSupportKHR() due to invalid remapped VkSurfaceKHR.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     replayResult = m_vkFuncs.real_vkGetPhysicalDeviceSurfaceSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex, remappedSurfaceKHR, pPacket->pSupported);
-//    VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
-//    if (remappedDevice == VK_NULL_HANDLE)
-//        return VK_ERROR_VALIDATION_FAILED_EXT;
-//
-//    gpuMemObj local_mem;
-//
-//    if (!m_objMapper.m_adjustForGPU)
-//        replayResult = m_vkFuncs.real_vkAllocateMemory(remappedDevice, pPacket->pAllocateInfo, &local_mem.replayGpuMem);
-//    if (replayResult == VK_SUCCESS || m_objMapper.m_adjustForGPU)
-//    {
-//        local_mem.pGpuMem = new (gpuMemory);
-//        if (local_mem.pGpuMem)
-//            local_mem.pGpuMem->setAllocInfo(pPacket->pAllocateInfo, m_objMapper.m_adjustForGPU);
-//        m_objMapper.add_to_devicememorys_map(pPacket->pMemory->handle, local_mem);
-//    }
+
     return replayResult;
 }
 
@@ -1815,7 +1988,18 @@ VkResult vkReplay::manually_replay_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(pac
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
 
     VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
+    if (remappedphysicalDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfaceCapabilitiesKHR() due to invalid remapped VkPhysicalDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     VkSurfaceKHR remappedSurfaceKHR = m_objMapper.remap_surfacekhrs(pPacket->surface);
+    if (remappedSurfaceKHR == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfaceCapabilitiesKHR() due to invalid remapped VkSurfaceKHR.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     m_display->resize_window(pPacket->pSurfaceCapabilities->currentExtent.width, pPacket->pSurfaceCapabilities->currentExtent.height);
 
@@ -1829,7 +2013,18 @@ VkResult vkReplay::manually_replay_vkGetPhysicalDeviceSurfaceFormatsKHR(packet_v
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
 
     VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
+    if (remappedphysicalDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfaceFormatsKHR() due to invalid remapped VkPhysicalDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     VkSurfaceKHR remappedSurfaceKHR = m_objMapper.remap_surfacekhrs(pPacket->surface);
+    if (remappedSurfaceKHR == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfaceFormatsKHR() due to invalid remapped VkSurfaceKHR.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     replayResult = m_vkFuncs.real_vkGetPhysicalDeviceSurfaceFormatsKHR(remappedphysicalDevice, remappedSurfaceKHR, pPacket->pSurfaceFormatCount, pPacket->pSurfaceFormats);
 
@@ -1841,7 +2036,18 @@ VkResult vkReplay::manually_replay_vkGetPhysicalDeviceSurfacePresentModesKHR(pac
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
 
     VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
+    if (remappedphysicalDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfacePresentModesKHR() due to invalid remapped VkPhysicalDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     VkSurfaceKHR remappedSurfaceKHR = m_objMapper.remap_surfacekhrs(pPacket->surface);
+    if (remappedSurfaceKHR == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetPhysicalDeviceSurfacePresentModesKHR() due to invalid remapped VkSurfaceKHR.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     replayResult = m_vkFuncs.real_vkGetPhysicalDeviceSurfacePresentModesKHR(remappedphysicalDevice, remappedSurfaceKHR, pPacket->pPresentModeCount, pPacket->pPresentModes);
 
@@ -1856,16 +2062,28 @@ VkResult vkReplay::manually_replay_vkCreateSwapchainKHR(packet_vkCreateSwapchain
     VkSurfaceKHR save_surface;
     pSC = (VkSwapchainKHR *) &pPacket->pCreateInfo->oldSwapchain;
     VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
+    if (remappeddevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateSwapchainKHR() due to invalid remapped VkDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
-//    if (pPacket->device != VK_NULL_HANDLE && remappeddevice == VK_NULL_HANDLE)
-//    {
-//        return vktrace_replay::VKTRACE_REPLAY_ERROR;
-//    }
     save_oldSwapchain = pPacket->pCreateInfo->oldSwapchain;
     (*pSC) = m_objMapper.remap_swapchainkhrs(save_oldSwapchain);
+    if ((*pSC) == VK_NULL_HANDLE && save_oldSwapchain != VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateSwapchainKHR() due to invalid remapped VkSwapchainKHR.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     save_surface = pPacket->pCreateInfo->surface;
     VkSurfaceKHR *pSurf = (VkSurfaceKHR *) &(pPacket->pCreateInfo->surface);
     *pSurf = m_objMapper.remap_surfacekhrs(*pSurf);
+    if (*pSurf == VK_NULL_HANDLE && pPacket->pCreateInfo->surface != VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateSwapchainKHR() due to invalid remapped VkSurfaceKHR.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     m_display->resize_window(pPacket->pCreateInfo->imageExtent.width, pPacket->pCreateInfo->imageExtent.height);
 
@@ -1885,14 +2103,19 @@ VkResult vkReplay::manually_replay_vkGetSwapchainImagesKHR(packet_vkGetSwapchain
 {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
     VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
-
-//    if (pPacket->device != VK_NULL_HANDLE && remappeddevice == VK_NULL_HANDLE)
-//    {
-//        return vktrace_replay::VKTRACE_REPLAY_ERROR;
-//    }
+    if (remappeddevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkGetSwapchainImagesKHR() due to invalid remapped VkDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkSwapchainKHR remappedswapchain;
     remappedswapchain = m_objMapper.remap_swapchainkhrs(pPacket->swapchain);
+    if (remappedswapchain == VK_NULL_HANDLE && pPacket->swapchain != VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateSwapchainKHR() due to invalid remapped VkSwapchainKHR.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkImage packetImage[128] = {0};
     uint32_t numImages = 0;
@@ -1924,6 +2147,12 @@ VkResult vkReplay::manually_replay_vkQueuePresentKHR(packet_vkQueuePresentKHR* p
 {
     VkResult replayResult = VK_SUCCESS;
     VkQueue remappedQueue = m_objMapper.remap_queues(pPacket->queue);
+    if (remappedQueue == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkQueuePresentKHR() due to invalid remapped VkQueue.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     VkSemaphore localSemaphores[5];
     VkSwapchainKHR localSwapchains[5];
     VkResult localResults[5];
@@ -1953,6 +2182,20 @@ VkResult vkReplay::manually_replay_vkQueuePresentKHR(packet_vkQueuePresentKHR* p
     if (replayResult == VK_SUCCESS) {
         for (i=0; i<pPacket->pPresentInfo->swapchainCount; i++) {
             pRemappedSwapchains[i] = m_objMapper.remap_swapchainkhrs(pPacket->pPresentInfo->pSwapchains[i]);
+            if (pRemappedSwapchains[i] == VK_NULL_HANDLE)
+            {
+                vktrace_LogError("Skipping vkQueuePresentKHR() due to invalid remapped VkSwapchainKHR.");
+                if (pRemappedWaitSems != NULL && pRemappedWaitSems != localSemaphores) {
+                    VKTRACE_DELETE(pRemappedWaitSems);
+                }
+                if (pResults != NULL && pResults != localResults) {
+                    VKTRACE_DELETE(pResults);
+                }
+                if (pRemappedSwapchains != NULL && pRemappedSwapchains != localSwapchains) {
+                    VKTRACE_DELETE(pRemappedSwapchains);
+                }
+                return VK_ERROR_VALIDATION_FAILED_EXT;
+            }
         }
         present.sType = pPacket->pPresentInfo->sType;
         present.pNext = pPacket->pPresentInfo->pNext;
@@ -1965,9 +2208,19 @@ VkResult vkReplay::manually_replay_vkQueuePresentKHR(packet_vkQueuePresentKHR* p
             present.pWaitSemaphores = pRemappedWaitSems;
             for (i = 0; i < pPacket->pPresentInfo->waitSemaphoreCount; i++) {
                 (*(pRemappedWaitSems + i)) = m_objMapper.remap_semaphores((*(pPacket->pPresentInfo->pWaitSemaphores + i)));
-                if (*(pRemappedWaitSems + i) == VK_NULL_HANDLE) {
-                    replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
-                    break;
+                if (*(pRemappedWaitSems + i) == VK_NULL_HANDLE)
+                {
+                    vktrace_LogError("Skipping vkQueuePresentKHR() due to invalid remapped wait VkSemaphore.");
+                    if (pRemappedWaitSems != NULL && pRemappedWaitSems != localSemaphores) {
+                        VKTRACE_DELETE(pRemappedWaitSems);
+                    }
+                    if (pResults != NULL && pResults != localResults) {
+                        VKTRACE_DELETE(pResults);
+                    }
+                    if (pRemappedSwapchains != NULL && pRemappedSwapchains != localSwapchains) {
+                        VKTRACE_DELETE(pRemappedSwapchains);
+                    }
+                    return VK_ERROR_VALIDATION_FAILED_EXT;
                 }
             }
         }
@@ -2013,9 +2266,10 @@ VkResult vkReplay::manually_replay_vkCreateXcbSurfaceKHR(packet_vkCreateXcbSurfa
 {
     VkResult replayResult;
     VkSurfaceKHR local_pSurface;
-    VkInstance remappedinstance = m_objMapper.remap_instances(pPacket->instance);
-
-    if (pPacket->instance != VK_NULL_HANDLE && remappedinstance == VK_NULL_HANDLE) {
+    VkInstance remappedInstance = m_objMapper.remap_instances(pPacket->instance);
+    if (remappedInstance == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateXcbSurfaceKHR() due to invalid remapped VkInstance.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
@@ -2026,7 +2280,7 @@ VkResult vkReplay::manually_replay_vkCreateXcbSurfaceKHR(packet_vkCreateXcbSurfa
     createInfo.flags = pPacket->pCreateInfo->flags;
     createInfo.connection = pSurf->connection;
     createInfo.window = pSurf->window;
-    replayResult = m_vkFuncs.real_vkCreateXcbSurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+    replayResult = m_vkFuncs.real_vkCreateXcbSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
     if (replayResult == VK_SUCCESS) {
         m_objMapper.add_to_surfacekhrs_map(*(pPacket->pSurface), local_pSurface);
     }
@@ -2065,9 +2319,10 @@ VkResult vkReplay::manually_replay_vkCreateWin32SurfaceKHR(packet_vkCreateWin32S
 {
     VkResult replayResult;
     VkSurfaceKHR local_pSurface;
-    VkInstance remappedinstance = m_objMapper.remap_instances(pPacket->instance);
-
-    if (pPacket->instance != VK_NULL_HANDLE && remappedinstance == VK_NULL_HANDLE) {
+    VkInstance remappedInstance = m_objMapper.remap_instances(pPacket->instance);
+    if (remappedInstance == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateWin32SurfaceKHR() due to invalid remapped VkInstance.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
@@ -2078,7 +2333,7 @@ VkResult vkReplay::manually_replay_vkCreateWin32SurfaceKHR(packet_vkCreateWin32S
     createInfo.flags = pPacket->pCreateInfo->flags;
     createInfo.hinstance = pSurf->hinstance;
     createInfo.hwnd = pSurf->hwnd;
-    replayResult = m_vkFuncs.real_vkCreateWin32SurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+    replayResult = m_vkFuncs.real_vkCreateWin32SurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
     if (replayResult == VK_SUCCESS) {
         m_objMapper.add_to_surfacekhrs_map(*(pPacket->pSurface), local_pSurface);
     }
@@ -2091,9 +2346,11 @@ VkResult  vkReplay::manually_replay_vkCreateDebugReportCallbackEXT(packet_vkCrea
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
     VkDebugReportCallbackEXT local_msgCallback;
     VkInstance remappedInstance = m_objMapper.remap_instances(pPacket->instance);
-
-    if (remappedInstance == NULL)
-        return replayResult;
+    if (remappedInstance == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkCreateDebugReportCallbackEXT() due to invalid remapped VkInstance.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     if (!g_fpDbgMsgCallback) {
         // just eat this call as we don't have local call back function defined
@@ -2118,9 +2375,22 @@ VkResult  vkReplay::manually_replay_vkCreateDebugReportCallbackEXT(packet_vkCrea
 void vkReplay::manually_replay_vkDestroyDebugReportCallbackEXT(packet_vkDestroyDebugReportCallbackEXT* pPacket)
 {
     VkInstance remappedInstance = m_objMapper.remap_instances(pPacket->instance);
+    if (remappedInstance == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkDestroyDebugReportCallbackEXT() due to invalid remapped VkInstance.");
+        return;
+    }
+
     VkDebugReportCallbackEXT remappedMsgCallback;
     remappedMsgCallback = m_objMapper.remap_debugreportcallbackexts(pPacket->callback);
-    if (!g_fpDbgMsgCallback) {
+    if (remappedMsgCallback == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkDestroyDebugReportCallbackEXT() due to invalid remapped VkDebugReportCallbackEXT.");
+        return;
+    }
+
+    if (!g_fpDbgMsgCallback)
+    {
         // just eat this call as we don't have local call back function defined
         return;
     } else
@@ -2132,19 +2402,24 @@ void vkReplay::manually_replay_vkDestroyDebugReportCallbackEXT(packet_vkDestroyD
 VkResult vkReplay::manually_replay_vkAllocateCommandBuffers(packet_vkAllocateCommandBuffers* pPacket)
 {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
-    VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
-
-//    if (pPacket->device != VK_NULL_HANDLE && remappeddevice == VK_NULL_HANDLE)
-//    {
-//        return vktrace_replay::VKTRACE_REPLAY_ERROR;
-//    }
+    VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
+    if (remappedDevice == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkAllocateCommandBuffers() due to invalid remapped VkDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
     VkCommandBuffer *local_pCommandBuffers = new VkCommandBuffer[pPacket->pAllocateInfo->commandBufferCount];
     VkCommandPool local_CommandPool;
     local_CommandPool = pPacket->pAllocateInfo->commandPool;
     ((VkCommandBufferAllocateInfo *) pPacket->pAllocateInfo)->commandPool = m_objMapper.remap_commandpools(pPacket->pAllocateInfo->commandPool);
+    if (pPacket->pAllocateInfo->commandPool == VK_NULL_HANDLE)
+    {
+        vktrace_LogError("Skipping vkAllocateCommandBuffers() due to invalid remapped VkCommandPool.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
 
-    replayResult = m_vkFuncs.real_vkAllocateCommandBuffers(remappeddevice, pPacket->pAllocateInfo, local_pCommandBuffers);
+    replayResult = m_vkFuncs.real_vkAllocateCommandBuffers(remappedDevice, pPacket->pAllocateInfo, local_pCommandBuffers);
     ((VkCommandBufferAllocateInfo *) pPacket->pAllocateInfo)->commandPool = local_CommandPool;
 
     if (replayResult == VK_SUCCESS)
@@ -2161,8 +2436,9 @@ VkResult vkReplay::manually_replay_vkAllocateCommandBuffers(packet_vkAllocateCom
 VkBool32 vkReplay::manually_replay_vkGetPhysicalDeviceXcbPresentationSupportKHR(packet_vkGetPhysicalDeviceXcbPresentationSupportKHR* pPacket)
 {
     VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
-    if (pPacket->physicalDevice != VK_NULL_HANDLE && remappedphysicalDevice == VK_NULL_HANDLE)
+    if (remappedphysicalDevice == VK_NULL_HANDLE)
     {
+        vktrace_LogError("Error detected in vkGetPhysicalDeviceXcbPresentationSupportKHR() due to invalid remapped VkPhysicalDevice.");
         return VK_FALSE;
     }
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *) m_display->get_surface();
@@ -2175,8 +2451,9 @@ VkBool32 vkReplay::manually_replay_vkGetPhysicalDeviceXcbPresentationSupportKHR(
 VkBool32 vkReplay::manually_replay_vkGetPhysicalDeviceXlibPresentationSupportKHR(packet_vkGetPhysicalDeviceXlibPresentationSupportKHR* pPacket)
 {
     VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
-    if (pPacket->physicalDevice != VK_NULL_HANDLE && remappedphysicalDevice == VK_NULL_HANDLE)
+    if (remappedphysicalDevice == VK_NULL_HANDLE)
     {
+        vktrace_LogError("Error detected in vkGetPhysicalDeviceXcbPresentationSupportKHR() due to invalid remapped VkPhysicalDevice.");
         return VK_FALSE;
     }
     VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *) m_display->get_surface();

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
@@ -1566,8 +1566,22 @@ VkResult vkReplay::manually_replay_vkWaitForFences(packet_vkWaitForFences* pPack
     {
         (*(pFence + i)) = m_objMapper.remap_fences((*(pPacket->pFences + i)));
     }
-    replayResult = m_vkFuncs.real_vkWaitForFences(remappedDevice, pPacket->fenceCount, pFence, pPacket->waitAll, pPacket->timeout);
-    VKTRACE_DELETE(pFence);
+	if (pPacket->result == VK_SUCCESS)
+	{
+		replayResult = m_vkFuncs.real_vkWaitForFences(remappedDevice, pPacket->fenceCount, pFence, pPacket->waitAll, UINT64_MAX);// mean as long as possible
+	}
+	else
+	{
+		if (pPacket->result == VK_TIMEOUT) 
+		{
+			replayResult = m_vkFuncs.real_vkWaitForFences(remappedDevice, pPacket->fenceCount, pFence, pPacket->waitAll, 0);
+		}
+		else
+		{
+			replayResult = m_vkFuncs.real_vkWaitForFences(remappedDevice, pPacket->fenceCount, pFence, pPacket->waitAll, pPacket->timeout);
+		}
+	}
+	VKTRACE_DELETE(pFence);
     return replayResult;
 }
 

--- a/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
@@ -1964,7 +1964,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcA
     vktrace_trace_packet_header* pHeader;
     PFN_vkVoidFunction addr;
     packet_vkGetInstanceProcAddr* pPacket = NULL;
-    assert(strcmp("vkGetInstanceProcAddr", funcName));
+    //assert(strcmp("vkGetInstanceProcAddr", funcName));
     CREATE_TRACE_PACKET(vkGetInstanceProcAddr, ((funcName != NULL) ? strlen(funcName) + 1 : 0));
     addr = __HOOKED_vkGetInstanceProcAddr(instance, funcName);
     vktrace_set_packet_entrypoint_end_time(pHeader);

--- a/vktrace/src/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/src/vktrace_replay/vkreplay_main.cpp
@@ -108,7 +108,7 @@ int main_loop(Sequencer &seq, vktrace_trace_packet_replay_library *replayerArray
                         res = replayer->Replay(replayer->Interpret(packet));
                         if (res != VKTRACE_REPLAY_SUCCESS)
                         {
-                           vktrace_LogError("Failed to replay packet_id %d.",packet->packet_id);
+                           vktrace_LogError("Failed to replay packet_id %d, with global_packet_index %d.", packet->packet_id, packet->global_packet_index);
 						   static BOOL QuitOnAnyError=FALSE;
                            if(QuitOnAnyError)
                            {

--- a/vktrace/src/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/src/vktrace_replay/vkreplay_main.cpp
@@ -109,7 +109,11 @@ int main_loop(Sequencer &seq, vktrace_trace_packet_replay_library *replayerArray
                         if (res != VKTRACE_REPLAY_SUCCESS)
                         {
                            vktrace_LogError("Failed to replay packet_id %d.",packet->packet_id);
-                           return -1;
+						   static BOOL QuitOnAnyError=FALSE;
+                           if(QuitOnAnyError)
+                           {
+                              return -1;
+                           }
                         }
 
                         // frame control logic

--- a/vktrace/src/vktrace_viewer/CMakeLists.txt
+++ b/vktrace/src/vktrace_viewer/CMakeLists.txt
@@ -153,9 +153,9 @@ if (MSVC)
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_BINS}/libEGL.dll" "${COPY_DEST}"
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_PLUGINS}/platforms/qwindows.dll" "${COPY_DEST}/platforms"
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_PLUGINS}/platforms/qwindowsd.dll"  "${COPY_DEST}/platforms"
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_BINS}/icudt52.dll" "${COPY_DEST}"
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_BINS}/icuin52.dll" "${COPY_DEST}"
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_BINS}/icuuc52.dll" "${COPY_DEST}"
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_BINS}/icudt54.dll" "${COPY_DEST}"
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_BINS}/icuin54.dll" "${COPY_DEST}"
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${QT_INSTALL_BINS}/icuuc54.dll" "${COPY_DEST}"
                     COMMENT "Copying vktraceviewer Qt5 dependencies to ${COPY_DEST}"
                     VERBATIM)
 

--- a/vktrace/src/vktrace_viewer/vktraceviewer_QTraceFileModel.h
+++ b/vktrace/src/vktrace_viewer/vktraceviewer_QTraceFileModel.h
@@ -179,26 +179,29 @@ public:
             QString tip;
             tip += "<html><table>";
 #if defined(_DEBUG)
-            tip += "<tr><td><b>Packet header:</b></td><td/></tr>";
-            tip += QString("<tr><td>pHeader->size</td><td>= %1 bytes</td></tr>").arg(pHeader->size);
-            tip += QString("<tr><td>pHeader->global_packet_index</td><td>= %1</td></tr>").arg(pHeader->global_packet_index);
-            tip += QString("<tr><td>pHeader->tracer_id</td><td>= %1</td></tr>").arg(pHeader->tracer_id);
-            tip += QString("<tr><td>pHeader->packet_id</td><td>= %1</td></tr>").arg(pHeader->packet_id);
-            tip += QString("<tr><td>pHeader->thread_id</td><td>= %1</td></tr>").arg(pHeader->thread_id);
-            tip += QString("<tr><td>pHeader->vktrace_begin_time</td><td>= %1</td></tr>").arg(pHeader->vktrace_begin_time);
-            tip += QString("<tr><td>pHeader->entrypoint_begin_time</td><td>= %1</td></tr>").arg(pHeader->entrypoint_begin_time);
-            tip += QString("<tr><td>pHeader->entrypoint_end_time</td><td>= %1 (%2)</td></tr>").arg(pHeader->entrypoint_end_time).arg(pHeader->entrypoint_end_time - pHeader->entrypoint_begin_time);
-            tip += QString("<tr><td>pHeader->vktrace_end_time</td><td>= %1 (%2)</td></tr>").arg(pHeader->vktrace_end_time).arg(pHeader->vktrace_end_time - pHeader->vktrace_begin_time);
-            tip += QString("<tr><td>pHeader->next_buffers_offset</td><td>= %1</td></tr>").arg(pHeader->next_buffers_offset);
-            tip += QString("<tr><td>pHeader->pBody</td><td>= %1</td></tr>").arg(pHeader->pBody);
+            tip += "<tr><td><b>Packet header (pHeader->):</b></td><td/></tr>";
+            tip += QString("<tr><td>size</td><td>= %1 bytes</td></tr>").arg(pHeader->size);
+            tip += QString("<tr><td>global_packet_index</td><td>= %1</td></tr>").arg(pHeader->global_packet_index);
+            tip += QString("<tr><td>tracer_id</td><td>= %1</td></tr>").arg(pHeader->tracer_id);
+            tip += QString("<tr><td>packet_id</td><td>= %1</td></tr>").arg(pHeader->packet_id);
+            tip += QString("<tr><td>thread_id</td><td>= %1</td></tr>").arg(pHeader->thread_id);
+            tip += QString("<tr><td>vktrace_begin_time</td><td>= %1</td></tr>").arg(pHeader->vktrace_begin_time);
+            tip += QString("<tr><td>entrypoint_begin_time</td><td>= %1</td></tr>").arg(pHeader->entrypoint_begin_time);
+            tip += QString("<tr><td>entrypoint_end_time</td><td>= %1 (%2)</td></tr>").arg(pHeader->entrypoint_end_time).arg(pHeader->entrypoint_end_time - pHeader->entrypoint_begin_time);
+            tip += QString("<tr><td>vktrace_end_time</td><td>= %1 (%2)</td></tr>").arg(pHeader->vktrace_end_time).arg(pHeader->vktrace_end_time - pHeader->vktrace_begin_time);
+            tip += QString("<tr><td>next_buffers_offset</td><td>= %1</td></tr>").arg(pHeader->next_buffers_offset);
+            tip += QString("<tr><td>pBody</td><td>= %1</td></tr>").arg(pHeader->pBody);
             tip += "<br>";
 #endif
             tip += "<tr><td><b>";
             QString multiline = this->get_packet_string_multiline(pHeader);
-            multiline.replace("(\n", "</b>(</td><td/></tr><tr><td>");
+            // only replaces the first '('
+            multiline.replace(multiline.indexOf("("), 1, "</b>(</td><td/></tr><tr><td>");
+            multiline.replace(", ", ", </td></tr><tr><td>");
             multiline.replace(" = ", "</td><td>= ");
-            multiline.replace("\n", "</td></tr><tr><td>");
-            multiline.replace("  ", "&nbsp;&nbsp;");
+
+            // only replaces the final ')'
+            multiline.replace(multiline.lastIndexOf(")"), 1, "</td></tr><tr><td>)</td><td>");
             tip += multiline;
             tip += "</td></tr></table>";
             tip += "</html>";

--- a/vktrace/vktrace_generate.py
+++ b/vktrace/vktrace_generate.py
@@ -147,8 +147,8 @@ class Subcommand(object):
             return ("%p", "(void*)&%s" % name, deref)
         if "_type" in vk_type.lower(): # TODO : This should be generic ENUM check
             return ("%s", "string_%s(%s)" % (vk_type.replace('const ', '').strip('*'), name), deref)
-        if "char*" == vk_type:
-            return ("%s", name, "*")
+        if "char*" in vk_type:
+            return ("\\\"%s\\\"", name, "*")
         if "uint64_t" in vk_type:
             if '*' in vk_type:
                 return ("%lu",  "(%s == NULL) ? 0 : *(%s)" % (name, name), "*")
@@ -182,7 +182,7 @@ class Subcommand(object):
                 return ("%i", "(%s == NULL) ? 0 : *(%s)" % (name, name), "*")
             return ("%i", name, deref)
         if output_param:
-            return ("%p", "(void*)%s" % name, deref)
+            return ("%p {%p}", "(void*)%s, (%s == NULL) ? 0 : *(%s)" % (name, name, name), deref)
         return ("%p", "(void*)(%s)" % name, deref)
 
     def _generate_init_funcs(self):

--- a/vktrace/vktrace_generate.py
+++ b/vktrace/vktrace_generate.py
@@ -1156,7 +1156,7 @@ class Subcommand(object):
         txt = '    %s remap_%s(const %s& value)\n    {\n' % (ty, name[2:], ty)
         txt += '        if (value == 0) { return 0; }\n'
         txt += '        std::map<%s, %s>::const_iterator q = %s.find(value);\n' % (ty, ty, name)
-        txt += '        if (q == %s.end()) { vktrace_LogError("Failed to remap %s."); return value; }\n' % (name, ty)
+        txt += '        if (q == %s.end()) { vktrace_LogError("Failed to remap %s."); return VK_NULL_HANDLE; }\n' % (name, ty)
         txt += '        return q->second;\n    }\n'
         return txt
 
@@ -1398,7 +1398,7 @@ class Subcommand(object):
                 rc_body.append('        if (value == 0) { return 0; }')
                 rc_body.append('')
                 rc_body.append('        std::map<VkImage, imageObj>::const_iterator q = m_images.find(value);')
-                rc_body.append('        if (q == m_images.end()) { vktrace_LogError("Failed to remap VkImage."); return value; }\n')
+                rc_body.append('        if (q == m_images.end()) { vktrace_LogError("Failed to remap VkImage."); return VK_NULL_HANDLE; }\n')
                 rc_body.append('        return q->second.replayImage;')
                 rc_body.append('    }\n')
             elif obj_map_dict[var] == 'VkBuffer':
@@ -1410,7 +1410,7 @@ class Subcommand(object):
                 rc_body.append('        if (value == 0) { return 0; }')
                 rc_body.append('')
                 rc_body.append('        std::map<VkBuffer, bufferObj>::const_iterator q = m_buffers.find(value);')
-                rc_body.append('        if (q == m_buffers.end()) { vktrace_LogError("Failed to remap VkBuffer."); return value; }\n')
+                rc_body.append('        if (q == m_buffers.end()) { vktrace_LogError("Failed to remap VkBuffer."); return VK_NULL_HANDLE; }\n')
                 rc_body.append('        return q->second.replayBuffer;')
                 rc_body.append('    }\n')
             elif obj_map_dict[var] == 'VkDeviceMemory':
@@ -1422,7 +1422,7 @@ class Subcommand(object):
                 rc_body.append('        if (value == 0) { return 0; }')
                 rc_body.append('')
                 rc_body.append('        std::map<VkDeviceMemory, gpuMemObj>::const_iterator q = m_devicememorys.find(value);')
-                rc_body.append('        if (q == m_devicememorys.end()) { vktrace_LogError("Failed to remap VkDeviceMemory."); return value; }')
+                rc_body.append('        if (q == m_devicememorys.end()) { vktrace_LogError("Failed to remap VkDeviceMemory."); return VK_NULL_HANDLE; }')
                 rc_body.append('        return q->second.replayGpuMem;')
                 rc_body.append('    }\n')
             else:
@@ -1745,10 +1745,22 @@ class Subcommand(object):
                     rbody.append('            memcpy(&createInfo, pPacket->pCreateInfo, sizeof(%s));' % (proto.params[1].ty.strip('*').replace('const ', '')))
                     if 'CreateComputePipeline' == proto.name:
                         rbody.append('            createInfo.cs.shader = m_objMapper.remap_shaders(pPacket->pCreateInfo->cs.shader);')
+                        rbody.append('            if (createInfo.cs.shader == VK_NULL_HANDLE && pPacket->pCreateInfo->cs.shader != VK_NULL_HANDLE)')
+                        rbody.append('            {')
+                        rbody.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
+                        rbody.append('            }')
                     elif 'CreateBufferView' == proto.name:
                         rbody.append('            createInfo.buffer = m_objMapper.remap_buffers(pPacket->pCreateInfo->buffer);')
+                        rbody.append('            if (createInfo.buffer == VK_NULL_HANDLE && pPacket->pCreateInfo->buffer != VK_NULL_HANDLE)')
+                        rbody.append('            {')
+                        rbody.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
+                        rbody.append('            }')
                     else:
                         rbody.append('            createInfo.image = m_objMapper.remap_images(pPacket->pCreateInfo->image);')
+                        rbody.append('            if (createInfo.image == VK_NULL_HANDLE && pPacket->pCreateInfo->image != VK_NULL_HANDLE)')
+                        rbody.append('            {')
+                        rbody.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
+                        rbody.append('            }')
                     rbody.append('            %s local_%s;' % (proto.params[-1].ty.strip('*').replace('const ', ''), proto.params[-1].name))
                 elif create_func: # Declare local var to store created handle into
                     if 'AllocateDescriptorSets' == proto.name:

--- a/vktrace/vktrace_generate.py
+++ b/vktrace/vktrace_generate.py
@@ -221,6 +221,10 @@ class Subcommand(object):
                                                  'finalize_txt': ''},
                            'VkPhysicalDevice': {'add_txt': 'vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pGpus), *pGpuCount*sizeof(VkPhysicalDevice), pGpus)',
                                                 'finalize_txt': 'default'},
+                           'VkImageCreateInfo': {'add_txt': 'vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkImageCreateInfo), pCreateInfo);\n'
+						                                    '    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pQueueFamilyIndices), sizeof(uint32_t) * pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices)',
+                                               'finalize_txt': 'vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pCreateInfo->pQueueFamilyIndices));\n'
+											                   '    vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pCreateInfo))'},
                            'pDataSize': {'add_txt': 'vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pDataSize), sizeof(size_t), &_dataSize)',
                                          'finalize_txt': 'vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pDataSize))'},
                            'pData': {'add_txt': 'vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pData), _dataSize, pData)',
@@ -1015,6 +1019,8 @@ class Subcommand(object):
                                                                                           '*ppCV = (VkClearValue*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)(pPacket->pRenderPassBegin->pClearValues));']},
                              'CreateShaderModule' : {'param': 'pCreateInfo', 'txt': ['void** ppCode = (void**)&(pPacket->pCreateInfo->pCode);\n',
                                                                                      '*ppCode = (void*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pPacket->pCreateInfo->pCode);']},
+                             'CreateImage' : {'param': 'pCreateInfo', 'txt': ['uint32_t** ppQueueFamilyIndices = (uint32_t**)&(pPacket->pCreateInfo->pQueueFamilyIndices);\n',
+                                                                              '*ppQueueFamilyIndices = (uint32_t*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pPacket->pCreateInfo->pQueueFamilyIndices);']},
                              'FlushMappedMemoryRanges' : {'param': 'ppData', 'txt': ['uint32_t i = 0;\n',
                                                                                      'for (i = 0; i < pPacket->memoryRangeCount; i++)\n',
                                                                                      '{\n',

--- a/vktrace/vktrace_generate.py
+++ b/vktrace/vktrace_generate.py
@@ -1494,6 +1494,7 @@ class Subcommand(object):
                         result = '        %s remapped%s = m_objMapper.remap_%ss(*pPacket->%s%s);\n' % (cleanParamType, paramName, paramName.lower(), paramName, objectTypeRemapParam)
                         result += '        if (pPacket->%s != VK_NULL_HANDLE && remapped%s == VK_NULL_HANDLE)\n' % (paramName, paramName)
                         result += '        {\n'
+                        result += '            vktrace_LogError("Error detected in %s() due to invalid remapped %s.");\n' % (funcName, cleanParamType)
                         result += '            return vktrace_replay::VKTRACE_REPLAY_ERROR;\n'
                         result += '        }\n'
                         return result
@@ -1507,6 +1508,7 @@ class Subcommand(object):
                         result += '                remapped%s[i] = m_objMapper.remap_%ss(pPacket->%s[i]%s);\n' % (paramName, cleanParamType.lower()[2:], paramName, objectTypeRemapParam)
                         result += '                if (pPacket->%s[i] != VK_NULL_HANDLE && remapped%s[i] == VK_NULL_HANDLE)\n' % (paramName, paramName)
                         result += '                {\n'
+                        result += '                    vktrace_LogError("Error detected in %s() due to invalid remapped %s.");\n' % (funcName, cleanParamType)
                         result += '                    return vktrace_replay::VKTRACE_REPLAY_ERROR;\n'
                         result += '                }\n'
                         result += '            }\n'
@@ -1516,6 +1518,7 @@ class Subcommand(object):
                 result += '%s\n' % self.lineinfo.get()
                 result += '            if (pPacket->%s != VK_NULL_HANDLE && remapped%s == VK_NULL_HANDLE)\n' % (paramName, paramName)
                 result += '            {\n'
+                result += '                vktrace_LogError("Error detected in %s() due to invalid remapped %s.");\n' % (funcName, cleanParamType)
                 result += '                return vktrace_replay::VKTRACE_REPLAY_ERROR;\n'
                 result += '            }\n'
                 return result
@@ -1543,6 +1546,7 @@ class Subcommand(object):
         ci_body.append('            VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);')
         ci_body.append('            if (remappedDevice == VK_NULL_HANDLE)')
         ci_body.append('            {')
+        ci_body.append('                vktrace_LogError("Error detected in vkCreateImage() due to invalid remapped VkDevice.");')
         ci_body.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
         ci_body.append('            }')
         ci_body.append('            replayResult = m_vkFuncs.real_vkCreateImage(remappedDevice, pPacket->pCreateInfo, NULL, &local_imageObj.replayImage);')
@@ -1558,6 +1562,7 @@ class Subcommand(object):
         cb_body.append('            VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);')
         cb_body.append('            if (remappedDevice == VK_NULL_HANDLE)')
         cb_body.append('            {')
+        cb_body.append('                vktrace_LogError("Error detected in vkCreateBuffer() due to invalid remapped VkDevice.");')
         cb_body.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
         cb_body.append('            }')
         cb_body.append('            replayResult = m_vkFuncs.real_vkCreateBuffer(remappedDevice, pPacket->pCreateInfo, NULL, &local_bufferObj.replayBuffer);')
@@ -1574,6 +1579,7 @@ class Subcommand(object):
         cb_body.append('            if (replayResult == VK_SUCCESS) {')
         cb_body.append('                VkInstance remappedInstance = m_objMapper.remap_instances(*pPacket->pInstance);')
         cb_body.append('                if (remappedInstance == VK_NULL_HANDLE) {')
+        cb_body.append('                    vktrace_LogError("Error detected in vkCreateInstance() due to invalid remapped VkInstance.");')
         cb_body.append('                    returnValue = vktrace_replay::VKTRACE_REPLAY_ERROR;')
         cb_body.append('                    break;')
         cb_body.append('                }')
@@ -1747,18 +1753,21 @@ class Subcommand(object):
                         rbody.append('            createInfo.cs.shader = m_objMapper.remap_shaders(pPacket->pCreateInfo->cs.shader);')
                         rbody.append('            if (createInfo.cs.shader == VK_NULL_HANDLE && pPacket->pCreateInfo->cs.shader != VK_NULL_HANDLE)')
                         rbody.append('            {')
+                        rbody.append('                vktrace_LogError("Error detected in vkCreateComputePipelines() due to invalid remapped VkShader.");')
                         rbody.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
                         rbody.append('            }')
                     elif 'CreateBufferView' == proto.name:
                         rbody.append('            createInfo.buffer = m_objMapper.remap_buffers(pPacket->pCreateInfo->buffer);')
                         rbody.append('            if (createInfo.buffer == VK_NULL_HANDLE && pPacket->pCreateInfo->buffer != VK_NULL_HANDLE)')
                         rbody.append('            {')
+                        rbody.append('                vktrace_LogError("Error detected in vkCreateBufferView() due to invalid remapped VkBuffer.");')
                         rbody.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
                         rbody.append('            }')
                     else:
                         rbody.append('            createInfo.image = m_objMapper.remap_images(pPacket->pCreateInfo->image);')
                         rbody.append('            if (createInfo.image == VK_NULL_HANDLE && pPacket->pCreateInfo->image != VK_NULL_HANDLE)')
                         rbody.append('            {')
+                        rbody.append('                vktrace_LogError("Error detected in vkCreateImageView() due to invalid remapped VkImage.");')
                         rbody.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
                         rbody.append('            }')
                     rbody.append('            %s local_%s;' % (proto.params[-1].ty.strip('*').replace('const ', ''), proto.params[-1].name))
@@ -1770,9 +1779,19 @@ class Subcommand(object):
                         rbody.append('            VkDescriptorSetAllocateInfo local_AllocInfo, *local_pAllocateInfo = &local_AllocInfo;')
                         rbody.append('            VkDescriptorPool local_descPool;')
                         rbody.append('            local_descPool = m_objMapper.remap_descriptorpools(pPacket->pAllocateInfo->descriptorPool);')
+                        rbody.append('            if (local_descPool == VK_NULL_HANDLE)')
+                        rbody.append('            {')
+                        rbody.append('                vktrace_LogError("Error detected in vkAllocateDescriptorSets() due to invalid remapped VkDescriptorPool.");')
+                        rbody.append('                return vktrace_replay::VKTRACE_REPLAY_ERROR;')
+                        rbody.append('            }')
                         rbody.append('            for (uint32_t i = 0; i < pPacket->pAllocateInfo->descriptorSetCount; i++)')
                         rbody.append('            {')
                         rbody.append('                local_pSetLayouts[i] = m_objMapper.remap_descriptorsetlayouts(pPacket->%s->pSetLayouts[i]);' % (proto.params[-2].name))
+                        rbody.append('                if (local_pSetLayouts[i] == VK_NULL_HANDLE)')
+                        rbody.append('                {')
+                        rbody.append('                    vktrace_LogError("Error detected in vkAllocateDescriptorSets() due to invalid remapped VkDescriptorSetLayout.");')
+                        rbody.append('                    return vktrace_replay::VKTRACE_REPLAY_ERROR;')
+                        rbody.append('                }')
                         rbody.append('            }')
                         rbody.append('            memcpy(local_pAllocateInfo, pPacket->pAllocateInfo, sizeof(VkDescriptorSetAllocateInfo));')
                         rbody.append('            local_pAllocateInfo->pSetLayouts = local_pSetLayouts;')
@@ -1784,6 +1803,11 @@ class Subcommand(object):
                     rbody.append('            for (uint32_t i = 0; i < pPacket->fenceCount; i++)')
                     rbody.append('            {')
                     rbody.append('                fences[i] = m_objMapper.remap_fences(pPacket->%s[i]);' % (proto.params[-1].name))
+                    rbody.append('                if (fences[i] == VK_NULL_HANDLE)')
+                    rbody.append('                {')
+                    rbody.append('                    vktrace_LogError("Error detected in vkResetFences() due to invalid remapped VkFence.");')
+                    rbody.append('                    return vktrace_replay::VKTRACE_REPLAY_ERROR;')
+                    rbody.append('                }')
                     rbody.append('            }')
                 elif proto.name in do_while_dict:
                     rbody.append('            do {')


### PR DESCRIPTION
vktrace:
* Use parallel threads when doing large memory copies.
* Fix tracing of entrypoints which include pQueueFamilyIndicies.

vkreplay:
* Report errors on replay if an object cannot be remapped, and don't replay that call because it will likely result in a driver crash.
* Fix a few memory leaks in vkreplay.

vktraceviewer:
* Enable printing of string parameters
* vkCreate calls now show the first object handle that was created.
* Improving formatting of packet header and parameters when printed in UI.
* Update to version 54 of some of the Qt dlls, which corresponds to Qt version 5.6 instead of version 5.3 (this update may have been required to build in VS2015, or it was the latest version available when we started on the project).
