### PR TITLE
VT generated files rework

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -31,15 +31,15 @@ py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml api_dump.c
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml api_dump_text.h
 
 REM vktrace
-py -3 ../../../vktrace/vktrace_generate.py AllPlatforms vktrace-trace-h vk_version_1_0 > vktrace_vk_vk.h
-py -3 ../../../vktrace/vktrace_generate.py AllPlatforms vktrace-trace-c vk_version_1_0 > vktrace_vk_vk.cpp
-py -3 ../../../vktrace/vktrace_generate.py AllPlatforms vktrace-core-trace-packets vk_version_1_0 > vktrace_vk_vk_packets.h
-py -3 ../../../vktrace/vktrace_generate.py AllPlatforms vktrace-packet-id vk_version_1_0 > vktrace_vk_packet_id.h
+py -3 ../../../scripts/vktrace_generate.py AllPlatforms vktrace-trace-h vk_version_1_0 > vktrace_vk_vk.h
+py -3 ../../../scripts/vktrace_generate.py AllPlatforms vktrace-trace-c vk_version_1_0 > vktrace_vk_vk.cpp
+py -3 ../../../scripts/vktrace_generate.py AllPlatforms vktrace-core-trace-packets vk_version_1_0 > vktrace_vk_vk_packets.h
+py -3 ../../../scripts/vktrace_generate.py AllPlatforms vktrace-packet-id vk_version_1_0 > vktrace_vk_packet_id.h
 
 REM vkreplay
-py -3 ../../../vktrace/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs vk_version_1_0 > vkreplay_vk_func_ptrs.h
-py -3 ../../../vktrace/vktrace_generate.py AllPlatforms vktrace-replay-c vk_version_1_0 > vkreplay_vk_replay_gen.cpp
-py -3 ../../../vktrace/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h vk_version_1_0 > vkreplay_vk_objmapper.h
+py -3 ../../../scripts/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs vk_version_1_0 > vkreplay_vk_func_ptrs.h
+py -3 ../../../scripts/vktrace_generate.py AllPlatforms vktrace-replay-c vk_version_1_0 > vkreplay_vk_replay_gen.cpp
+py -3 ../../../scripts/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h vk_version_1_0 > vkreplay_vk_objmapper.h
 
 cd ../..
 

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -35,15 +35,15 @@ mkdir -p generated/include generated/common
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml api_dump_text.h )
 
 # vktrace
-python3 ../vktrace/vktrace_generate.py AllPlatforms vktrace-trace-h vk_version_1_0 > generated/include/vktrace_vk_vk.h
-python3 ../vktrace/vktrace_generate.py AllPlatforms vktrace-trace-c vk_version_1_0 > generated/include/vktrace_vk_vk.cpp
-python3 ../vktrace/vktrace_generate.py AllPlatforms vktrace-core-trace-packets vk_version_1_0 > generated/include/vktrace_vk_vk_packets.h
-python3 ../vktrace/vktrace_generate.py AllPlatforms vktrace-packet-id vk_version_1_0 > generated/include/vktrace_vk_packet_id.h
+python3 ../scripts/vktrace_generate.py AllPlatforms vktrace-trace-h vk_version_1_0 > generated/include/vktrace_vk_vk.h
+python3 ../scripts/vktrace_generate.py AllPlatforms vktrace-trace-c vk_version_1_0 > generated/include/vktrace_vk_vk.cpp
+python3 ../scripts/vktrace_generate.py AllPlatforms vktrace-core-trace-packets vk_version_1_0 > generated/include/vktrace_vk_vk_packets.h
+python3 ../scripts/vktrace_generate.py AllPlatforms vktrace-packet-id vk_version_1_0 > generated/include/vktrace_vk_packet_id.h
 
 # vkreplay
