### PR TITLE
vktrace: Remove memcpy to shadow memory in map memory process

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
@@ -82,6 +82,10 @@ typedef class PageGuardMappedMemory {
 
     bool isMappedBlockChanged(uint64_t index, int useWhich);
 
+    bool isMappedBlockLoaded(uint64_t index);
+
+    void setMappedBlockLoaded(uint64_t index, bool bLoaded);
+
     uint64_t getMappedBlockSize(uint64_t index);
 
     uint64_t getMappedBlockOffset(uint64_t index);

--- a/vktrace/vktrace_layer/vktrace_lib_pagestatusarray.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pagestatusarray.cpp
@@ -48,10 +48,14 @@ PageStatusArray::PageStatusArray(uint64_t pageCount) {
     activeReadArray = pReadArray[0];
     capturedReadArray = pReadArray[1];
 
+    firstTimeLoadArray = new uint8_t[ByteCount];
+    assert(firstTimeLoadArray);
+
     clearAll();
 }
 
 PageStatusArray::~PageStatusArray() {
+    delete[] firstTimeLoadArray;
     delete[] pChangedArray[0];
     delete[] pChangedArray[1];
     delete[] pReadArray[0];
@@ -88,6 +92,10 @@ bool PageStatusArray::getBlockReadArraySnapshot(uint64_t index) {
     return capturedReadArray[index >> PAGE_NUMBER_FROM_BIT_SHIFT] & (1 << (index % PAGE_FLAG_AMOUNT_PER_BYTE));
 }
 
+bool PageStatusArray::getBlockFirstTimeLoadArray(uint64_t index) {
+    return firstTimeLoadArray[index >> PAGE_NUMBER_FROM_BIT_SHIFT] & (1 << (index % PAGE_FLAG_AMOUNT_PER_BYTE));
+}
+
 void PageStatusArray::setBlockChangedArray(uint64_t index, bool changed) {
     if (changed) {
         activeChangesArray[index >> PAGE_NUMBER_FROM_BIT_SHIFT] |= (1 << (index % PAGE_FLAG_AMOUNT_PER_BYTE));
@@ -120,6 +128,14 @@ void PageStatusArray::setBlockReadArraySnapshot(uint64_t index, bool changed) {
     }
 }
 
+void PageStatusArray::setBlockFirstTimeLoadArray(uint64_t index, bool loaded) {
+    if (loaded) {
+        firstTimeLoadArray[index >> PAGE_NUMBER_FROM_BIT_SHIFT] |= (1 << (index % PAGE_FLAG_AMOUNT_PER_BYTE));
+    } else {
+        firstTimeLoadArray[index >> PAGE_NUMBER_FROM_BIT_SHIFT] &= ~((uint8_t)(1 << (index % PAGE_FLAG_AMOUNT_PER_BYTE)));
+    }
+}
+
 void PageStatusArray::backupChangedArray() { toggleChangedArray(); }
 
 void PageStatusArray::backupReadArray() { toggleReadArray(); }
@@ -129,4 +145,5 @@ void PageStatusArray::clearAll() {
     memset(capturedChangesArray, 0, ByteCount);
     memset(activeReadArray, 0, ByteCount);
     memset(capturedReadArray, 0, ByteCount);
+    memset(firstTimeLoadArray, 0, ByteCount);
 }


### PR DESCRIPTION
In current implementation, once vkMapMemory get captured, vktrace allocate shadow memory with same mapped size, then memcpy real mapped memory to shadow memory. The change (only for Windows) removes the memcpy, and adds additional process in page guard exception handler: only if a page is first time accessed, the handler memcpy that page from real mapped memory to shadow memory. This optimization significantly improve target title capture time from hours to minutes, because the title use lots of big size map/unmap, and only a small portion of mapped size accessed by host side.

XCAP-585

Change-Id: I29f3add4553576679b3196f0b1595c096b77143e