### PR TITLE
Hologram problem

### DIFF
--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -45,15 +45,6 @@ void pageguardExit()
 }
 #if defined(WIN32) //page guard solution for windows
 
-#define PAGEGUARD_TARGET_RANGE_SIZE_CONTROL
-
-//PAGEGUARD_ADD_PAGEGUARD_ON_REAL_MAPPED_MEMORY is a compile flag for add page guard on real mapped memory.
-//If comment this flag, pageguard will be added on a copy of mapped memory, with the flag, page guard will be added to
-//real mapped memory.
-//for some hareware, add to mapped memory not the copy of it may not be allowed, so turn on this flag just for you are already sure page guard can work on that hardware.
-//If add page guard to the copy of mapped memory, it's always allowed but need to do synchonization between the mapped memory and its copy.
-
-//#define PAGEGUARD_ADD_PAGEGUARD_ON_REAL_MAPPED_MEMORY
 
 VkDeviceSize& ref_target_range_size()
 {

--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguard.h
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguard.h
@@ -72,7 +72,7 @@
 
 #if defined(WIN32) /// page guard solution for windows
 
-
+VkDeviceSize& ref_target_range_size();
 bool getPageGuardEnableFlag();
 void setPageGuardExceptionHandler();
 void removePageGuardExceptionHandler();

--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.cpp
@@ -59,6 +59,7 @@ void PageGuardCapture::vkMapMemoryPageGuardHandle(
         }
     }
     MapMemoryPtr[memory] = (PBYTE)(*ppData);
+    MapMemoryOffset[memory] = offset;
 }
 
 void PageGuardCapture::vkUnmapMemoryPageGuardHandle(VkDevice device, VkDeviceMemory memory, void** MappedData, vkFlushMappedMemoryRangesFunc pFunc)
@@ -75,6 +76,11 @@ void PageGuardCapture::vkUnmapMemoryPageGuardHandle(VkDevice device, VkDeviceMem
 void* PageGuardCapture::getMappedMemoryPointer(VkDevice device, VkDeviceMemory memory)
 {
     return MapMemoryPtr[memory];
+}
+
+VkDeviceSize PageGuardCapture::getMappedMemoryOffset(VkDevice device, VkDeviceMemory memory)
+{
+    return MapMemoryOffset[memory];
 }
 
 //return: if it's target mapped memory and no change at all;
@@ -94,8 +100,13 @@ bool PageGuardCapture::vkFlushMappedMemoryRangesPageGuardHandle(
 
         ppPackageDataforOutOfMap[i] = nullptr;
         LPPageGuardMappedMemory lpOPTMemoryTemp = findMappedMemoryObject(device, pRange->memory);
+
         if (lpOPTMemoryTemp)
         {
+            if (pRange->size == VK_WHOLE_SIZE)
+            {
+                pRange->size = lpOPTMemoryTemp->getMappedSize() - pRange->offset;
+            }
             if (lpOPTMemoryTemp->vkFlushMappedMemoryRangePageGuardHandle(device, pRange->memory, pRange->offset, pRange->size, nullptr, nullptr, nullptr))
             {
                 bChanged = true;
@@ -115,13 +126,13 @@ bool PageGuardCapture::vkFlushMappedMemoryRangesPageGuardHandle(
             pInfoTemp[0].length = (DWORD)RealRangeSize;
             pInfoTemp[0].reserve0 = 0;
             pInfoTemp[0].reserve1 = 0;
-            pInfoTemp[1].offset = 0;
+            pInfoTemp[1].offset = pRange->offset - getMappedMemoryOffset(device, pRange->memory);
             pInfoTemp[1].length = (DWORD)RealRangeSize;
             pInfoTemp[1].reserve0 = 0;
             pInfoTemp[1].reserve1 = 0;
             PBYTE pDataInPackage = (PBYTE)(pInfoTemp + 2);
             void* pDataMapped = getMappedMemoryPointer(device, pRange->memory);
-            vktrace_pageguard_memcpy(pDataInPackage, pDataMapped, RealRangeSize);
+            vktrace_pageguard_memcpy(pDataInPackage, reinterpret_cast<PBYTE>(pDataMapped) + pInfoTemp[1].offset, RealRangeSize);
         }
     }
     if (!bChanged)

--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.h
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.h
@@ -32,6 +32,16 @@
 
 #if defined(WIN32) /// page guard solution for windows
 
+#define PAGEGUARD_TARGET_RANGE_SIZE_CONTROL
+
+//PAGEGUARD_ADD_PAGEGUARD_ON_REAL_MAPPED_MEMORY is a compile flag for add page guard on real mapped memory.
+//If comment this flag, pageguard will be added on a copy of mapped memory, with the flag, page guard will be added to
+//real mapped memory.
+//for some hareware, add to mapped memory not the copy of it may not be allowed, so turn on this flag just for you are already sure page guard can work on that hardware.
+//If add page guard to the copy of mapped memory, it's always allowed but need to do synchonization between the mapped memory and its copy.
+
+//#define PAGEGUARD_ADD_PAGEGUARD_ON_REAL_MAPPED_MEMORY
+
 typedef VkResult(*vkFlushMappedMemoryRangesFunc)(VkDevice device, uint32_t memoryRangeCount, const VkMappedMemoryRange*  pMemoryRanges);
 
 typedef class PageGuardCapture
@@ -40,6 +50,7 @@ private:
     PageGuardChangedBlockInfo EmptyChangedInfoArray;
     std::unordered_map< VkDeviceMemory, PageGuardMappedMemory > MapMemory;
     std::unordered_map< VkDeviceMemory, PBYTE > MapMemoryPtr;
+    std::unordered_map< VkDeviceMemory, VkDeviceSize > MapMemoryOffset;
 public:
 
     PageGuardCapture();
@@ -51,6 +62,8 @@ public:
     void vkUnmapMemoryPageGuardHandle(VkDevice device, VkDeviceMemory memory, void** MappedData, vkFlushMappedMemoryRangesFunc pFunc);
 
     void* getMappedMemoryPointer(VkDevice device, VkDeviceMemory memory);
+
+    VkDeviceSize PageGuardCapture::getMappedMemoryOffset(VkDevice device, VkDeviceMemory memory);
 
     /// return: if it's target mapped memory and no change at all;
     /// PBYTE *ppPackageDataforOutOfMap, must be an array include memoryRangeCount elements


### PR DESCRIPTION
there were missing teapots in the replay. sometimes, the Hologram process would crash during trace and the replay process would crash during replay.

XCAP-409

Change-Id: I752a95ed97889526c8e0b2c1214005dcea59b289