### PR TITLE
vktrace: fix missed pmb changes

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -182,8 +182,9 @@ void* pageguardAllocateMemory(size_t size)
     if (size != 0)
     {
 #if defined(WIN32)
-        pMemory = (PBYTE)VirtualAlloc(nullptr, pageguardGetAdjustedSize(size),
-                                      MEM_WRITE_WATCH|MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
+        pMemory = (PBYTE)VirtualAlloc(
+            nullptr, pageguardGetAdjustedSize(size),
+            MEM_WRITE_WATCH | MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
 #else
         pMemory = mmap(NULL, pageguardGetAdjustedSize(size),
                        PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -183,7 +183,7 @@ void* pageguardAllocateMemory(size_t size)
     {
 #if defined(WIN32)
         pMemory = (PBYTE)VirtualAlloc(nullptr, pageguardGetAdjustedSize(size),
-                                      MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+                                      MEM_WRITE_WATCH|MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
 #else
         pMemory = mmap(NULL, pageguardGetAdjustedSize(size),
                        PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
@@ -215,8 +215,27 @@ void PageGuardMappedMemory::resetMemoryObjectAllChangedFlagAndPageGuard()
         if (isMappedBlockChanged(i, BLOCK_FLAG_ARRAY_CHANGED_SNAPSHOT))
         {
             #if defined(WIN32)
+            SIZE_T pageSize = pageguardGetSystemPageSize();
+            SIZE_T pmask = ~(pageSize-1);
+            PVOID Addresses[1];
+            ULONG Granularity;
+            ULONG_PTR Count = 1;
+            UINT rval;
             DWORD oldProt;
-            VirtualProtect(pMappedData + i*PageGuardSize, (SIZE_T)getMappedBlockSize(i), PAGE_READWRITE | PAGE_GUARD, &oldProt);
+            void *pgAddr = (void *)((uint64_t)(pMappedData + i*PageGuardSize));
+            assert(((SIZE_T)pgAddr & (~pmask)) == 0);
+            VirtualProtect(pgAddr, (SIZE_T)getMappedBlockSize(i), PAGE_READWRITE | PAGE_GUARD, &oldProt);
+            rval = GetWriteWatch(WRITE_WATCH_FLAG_RESET, pgAddr, pageSize, &Addresses[0], &Count, &Granularity);
+            assert(rval == 0);
+            assert(Count == 0 || Count == 1);
+            assert(Granularity == pageSize);
+            assert((Count == 1) ? (Addresses[0] == pgAddr) : 1);
+            if (Count == 1)
+            {
+                // Page was modified after we copied it, so mark the page as changed.
+                VirtualProtect(pgAddr, (SIZE_T)getMappedBlockSize(i), PAGE_READWRITE, &oldProt);
+                setMappedBlockChanged(i, true, BLOCK_FLAG_ARRAY_CHANGED);
+            }
             #endif
             setMappedBlockChanged(i, false, BLOCK_FLAG_ARRAY_CHANGED_SNAPSHOT);
         }
@@ -241,6 +260,14 @@ void PageGuardMappedMemory::resetMemoryObjectAllReadFlagAndPageGuard()
 
 bool PageGuardMappedMemory::setAllPageGuardAndFlag(bool bSetPageGuard, bool bSetBlockChanged)
 {
+
+    // Note that we don't call GetWriteWatch from this method to check write counts on pages.
+    // This is because this method is only called during vkMapMemory and vkUnMapMemory, so
+    // we don't need to be concerned with missing a write on mapped memory, since the memory
+    // is either being created or destroyed.  If this method were to be called from some other
+    // api call besides vkMapMemory or vkUnmapMemory, this method would have to be modified to
+    // check write counts of pages.
+
     bool setSuccessfully = true;
     #if defined(WIN32)
     DWORD dwMemSetting = bSetPageGuard ? (PAGE_READWRITE | PAGE_GUARD) : PAGE_READWRITE;
@@ -407,6 +434,7 @@ DWORD PageGuardMappedMemory::getChangedBlockInfo(VkDeviceSize RangeOffset, VkDev
     DWORD infosize = sizeof(PageGuardChangedBlockInfo)*(dwAmount + 1), SaveSize = 0, CurrentBlockSize = 0;
     PBYTE pChangedData;
     PageGuardChangedBlockInfo *pChangedInfoArray = (PageGuardChangedBlockInfo *)(pData ? (pData + DataOffset) : nullptr);
+    void *srcAddr;
 
     if (pInfoSize)
     {
@@ -425,7 +453,32 @@ DWORD PageGuardMappedMemory::getChangedBlockInfo(VkDeviceSize RangeOffset, VkDev
                 pChangedInfoArray[dwIndex + 1].reserve0 = 0;
                 pChangedInfoArray[dwIndex + 1].reserve1 = 0;
                 pChangedData = pData + DataOffset + infosize + SaveSize;
-                vktrace_pageguard_memcpy(pChangedData, pMappedData + offset, CurrentBlockSize);
+
+                srcAddr = (void *)((uint64_t)(pMappedData + offset));
+#ifdef WIN32
+                // We are about to copy from mapped memory to a temporary buffer.
+                // If another thread were to change this mapped memory after the
+                // copy but before the VirtualProtect we'll be doing later to
+                // re-arm PAGE_GUARD exceptions for this page, we would not see
+                // the change to mapped memory. So we call GetWriteWatch to reset the
+                // write count on this page, and then we'll call it again after the
+                // the VirtualProtect to see if it was written to between the copy
+                // and the VirtualProtect.
+
+                SIZE_T pageSize = pageguardGetSystemPageSize();
+                SIZE_T pmask = ~(pageSize-1);
+                PVOID Addresses[1];
+                ULONG Granularity;
+                ULONG_PTR Count = 1;
+                UINT rval;
+                assert((((SIZE_T)(srcAddr)) & (~pmask)) == 0);
+                rval = GetWriteWatch(WRITE_WATCH_FLAG_RESET, srcAddr, pageSize, Addresses, &Count, &Granularity);
+                assert(rval==0);
+                assert(Count==0 || Count==1);
+                assert(Granularity == pageSize);
+                assert((Count == 1) ? (Addresses[0] == srcAddr) : true);
+#endif
+                vktrace_pageguard_memcpy(pChangedData, srcAddr, CurrentBlockSize);
             }
             SaveSize += CurrentBlockSize;
             dwIndex++;

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
@@ -216,24 +216,28 @@ void PageGuardMappedMemory::resetMemoryObjectAllChangedFlagAndPageGuard()
         {
             #if defined(WIN32)
             SIZE_T pageSize = pageguardGetSystemPageSize();
-            SIZE_T pmask = ~(pageSize-1);
+            SIZE_T pmask = ~(pageSize - 1);
             PVOID Addresses[1];
             ULONG Granularity;
             ULONG_PTR Count = 1;
             UINT rval;
             DWORD oldProt;
-            void *pgAddr = (void *)((uint64_t)(pMappedData + i*PageGuardSize));
+            void *pgAddr =
+                (void *)((uint64_t)(pMappedData + i * PageGuardSize));
             assert(((SIZE_T)pgAddr & (~pmask)) == 0);
-            VirtualProtect(pgAddr, (SIZE_T)getMappedBlockSize(i), PAGE_READWRITE | PAGE_GUARD, &oldProt);
-            rval = GetWriteWatch(WRITE_WATCH_FLAG_RESET, pgAddr, pageSize, &Addresses[0], &Count, &Granularity);
+            VirtualProtect(pgAddr, (SIZE_T)getMappedBlockSize(i),
+                           PAGE_READWRITE | PAGE_GUARD, &oldProt);
+            rval = GetWriteWatch(WRITE_WATCH_FLAG_RESET, pgAddr, pageSize,
+                                 &Addresses[0], &Count, &Granularity);
             assert(rval == 0);
             assert(Count == 0 || Count == 1);
             assert(Granularity == pageSize);
             assert((Count == 1) ? (Addresses[0] == pgAddr) : 1);
-            if (Count == 1)
-            {
-                // Page was modified after we copied it, so mark the page as changed.
-                VirtualProtect(pgAddr, (SIZE_T)getMappedBlockSize(i), PAGE_READWRITE, &oldProt);
+            if (Count == 1) {
+                // Page was modified after we copied it, so mark the page as
+                // changed.
+                VirtualProtect(pgAddr, (SIZE_T)getMappedBlockSize(i),
+                               PAGE_READWRITE, &oldProt);
                 setMappedBlockChanged(i, true, BLOCK_FLAG_ARRAY_CHANGED);
             }
             #endif
@@ -261,11 +265,16 @@ void PageGuardMappedMemory::resetMemoryObjectAllReadFlagAndPageGuard()
 bool PageGuardMappedMemory::setAllPageGuardAndFlag(bool bSetPageGuard, bool bSetBlockChanged)
 {
 
-    // Note that we don't call GetWriteWatch from this method to check write counts on pages.
-    // This is because this method is only called during vkMapMemory and vkUnMapMemory, so
-    // we don't need to be concerned with missing a write on mapped memory, since the memory
-    // is either being created or destroyed.  If this method were to be called from some other
-    // api call besides vkMapMemory or vkUnmapMemory, this method would have to be modified to
+    // Note that we don't call GetWriteWatch from this method to check write
+    // counts on pages.
+    // This is because this method is only called during vkMapMemory and
+    // vkUnMapMemory, so
+    // we don't need to be concerned with missing a write on mapped memory,
+    // since the memory
+    // is either being created or destroyed.  If this method were to be called
+    // from some other
+    // api call besides vkMapMemory or vkUnmapMemory, this method would have to
+    // be modified to
     // check write counts of pages.
 
     bool setSuccessfully = true;
@@ -456,29 +465,35 @@ DWORD PageGuardMappedMemory::getChangedBlockInfo(VkDeviceSize RangeOffset, VkDev
 
                 srcAddr = (void *)((uint64_t)(pMappedData + offset));
 #ifdef WIN32
-                // We are about to copy from mapped memory to a temporary buffer.
+                // We are about to copy from mapped memory to a temporary
+                // buffer.
                 // If another thread were to change this mapped memory after the
                 // copy but before the VirtualProtect we'll be doing later to
                 // re-arm PAGE_GUARD exceptions for this page, we would not see
-                // the change to mapped memory. So we call GetWriteWatch to reset the
-                // write count on this page, and then we'll call it again after the
-                // the VirtualProtect to see if it was written to between the copy
+                // the change to mapped memory. So we call GetWriteWatch to
+                // reset the
+                // write count on this page, and then we'll call it again after
+                // the
+                // the VirtualProtect to see if it was written to between the
+                // copy
                 // and the VirtualProtect.
 
                 SIZE_T pageSize = pageguardGetSystemPageSize();
-                SIZE_T pmask = ~(pageSize-1);
+                SIZE_T pmask = ~(pageSize - 1);
                 PVOID Addresses[1];
                 ULONG Granularity;
                 ULONG_PTR Count = 1;
                 UINT rval;
                 assert((((SIZE_T)(srcAddr)) & (~pmask)) == 0);
-                rval = GetWriteWatch(WRITE_WATCH_FLAG_RESET, srcAddr, pageSize, Addresses, &Count, &Granularity);
-                assert(rval==0);
-                assert(Count==0 || Count==1);
+                rval = GetWriteWatch(WRITE_WATCH_FLAG_RESET, srcAddr, pageSize,
+                                     Addresses, &Count, &Granularity);
+                assert(rval == 0);
+                assert(Count == 0 || Count == 1);
                 assert(Granularity == pageSize);
                 assert((Count == 1) ? (Addresses[0] == srcAddr) : true);
 #endif
-                vktrace_pageguard_memcpy(pChangedData, srcAddr, CurrentBlockSize);
+                vktrace_pageguard_memcpy(pChangedData, srcAddr,
+                                         CurrentBlockSize);
             }
             SaveSize += CurrentBlockSize;
             dwIndex++;


### PR DESCRIPTION
Use GetWriteWatch to detect changes to pmb after pmb page is
copied but before VirtualProtect is called.

Change-Id: I969964b63e1192c777d84d07c831a1dce8e47dbf