### PR TITLE
CMakeLists: do not use hardcoded paths

### DIFF
--- a/vktrace/vktrace_replay/CMakeLists.txt
+++ b/vktrace/vktrace_replay/CMakeLists.txt
@@ -40,7 +40,7 @@ set(SRC_LIST
     vkreplay_main.cpp
     vkreplay_seq.cpp
     vkreplay_factory.cpp
-    ../../../layersvt/screenshot_parsing.cpp
+    ${SRC_DIR}/../layersvt/screenshot_parsing.cpp
 )
 
 set (HDR_LIST
@@ -48,7 +48,7 @@ set (HDR_LIST
     vkreplay_settings.h
     vkreplay_vkdisplay.h
     vkreplay_vkreplay.h
-    ../../../layersvt/screenshot_parsing.h
+    ${SRC_DIR}/../layersvt/screenshot_parsing.h
     ${GENERATED_FILES_DIR}/vkreplay_vk_objmapper.h
     ${GENERATED_FILES_DIR}/vkreplay_vk_func_ptrs.h
     ${GENERATED_FILES_DIR}/vktrace_vk_packet_id.h

--- a/vktrace/vktrace_trace/CMakeLists.txt
+++ b/vktrace/vktrace_trace/CMakeLists.txt
@@ -12,8 +12,8 @@ set(SRC_LIST
     vktrace.cpp
     vktrace_process.h
     vktrace_process.cpp
-    ../../../layersvt/screenshot_parsing.h
-    ../../../layersvt/screenshot_parsing.cpp
+    ${SRC_DIR}/../layersvt/screenshot_parsing.h
+    ${SRC_DIR}/../layersvt/screenshot_parsing.cpp
 )
 
 include_directories(


### PR DESCRIPTION
Using hardcoded paths for source/header files
tends to break out-of-tree builds.

Signed-off-by: Awais Belal <awais_belal@mentor.com>