### PR TITLE
Avoid modifying application memory in __HOOKED_vkCreateDevice()

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -953,14 +953,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDevice(VkPhysica
     // remove the loader extended createInfo structure
     VkDeviceCreateInfo localCreateInfo;
     memcpy(&localCreateInfo, pCreateInfo, sizeof(localCreateInfo));
-    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-        char** ppName = (char**)&localCreateInfo.ppEnabledExtensionNames[i];
-        *ppName = (char*)pCreateInfo->ppEnabledExtensionNames[i];
-    }
-    for (uint32_t i = 0; i < pCreateInfo->enabledLayerCount; i++) {
-        char** ppName = (char**)&localCreateInfo.ppEnabledLayerNames[i];
-        *ppName = (char*)pCreateInfo->ppEnabledLayerNames[i];
-    }
     localCreateInfo.pNext = strip_create_extensions(pCreateInfo->pNext);
 
     CREATE_TRACE_PACKET(vkCreateDevice,


### PR DESCRIPTION
Fixes a crash when an application uses a static const array for
ppEnabledLayerNames or ppEnabledExtensionNames.

Allocate memory for ppEnabledLayerNames and ppEnabledExtensionNames
arrays similarly how it's done in __HOOKED_vkCreateInstance().