### PR TITLE
build: add dependencies to enable parallel build

### DIFF
--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -43,6 +43,7 @@ if (WIN32)
                     COMMAND copy ${src_json} ${dst_json}
                     VERBATIM
                     )
+                add_dependencies(${config_file}-json ${config_file})
             endforeach(config_file)
         else()
             foreach (config_file ${LAYER_JSON_FILES})
@@ -52,6 +53,7 @@ if (WIN32)
                     COMMAND copy ${src_json} ${dst_json}
                     VERBATIM
                     )
+                add_dependencies(${config_file}-json ${config_file})
             endforeach(config_file)
         endif()
     endif()
@@ -63,6 +65,7 @@ else()
                 COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/linux/${config_file}.json
                 VERBATIM
                 )
+             add_dependencies(${config_file}-json ${config_file})
         endforeach(config_file)
     endif()
 endif()
@@ -133,8 +136,30 @@ run_vk_helper(gen_struct_wrappers
     vk_struct_wrappers.h
     vk_struct_wrappers.cpp
     vk_safe_struct.h
-    vk_safe_struct.cpp
+# Don't list vk_safe_struct.cpp as OUTPUT to avoid duplicate builds.
+# If listed here use of it for add_library will cause it to be created
+# independently of custom target generate_vk_layer_helpers .
+# That breaks parallel builds.
+#   vk_safe_struct.cpp
 )
+
+# Let gen_struct_wrappers really create vk_safe_struct.cpp
+add_custom_command(OUTPUT vk_safe_struct.cpp
+    COMMAND echo defer making vk_safe_struct.cpp
+)
+
+set_source_files_properties(
+    vk_struct_string_helper.h
+    vk_struct_string_helper_cpp.h
+    vk_struct_string_helper_no_addr.h
+    vk_struct_string_helper_no_addr_cpp.h
+    vk_struct_size_helper.h
+    vk_struct_size_helper.c
+    vk_struct_wrappers.h
+    vk_struct_wrappers.cpp
+    vk_safe_struct.h
+    vk_safe_struct.cpp
+    PROPERTIES GENERATED TRUE)
 
 add_custom_target(generate_vt_helpers DEPENDS
     vk_dispatch_table_helper.h

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
@@ -61,6 +61,8 @@ endif()
 
 add_library(${PROJECT_NAME} STATIC ${SRC_LIST} ${HDR_LIST})
 
+add_dependencies(${PROJECT_NAME} "vulkan-${MAJOR}")
+
 target_link_libraries(${PROJECT_NAME} 
     ${OS_REPLAYER_LIBS}
     ${VKTRACE_VULKAN_LIB}

--- a/vktrace/src/vktrace_layer/CMakeLists.txt
+++ b/vktrace/src/vktrace_layer/CMakeLists.txt
@@ -113,6 +113,7 @@ else()
             COMMAND copy ${src_json} ${dst_json}
             VERBATIM
             )
+        add_dependencies(vktrace_layer-json VkLayer_vktrace_layer)
     endif()
 endif()
 

--- a/vktrace/src/vktrace_replay/CMakeLists.txt
+++ b/vktrace/src/vktrace_replay/CMakeLists.txt
@@ -24,6 +24,8 @@ set (LIBRARIES vktrace_common vulkan_replay)
 
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 
+add_dependencies(${PROJECT_NAME} "vulkan-${MAJOR}")
+
 target_link_libraries(${PROJECT_NAME}
     ${LIBRARIES}
 )


### PR DESCRIPTION
This gets parallel windows builds working.

Fix parallel build of layersvt
 Change layer dependencies to prevent collisions of scripts creating headers.
 Use dependency on one custom target for each group of headers built by a custom command.
 The layers json targets need to depend on the layers targets.
 They expect to copy into a directory created by those targets.
 Make dependency of vk_safe_struct.cpp indirect through generate_vk_layer_helpers.
 That will wait for a single build of the generated files.
vktrace_layer json copy depends on vktrace layer.
vktrace_replay depends on vulkan loader project.