-python3 ../vktrace/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs vk_version_1_0 > generated/include/vkreplay_vk_func_ptrs.h
-python3 ../vktrace/vktrace_generate.py AllPlatforms vktrace-replay-c vk_version_1_0 > generated/include/vkreplay_vk_replay_gen.cpp
-python3 ../vktrace/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h vk_version_1_0 > generated/include/vkreplay_vk_objmapper.h
+python3 ../scripts/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs vk_version_1_0 > generated/include/vkreplay_vk_func_ptrs.h
+python3 ../scripts/vktrace_generate.py AllPlatforms vktrace-replay-c vk_version_1_0 > generated/include/vkreplay_vk_replay_gen.cpp
+python3 ../scripts/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h vk_version_1_0 > generated/include/vkreplay_vk_objmapper.h
 
 cp -f ../layers/vk_layer_config.cpp   generated/common/
 cp -f ../layers/vk_layer_extension_utils.cpp  generated/common/

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -257,7 +257,6 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_vktrace_layer
 LOCAL_SRC_FILES += $(LAYER_DIR)/include/vktrace_vk_vk.cpp
-LOCAL_SRC_FILES += $(LAYER_DIR)/include/vk_struct_size_helper.c
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/src/vktrace_common/vktrace_filelike.c
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/src/vktrace_common/vktrace_interconnect.c
@@ -295,7 +294,6 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := vkreplay
-LOCAL_SRC_FILES += $(LAYER_DIR)/include/vk_struct_size_helper.c
 LOCAL_SRC_FILES += $(LAYER_DIR)/include/vkreplay_vk_replay_gen.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/src/vktrace_common/vktrace_trace_packet_utils.c
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/src/vktrace_common/vktrace_filelike.c

--- a/scripts/vktrace_generate.py
+++ b/scripts/vktrace_generate.py
@@ -24,11 +24,6 @@
 
 import os, sys
 
-
-# add main repo directory so vulkan.py can be imported. This needs to be a complete path.
-vktrace_scripts_path = os.path.dirname(os.path.abspath(__file__))
-main_path = os.path.abspath(vktrace_scripts_path + "/../scripts/")
-sys.path.append(main_path)
 from source_line_info import sourcelineinfo
 
 import vulkan

