### PR TITLE
fix error for copy app memory

### DIFF
--- a/vktrace/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
@@ -1322,19 +1322,35 @@ void vkReplay::manually_replay_vkUpdateDescriptorSets(packet_vkUpdateDescriptorS
         m_vkFuncs.real_vkUpdateDescriptorSets(remappedDevice, pPacket->descriptorWriteCount, pRemappedWrites, pPacket->descriptorCopyCount, pRemappedCopies);
     }
 
-    for (uint32_t d = 0; d < pPacket->descriptorWriteCount; d++)
-    {
-        if (pRemappedWrites[d].pImageInfo != NULL) {
-            VKTRACE_DELETE((void*)pRemappedWrites[d].pImageInfo);
-            pRemappedWrites[d].pImageInfo = NULL;
-        }
-        if (pRemappedWrites[d].pBufferInfo != NULL) {
-            VKTRACE_DELETE((void*)pRemappedWrites[d].pBufferInfo);
-            pRemappedWrites[d].pImageInfo = NULL;
-        }
-        if (pRemappedWrites[d].pTexelBufferView != NULL) {
-            VKTRACE_DELETE((void*)pRemappedWrites[d].pTexelBufferView);
-            pRemappedWrites[d].pTexelBufferView = NULL;
+    for (uint32_t d = 0; d < pPacket->descriptorWriteCount; d++) {
+        switch (pPacket->pDescriptorWrites[d].descriptorType) {
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            if (pRemappedWrites[d].pImageInfo != NULL) {
+                VKTRACE_DELETE((void *)pRemappedWrites[d].pImageInfo);
+                pRemappedWrites[d].pImageInfo = NULL;
+            }
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            if (pRemappedWrites[d].pTexelBufferView != NULL) {
+                VKTRACE_DELETE((void *)pRemappedWrites[d].pTexelBufferView);
+                pRemappedWrites[d].pTexelBufferView = NULL;
+            }
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            if (pRemappedWrites[d].pBufferInfo != NULL) {
+                VKTRACE_DELETE((void *)pRemappedWrites[d].pBufferInfo);
+                pRemappedWrites[d].pBufferInfo = NULL;
+            }
+        default:
+            break;
         }
     }
     VKTRACE_DELETE(pRemappedWrites);

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -472,6 +472,26 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(
 {
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeMemory* pPacket = NULL;
+#ifdef USE_PAGEGUARD_SPEEDUP
+    // There are some apps call vkFreeMemory without call vkUnmapMemory on
+    // same memory object. in that situation, capture/playback run into error.
+    // so add process here for that situation.
+    pageguardEnter();
+    if (getPageGuardControlInstance().findMappedMemoryObject(device, memory) !=
+        nullptr) {
+        void *PageGuardMappedData = nullptr;
+#if defined(PLATFORM_LINUX)
+        getMappedDirtyPagesLinux();
+#endif
+        getPageGuardControlInstance().vkUnmapMemoryPageGuardHandle(
+            device, memory, &PageGuardMappedData,
+            &vkFlushMappedMemoryRangesWithoutAPICall);
+        if (PageGuardMappedData != nullptr) {
+            pageguardFreeMemory(PageGuardMappedData);
+        }
+    }
+    pageguardExit();
+#endif
     CREATE_TRACE_PACKET(vkFreeMemory, sizeof(VkAllocationCallbacks));
     mdd(device)->devTable.FreeMemory(device, memory, pAllocator);
     vktrace_set_packet_entrypoint_end_time(pHeader);


### PR DESCRIPTION
Add additional process in vkFreeMemory in case target app doesn't call vkUnmapMemory. 

There are some apps call vkFreeMemory without call vkUnmapMemory on same memory object. In that situation, capture/playback runs into error.