### PR TITLE
vktrace: Fix a 4 bytes alignment issue

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.cpp
@@ -240,7 +240,7 @@ VkDeviceSize PageGuardCapture::getALLChangedPackageSizeInMappedMemory(VkDevice d
         }
         allChangedPackageSize += PackageSize;
     }
-    return allChangedPackageSize;
+    return ROUNDUP_TO_4(allChangedPackageSize);
 }
 
 //get ptr and size of OPTChangedDataPackage;

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -645,7 +645,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
         dataSize += ROUNDUP_TO_4(((size_t)(getPageGuardControlInstance().getMappedMemorySize(device, pRange->memory));
     }
 #else
-    dataSize = ROUNDUP_TO_4(getPageGuardControlInstance().getALLChangedPackageSizeInMappedMemory(device, memoryRangeCount, pMemoryRanges, ppPackageData));
+    dataSize = getPageGuardControlInstance().getALLChangedPackageSizeInMappedMemory(device, memoryRangeCount, pMemoryRanges, ppPackageData);
 #endif
     rangesSize = sizeof(VkMappedMemoryRange) * memoryRangeCount;
 


### PR DESCRIPTION
Both __HOOKED_vkFlushMappedMemoryRanges() and
vkFlushMappedMemoryRangesWithoutAPICall call
getALLChangedPackageSizeInMappedMemory(), but
only __HOOKED_vkFlushMappedMemoryRange rounds
the size to 4 bytes alignment.

Move the ROUNDUP_TO_4() into the function to
avoid calling it in two places.