### PR TITLE
Android support for api_dump

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -23,9 +23,11 @@ python ../vk-generate.py Android dispatch-table-ops layer > generated/include/vk
 
 python ../vk_helper.py --gen_enum_string_helper ../include/vulkan/vulkan.h --abs_out_dir generated/include
 python ../vk_helper.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
+python ../vk_helper_api_dump.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
 
 python ../vk-layer-generate.py Android object_tracker ../include/vulkan/vulkan.h > generated/include/object_tracker.cpp
 python ../vk-layer-generate.py Android unique_objects ../include/vulkan/vulkan.h > generated/include/unique_objects.cpp
+python ../vk-vtlayer-generate.py Android api_dump ../include/vulkan/vulkan.h > generated/include/api_dump.cpp
 
 cd generated/include
 python ../../../genvk.py threading -registry ../../../vk.xml thread_check.h
@@ -45,16 +47,17 @@ mkdir  core_validation image object_tracker parameter_validation swapchain threa
 cd ..\..
 mkdir generated\layer-src
 cd generated\layer-src
-mkdir  core_validation image object_tracker parameter_validation swapchain threading unique_objects
+mkdir  core_validation image object_tracker parameter_validation swapchain threading unique_objects api_dump
 cd ..\..
 xcopy /s gradle-templates\*   generated\gradle-build\
