### PR TITLE
vktrace: fix vkQueueSubmit problem

### DIFF
--- a/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
@@ -1352,7 +1352,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(
         vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pSubmits[i].pWaitSemaphores));
         vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSubmits[i].pSignalSemaphores), pPacket->pSubmits[i].signalSemaphoreCount * sizeof(VkSemaphore), pSubmits[i].pSignalSemaphores);
         vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pSubmits[i].pSignalSemaphores));
-        vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSubmits[i].pWaitDstStageMask), sizeof(VkPipelineStageFlags), pSubmits[i].pWaitDstStageMask);
+        vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSubmits[i].pWaitDstStageMask), pPacket->pSubmits[i].waitSemaphoreCount * sizeof(VkPipelineStageFlags), pSubmits[i].pWaitDstStageMask);
         vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pSubmits[i].pWaitDstStageMask));
     }
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pSubmits));


### PR DESCRIPTION
The bug make vktrace_add_buffer_to_trace_packet get wrong buffer size.

XCAP-485

Change-Id: Ic905afe3dcab10c61b4ed832dc71aefde5e034c1