### PR TITLE
vktrace: fix add buffer error in __HOOKED_vkMapMemory

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -402,7 +402,9 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
     pPacket->size = size;
     pPacket->flags = flags;
     if (ppData != NULL) {
-        vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->ppData), sizeof(void*), *ppData);
+        // here we add data(type is void*) pointed by ppData to trace_packet, and put its address to pPacket->ppData
+        // after adding to trace_packet.
+        vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->ppData), sizeof(void*), ppData);
         vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->ppData));
         add_data_to_mem_info(memory, size, offset, *ppData);
     }


### PR DESCRIPTION
Change *ppData to ppData in vktrace_add_buffer_to_trace_packet. The error cause unexpected page guard exception and wrong read PMB process on Windows platform.

XCAP-585

Change-Id: I522939fabe3bed86d13e5fa7a38cde85d301c474