--- a/vktrace/.gitignore
+++ b/vktrace/.gitignore
@@ -22,4 +22,3 @@ libs/Win32/Debug/*
 *.filters
 build
 dbuild
-src/vktrace_layer/codegen/*

--- a/vktrace/CMakeLists.txt
+++ b/vktrace/CMakeLists.txt
@@ -86,6 +86,8 @@ message("")
 #
 set(VKTRACE_VULKAN_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+set(GENERATED_FILES_DIR ${CMAKE_BINARY_DIR}/vktrace)
+
 add_subdirectory(src/vktrace_common)
 add_subdirectory(src/vktrace_trace)
 

--- a/vktrace/CMakeLists.txt
+++ b/vktrace/CMakeLists.txt
@@ -51,7 +51,6 @@ if (WIN32)
     set(WIN32_PTHREADS_INCLUDE_PATH "${WIN32_PTHREADS_PATH}/include")
 endif()
 
-set(PYTHON_EXECUTABLE ${PYTHON_CMD})
 find_package(PythonInterp)
 
 if (NOT PYTHONINTERP_FOUND)

--- a/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
@@ -50,22 +50,15 @@ message(STATUS "VKTRACE_VULKAN_LIB = " ${VKTRACE_VULKAN_LIB})
 #message(STATUS "VKTRACE_VULKAN_DRIVER_DIR = " ${VKTRACE_VULKAN_DRIVER_DIR})
 #message(STATUS "VKTRACE_VULKAN_HEADER = " ${VKTRACE_VULKAN_HEADER})
 
-# Run a codegen script to generate utilities that are vulkan-specific, dependent on the vulkan header files, and may be shared by the tracer, replayer, or debugger.
-# Generally, these are likely to be things that SHOULD be provided by the vulkan SDK.
-set(VKTRACE_VULKAN_CODEGEN_UTILS "vulkan/codegen_utils")
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${VKTRACE_VULKAN_CODEGEN_UTILS})
-
 # generate files for vulkan.h
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${CMAKE_CURRENT_SOURCE_DIR}/${VKTRACE_VULKAN_CODEGEN_UTILS} vk_struct_size_helper.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${CMAKE_CURRENT_SOURCE_DIR}/${VKTRACE_VULKAN_CODEGEN_UTILS} vk_struct_size_helper.c)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${CMAKE_CURRENT_SOURCE_DIR}/${VKTRACE_VULKAN_CODEGEN_UTILS} vk_enum_string_helper.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_struct_size_helper.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_struct_size_helper.c)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_enum_string_helper.h)
 
 # Run a codegen script to generate vktrace-specific vulkan utils
-set(CODEGEN_VKTRACE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/codegen_vktrace_utils")
-file(MAKE_DIRECTORY ${CODEGEN_VKTRACE_DIR})
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-packet-id VK_VERSION_1_0 OUTPUT_FILE ${CODEGEN_VKTRACE_DIR}/vktrace_vk_packet_id.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-core-trace-packets VK_VERSION_1_0 OUTPUT_FILE ${CODEGEN_VKTRACE_DIR}/vktrace_vk_vk_packets.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-ext-trace-packets vk_lunarg_debug_marker OUTPUT_FILE ${CODEGEN_VKTRACE_DIR}/vktrace_vk_vk_lunarg_debug_marker_packets.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-packet-id VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-core-trace-packets VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-ext-trace-packets vk_lunarg_debug_marker OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk_lunarg_debug_marker_packets.h)
 
 # Directories which actually contain vulkan-specific vktrace plugins.
 add_subdirectory(vkreplay/)

--- a/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
@@ -3,28 +3,11 @@ cmake_minimum_required(VERSION 2.8)
 
 #include(FindPkgConfig)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(PYTHON_CMD "python3")
-else()
-    set(PYTHON_CMD "py")
-endif()
-
-
 # if Vktrace is being built as part of a vulkan driver build, then use that target instead of the locally-commited binary.
-#if (TARGET vulkan)
-#    message(STATUS "Using external Vulkan header and library.")
-#    set(VKTRACE_VULKAN_LIB vulkan)
     set(VKTRACE_VULKAN_DRIVER_DIR ${CMAKE_SOURCE_DIR})
     set(VKTRACE_VULKAN_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include/vulkan)
     set(VKTRACE_VULKAN_HEADER ${CMAKE_SOURCE_DIR}/include/vulkan/vulkan.h)
     #set(VKTRACE_VULKAN_LUNARG_DEBUG_MARKER_HEADER ${VKTRACE_VULKAN_INCLUDE_DIR}/vk_lunarg_debug_marker.h)
-#else()
-    # Use a locally committed vulkan header and binary
-#    message(STATUS "Using Vktrace-supplied Vulkan header and library.")
-#    set(VKTRACE_VULKAN_DRIVER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vulkan)
-#    set(VKTRACE_VULKAN_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vulkan/include)
-#    set(VKTRACE_VULKAN_HEADER ${VKTRACE_VULKAN_INCLUDE_DIR}/vulkan/vulkan.h)
-#    set(VKTRACE_VULKAN_DEBUG_REPORT_LUNARG_HEADER ${VKTRACE_VULKAN_INCLUDE_DIR}/vk_debug_report_lunarg.h)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
    if (CMAKE_GENERATOR MATCHES "^Visual Studio.*")
@@ -47,8 +30,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR
 endif()
 
 message(STATUS "VKTRACE_VULKAN_LIB = " ${VKTRACE_VULKAN_LIB})
-#message(STATUS "VKTRACE_VULKAN_DRIVER_DIR = " ${VKTRACE_VULKAN_DRIVER_DIR})
-#message(STATUS "VKTRACE_VULKAN_HEADER = " ${VKTRACE_VULKAN_HEADER})
 
 # generate files for vulkan.h
 execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_struct_size_helper.h)
@@ -62,6 +43,7 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_gener
 
 # Directories which actually contain vulkan-specific vktrace plugins.
 add_subdirectory(vkreplay/)
+
 # Only build vktraceviewer when Qt5 is available
 if (Qt5_FOUND AND BUILD_VKTRACEVIEWER)
     add_subdirectory(vktraceviewer/)

--- a/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
@@ -31,11 +31,6 @@ endif()
 
 message(STATUS "VKTRACE_VULKAN_LIB = " ${VKTRACE_VULKAN_LIB})
 
-# generate files for vulkan.h
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_struct_size_helper.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_struct_size_helper.c)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_enum_string_helper.h)
-
 # Run a codegen script to generate vktrace-specific vulkan utils
 execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-packet-id VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-core-trace-packets VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h)

--- a/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/CMakeLists.txt
@@ -37,9 +37,9 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -regist
 execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_enum_string_helper.h)
 
 # Run a codegen script to generate vktrace-specific vulkan utils
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-packet-id VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-core-trace-packets VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-ext-trace-packets vk_lunarg_debug_marker OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk_lunarg_debug_marker_packets.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-packet-id VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-core-trace-packets VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-ext-trace-packets vk_lunarg_debug_marker OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk_lunarg_debug_marker_packets.h)
 
 # Directories which actually contain vulkan-specific vktrace plugins.
 add_subdirectory(vkreplay/)

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
@@ -38,7 +38,6 @@ set (HDR_LIST
     vkreplay_vkreplay.h
     ${GENERATED_FILES_DIR}/vkreplay_vk_func_ptrs.h
     ${GENERATED_FILES_DIR}/vkreplay_vk_objmapper.h
-    ${GENERATED_FILES_DIR}/vk_enum_string_helper.h
     ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h
     ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h
 )
@@ -51,6 +50,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${GENERATED_FILES_DIR}
     ${VKTRACE_VULKAN_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}
 )
 # needed for vktraceviewer_vk library which is shared
 if (NOT MSVC)
@@ -62,9 +62,9 @@ add_definitions(-DAPI_LOWERCASE="${API_LOWERCASE}")
 add_library(${PROJECT_NAME} STATIC ${SRC_LIST} ${HDR_LIST})
 
 if(WIN32)
-    add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}-${MAJOR}")
+    add_dependencies(${PROJECT_NAME} generate_helper_files "${API_LOWERCASE}-${MAJOR}")
 else()
-    add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}")
+    add_dependencies(${PROJECT_NAME} generate_helper_files "${API_LOWERCASE}")
 endif()
 
 target_link_libraries(${PROJECT_NAME}

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
@@ -4,9 +4,9 @@ project(vulkan_replay)
 
 include("${SRC_DIR}/build_options.cmake")
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs     VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_func_ptrs.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-c            VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_replay_gen.cpp)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_objmapper.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs     VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_func_ptrs.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-c            VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_replay_gen.cpp)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_objmapper.h)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vkreplay/CMakeLists.txt
@@ -4,10 +4,9 @@ project(vulkan_replay)
 
 include("${SRC_DIR}/build_options.cmake")
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/codegen)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs     VK_VERSION_1_0 OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/codegen/vkreplay_vk_func_ptrs.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-c            VK_VERSION_1_0 OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/codegen/vkreplay_vk_replay_gen.cpp)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h VK_VERSION_1_0 OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/codegen/vkreplay_vk_objmapper.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-vk-funcs     VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_func_ptrs.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-c            VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_replay_gen.cpp)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-replay-obj-mapper-h VK_VERSION_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vkreplay_vk_objmapper.h)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
@@ -29,7 +28,7 @@ set(SRC_LIST
     vkreplay_settings.cpp
     vkreplay_vkreplay.cpp
     vkreplay_vkdisplay.cpp
-    codegen/vkreplay_vk_replay_gen.cpp
+    ${GENERATED_FILES_DIR}/vkreplay_vk_replay_gen.cpp
 )
 
 set (HDR_LIST
@@ -37,12 +36,11 @@ set (HDR_LIST
     vkreplay_settings.h
     vkreplay_vkdisplay.h
     vkreplay_vkreplay.h
-    codegen/vkreplay_vk_func_ptrs.h
-    codegen/vkreplay_vk_objmapper.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../vulkan/codegen_utils/vk_enum_string_helper.h
-    ${CODEGEN_VKTRACE_DIR}/vktrace_vk_packet_id.h
-    ${CODEGEN_VKTRACE_DIR}/vktrace_vk_vk_packets.h
-
+    ${GENERATED_FILES_DIR}/vkreplay_vk_func_ptrs.h
+    ${GENERATED_FILES_DIR}/vkreplay_vk_objmapper.h
+    ${GENERATED_FILES_DIR}/vk_enum_string_helper.h
+    ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h
+    ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h
 )
 
 include_directories(
@@ -51,9 +49,8 @@ include_directories(
     ${SRC_DIR}/vktrace_common
     ${SRC_DIR}/thirdparty
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CODEGEN_VKTRACE_DIR}
+    ${GENERATED_FILES_DIR}
     ${VKTRACE_VULKAN_INCLUDE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/../vulkan/codegen_utils
 )
 # needed for vktraceviewer_vk library which is shared
 if (NOT MSVC)

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vktraceviewer/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vktraceviewer/CMakeLists.txt
@@ -43,20 +43,18 @@ set(HDR_LIST
     ${SRC_DIR}/vktrace_viewer/vktraceviewer_qgroupthreadsproxymodel.h
     ${SRC_DIR}/vktrace_viewer/vktraceviewer_controller.h
     ${SRC_DIR}/vktrace_replay/vkreplay_factory.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../vulkan/codegen_utils/vk_enum_string_helper.h
-    ${CODEGEN_VKTRACE_DIR}/vktrace_vk_packet_id.h
-    ${CODEGEN_VKTRACE_DIR}/vktrace_vk_vk_packets.h
+    ${GENERATED_FILES_DIR}/vk_enum_string_helper.h
+    ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h
+    ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h
 )
 
 include_directories(
-    ${CODEGEN_VKTRACE_DIR}
+    ${GENERATED_FILES_DIR}
     ${SRC_DIR}/vktrace_common
     ${SRC_DIR}/vktrace_viewer
     ${SRC_DIR}/vktrace_replay
     ${SRC_DIR}/thirdparty
     ${CMAKE_CURRENT_SOURCE_DIR}/../vkreplay
-    ${CMAKE_CURRENT_SOURCE_DIR}/../vulkan/codegen_utils
-    ${VKTRACE_VULKAN_DIR}/${CODEGEN_VKTRACE_DIR}
     ${VKTRACE_VULKAN_INCLUDE_DIR}
     ${Qt5Widgets_INCLUDE_DIRS}
 )

--- a/vktrace/src/vktrace_extensions/vktracevulkan/vktraceviewer/CMakeLists.txt
+++ b/vktrace/src/vktrace_extensions/vktracevulkan/vktraceviewer/CMakeLists.txt
@@ -43,7 +43,6 @@ set(HDR_LIST
     ${SRC_DIR}/vktrace_viewer/vktraceviewer_qgroupthreadsproxymodel.h
     ${SRC_DIR}/vktrace_viewer/vktraceviewer_controller.h
     ${SRC_DIR}/vktrace_replay/vkreplay_factory.h
-    ${GENERATED_FILES_DIR}/vk_enum_string_helper.h
     ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h
     ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h
 )
@@ -57,6 +56,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../vkreplay
     ${VKTRACE_VULKAN_INCLUDE_DIR}
     ${Qt5Widgets_INCLUDE_DIRS}
+    ${CMAKE_BINARY_DIR}
 )
 
 QT5_WRAP_CPP(QT_GEN_HEADER_MOC_LIST ${UI_HEADER_LIST})
@@ -67,7 +67,9 @@ add_library(${PROJECT_NAME} STATIC ${SRC_LIST} ${HDR_LIST}
     ${QT_GEN_HEADER_MOC_LIST}
 )
 
-target_link_libraries(${PROJECT_NAME} 
+add_dependencies(${PROJECT_NAME} generate_helper_files)
+
+target_link_libraries(${PROJECT_NAME}
     Qt5::Widgets
     Qt5::Core
     Qt5::Svg

--- a/vktrace/src/vktrace_layer/CMakeLists.txt
+++ b/vktrace/src/vktrace_layer/CMakeLists.txt
@@ -19,7 +19,6 @@ include("${SRC_DIR}/build_options.cmake")
 
 execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-h      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.h)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-c      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.cpp)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_dispatch_table_helper.h)
 
 if (WIN32)
     # Put VkLayer_vktrace_layer.dll in the same directory as vktrace.exe
@@ -49,11 +48,6 @@ set(HDR_LIST
     vktrace_lib_pageguardcapture.h
     vktrace_lib_pageguard.h
     vktrace_vk_exts.h
-    ${GENERATED_FILES_DIR}/vktrace_vk_vk.h
-    ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h
-    ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h
-    ${GENERATED_FILES_DIR}/vk_struct_size_helper.h
-    ${GENERATED_FILES_DIR}/vk_dispatch_table_helper.h
 )
 
 # def file - needed for Windows 32-bit so that vk functions names aren't mangled
@@ -102,6 +96,7 @@ add_library(${PROJECT_NAME} SHARED ${SRC_LIST} ${HDR_LIST})
 
 add_dependencies(${PROJECT_NAME} generate_helper_files)
 
+# Set Compiler Flags, Libraries
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     set(OS_TRACER_LIBS

--- a/vktrace/src/vktrace_layer/CMakeLists.txt
+++ b/vktrace/src/vktrace_layer/CMakeLists.txt
@@ -17,8 +17,8 @@ project(VkLayer_vktrace_layer)
 
 include("${SRC_DIR}/build_options.cmake")
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-h      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-c      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.cpp)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-h      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-c      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.cpp)
 
 if (WIN32)
     # Put VkLayer_vktrace_layer.dll in the same directory as vktrace.exe

--- a/vktrace/src/vktrace_layer/CMakeLists.txt
+++ b/vktrace/src/vktrace_layer/CMakeLists.txt
@@ -17,20 +17,15 @@ project(VkLayer_vktrace_layer)
 
 include("${SRC_DIR}/build_options.cmake")
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/codegen)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-h      vk_version_1_0 OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/codegen/vktrace_vk_vk.h)
-execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-c      vk_version_1_0 OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/codegen/vktrace_vk_vk.cpp)
-#execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-ext-trace-h vk_lunarg_debug_marker OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/codegen/vktrace_vk_vk_lunarg_debug_marker.h)
-#execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-ext-trace-c vk_lunarg_debug_marker OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/codegen/vktrace_vk_vk_lunarg_debug_marker.cpp)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-h      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.h)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${VKTRACE_VULKAN_DIR}/vktrace_generate.py AllPlatforms vktrace-trace-c      vk_version_1_0 OUTPUT_FILE ${GENERATED_FILES_DIR}/vktrace_vk_vk.cpp)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml -o ${GENERATED_FILES_DIR} vk_dispatch_table_helper.h)
 
 if (WIN32)
     # Put VkLayer_vktrace_layer.dll in the same directory as vktrace.exe
     # so that vktrace.exe can find VkLayer_vktrace_layer.dll.
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../../../layersvt/)
 endif()
-
-set (CODEGEN_UTILS_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/../vktrace_extensions/vktracevulkan/vulkan/codegen_utils)
-set(CODEGEN_VKTRACE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../vktrace_extensions/vktracevulkan/codegen_vktrace_utils")
 
 set(SRC_LIST
     ${SRC_LIST}
@@ -41,25 +36,24 @@ set(SRC_LIST
     vktrace_lib_pageguard.cpp
     vktrace_lib_trace.cpp
     vktrace_vk_exts.cpp
-    codegen/vktrace_vk_vk.cpp
-    ${CODEGEN_UTILS_DIR}/vk_struct_size_helper.c
+    ${GENERATED_FILES_DIR}/vktrace_vk_vk.cpp
+    ${GENERATED_FILES_DIR}/vk_struct_size_helper.c
 )
-#    codegen/vktrace_vk_vk_lunarg_debug_marker.cpp
-#    ${CODEGEN_UTILS_DIR}/vk_lunarg_debug_marker_struct_size_helper.c
 
 set_source_files_properties( ${SRC_LIST} PROPERTIES LANGUAGE CXX)
 
-set (HDR_LIST
+set(HDR_LIST
     vktrace_lib_helpers.h
     vktrace_lib_pagestatusarray.h
     vktrace_lib_pageguardmappedmemory.h
     vktrace_lib_pageguardcapture.h
     vktrace_lib_pageguard.h
     vktrace_vk_exts.h
-    codegen/vktrace_vk_vk.h
-    ${CODEGEN_VKTRACE_DIR}/vktrace_vk_packet_id.h
-    ${CODEGEN_VKTRACE_DIR}/vktrace_vk_vk_packets.h
-    ${CODEGEN_UTILS_DIR}/vk_struct_size_helper.h
+    ${GENERATED_FILES_DIR}/vktrace_vk_vk.h
+    ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h
+    ${GENERATED_FILES_DIR}/vktrace_vk_vk_packets.h
+    ${GENERATED_FILES_DIR}/vk_struct_size_helper.h
+    ${GENERATED_FILES_DIR}/vk_dispatch_table_helper.h
 )
 
 # def file - needed for Windows 32-bit so that vk functions names aren't mangled
@@ -69,22 +63,15 @@ if (WIN32)
     endif()
 endif()
 
-
-#    codegen/vktrace_vk_vk_lunarg_debug_marker.h
-#    ${CODEGEN_VKTRACE_DIR}/vktrace_vk_vk_lunarg_debug_marker_packets.h
-#    ${CODEGEN_UTILS_DIR}/vk_lunarg_debug_marker_struct_size_helper.h
-
 include_directories(
-    codegen
     ${SRC_DIR}/vktrace_common
     ${SRC_DIR}/vktrace_trace
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CODEGEN_VKTRACE_DIR}
     ${VKTRACE_VULKAN_INCLUDE_DIR}
-    ${CODEGEN_UTILS_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/../../../layersvt
     ${CMAKE_BINARY_DIR}
+    ${GENERATED_FILES_DIR}
 )
+
 # copy/link layer json file into build/layersvt directory
 if (NOT WIN32)
     # extra setup for out-of-tree builds

--- a/vktrace/src/vktrace_layer/CMakeLists.txt
+++ b/vktrace/src/vktrace_layer/CMakeLists.txt
@@ -36,7 +36,6 @@ set(SRC_LIST
     vktrace_lib_trace.cpp
     vktrace_vk_exts.cpp
     ${GENERATED_FILES_DIR}/vktrace_vk_vk.cpp
-    ${GENERATED_FILES_DIR}/vk_struct_size_helper.c
 )
 
 set_source_files_properties( ${SRC_LIST} PROPERTIES LANGUAGE CXX)

--- a/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/src/vktrace_layer/vktrace_lib_trace.cpp
@@ -45,6 +45,9 @@
 #include "vktrace_lib_pageguardcapture.h"
 #include "vktrace_lib_pageguard.h"
 
+// Intentionally include the struct_size source file
+#include "vk_struct_size_helper.c"
+
 // declared as extern in vktrace_lib_helpers.h
 VKTRACE_CRITICAL_SECTION g_memInfoLock;
 VKMemInfo g_memInfo = {0, NULL, NULL, 0};

--- a/vktrace/src/vktrace_viewer/CMakeLists.txt
+++ b/vktrace/src/vktrace_viewer/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(
     ${SRC_DIR}/vktrace_extensions/vktracevulkan/vktraceviewer
     ${SRC_DIR}/vktrace_viewer
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_BINARY_DIR}
     ${Qt5Widgets_INCLUDE_DIRS}
 )
 
@@ -116,7 +117,7 @@ if (TARGET SDL)
     add_dependencies(${PROJECT_NAME} SDL)
 endif ()
 
-add_dependencies(${PROJECT_NAME} vktraceviewer_vk)
+add_dependencies(${PROJECT_NAME} generate_helper_files vktraceviewer_vk)
 
 target_link_libraries(${PROJECT_NAME}
     Qt5::Widgets


### PR DESCRIPTION
Common code-gen'd files now end up in single location, including those in vktrace.  VKtrace code-gen'd files now end up in build directory.  Common generated files are now built from dependencies instead of when cmake is run (vktrace files are still built at cmake time -- this is next).  