### PR TITLE
vktrace: CMake dependencies corrected for LINUX

### DIFF
--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
@@ -64,7 +64,11 @@ add_definitions(-DAPI_LOWERCASE="${API_LOWERCASE}")
 
 add_library(${PROJECT_NAME} STATIC ${SRC_LIST} ${HDR_LIST})
 
-add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}-${MAJOR}")
+if(WIN32)
+    add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}-${MAJOR}")
+else()
+    add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}")
+endif()
 
 target_link_libraries(${PROJECT_NAME}
     ${OS_REPLAYER_LIBS}

--- a/vktrace/src/vktrace_replay/CMakeLists.txt
+++ b/vktrace/src/vktrace_replay/CMakeLists.txt
@@ -24,7 +24,11 @@ set (LIBRARIES vktrace_common vulkan_replay)
 
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 
-add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}-${MAJOR}")
+if(WIN32)
+    add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}-${MAJOR}")
+else()
+    add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}")
+endif()
 
 target_link_libraries(${PROJECT_NAME}
     ${LIBRARIES}


### PR DESCRIPTION
Existing Cmake dependencies was for WIN32. Linux
version added.

Change-Id: I08b16d0bc8029ea2e54c54e2c691903c8f27d4e1