### PR TITLE
screenshot: Fix screenshot layer + trim compatibility.

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -678,8 +678,7 @@ static void writePPM(const char *filename, VkImage image1) {
 
     // Set up the command buffer.  We get a command buffer from a pool we saved
     // in a hooked function, which would be the application's pool.
-    if (deviceMap[device]->commandPools.empty())
-    {
+    if (deviceMap[device]->commandPools.empty()) {
         assert(!deviceMap[device]->commandPools.empty());
         return;
     }


### PR DESCRIPTION
Screenshot layer was not handling the case that the most recently created
CommandPool object was also being destroyed, and thus was trying to use a
destroyed object. The layer now keeps a most-recently-created list of
CommandPools, and will utilize the one that was most recently created and
not yet destroyed. If there are no available CommandPools, then the
screenshot layer will not generate a file.

Fixes issue #182 

Change-Id: I8f248b44272f6b414f6ef578b962a2584c200e62