### PR TITLE
Add ROUNDUP_TO_4 when calculate VkGraphicsPipelineCreateInfo size

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -2226,7 +2226,7 @@ size_t get_VkGraphicsPipelineCreateInfo_size_ROUNDUP_TO_4(const VkGraphicsPipeli
 
     if ((pCreateInfos->stageCount) && (pCreateInfos->pStages != nullptr)) {
         VkPipelineShaderStageCreateInfo* pStage = const_cast<VkPipelineShaderStageCreateInfo*>(pCreateInfos->pStages);
-        for (int i = 0; i < pCreateInfos->stageCount; i++) {
+        for (uint32_t i = 0; i < pCreateInfos->stageCount; i++) {
             if (pStage->pName) {
                 entryPointNameLength = strlen(pStage->pName) + 1;
                 struct_size += ROUNDUP_TO_4(entryPointNameLength) - entryPointNameLength;

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -2217,6 +2217,26 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPipelineCacheData(V
     return result;
 }
 
+// The accurate size of VkGraphicsPipelineCreateInfo can be got from
+// get_struct_chain_size, but it's needed to ROUNDUP_TO_4 because
+// VkGraphicsPipelineCreateInfo might include valid entry point name of shader.
+size_t get_VkGraphicsPipelineCreateInfo_size_ROUNDUP_TO_4(const VkGraphicsPipelineCreateInfo* pCreateInfos) {
+    size_t entryPointNameLength = 0;
+    size_t struct_size = get_struct_chain_size(pCreateInfos);
+
+    if ((pCreateInfos->stageCount) && (pCreateInfos->pStages != nullptr)) {
+        VkPipelineShaderStageCreateInfo* pStage = const_cast<VkPipelineShaderStageCreateInfo*>(pCreateInfos->pStages);
+        for (int i = 0; i < pCreateInfos->stageCount; i++) {
+            if (pStage->pName) {
+                entryPointNameLength = strlen(pStage->pName) + 1;
+                struct_size += ROUNDUP_TO_4(entryPointNameLength) - entryPointNameLength;
+            }
+            ++pStage;
+        }
+    }
+    return struct_size;
+}
+
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache,
                                                                                   uint32_t createInfoCount,
                                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
@@ -2228,7 +2248,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipeline
     size_t total_size = 0;
     uint32_t i;
     for (i = 0; i < createInfoCount; i++) {
-        total_size += get_struct_chain_size((void*)&pCreateInfos[i]);
+        total_size += get_VkGraphicsPipelineCreateInfo_size_ROUNDUP_TO_4(&pCreateInfos[i]);
     }
     CREATE_TRACE_PACKET(vkCreateGraphicsPipelines,
                         total_size + sizeof(VkAllocationCallbacks) + createInfoCount * sizeof(VkPipeline));


### PR DESCRIPTION
Add ROUNDUP_TO_4 when calculate VkGraphicsPipelineCreateInfo size in __HOOKED_vkCreateGraphicsPipelines, the change is for fix some title crash on vkCreateGraphicsPipelines problem during capture.

XCAP-585

Change-Id: I0a2e9d58910f373fd17087cb74c60ba42333783e