### PR TITLE
vktrace screenshots: add an ability to generate screenshots with specified frame range and interval

### DIFF
--- a/vktrace/src/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/src/vktrace_replay/vkreplay_main.cpp
@@ -47,7 +47,7 @@ vktrace_SettingInfo g_settings_info[] =
     { "l", "NumLoops", VKTRACE_SETTING_UINT, { &replaySettings.numLoops }, { &replaySettings.numLoops }, TRUE, "The number of times to replay the trace file or loop range." },
     { "lsf", "LoopStartFrame", VKTRACE_SETTING_INT, { &replaySettings.loopStartFrame }, { &replaySettings.loopStartFrame }, TRUE, "The start frame number of the loop range." },
     { "lef", "LoopEndFrame", VKTRACE_SETTING_INT, { &replaySettings.loopEndFrame }, { &replaySettings.loopEndFrame }, TRUE, "The end frame number of the loop range." },
-    { "s", "Screenshot", VKTRACE_SETTING_STRING, { &replaySettings.screenshotList }, { &replaySettings.screenshotList }, TRUE, "Comma separated list of frames to take a snapshot of."},
+    { "s", "Screenshot", VKTRACE_SETTING_STRING, { &replaySettings.screenshotList }, { &replaySettings.screenshotList }, TRUE, "Generate screenshots with specified frames, the frames are comma separated list of frames or a range like <start_frame>-<frame_count>-<interval>."},
 #if _DEBUG
     { "v", "Verbosity", VKTRACE_SETTING_STRING, { &replaySettings.verbosity }, { &replaySettings.verbosity }, TRUE, "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", \"full\", \"debug\"."},
 #else
@@ -252,8 +252,12 @@ int vkreplay_main(int argc, char **argv, vktrace_window_handle window = 0)
     {
         // Set env var that communicates list to ScreenShot layer
         vktrace_set_global_var("_VK_SCREENSHOT", replaySettings.screenshotList);
-
     }
+    else
+    {
+        vktrace_set_global_var("_VK_SCREENSHOT", "");
+    }
+
 
     // open trace file and read in header
     const char* pTraceFile = replaySettings.pTraceFilePath;

--- a/vktrace/src/vktrace_trace/vktrace.cpp
+++ b/vktrace/src/vktrace_trace/vktrace.cpp
@@ -44,7 +44,7 @@ vktrace_SettingInfo g_settings_info[] =
     { "a", "Arguments", VKTRACE_SETTING_STRING, { &g_settings.arguments }, { &g_default_settings.arguments }, TRUE, "Command line arguments to pass to trace program."},
     { "w", "WorkingDir", VKTRACE_SETTING_STRING, { &g_settings.working_dir }, { &g_default_settings.working_dir }, TRUE, "The program's working directory."},
     { "o", "OutputTrace", VKTRACE_SETTING_STRING, { &g_settings.output_trace }, { &g_default_settings.output_trace }, TRUE, "Path to the generated output trace file."},
-    { "s", "ScreenShot", VKTRACE_SETTING_STRING, { &g_settings.screenshotList }, { &g_default_settings.screenshotList }, TRUE, "Comma separated list of frames to take a snapshot of."},
+    { "s", "ScreenShot", VKTRACE_SETTING_STRING, { &g_settings.screenshotList }, { &g_default_settings.screenshotList }, TRUE, "Generate screenshots with specified frames, the frames are comma separated list of frames or a range like <start_frame>-<frame_count>-<interval>."},
     { "ptm", "PrintTraceMessages", VKTRACE_SETTING_BOOL, { &g_settings.print_trace_messages }, { &g_default_settings.print_trace_messages }, TRUE, "Print trace messages to vktrace console."},
     { "P", "PMB", VKTRACE_SETTING_BOOL, { &g_settings.enable_pmb }, { &g_default_settings.enable_pmb }, TRUE, "Optimize tracing of persistently mapped buffers, default is FALSE."},
 #if _DEBUG


### PR DESCRIPTION
     This feature provides an ability for vktrace/vkreplay to generate screenshots with specified frame range and interval, and also keep compatible with existing -s option. With this feature, the -s command line option for screenshots can generate screenshots with a list(existing option) or a specified frame range and interval.

 Command line option

--ScreenShot  <start_frame> - <count> - <interval>
--ScreenShot  <frame-1>, <frame-2>, ... <frame-n> 
             or
-s  <start_frame> - <count> - <interval>
-s  <frame-1>, <frame-2>, ... <frame-n>

XCAP-379

Change-Id: Ieeb86b33140b771ada8e9b52866839fbaadde74a