### PR TITLE
vktrace: fix corruption and flickering problem of xcap-507.

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -108,17 +108,17 @@ bool getPageGuardEnableFlag()
     return EnablePageGuard;
 }
 
-bool getEnableReadPMBFlag()
-{
+bool getEnableReadProcessFlag(const char* name) {
     static bool EnableReadPMB;
     static bool FirstTimeRun = true;
-    if (FirstTimeRun)
-    {
-        EnableReadPMB = (vktrace_get_global_var(PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_ENV) != NULL);
+    if (FirstTimeRun) {
+        EnableReadPMB = (vktrace_get_global_var(name) != NULL);
         FirstTimeRun = false;
     }
     return EnableReadPMB;
 }
+bool getEnableReadPMBFlag() { return getEnableReadProcessFlag(PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_ENV); }
+bool getEnableReadPMBPostProcessFlag() { return getEnableReadProcessFlag(PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS_ENV); }
 
 #if defined(WIN32)
 void setPageGuardExceptionHandler()
@@ -321,8 +321,10 @@ LONG WINAPI PageGuardExceptionHandler(PEXCEPTION_POINTERS ExceptionInfo)
                         pBlock, pMappedMem->getRealMappedDataPointer() +
                                     OffsetOfAddr - OffsetOfAddr % BlockSize,
                         pMappedMem->getMappedBlockSize(index));
-                    pMappedMem->setMappedBlockChanged(index, true,
-                                                      BLOCK_FLAG_ARRAY_READ);
+                    pMappedMem->setMappedBlockChanged(index, true, BLOCK_FLAG_ARRAY_READ);
+                    if (getEnableReadPMBPostProcessFlag()) {
+                        pMappedMem->setMappedBlockChanged(index, true, BLOCK_FLAG_ARRAY_CHANGED);
+                    }
 
 #else
                     pMappedMem->setMappedBlockChanged(index, true);

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.h
@@ -72,6 +72,10 @@
 // VKTRACE_PAGEGUARD_ENABLE_READ_PMB env var enables read PMB support. Only
 // supported on Windows. Not yet tested.
 #define PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_ENV "VKTRACE_PAGEGUARD_ENABLE_READ_PMB"
+// PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS_ENV env var enables post process for read PMB support. Only
+// supported on Windows. page guard process miss following write access if read access happen on same page for some titles which
+// need read PMB support, the env var is used to enable post process to fix missed pmb writes.
+#define PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS_ENV "VKTRACE_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS"
 
 // Usefull macro for handling fatal errors during tracing
 #define VKTRACE_FATAL_ERROR(_m) \


### PR DESCRIPTION
page guard process miss following write access if read access happen on same page, this cause show corruption and flickering during capture in some titles. the change fix the problem.

XCAP-507

Change-Id: Icde4628641b98600072a85418a7824ccec55fa62