### PR TITLE
vkreplay: Fix GH184 - Unmap swapchain images

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -589,6 +589,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                  'GetPhysicalDeviceSurfaceFormatsKHR',
                                  'GetPhysicalDeviceSurfacePresentModesKHR',
                                  'CreateSwapchainKHR',
+                                 'DestroySwapchainKHR',
                                  'GetSwapchainImagesKHR',
                                  'CreateXcbSurfaceKHR',
                                  'CreateXlibSurfaceKHR',

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -3037,6 +3037,30 @@ VkResult vkReplay::manually_replay_vkCreateSwapchainKHR(packet_vkCreateSwapchain
     return replayResult;
 }
 
+void vkReplay::manually_replay_vkDestroySwapchainKHR(packet_vkDestroySwapchainKHR *pPacket) {
+    VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
+    if (pPacket->device != VK_NULL_HANDLE && remappeddevice == VK_NULL_HANDLE) {
+        vktrace_LogError("Skipping vkDestroySwapchainKHR() due to invalid remapped VkDevice.");
+        return;
+    }
+
+    VkSwapchainKHR remappedswapchain = m_objMapper.remap_swapchainkhrs(pPacket->swapchain);
+    if (pPacket->swapchain != VK_NULL_HANDLE && remappedswapchain == VK_NULL_HANDLE) {
+        vktrace_LogError("Skipping vkDestroySwapchainKHR() due to invalid remapped VkSwapchainKHR.");
+        return;
+    }
+
+    // Need to unmap images obtained with vkGetSwapchainImagesKHR
+    while (!traceSwapchainToImages[pPacket->swapchain].empty()) {
+        VkImage image = traceSwapchainToImages[pPacket->swapchain].back();
+        m_objMapper.rm_from_images_map(image);
+        traceSwapchainToImages[pPacket->swapchain].pop_back();
+    }
+
+    m_vkFuncs.real_vkDestroySwapchainKHR(remappeddevice, remappedswapchain, pPacket->pAllocator);
+    m_objMapper.rm_from_swapchainkhrs_map(pPacket->swapchain);
+}
+
 VkResult vkReplay::manually_replay_vkGetSwapchainImagesKHR(packet_vkGetSwapchainImagesKHR *pPacket) {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
     VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
@@ -3074,6 +3098,7 @@ VkResult vkReplay::manually_replay_vkGetSwapchainImagesKHR(packet_vkGetSwapchain
                 local_imageObj.replayImage = pReplayImages[i];
                 m_objMapper.add_to_images_map(packetImage[i], local_imageObj);
                 replayImageToDevice[pReplayImages[i]] = remappeddevice;
+                traceSwapchainToImages[pPacket->swapchain].push_back(packetImage[i]);
             }
         }
     }

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -168,6 +168,7 @@ class vkReplay {
     VkResult manually_replay_vkGetPhysicalDeviceSurfaceFormatsKHR(packet_vkGetPhysicalDeviceSurfaceFormatsKHR* pPacket);
     VkResult manually_replay_vkGetPhysicalDeviceSurfacePresentModesKHR(packet_vkGetPhysicalDeviceSurfacePresentModesKHR* pPacket);
     VkResult manually_replay_vkCreateSwapchainKHR(packet_vkCreateSwapchainKHR* pPacket);
+    void manually_replay_vkDestroySwapchainKHR(packet_vkDestroySwapchainKHR* pPacket);
     VkResult manually_replay_vkGetSwapchainImagesKHR(packet_vkGetSwapchainImagesKHR* pPacket);
     VkResult manually_replay_vkQueuePresentKHR(packet_vkQueuePresentKHR* pPacket);
     VkResult manually_replay_vkCreateXcbSurfaceKHR(packet_vkCreateXcbSurfaceKHR* pPacket);
@@ -226,6 +227,9 @@ class vkReplay {
     // Map VkImage to VkDevice, so we can search for the VkDevice used to create an image
     std::unordered_map<VkImage, VkDevice> traceImageToDevice;
     std::unordered_map<VkImage, VkDevice> replayImageToDevice;
+
+    // Map VkSwapchainKHR to vector of VkImage, so we can unmap swapchain images at vkDestroySwapchainKHR
+    std::unordered_map<VkSwapchainKHR, std::vector<VkImage>> traceSwapchainToImages;
 
     // Map VkPhysicalDevice to VkPhysicalDeviceMemoryProperites
     std::unordered_map<VkPhysicalDevice, VkPhysicalDeviceMemoryProperties> traceMemoryProperties;


### PR DESCRIPTION
VkImages obtained through vkGetSwapchainImagesKHR are inserted into the
images map, but never removed when the VkSwapchainKHR is destroyed.

It may cause issues with traces from applications that re-create a
VkSwapchainKHR multiple times (e.g. upon window resize) due to the fact
that VkImage handles might be re-used by the underlying driver.

A call to vkCreateImage could return the same handle of a swapchain
VkImage that no longer exists, but since vkreplay didn't clean those
mappings up, it thinks the image was already created and skip the real
vkCreateImage call.

This change adds a swapchainToImages map to keep track of what images
were obtained through vkGetSwapchainImagesKHR, can remove the
corresponding mappings at VkDestroySwapchainKHR time.