### PR TITLE
add ROUNDUP_TO_4 process for adding buffer to trace_packet and vkUnmapMemory 

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -217,6 +217,12 @@ void* vktrace_trace_packet_get_new_buffer_address(vktrace_trace_packet_header* p
     return pBufferStart;
 }
 
+// size is the buffer size pointed by pBuffer, it should be 4 byte aligned.
+// if size is not 4 byte aligned (some title is not 4 byte aligned when call
+// vkMapMemory), it will be ROUNDUP_TO_4 when get new buffer address in the
+// function.
+// as input parameter, size must be size of pBuffer because we also memcpy
+// pBuffer in the function.
 void vktrace_add_buffer_to_trace_packet(vktrace_trace_packet_header* pHeader, void** ptr_address, uint64_t size,
                                         const void* pBuffer) {
     // Make sure we have valid pointers and sizes. All pointers and sizes must be 4 byte aligned.
@@ -227,7 +233,7 @@ void vktrace_add_buffer_to_trace_packet(vktrace_trace_packet_header* pHeader, vo
         *ptr_address = NULL;
     } else {
         // set ptr to the location of the added buffer
-        *ptr_address = vktrace_trace_packet_get_new_buffer_address(pHeader, size);
+        *ptr_address = vktrace_trace_packet_get_new_buffer_address(pHeader, ROUNDUP_TO_4(size));
 
         // address of buffer in packet adding must be 4 byte aligned
         assert(((uint64_t)*ptr_address & 0x3) == 0);

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -455,7 +455,9 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice devic
             siz = (size_t)entry->rangeSize;
         }
     }
-    CREATE_TRACE_PACKET(vkUnmapMemory, siz);
+    // some title is not 4 byte aligned when call vkMapMemory, so we need
+    // ROUNDUP_TO_4 to avoid access invalid memory
+    CREATE_TRACE_PACKET(vkUnmapMemory, ROUNDUP_TO_4(siz));
     pHeader->vktrace_begin_time = trace_begin_time;
     pPacket = interpret_body_as_vkUnmapMemory(pHeader);
     if (siz) {

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -402,7 +402,9 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
     pPacket->size = size;
     pPacket->flags = flags;
     if (ppData != NULL) {
-        vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->ppData), sizeof(void*), *ppData);
+        // here we add data(type is void*) pointed by ppData to trace_packet, and put its address to pPacket->ppData
+        // after adding to trace_packet.
+        vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->ppData), sizeof(void*), ppData);
         vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->ppData));
         add_data_to_mem_info(memory, size, offset, *ppData);
     }


### PR DESCRIPTION
Some title is not 4 byte aligned when call vkMapMemory, it cause error at adding buffer to trace_packet and vkUnmapMemory.