### PR TITLE
Change vktrace/replay env vars

### DIFF
--- a/vktrace/vktrace_common/vktrace_common.h
+++ b/vktrace/vktrace_common/vktrace_common.h
@@ -60,3 +60,43 @@
 #define ROUNDUP_TO_4(_len) ((((_len) + 3) >> 2) << 2)
 #define ROUNDUP_TO_8(_len) ((((_len) + 7) >> 3) << 3)
 #define ROUNDUP_TO_16(_len) ((((_len) + 15) >> 4) << 4)
+
+// Enviroment variables used by vktrace/replay
+
+// VKTRACE_PMB_ENABLE env var enables tracking of PMB if the value is 1.
+// Other values disable PMB tracking. If this env var is undefined, PMB
+// tracking is enabled. The env var is set by the vktrace program to
+// communicate the --PMB arg value to the trace layer.
+#define VKTRACE_PMB_ENABLE_ENV "VKTRACE_PMB_ENABLE"
+
+// _VKTRACE_PMB_TARGET_RANGE_SIZE env var specifies the minimum size of
+// memory objects tracked by pmb. vktrace only tracks changes to memory
+// objects of whose size > this value. If this env var is not defined,
+// pmb tracks all mapped memory - this is the default option. There is
+// typically no need for a user to specify this env variable, it's
+// primary use is for debugging the trace layer.
+#define _VKTRACE_PMB_TARGET_RANGE_SIZE_ENV "_VKTRACE_PMB_TARGET_RANGE_SIZE"
+
+// VKTRACE_PAGEGUARD_ENABLE_READ_PMB env var enables read PMB support.
+// It is only supported on Windows. If PMB data changes comes from the
+// GPU side, PMB tracking does not usually capture those changes. This
+// env var is used to enable capture of such GPU initiated PMB data
+// changes.
+#define VKTRACE_PAGEGUARD_ENABLE_READ_PMB_ENV "VKTRACE_PAGEGUARD_ENABLE_READ_PMB"
+
+// VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS env var enables post
+// processing in read PMB support. It is only supported on Windows.
+// PMB processing will miss writes following reads if writes occur
+// on the same page as a read. This env var is used to enable post
+// processing to fix missed pmb writes.
+#define VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS_ENV "VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS"
+
+// VKTRACE_TRIM_TRIGGER env var is set by the vktrace program to
+// communicate the --TraceTrigger command line argument to the
+// trace layer.
+#define VKTRACE_TRIM_TRIGGER_ENV "VKTRACE_TRIM_TRIGGER"
+
+// _VKTRACE_VERBOSITY env var is set by the vktrace program to
+// communicate verbosity level to the trace layer. It is set to
+// one of "quiet", "errors", "warnings", "full", or "debug".
+#define _VKTRACE_VERBOSITY_ENV "_VKTRACE_VERBOSITY"

--- a/vktrace/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_extensions/vktracevulkan/vkreplay/vkreplay_vkreplay.cpp
@@ -313,7 +313,6 @@ VkResult vkReplay::manually_replay_vkCreateDevice(packet_vkCreateDevice *pPacket
             return VK_ERROR_VALIDATION_FAILED_EXT;
         }
         const char strScreenShot[] = "VK_LAYER_LUNARG_screenshot";
