### PR TITLE
loader: support discovering manifests in XDG locations on Linux

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -50,42 +50,23 @@
 #define PATH_SEPERATOR ':'
 #define DIRECTORY_SYMBOL '/'
 
-#define VULKAN_ICDCONF_DIR                                                     \
-    "/"                                                                        \
-    "vulkan"                                                                   \
-    "/"                                                                        \
-    "icd.d"
-#define VULKAN_ICD_DIR                                                         \
-    "/"                                                                        \
-    "vulkan"                                                                   \
-    "/"                                                                        \
-    "icd"
-#define VULKAN_ELAYERCONF_DIR                                                  \
-    "/"                                                                        \
-    "vulkan"                                                                   \
-    "/"                                                                        \
-    "explicit_layer.d"
-#define VULKAN_ILAYERCONF_DIR                                                  \
-    "/"                                                                        \
-    "vulkan"                                                                   \
-    "/"                                                                        \
-    "implicit_layer.d"
-#define VULKAN_LAYER_DIR                                                       \
-    "/"                                                                        \
-    "vulkan"                                                                   \
-    "/"                                                                        \
-    "layer"
+#define VULKAN_DIR            "/vulkan/"
+#define VULKAN_ICDCONF_DIR    "icd.d"
+#define VULKAN_ICD_DIR        "icd"
+#define VULKAN_ELAYERCONF_DIR "explicit_layer.d"
+#define VULKAN_ILAYERCONF_DIR "implicit_layer.d"
+#define VULKAN_LAYER_DIR      "layer"
 
 #if defined(LOCALPREFIX)
 #define LOCAL_DRIVERS_INFO                                                     \
-    LOCALPREFIX "/" SYSCONFDIR VULKAN_ICDCONF_DIR ":" LOCALPREFIX              \
-                "/" DATADIR VULKAN_ICDCONF_DIR ":"
+    LOCALPREFIX "/" SYSCONFDIR VULKAN_DIR VULKAN_ICDCONF_DIR ":"               \
+    LOCALPREFIX "/" DATADIR    VULKAN_DIR VULKAN_ICDCONF_DIR ":"
 #define LOCAL_ELAYERS_INFO                                                     \
-    LOCALPREFIX "/" SYSCONFDIR VULKAN_ELAYERCONF_DIR ":" LOCALPREFIX           \
-                "/" DATADIR VULKAN_ELAYERCONF_DIR ":"
+    LOCALPREFIX "/" SYSCONFDIR VULKAN_DIR VULKAN_ELAYERCONF_DIR ":"            \
+    LOCALPREFIX "/" DATADIR    VULKAN_DIR VULKAN_ELAYERCONF_DIR ":"
 #define LOCAL_ILAYERS_INFO                                                     \
-    LOCALPREFIX "/" SYSCONFDIR VULKAN_ILAYERCONF_DIR ":" LOCALPREFIX           \
-                "/" DATADIR VULKAN_ILAYERCONF_DIR ":"
+    LOCALPREFIX "/" SYSCONFDIR VULKAN_DIR VULKAN_ILAYERCONF_DIR ":"            \
+    LOCALPREFIX "/" DATADIR    VULKAN_DIR VULKAN_ILAYERCONF_DIR ":"
 #else
 #define LOCAL_DRIVERS_INFO
 #define LOCAL_ELAYERS_INFO
@@ -94,25 +75,25 @@
 
 #define DEFAULT_VK_DRIVERS_INFO                                                \
     LOCAL_DRIVERS_INFO                                                         \
-    "/" SYSCONFDIR VULKAN_ICDCONF_DIR ":"                                      \
-    "/usr/" DATADIR VULKAN_ICDCONF_DIR
+    "/"  SYSCONFDIR VULKAN_DIR VULKAN_ICDCONF_DIR ":"                          \
+    "/usr/" DATADIR VULKAN_DIR VULKAN_ICDCONF_DIR
 #define DEFAULT_VK_DRIVERS_PATH ""
 #define DEFAULT_VK_ELAYERS_INFO                                                \
     LOCAL_ELAYERS_INFO                                                         \
-    "/" SYSCONFDIR VULKAN_ELAYERCONF_DIR ":"                                   \
-    "/usr/" DATADIR VULKAN_ELAYERCONF_DIR
+    "/"  SYSCONFDIR VULKAN_DIR VULKAN_ELAYERCONF_DIR ":"                       \
+    "/usr/" DATADIR VULKAN_DIR VULKAN_ELAYERCONF_DIR
 #define DEFAULT_VK_ILAYERS_INFO                                                \
     LOCAL_ILAYERS_INFO                                                         \
-    "/" SYSCONFDIR VULKAN_ILAYERCONF_DIR ":"                                   \
-    "/usr/" DATADIR VULKAN_ILAYERCONF_DIR
+    "/"  SYSCONFDIR VULKAN_DIR VULKAN_ILAYERCONF_DIR ":"                       \
+    "/usr/" DATADIR VULKAN_DIR VULKAN_ILAYERCONF_DIR
 #define DEFAULT_VK_LAYERS_PATH ""
 #if !defined(LAYERS_SOURCE_PATH)
 #define LAYERS_SOURCE_PATH NULL
 #endif
 #define LAYERS_PATH_ENV "VK_LAYER_PATH"
-#define HOME_VK_DRIVERS_INFO "/.local/share" VULKAN_ICDCONF_DIR
-#define HOME_VK_ELAYERS_INFO "/.local/share" VULKAN_ELAYERCONF_DIR
-#define HOME_VK_ILAYERS_INFO "/.local/share" VULKAN_ILAYERCONF_DIR
+#define HOME_VK_DRIVERS_INFO VULKAN_DIR VULKAN_ICDCONF_DIR
+#define HOME_VK_ELAYERS_INFO VULKAN_DIR VULKAN_ELAYERCONF_DIR
+#define HOME_VK_ILAYERS_INFO VULKAN_DIR VULKAN_ILAYERCONF_DIR
 
 // C99:
 #define PRINTF_SIZE_T_SPECIFIER "%zu"


### PR DESCRIPTION
Some users set the environment variable XDG_DATA_HOME to relocate
~/.local/share/ to a more friendly location and so it is not wise to
look solely at that location.

This change adds basic support for that env var without changing the
behaviour for typical users. If XDG_DATA_HOME is defined, the loader
checks XDG_DATA_HOME/vulkan/..., if HOME is defined the loader will
check HOME/.local/share/vulkan/..., and with neither it skips looking
for manifests in the user dir tree.

loader_get_manifest_files() now takes a relative location inside the
config path eg `/vulkan/implicit_layer.d` and appends that onto the
preferred location. As this was only used for the Linux side of the
loader, I thought this was ok.

vk_loader_platform.h Linux defines got minor adjustments to support
this change, with an added bonus of being more readable.

Have tested locally with debug/release builds, and with the
applications vulkaninfo, Dota2, Talos Principle, and the Tools test
suite.
https://gist.github.com/johndrinkwater/4e7ac2c72db5d52c9d2045c9b2a714df for log output from them.