### PR TITLE
tests: fix disabledIndependentBlend of VkLayerTest problem

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3556,6 +3556,8 @@ TEST_F(VkLayerTest, DisabledIndependentBlend) {
     VkAttachmentReference attachments[2] = {};
     attachments[0].layout = VK_IMAGE_LAYOUT_GENERAL;
     attachments[1].layout = VK_IMAGE_LAYOUT_GENERAL;
+    attachments[0].attachment = 0;
+    attachments[1].attachment = 1;
 
     VkSubpassDescription subpass = {};
     subpass.pColorAttachments = attachments;
@@ -3564,15 +3566,15 @@ TEST_F(VkLayerTest, DisabledIndependentBlend) {
     VkRenderPassCreateInfo rpci = {};
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
+    rpci.attachmentCount = 2;
 
-    VkAttachmentDescription attach_desc = {};
-    attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+    VkAttachmentDescription attach_desc[] = {
+        {0, VK_FORMAT_B8G8R8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
+         VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL},
+        {0, VK_FORMAT_B8G8R8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
+         VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL}};
 
-    rpci.pAttachments = &attach_desc;
+    rpci.pAttachments = attach_desc;
     rpci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
 
     VkRenderPass renderpass;


### PR DESCRIPTION
disabledIndependentBlend of VkLayerTest hang at vkCreateRenderPass for some graphic cards. the commit fix the problem.  the error is: A given attachment index must not be used multiple times in a single subpass...

XCAP-562
Change-Id: I9b5d6485a7e011e3e6e07fa4445295a20207764c