-        // char *strScreenShotEnv = vktrace_get_global_var("_VK_SCREENSHOT");
 
         pCreateInfo = (VkDeviceCreateInfo *)pPacket->pCreateInfo;
         if (g_pReplaySettings->screenshotList != NULL) {

--- a/vktrace/vktrace_layer/vktrace_lib.c
+++ b/vktrace/vktrace_layer/vktrace_lib.c
@@ -125,7 +125,7 @@ extern VKTRACER_ENTRY _Load(void) {
     if (vktrace_is_loaded_into_vktrace() == FALSE) {
         char *verbosity;
         vktrace_LogSetCallback(loggingCallback);
-        verbosity = vktrace_layer_getenv("_VK_TRACE_VERBOSITY");
+        verbosity = vktrace_layer_getenv(_VKTRACE_VERBOSITY_ENV);
         if (verbosity && !strcmp(verbosity, "quiet"))
             vktrace_LogSetLevel(VKTRACE_LOG_NONE);
         else if (verbosity && !strcmp(verbosity, "warnings"))

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -135,13 +135,13 @@ bool getPageGuardEnableFlag() {
     static bool FirstTimeRun = true;
     if (FirstTimeRun) {
         FirstTimeRun = false;
-        const char* env_pageguard = vktrace_get_global_var(PAGEGUARD_PAGEGUARD_ENABLE_ENV);
+        const char* env_pageguard = vktrace_get_global_var(VKTRACE_PMB_ENABLE_ENV);
         if (env_pageguard) {
             int envvalue;
             if (sscanf(env_pageguard, "%d", &envvalue) == 1) {
                 if (envvalue) {
                     EnablePageGuard = true;
-                    const char* env_target_range_size = vktrace_get_global_var(PAGEGUARD_PAGEGUARD_TARGET_RANGE_SIZE_ENV);
+                    const char* env_target_range_size = vktrace_get_global_var(_VKTRACE_PMB_TARGET_RANGE_SIZE_ENV);
                     if (env_target_range_size) {
                         VkDeviceSize rangesize;
                         if (sscanf(env_target_range_size, "%" PRIx64, &rangesize) == 1) {
@@ -170,8 +170,8 @@ bool getEnableReadProcessFlag(const char* name) {
     }
     return EnableReadPMB;
 }
-bool getEnableReadPMBFlag() { return getEnableReadProcessFlag(PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_ENV); }
-bool getEnableReadPMBPostProcessFlag() { return getEnableReadProcessFlag(PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS_ENV); }
+bool getEnableReadPMBFlag() { return getEnableReadProcessFlag(VKTRACE_PAGEGUARD_ENABLE_READ_PMB_ENV); }
+bool getEnableReadPMBPostProcessFlag() { return getEnableReadProcessFlag(VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS_ENV); }
 
 #if defined(WIN32)
 void setPageGuardExceptionHandler() {

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.h
@@ -81,31 +81,6 @@
 
 #include "vktrace_pageguard_memorycopy.h"
 
-// VKTRACE_PMB_ENABLE env var enables tracking of PMB if the value is 1, other
-// values disable PMB tracking. If this env var is undefined, PMB tracking
-// is enabled.
-#define PAGEGUARD_PAGEGUARD_ENABLE_ENV "VKTRACE_PMB_ENABLE"
-
-// VKTRACE_PMB_TARGETSIZE env var specify the mapped size of memory
-// objects managed by page guard, vktrace only adds pageguard for memory
-// object of which mapped memory size > this value. If this env var is
-// not defined, page guard manages all mapped memory, this is the default
-// option. There is no need for user to specify this env variable except
-// for debug.
-#define PAGEGUARD_PAGEGUARD_TARGET_RANGE_SIZE_ENV "VKTRACE_PMB_TARGETSIZE"
-
-// VKTRACE_PAGEGUARD_ENABLE_READ_PMB env var enables read PMB support. Only
-// supported on Windows. Some PMB data change come from GPU side and cannot
-// be captured by writes page guard, such data change may affect target
-// application running if target application read it. the env var is used
-// to enable capture such PMB data change.
-#define PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_ENV "VKTRACE_PAGEGUARD_ENABLE_READ_PMB"
-
-// PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS_ENV env var enables post process for read PMB support. Only
-// supported on Windows. page guard process miss following write access if read access happen on same page for some titles which
-// need read PMB support, the env var is used to enable post process to fix missed pmb writes.
-#define PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS_ENV "VKTRACE_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS"
-
 // Usefull macro for handling fatal errors during tracing
 #define VKTRACE_FATAL_ERROR(_m)               \
     do {                                      \

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.h
@@ -81,17 +81,18 @@
 
 #include "vktrace_pageguard_memorycopy.h"
 
-//_VKTRACE_OPTIMIZE_PMB env var enable PMB support if the value is 1, other
-// value disable PMB support, if this env var is undefined,a default value
-// will be used;
-#define PAGEGUARD_PAGEGUARD_ENABLE_ENV "_VKTRACE_OPTIMIZE_PMB"
-// VKTRACE_PAGEGUARDTARGETSIZE env var specify the mapped size of memory
-// objects managed by page guard, vktrace only add page guard for memory
+// VKTRACE_PMB_ENABLE env var enables tracking of PMB if the value is 1, other
+// values disable PMB tracking. If this env var is undefined, PMB tracking
+// is enabled.
+#define PAGEGUARD_PAGEGUARD_ENABLE_ENV "VKTRACE_PMB_ENABLE"
+
+// VKTRACE_PMB_TARGETSIZE env var specify the mapped size of memory
+// objects managed by page guard, vktrace only adds pageguard for memory
 // object of which mapped memory size > this value. If this env var is
 // not defined, page guard manages all mapped memory, this is the default
-// option. There’s no need for user to specify this env variable except
+// option. There is no need for user to specify this env variable except
 // for debug.
-#define PAGEGUARD_PAGEGUARD_TARGET_RANGE_SIZE_ENV "VKTRACE_PAGEGUARDTARGETSIZE"
+#define PAGEGUARD_PAGEGUARD_TARGET_RANGE_SIZE_ENV "VKTRACE_PMB_TARGETSIZE"
 
 // VKTRACE_PAGEGUARD_ENABLE_READ_PMB env var enables read PMB support. Only
 // supported on Windows. Some PMB data change come from GPU side and cannot
@@ -99,6 +100,7 @@
 // application running if target application read it. the env var is used
 // to enable capture such PMB data change.
 #define PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_ENV "VKTRACE_PAGEGUARD_ENABLE_READ_PMB"
+
 // PAGEGUARD_PAGEGUARD_ENABLE_READ_PMB_POST_PROCESS_ENV env var enables post process for read PMB support. Only
 // supported on Windows. page guard process miss following write access if read access happen on same page for some titles which
 // need read PMB support, the env var is used to enable post process to fix missed pmb writes.

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -347,7 +347,6 @@ bool is_hotkey_trim_triggered() {
 
 //=========================================================================
 char *getTraceTriggerOptionString(enum enum_trim_trigger triggerType) {
-    static const char TRIM_TRIGGER_ENV_NAME[] = "VKTRACE_TRIM_TRIGGER";
     static const char TRIM_TRIGGER_HOTKEY_TYPE_STRING[] = "hotkey";
     static const char TRIM_TRIGGER_FRAMES_TYPE_STRING[] = "frames";
     static const char TRIM_TRIGGER_FRAMES_DEFAULT_HOTKEY_STRING[] = "F12";
@@ -360,7 +359,7 @@ char *getTraceTriggerOptionString(enum enum_trim_trigger triggerType) {
 
     if (firstTimeRunning) {
         firstTimeRunning = false;
-        const char *trim_trigger_string = vktrace_get_global_var(TRIM_TRIGGER_ENV_NAME);
+        const char *trim_trigger_string = vktrace_get_global_var(VKTRACE_TRIM_TRIGGER_ENV);
         if (trim_trigger_string) {
             assert(strlen(trim_trigger_string) < TRACE_TRIGGER_STRING_LENGTH);
 

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -335,10 +335,10 @@ int vkreplay_main(int argc, char** argv, vktrace_window_handle window = 0) {
             return -1;
         } else {
             // Set env var that communicates list to ScreenShot layer
-            vktrace_set_global_var("_VK_SCREENSHOT", replaySettings.screenshotList);
+            vktrace_set_global_var("VK_SCREENSHOT_FRAMES", replaySettings.screenshotList);
         }
     } else {
-        vktrace_set_global_var("_VK_SCREENSHOT", "");
+        vktrace_set_global_var("VK_SCREENSHOT_FRAMES", "");
     }
 
     // open trace file and read in header

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -85,7 +85,7 @@ vktrace_SettingInfo g_settings_info[] = {
      {&g_settings.enable_pmb},
      {&g_default_settings.enable_pmb},
      TRUE,
-     "Optimize tracing of persistently mapped buffers, default is TRUE."},
+     "Enable tracking of persistently mapped buffers, default is TRUE."},
 #if _DEBUG
     {"v",
      "Verbosity",
@@ -337,7 +337,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    vktrace_set_global_var("_VKTRACE_OPTIMIZE_PMB", g_settings.enable_pmb ? "1" : "0");
+    vktrace_set_global_var("VKTRACE_PMB_ENABLE", g_settings.enable_pmb ? "1" : "0");
     if (g_settings.traceTrigger) {
         // Export list to screenshot layer
         vktrace_set_global_var("VKTRACE_TRIM_TRIGGER", g_settings.traceTrigger);

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -268,6 +268,12 @@ int main(int argc, char* argv[]) {
     g_default_settings.screenshotList = NULL;
     g_default_settings.enable_pmb = true;
 
+    // Check to see if the PAGEGUARD_PAGEGUARD_ENABLE_ENV env var is set.
+    // If it is set to anything but "1", set the default to false.
+    // Note that the command line option will override the env variable.
+    char* pmbEnableEnv = vktrace_get_global_var(VKTRACE_PMB_ENABLE_ENV);
+    if (pmbEnableEnv && strcmp(pmbEnableEnv, "1")) g_default_settings.enable_pmb = false;
+
     if (vktrace_SettingGroup_init(&g_settingGroup, NULL, argc, argv, &g_settings.arguments) != 0) {
         // invalid cmd-line parameters
         vktrace_SettingGroup_delete(&g_settingGroup);
@@ -297,7 +303,7 @@ int main(int argc, char* argv[]) {
             vktrace_LogSetLevel(VKTRACE_LOG_ERROR);
             validArgs = FALSE;
         }
-        vktrace_set_global_var("_VK_TRACE_VERBOSITY", g_settings.verbosity);
+        vktrace_set_global_var(_VKTRACE_VERBOSITY_ENV, g_settings.verbosity);
 
         if (g_settings.screenshotList) {
             if (!screenshot::checkParsingFrameRange(g_settings.screenshotList)) {
@@ -305,10 +311,10 @@ int main(int argc, char* argv[]) {
                 validArgs = FALSE;
             } else {
                 // Export list to screenshot layer
-                vktrace_set_global_var("_VK_SCREENSHOT", g_settings.screenshotList);
+                vktrace_set_global_var("VK_SCREENSHOT_FRAMES", g_settings.screenshotList);
             }
         } else {
-            vktrace_set_global_var("_VK_SCREENSHOT", "");
+            vktrace_set_global_var("VK_SCREENSHOT_FRAMES", "");
         }
 
         if (validArgs == FALSE) {
@@ -337,12 +343,13 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    vktrace_set_global_var("VKTRACE_PMB_ENABLE", g_settings.enable_pmb ? "1" : "0");
+    vktrace_set_global_var(VKTRACE_PMB_ENABLE_ENV, g_settings.enable_pmb ? "1" : "0");
+
     if (g_settings.traceTrigger) {
         // Export list to screenshot layer
-        vktrace_set_global_var("VKTRACE_TRIM_TRIGGER", g_settings.traceTrigger);
+        vktrace_set_global_var(VKTRACE_TRIM_TRIGGER_ENV, g_settings.traceTrigger);
     } else {
-        vktrace_set_global_var("VKTRACE_TRIM_TRIGGER", "");
+        vktrace_set_global_var(VKTRACE_TRIM_TRIGGER_ENV, "");
     }
 
     unsigned int serverIndex = 0;


### PR DESCRIPTION
I have changed the names of some of the environment variables used by vktrace/replay to be more consistent, consolidated the definitions of them into one header file, and added/modified the comments describing them.