-for %%G in (core_validation image parameter_validation swapchain threading) Do (
+for %%G in (core_validation image parameter_validation swapchain threading api_dump) Do (
     copy ..\layers\%%G.cpp   generated\layer-src\%%G
     echo apply from: "../common.gradle"  > generated\gradle-build\%%G\build.gradle
 )
 copy generated\include\object_tracker.cpp   generated\layer-src\object_tracker
 echo apply from: "../common.gradle"  > generated\gradle-build\object_tracker\build.gradle
 copy generated\include\unique_objects.cpp   generated\layer-src\unique_objects
+copy generated\include\api_dump.cpp   generated\layer-src\api_dump
 copy generated\common\descriptor_sets.cpp generated\layer-src\core_validation\descriptor_sets.cpp
 copy generated\include\vk_safe_struct.cpp generated\layer-src\core_validation\vk_safe_struct.cpp
 move generated\include\vk_safe_struct.cpp generated\layer-src\unique_objects\vk_safe_struct.cpp
@@ -62,3 +65,4 @@ echo apply from: "../common.gradle"  > generated\gradle-build\unique_objects\bui
 
 del  /f /q generated\include\object_tracker.cpp
 del  /f /q generated\include\unique_objects.cpp
+del  /f /q generated\include\api_dump.cpp

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -25,9 +25,11 @@ python ../vk-generate.py Android dispatch-table-ops layer > generated/include/vk
 
 python ../vk_helper.py --gen_enum_string_helper ../include/vulkan/vulkan.h --abs_out_dir generated/include
 python ../vk_helper.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
+python ../vk_helper_api_dump.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
 
 python ../vk-layer-generate.py Android object_tracker ../include/vulkan/vulkan.h > generated/include/object_tracker.cpp
 python ../vk-layer-generate.py Android unique_objects ../include/vulkan/vulkan.h > generated/include/unique_objects.cpp
+python ../vk-vtlayer-generate.py Android api_dump ../include/vulkan/vulkan.h > generated/include/api_dump.cpp
 ( cd generated/include; python ../../../genvk.py threading -registry ../../../vk.xml thread_check.h )
 ( cd generated/include; python ../../../genvk.py paramchecker -registry ../../../vk.xml parameter_validation.h )
 
@@ -40,8 +42,8 @@ cp -f ../layers/descriptor_sets.cpp   generated/common/
 # layer names and their original source files directory
 # 1 to 1 correspondence -- one layer one source file; additional files are copied
 # at fixup step
-declare layers=(core_validation image object_tracker parameter_validation swapchain threading unique_objects)
-declare src_dirs=(../layers ../layers generated/include ../layers ../layers ../layers generated/include)
+declare layers=(core_validation image object_tracker parameter_validation swapchain threading unique_objects api_dump)
+declare src_dirs=(../layers ../layers generated/include ../layers ../layers ../layers generated/include generated/include)
 
 SRC_ROOT=generated/layer-src
 BUILD_ROOT=generated/gradle-build
@@ -67,5 +69,6 @@ mv  generated/include/vk_safe_struct.cpp ${SRC_ROOT}/unique_objects/vk_safe_stru
 # fixup - remove copied files from generated/include
 rm  generated/include/object_tracker.cpp
 rm  generated/include/unique_objects.cpp
+rm  generated/include/api_dump.cpp
 
 exit 0

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -124,6 +124,20 @@ LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR
 LOCAL_LDLIBS    := -llog
 include $(BUILD_SHARED_LIBRARY)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE := VkLayer_api_dump
+LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/api_dump/api_dump.cpp
+LOCAL_SRC_FILES += $(LAYER_DIR)/common/vk_layer_table.cpp
+LOCAL_C_INCLUDES += $(SRC_DIR)/include \
+                    $(SRC_DIR)/layers \
+                    $(SRC_DIR)/layersvt \
+                    $(LAYER_DIR)/include \
+                    $(SRC_DIR)/loader
+LOCAL_STATIC_LIBRARIES += layer_utils
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR
+LOCAL_LDLIBS    := -llog
+include $(BUILD_SHARED_LIBRARY)
+
 # Pull in prebuilt shaderc
 include $(CLEAR_VARS)
 LOCAL_MODULE := shaderc-prebuilt

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -16,6 +16,6 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64 mips mips64
 APP_PLATFORM := android-22
 APP_STL := gnustl_static
-APP_MODULES := layer_utils VkLayer_core_validation VkLayer_image VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_swapchain VkLayer_unique_objects VkLayerValidationTests
+APP_MODULES := layer_utils VkLayer_core_validation VkLayer_image VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_swapchain VkLayer_unique_objects VkLayer_api_dump VkLayerValidationTests
 APP_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 NDK_TOOLCHAIN_VERSION := clang

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -41,6 +41,7 @@
 #define SHADER_CHECKER_TESTS 1
 #define DEVICE_LIMITS_TESTS 1
 #define IMAGE_TESTS 1
+#define API_DUMP_TESTS 0
 
 //--------------------------------------------------------------------------------------
 // Mesh and VertexFormat Data
@@ -268,6 +269,7 @@ class VkLayerTest : public VkRenderFramework {
   protected:
     ErrorMonitor *m_errorMonitor;
     bool m_enableWSI;
+    bool m_enableApiDump;
 
     virtual void SetUp() {
         std::vector<const char *> instance_layer_names;
@@ -276,6 +278,12 @@ class VkLayerTest : public VkRenderFramework {
         std::vector<const char *> device_extension_names;
 
         instance_extension_names.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+
+        if (m_enableApiDump) {
+            instance_layer_names.push_back("VK_LAYER_LUNARG_api_dump");
+            device_layer_names.push_back("VK_LAYER_LUNARG_api_dump");
+        }
+
         /*
          * Since CreateDbgMsgCallback is an instance level extension call
          * any extension / layer that utilizes that feature also needs
@@ -345,6 +353,7 @@ class VkLayerTest : public VkRenderFramework {
 
     VkLayerTest() {
         m_enableWSI = false;
+        m_enableApiDump = false;
     }
 };
 
@@ -557,6 +566,15 @@ protected:
         m_enableWSI = true;
     }
 };
+
+class VkApiDumpEnabledLayerTest : public VkLayerTest {
+  public:
+protected:
+    VkApiDumpEnabledLayerTest() {
+        m_enableApiDump = true;
+    }
+};
+
 
 class VkBufferTest {
 public:
@@ -820,6 +838,7 @@ protected:
 };
 
 uint32_t VkVerticesObj::BindIdGenerator;
+
 // ********************************************************************************************************************
 // ********************************************************************************************************************
 // ********************************************************************************************************************
@@ -15044,6 +15063,17 @@ TEST_F(VkLayerTest, ClearImageErrors) {
     m_errorMonitor->VerifyFound();
 }
 #endif // IMAGE_TESTS
+
+#if API_DUMP_TESTS
+TEST_F(VkApiDumpEnabledLayerTest, TestApiDump) {
+
+    // This test invokes the framework only, dumping commands.
+    // Ideally we would have a test harness that automatically verifies
+    // we can dump the entire API.
+    // This test just checks for a pulse, using visual inspection.
+    TEST_DESCRIPTION("Empty test with ApiDump enabled.");
+}
+#endif
 
 int main(int argc, char **argv) {
     int result;

--- a/vk-vtlayer-generate.py
+++ b/vk-vtlayer-generate.py
@@ -1232,7 +1232,6 @@ class ApiDumpSubcommand(Subcommand):
                  '{\n'
                  '    using namespace StreamControl;\n'
                  '    using namespace std;\n'
-                 '    dispatch_key key = get_dispatch_key(queue);\n'
                  '    VkLayerDispatchTable *pDisp  = %s_dispatch_table(%s);\n'
                  '    %spDisp->%s;\n'
                  '    %s%s%s\n'


### PR DESCRIPTION
These changes get api_dump working on Android.  It routes the dump to stdout.  I added a test that is disabled, it is a little too verbose.  I'll try to come back to that at some point so we can ensure api_dump works on all platforms.