### PR TITLE
vktrace: Fixes for Android

### DIFF
--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -326,7 +326,7 @@ VkResult vkFlushMappedMemoryRangesWithoutAPICall(
 
 #ifdef USE_PAGEGUARD_SPEEDUP
     PBYTE *ppPackageData = new PBYTE[memoryRangeCount];
-    bool bOPTTargetWithoutChange = getPageGuardControlInstance().vkFlushMappedMemoryRangesPageGuardHandle(device, memoryRangeCount, pMemoryRanges, ppPackageData);//the packet is not needed if no any change on data of all ranges
+    getPageGuardControlInstance().vkFlushMappedMemoryRangesPageGuardHandle(device, memoryRangeCount, pMemoryRanges, ppPackageData);//the packet is not needed if no any change on data of all ranges
 #endif
 
     // find out how much memory is in the ranges

--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.cpp
@@ -31,7 +31,7 @@ PageGuardCapture::PageGuardCapture()
     EmptyChangedInfoArray.offset = 0;
     EmptyChangedInfoArray.length = 0;
 
-#if defined(PLATFORM_LINUX)
+#if defined(PLATFORM_LINUX) && !defined(ANDROID)
     // Open the /proc/self/clear_refs file. We'll write to that file
     // when we want to clear all the page dirty bits in /proc/self/pagemap.
     clearRefsFd = open("/proc/self/clear_refs", O_WRONLY);
@@ -378,7 +378,7 @@ bool PageGuardCapture::isReadyForHostRead(VkPipelineStageFlags srcStageMask, VkP
     return isReady;
 }
 
-#if defined(PLATFORM_LINUX)
+#if defined(PLATFORM_LINUX) && !defined(ANDROID)
 void PageGuardCapture::pageRefsDirtyClear()
 {
     char four='4';

--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.h
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguardcapture.h
@@ -49,7 +49,7 @@ private:
     std::unordered_map< VkDeviceMemory, PageGuardMappedMemory > MapMemory;
     std::unordered_map< VkDeviceMemory, PBYTE > MapMemoryPtr;
     std::unordered_map< VkDeviceMemory, VkDeviceSize > MapMemoryOffset;
-#if defined(PLATFORM_LINUX)
+#if defined(PLATFORM_LINUX) && !defined(ANDROID)
     int clearRefsFd;
 #endif
 
@@ -107,7 +107,7 @@ public:
         uint32_t  bufferMemoryBarrierCount, const VkBufferMemoryBarrier*  pBufferMemoryBarriers,
         uint32_t  imageMemoryBarrierCount, const VkImageMemoryBarrier*  pImageMemoryBarriers);
 
-#if defined(PLATFORM_LINUX)
+#if defined(PLATFORM_LINUX) && !defined(ANDROID)
     void pageRefsDirtyClear();
 #endif
 

--- a/vktrace/src/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
@@ -240,7 +240,7 @@ void PageGuardMappedMemory::resetMemoryObjectAllChangedFlagAndPageGuard()
             #endif
         }
     }
-    #if defined(PLATFORM_LINUX)
+    #if defined(PLATFORM_LINUX) && !defined(ANDROID)
     PageGuardCapture pageGuardCapture = getPageGuardControlInstance();
     pageGuardCapture.pageRefsDirtyClear();
     #endif

--- a/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
@@ -276,7 +276,9 @@ void getMappedDirtyPagesLinux(void)
     }
 
     // Clear all dirty bits for this process
+#if !defined(ANDROID)
     getPageGuardControlInstance().pageRefsDirtyClear();
+#endif
 
     // Re-enable write permission for all mapped memory
     for (std::unordered_map< VkDeviceMemory, PageGuardMappedMemory >::iterator it = getPageGuardControlInstance().getMapMemory().begin();


### PR DESCRIPTION
Turned off some code that doesn't work on Android yet.
Also removed an unused variable.

Verified with:

    ./build_vktracereplay.sh
    ./vktracereplay.sh --serial <...> --abi armeabi-v7a --apk ../demos/android/cube-with-layers/bin/NativeActivity-debug.apk --package com.example.CubeWithLayers --activity android.app.NativeActivity --frame 100
