### PR TITLE
Fix location of vk_layer_settings.txt on Android

### DIFF
--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -200,7 +200,7 @@ const char *ConfigFile::getOption(const std::string &_option) {
             }
             parseFile(envPath.c_str());
         } else {
-            parseFile("vk_layer_settings.txt");
+            parseFile(m_fileName.c_str());
         }
     }
 
@@ -223,7 +223,7 @@ void ConfigFile::setOption(const std::string &_option, const std::string &_val) 
             }
             parseFile(envPath.c_str());
         } else {
-            parseFile("vk_layer_settings.txt");
+            parseFile(m_fileName.c_str());
         }
     }
 


### PR DESCRIPTION
Commit 969ab0680dd434f0 ('api_dump: Support config file and logging on Android')
added a custom location for vk_layer_settings.txt on Android. However, commit
750837a5dedf524c81c ('Merge branch 'trunk'') ended up partly overwriting these changes,
breaking the functionality.

As a result, using the config file on Android hasn't worked since October 2016. This commit
restores the changes in the original commit to fix this.