### PR TITLE
docs: Add a missing 32-bit dependency

### DIFF
--- a/BUILDVT.md
+++ b/BUILDVT.md
@@ -25,6 +25,8 @@ These additional packages are needed for building the components in this repo.
 sudo apt-get install git cmake build-essential bison libx11-dev libxcb1-dev libxkbcommon-dev libmirclient-dev libwayland-dev
 # Additional dependencies for this repo:
 sudo apt-get install wget autotools-dev
+# If performing 32-bit builds, you'll also need:
+sudo apt-get install libc6-dev-i386
 ```
 
 ## Clone the Repository


### PR DESCRIPTION
Ran into this while setting up a different machine for VulkanTools builds.  Cmake was failing for vktrace32 with "pthread not found".  This change installs libpthreads.so for i386.