### PR TITLE
VulkanTools: screenshot commandline options

### DIFF
--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 # VulkanTools layers
 add_vk_layer(monitor monitor.cpp ../layers/vk_layer_table.cpp)
-add_vk_layer(screenshot screenshot.cpp ../layers/vk_layer_table.cpp)
+add_vk_layer(screenshot screenshot.cpp screenshot_parsing.h screenshot_parsing.cpp ../layers/vk_layer_table.cpp)
 # generated
 add_vk_layer(api_dump api_dump.cpp ../layers/vk_layer_table.cpp)
 

--- a/layersvt/screenshot_parsing.cpp
+++ b/layersvt/screenshot_parsing.cpp
@@ -1,0 +1,145 @@
+/*
+* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2015-2016 LunarG, Inc.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "screenshot_parsing.h"
+
+using namespace std;
+
+namespace screenshot {
+
+// initialize pFrameRange, parse rangeString and set value to members of *pFrameRange.
+// the string of rangeString can be and must be one of the following values:
+// 1. all
+// 2. <startFrame>-<frameCount>-<interval>
+//    if frameCount is 0, it means the range is unlimited range or all frames from startFrame.
+// return:
+// return 0 if parsing rangeString successfully, other value is a status value indicating a specified error was encountered,
+// currently support the following values:
+//        1, parsing error or input parameters less than two.
+//        2, start frame number < 0.
+//        3, frameCount < 0.
+//        4, interval <= 0
+//        .......
+int initScreenShotFrameRange(const char *rangeString, FrameRange *pFrameRange) {
+    int parsingStatus = 0;
+
+    if (rangeString && *rangeString) {
+        string parameter(rangeString);
+        pFrameRange->valid = false;
+        if (!parameter.empty()) {
+            if (parameter.compare("all") == 0) {
+                pFrameRange->valid = true;
+                pFrameRange->startFrame = 0;
+                pFrameRange->count = SCREEN_SHOT_FRAMES_UNLIMITED;
+                pFrameRange->interval = SCREEN_SHOT_FRAMES_INTERVAL_DEFAULT;
+            } else {
+                int frameCount = 0;
+                int itemCount =
+                    sscanf(parameter.c_str(), "%d-%d-%d", &pFrameRange->startFrame, &frameCount, &pFrameRange->interval);
+                if (itemCount >= 2) {
+                    if (itemCount == 2) {
+                        pFrameRange->interval = SCREEN_SHOT_FRAMES_INTERVAL_DEFAULT;
+                    }
+
+                    if ((pFrameRange->startFrame < 0) || (frameCount < 0) || (pFrameRange->interval <= 0)) {
+                        if (pFrameRange->startFrame < 0) {
+                            parsingStatus = 2;
+                        } else if (frameCount < 0) {
+                            parsingStatus = 3;
+                        } else {
+                            parsingStatus = 4;
+                        }
+                    } else {
+                        pFrameRange->valid = true;
+                    }
+
+                    if (parsingStatus == 0) {
+                        if (frameCount == 0) {
+                            pFrameRange->count = SCREEN_SHOT_FRAMES_UNLIMITED;
+                        } else {
+                            pFrameRange->count = frameCount / pFrameRange->interval;
+                            if ((frameCount % pFrameRange->interval) != 0) {
+                                pFrameRange->count++;
+                            }
+                        }
+                    }
+                } else {
+                    parsingStatus = 1;
+                }
+            }
+        }
+    }
+    return parsingStatus;
+}
+
+// detect if the input command option _vk_screenshot is definition of frame range or a frame list.
+bool isOptionBelongToScreenShotRange(const char *_vk_screenshot) {
+    bool belongToScreenShotRange = false;
+    if ((strstr(_vk_screenshot, "-") != nullptr) || (strcmp(_vk_screenshot, "all") == 0)) {
+        belongToScreenShotRange = true;
+    }
+    return belongToScreenShotRange;
+}
+
+// get error message by parsing status
+const char *getFrameRangeErrorMessage(int parsingStatus) {
+    static const char *message[] = {"no error",
+                                    "parsing error or the number of input parameters less than two",
+                                    "start frame number cannot be negative",
+                                    "frame count cannot be negative",
+                                    "interval cannot be negative or 0",
+                                    "unknown errors"};
+    const char *parsingMessage = nullptr;
+
+    switch (parsingStatus) {
+    case 0:
+        parsingMessage = message[0];
+        break;
+    case 1:
+        parsingMessage = message[1];
+        break;
+    case 2:
+        parsingMessage = message[2];
+        break;
+    case 3:
+        parsingMessage = message[3];
+        break;
+    case 4:
+        parsingMessage = message[4];
+        break;
+    default:
+        parsingMessage = message[5];
+        break;
+    }
+    return parsingMessage;
+}
+
+// check screenshot frame range command line option
+bool checkParsingFrameRange(const char *_vk_screenshot, char **ppErrorMessage) {
+    bool checkPassed = true;
+    if (isOptionBelongToScreenShotRange(_vk_screenshot)) {
+        screenshot::FrameRange frameRange;
+        int parsingStatus = initScreenShotFrameRange(_vk_screenshot, &frameRange);
+        if (parsingStatus != 0) {
+            checkPassed = false;
+            if (ppErrorMessage != nullptr) {
+                *ppErrorMessage = const_cast<char *>(getFrameRangeErrorMessage(parsingStatus));
+            }
+        }
+    }
+    return checkPassed;
+}
+}

--- a/layersvt/screenshot_parsing.h
+++ b/layersvt/screenshot_parsing.h
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2015-2016 LunarG, Inc.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <string.h>
+#include <assert.h>
+#include <iostream>
+
+namespace screenshot {
+
+static const int SCREEN_SHOT_FRAMES_INTERVAL_DEFAULT = 1;
+static const int SCREEN_SHOT_FRAMES_UNLIMITED = -1;
+
+typedef struct {
+    bool valid;
+    int startFrame; // the range begin from (include) this frame.
+    int count;      // if the value is SCREEN_SHOT_FRAMES_UNLIMITED, it means unlimited screenshots until capture/playback to end.
+    int interval;
+} FrameRange;
+
+// initialize pFrameRange, parse rangeString and set value to members of *pFrameRange.
+// the string of rangeString can be and must be one of the following values:
+// 1. all
+// 2. <startFrame>-<frameCount>-<interval>
+// 3. <startFrame>-<frameCount>
+//    if frameCount is 0, it means the range is unlimited range or all frames from startFrame.
+// return:
+// return 0 if parsing rangeString successfully, other value is a status value indicating a specified error was encountered,
+// currently support the following values:
+//        1, parsing error or input parameters less than two.
+//        2, start frame number < 0.
+//        3, frameCount < 0.
+//        4, interval <= 0
+//        .......
+int initScreenShotFrameRange(const char *rangeString, FrameRange *pFrameRange);
+
+// detect if the input command line option _vk_screenshot is definition of frame range or a frame list.
+bool isOptionBelongToScreenShotRange(const char *_vk_screenshot);
+
+// get error message by parsing status
+// return:
+//       error message.
+const char *getFrameRangeErrorMessage(int parsingStatus);
+
+// check screenshot frame range command line option
+// return:
+//      indicate check success or not. if fail, return false,  *ppErrorMessage return error message if it's not nullptr.
+bool checkParsingFrameRange(const char *_vk_screenshot, char **ppErrorMessage);
+}

--- a/vktrace/src/vktrace_replay/CMakeLists.txt
+++ b/vktrace/src/vktrace_replay/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SRC_LIST
     vkreplay_main.cpp
     vkreplay_seq.cpp
     vkreplay_factory.cpp
+    ../../../layersvt/screenshot_parsing.h
+    ../../../layersvt/screenshot_parsing.cpp
 )
 
 include_directories(
@@ -18,6 +20,7 @@ include_directories(
     ${SRC_DIR}/vktrace_common
     ${SRC_DIR}/thirdparty
     ${CMAKE_CURRENT_SOURCE_DIR}/../vktrace_extensions/vktracevulkan/vkreplay/
+    ${VULKAN_TOOLS_SOURCE_DIR}/layersvt
 )
 
 set (LIBRARIES vktrace_common vulkan_replay)
@@ -28,6 +31,7 @@ if(WIN32)
     add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}-${MAJOR}")
 else()
     add_dependencies(${PROJECT_NAME} "${API_LOWERCASE}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 target_link_libraries(${PROJECT_NAME}

--- a/vktrace/src/vktrace_trace/CMakeLists.txt
+++ b/vktrace/src/vktrace_trace/CMakeLists.txt
@@ -10,13 +10,20 @@ set(SRC_LIST
     vktrace.cpp
     vktrace_process.h
     vktrace_process.cpp
+    ../../../layersvt/screenshot_parsing.h
+    ../../../layersvt/screenshot_parsing.cpp
 )
 
 include_directories(
     ${SRC_DIR}
     ${SRC_DIR}/vktrace_common
     ${SRC_DIR}/vktrace_trace
+    ${VULKAN_TOOLS_SOURCE_DIR}/layersvt
 )
+
+if (NOT WIN32)
+	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
 
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 

--- a/vktrace/src/vktrace_trace/vktrace.cpp
+++ b/vktrace/src/vktrace_trace/vktrace.cpp
@@ -33,27 +33,86 @@ extern "C" {
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "screenshot_parsing.h"
 
 vktrace_settings g_settings;
 vktrace_settings g_default_settings;
 
-vktrace_SettingInfo g_settings_info[] =
-{
+vktrace_SettingInfo g_settings_info[] = {
     // common command options
-    { "p", "Program", VKTRACE_SETTING_STRING, { &g_settings.program }, { &g_default_settings.program }, TRUE, "The program to trace."},
-    { "a", "Arguments", VKTRACE_SETTING_STRING, { &g_settings.arguments }, { &g_default_settings.arguments }, TRUE, "Command line arguments to pass to trace program."},
-    { "w", "WorkingDir", VKTRACE_SETTING_STRING, { &g_settings.working_dir }, { &g_default_settings.working_dir }, TRUE, "The program's working directory."},
-    { "o", "OutputTrace", VKTRACE_SETTING_STRING, { &g_settings.output_trace }, { &g_default_settings.output_trace }, TRUE, "Path to the generated output trace file."},
-    { "s", "ScreenShot", VKTRACE_SETTING_STRING, { &g_settings.screenshotList }, { &g_default_settings.screenshotList }, TRUE, "Comma separated list of frames to take a snapshot of."},
-    { "ptm", "PrintTraceMessages", VKTRACE_SETTING_BOOL, { &g_settings.print_trace_messages }, { &g_default_settings.print_trace_messages }, TRUE, "Print trace messages to vktrace console."},
-    { "P", "PMB", VKTRACE_SETTING_BOOL, { &g_settings.enable_pmb }, { &g_default_settings.enable_pmb }, TRUE, "Optimize tracing of persistently mapped buffers, default is TRUE."},
+    {"p",
+     "Program",
+     VKTRACE_SETTING_STRING,
+     {&g_settings.program},
+     {&g_default_settings.program},
+     TRUE,
+     "The program to trace."},
+    {"a",
+     "Arguments",
+     VKTRACE_SETTING_STRING,
+     {&g_settings.arguments},
+     {&g_default_settings.arguments},
+     TRUE,
+     "Command line arguments to pass to trace program."},
+    {"w",
+     "WorkingDir",
+     VKTRACE_SETTING_STRING,
+     {&g_settings.working_dir},
+     {&g_default_settings.working_dir},
+     TRUE,
+     "The program's working directory."},
+    {"o",
+     "OutputTrace",
+     VKTRACE_SETTING_STRING,
+     {&g_settings.output_trace},
+     {&g_default_settings.output_trace},
+     TRUE,
+     "Path to the generated output trace file."},
+    {"s",
+     "ScreenShot",
+     VKTRACE_SETTING_STRING,
+     {&g_settings.screenshotList},
+     {&g_default_settings.screenshotList},
+     TRUE,
+     "Get screenshots with comma separated list of frames, "
+     "<start>-<count>-<interval> or <all>."},
+    {"ptm",
+     "PrintTraceMessages",
+     VKTRACE_SETTING_BOOL,
+     {&g_settings.print_trace_messages},
+     {&g_default_settings.print_trace_messages},
+     TRUE,
+     "Print trace messages to vktrace console."},
+    {"P",
+     "PMB",
+     VKTRACE_SETTING_BOOL,
+     {&g_settings.enable_pmb},
+     {&g_default_settings.enable_pmb},
+     TRUE,
+     "Optimize tracing of persistently mapped buffers, default is TRUE."},
 #if _DEBUG
-    { "v", "Verbosity", VKTRACE_SETTING_STRING, { &g_settings.verbosity }, { &g_default_settings.verbosity }, TRUE, "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", \"full\", \"debug\"."},
+    {"v",
+     "Verbosity",
+     VKTRACE_SETTING_STRING,
+     {&g_settings.verbosity},
+     {&g_default_settings.verbosity},
+     TRUE,
+     "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", \"full\", "
+     "\"debug\"."},
 #else
-    { "v", "Verbosity", VKTRACE_SETTING_STRING, { &g_settings.verbosity }, { &g_default_settings.verbosity }, TRUE, "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", \"full\"."},
+    {"v",
+     "Verbosity",
+     VKTRACE_SETTING_STRING,
+     {&g_settings.verbosity},
+     {&g_default_settings.verbosity},
+     TRUE,
+     "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", "
+     "\"full\"."},
 #endif
 
-    //{ "z", "pauze", VKTRACE_SETTING_BOOL, &g_settings.pause, &g_default_settings.pause, TRUE, "Wait for a key at startup (so a debugger can be attached)" },
+    //{ "z", "pauze", VKTRACE_SETTING_BOOL, &g_settings.pause,
+    //&g_default_settings.pause, TRUE, "Wait for a key at startup (so a debugger
+    // can be attached)" },
 };
 
 vktrace_SettingGroup g_settingGroup =
@@ -284,8 +343,17 @@ int main(int argc, char* argv[])
 
     if (g_settings.screenshotList)
     {
-        // Export list to screenshot layer
-        vktrace_set_global_var("_VK_SCREENSHOT", g_settings.screenshotList);
+        char *frameRangeErrorMessage;
+        if (!screenshot::checkParsingFrameRange(g_settings.screenshotList,
+                                                &frameRangeErrorMessage)) {
+            vktrace_LogError(
+                "Screenshots command line option include errors: %s.",
+                frameRangeErrorMessage);
+            vktrace_set_global_var("_VK_SCREENSHOT", "");
+        } else {
+            // Export list to screenshot layer
+            vktrace_set_global_var("_VK_SCREENSHOT", g_settings.screenshotList);
+        }
     }
     else
     {


### PR DESCRIPTION
Command line option:

The user could specify the frames with a range.

--ScreenShot <start_frame> - -
--ScreenShot <start_frame> -
--ScreenShot all
or
-s <start_frame> - -
-s <start_frame> -
-s all

Change-Id: I9285c0aff17317f962d010cee96dbbe445866352