### PR TITLE
vktrace/replay: Add Wayland support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
     option(BUILD_WSI_MIR_SUPPORT "Build Mir WSI support" OFF)
     set(DEMOS_WSI_SELECTION "XCB" CACHE STRING "Select WSI target for demos (XCB, XLIB, WAYLAND, MIR, DISPLAY)")
+    set(VKREPLAY_WSI_SELECTION "XCB" CACHE STRING "Select WSI target for vkreplay (XCB, WAYLAND, DISPLAY)")
+
+    # Need to turn WSI_SELECTION into boolean definitions for preprocessor directives
+    if (VKREPLAY_WSI_SELECTION STREQUAL "XCB")
+        add_definitions(-DVKREPLAY_USE_WSI_XCB)
+    elseif (VKREPLAY_WSI_SELECTION STREQUAL "WAYLAND")
+        add_definitions(-DVKREPLAY_USE_WSI_WAYLAND)
+    endif()
 
     if (BUILD_WSI_XCB_SUPPORT)
         find_package(XCB REQUIRED)
@@ -40,7 +48,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         find_package(Wayland REQUIRED)
     endif()
 
-    if (BUILD_WSI_MIR_SUPPORT)
+    if(BUILD_WSI_MIR_SUPPORT)
         find_package(Mir REQUIRED)
     endif()
 
@@ -133,7 +141,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows" OR
     option(BUILD_VIA "Build via" ON)
     option(CUSTOM_GLSLANG_BIN_ROOT "Use the user defined GLSLANG_BINARY_ROOT" OFF)
     option(CUSTOM_SPIRV_TOOLS_BIN_ROOT "Use the user defined SPIRV_TOOLS_BINARY_ROOT" OFF)
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT BUILD_WSI_XCB_SUPPORT)
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT (BUILD_WSI_XCB_SUPPORT OR BUILD_WSI_WAYLAND_SUPPORT))
         option(BUILD_VKTRACE_REPLAY "Build VkReplay" OFF)
     else()
         option(BUILD_VKTRACE_REPLAY "Build VkReplay" ON)

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -113,9 +113,7 @@ temporary_script_porting_exclusions = ['vkGetPhysicalDeviceFeatures2KHR',
                                        'vkGetImageSparseMemoryRequirements2KHR',
                                        ]
 
-api_exclusions = ['CreateWaylandSurfaceKHR',
-                  'CreateMirSurfaceKHR',
-                  'GetPhysicalDeviceWaylandPresentationSupportKHR',
+api_exclusions = ['CreateMirSurfaceKHR',
                   'GetPhysicalDeviceMirPresentationSupportKHR',
                   'GetPhysicalDeviceDisplayPropertiesKHR',
                   'GetPhysicalDeviceDisplayPlanePropertiesKHR',
@@ -552,6 +550,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
 
         wsi_platform_manual_funcs = ['CreateWin32SurfaceKHR',
                                      'CreateXcbSurfaceKHR',
+                                     'CreateWaylandSurfaceKHR',
                                      'CreateXlibSurfaceKHR',
                                      'CreateAndroidSurfaceKHR']
         manually_replay_funcs = ['AllocateMemory',
@@ -591,8 +590,10 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                  'CreateSwapchainKHR',
                                  'GetSwapchainImagesKHR',
                                  'CreateXcbSurfaceKHR',
+                                 'CreateWaylandSurfaceKHR',
                                  'CreateXlibSurfaceKHR',
                                  'GetPhysicalDeviceXcbPresentationSupportKHR',
+                                 'GetPhysicalDeviceWaylandPresentationSupportKHR',
                                  'GetPhysicalDeviceXlibPresentationSupportKHR',
                                  'CreateWin32SurfaceKHR',
                                  'GetPhysicalDeviceWin32PresentationSupportKHR',
@@ -616,6 +617,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
         # Map APIs to functions if body is fully custom
         custom_body_dict = {'CreateInstance': self.GenReplayCreateInstance,
                             'GetPhysicalDeviceXcbPresentationSupportKHR': self.GenReplayGetPhysicalDeviceXcbPresentationSupportKHR,
+                            'GetPhysicalDeviceWaylandPresentationSupportKHR': self.GenReplayGetPhysicalDeviceWaylandPresentationSupportKHR,
                             'GetPhysicalDeviceXlibPresentationSupportKHR': self.GenReplayGetPhysicalDeviceXlibPresentationSupportKHR,
                             'GetPhysicalDeviceWin32PresentationSupportKHR': self.GenReplayGetPhysicalDeviceWin32PresentationSupportKHR }
         # Special cases for functions that use do-while loops
@@ -1010,6 +1012,16 @@ class VkTraceFileOutputGenerator(OutputGenerator):
         cb_body.append('            VkBool32 rval = manually_replay_vkGetPhysicalDeviceXcbPresentationSupportKHR(pPacket);')
         cb_body.append('            if (rval != pPacket->result) {')
         cb_body.append('                vktrace_LogError("Return value %d from API call (vkGetPhysicalDeviceXcbPresentationSupportKHR) does not match return value from trace file %d.",')
+        cb_body.append('                                 rval, pPacket->result);')
+        cb_body.append('                returnValue = vktrace_replay::VKTRACE_REPLAY_BAD_RETURN;')
+        cb_body.append('            }')
+        return "\n".join(cb_body)
+
+    def GenReplayGetPhysicalDeviceWaylandPresentationSupportKHR (self):
+        cb_body = []
+        cb_body.append('            VkBool32 rval = manually_replay_vkGetPhysicalDeviceWaylandPresentationSupportKHR(pPacket);')
+        cb_body.append('            if (rval != pPacket->result) {')
+        cb_body.append('                vktrace_LogError("Return value %d from API call (vkGetPhysicalDeviceWaylandPresentationSupportKHR) does not match return value from trace file %d.",')
         cb_body.append('                                 rval, pPacket->result);')
         cb_body.append('                returnValue = vktrace_replay::VKTRACE_REPLAY_BAD_RETURN;')
         cb_body.append('            }')
@@ -2255,10 +2267,12 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                          'vkCreateSwapchainKHR',
                                          'vkGetSwapchainImagesKHR',
                                          'vkQueuePresentKHR',
-                                         #TODO add Wayland, Mir
+                                         #TODO add Mir
                                          'vkCreateXcbSurfaceKHR',
+                                         'vkCreateWaylandSurfaceKHR',
                                          'vkCreateXlibSurfaceKHR',
                                          'vkGetPhysicalDeviceXcbPresentationSupportKHR',
+                                         'vkGetPhysicalDeviceWaylandPresentationSupportKHR',
                                          'vkGetPhysicalDeviceXlibPresentationSupportKHR',
                                          'vkCreateWin32SurfaceKHR',
                                          'vkGetPhysicalDeviceWin32PresentationSupportKHR',
@@ -2268,20 +2282,23 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                          'vkUpdateDescriptorSetWithTemplateKHR',
                                          'vkCmdPushDescriptorSetWithTemplateKHR',
                                          ]
-       
+
         # Validate the manually_written_hooked_funcs list
         protoFuncs = [proto.name for proto in self.cmdMembers]
         wsi_platform_manual_funcs = ['vkCreateWin32SurfaceKHR',
                                      'vkCreateXcbSurfaceKHR',
+                                     'vkCreateWaylandSurfaceKHR',
                                      'vkCreateXlibSurfaceKHR',
                                      'vkCreateAndroidSurfaceKHR',
                                      'vkGetPhysicalDeviceXcbPresentationSupportKHR',
+                                     'vkGetPhysicalDeviceWaylandPresentationSupportKHR',
                                      'vkGetPhysicalDeviceXlibPresentationSupportKHR',
                                      'vkGetPhysicalDeviceWin32PresentationSupportKHR']
         approved_ext = ['VK_KHR_surface',
                         'VK_KHR_swapchain',
                         'VK_KHR_win32_surface',
                         'VK_KHR_xcb_surface',
+                        'VK_KHR_wayland_surface',
                         'VK_EXT_debug_report',
                         'VK_KHR_descriptor_update_template']
         for func in manually_written_hooked_funcs:

--- a/vktrace/CMakeLists.txt
+++ b/vktrace/CMakeLists.txt
@@ -509,24 +509,25 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+
     if (BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     endif()
 
     if (BUILD_WSI_XLIB_SUPPORT)
-       add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
+        add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
     endif()
 
     if (BUILD_WSI_WAYLAND_SUPPORT)
-       # TODO Add Wayland Support
-       # add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
+        add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
     endif()
 
     if (BUILD_WSI_MIR_SUPPORT)
-       # TODO Add Mir Support
-       # add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
-       # include_directories(${MIR_INCLUDE_DIR})
+        # TODO Add Mir Support
+        # add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
+        # include_directories(${MIR_INCLUDE_DIR})
     endif()
+
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # Only vktrace is supported on macOS
 else()

--- a/vktrace/vktrace_common/vktrace_multiplatform.h
+++ b/vktrace/vktrace_common/vktrace_multiplatform.h
@@ -87,6 +87,27 @@ typedef struct {
 } VkIcdSurfaceXlib;
 #endif
 
+#if !defined(VK_USE_PLATFORM_WAYLAND_KHR)
+typedef VkFlags VkWaylandSurfaceCreateFlagsKHR;
+typedef struct VkWaylandSurfaceCreateInfoKHR {
+    VkStructureType sType;
+    const void* pNext;
+    VkWaylandSurfaceCreateFlagsKHR flags;
+    struct wl_display* display;
+    struct wl_surface* surface;
+} VkWaylandSurfaceCreateInfoKHR;
+typedef VkResult(VKAPI_PTR* PFN_vkCreateWaylandSurfaceKHR)(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
+                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)(VkPhysicalDevice physicalDevice,
+                                                                                  uint32_t queueFamilyIndex,
+                                                                                  struct wl_display* display);
+typedef struct {
+    VkIcdSurfaceBase base;
+    struct wl_display* display;
+    struct wl_surface* surface;
+} VkIcdSurfaceWayland;
+#endif
+
 #if !defined(VK_USE_PLATFORM_ANDROID_KHR)
 typedef VkFlags VkAndroidSurfaceCreateFlagsKHR;
 typedef uint32_t* ANativeWindow;

--- a/vktrace/vktrace_common/vktrace_trace_packet_identifiers.h
+++ b/vktrace/vktrace_common/vktrace_trace_packet_identifiers.h
@@ -251,6 +251,8 @@ typedef enum _VKTRACE_TRACE_PACKET_ID_VK {
     VKTRACE_TPI_VK_vkDestroyDescriptorUpdateTemplateKHR = 176,
     VKTRACE_TPI_VK_vkUpdateDescriptorSetWithTemplateKHR = 177,
     VKTRACE_TPI_VK_vkCmdPushDescriptorSetWithTemplateKHR = 178,
+    VKTRACE_TPI_VK_vkCreateWaylandSurfaceKHR = 179,
+    VKTRACE_TPI_VK_vkGetPhysicalDeviceWaylandPresentationSupportKHR = 180
 } VKTRACE_TRACE_PACKET_ID_VK;
 
 #define VKTRACE_BIG_ENDIAN 0

--- a/vktrace/vktrace_replay/CMakeLists.txt
+++ b/vktrace/vktrace_replay/CMakeLists.txt
@@ -20,7 +20,14 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/lvl_genvk.py -regist
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    set(OS_REPLAYER_LIBS xcb  ${LIBRARIES})
+
+    if(BUILD_WSI_XCB_SUPPORT AND VKREPLAY_WSI_SELECTION STREQUAL XCB)
+        set(OS_REPLAYER_LIBS xcb ${LIBRARIES})
+    elseif(BUILD_WSI_WAYLAND_SUPPORT AND VKREPLAY_WSI_SELECTION STREQUAL WAYLAND)
+        set(OS_REPLAYER_LIBS ${WAYLAND_CLIENT_LIBRARIES} ${LIBRARIES})
+    endif()
+    
+    # TODO Add Mir Support
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR
@@ -46,7 +53,6 @@ set(SRC_LIST
 set (HDR_LIST
     vkreplay.h
     vkreplay_settings.h
-    vkreplay_vkdisplay.h
     vkreplay_vkreplay.h
     ${SRC_DIR}/../layersvt/screenshot_parsing.h
     ${GENERATED_FILES_DIR}/vkreplay_vk_objmapper.h

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
@@ -1,7 +1,7 @@
 /*
  *
- * Copyright (C) 2015-2016 Valve Corporation
- * Copyright (C) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2017 Valve Corporation
+ * Copyright (C) 2015-2017 LunarG, Inc.
  * All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,10 +20,15 @@
  * Author: Jon Ashburn <jon@lunarg.com>
  * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
  * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Joey Bzdek <joey@lunarg.com>
  */
 
-#include "vkreplay_vkreplay.h"
-#include "vk_icd.h"
+#include "vkreplay_vkdisplay.h"
+
+#if defined PLATFORM_LINUX && !defined ANDROID && defined VKREPLAY_USE_WSI_WAYLAND
+#include <linux/input.h>
+#endif
+
 #define APP_NAME "vkreplay_vk"
 #define IDI_ICON 101
 
@@ -33,10 +38,16 @@ vkDisplay::vkDisplay() : m_initedVK(false), m_windowWidth(0), m_windowHeight(0),
     memset(&m_surface, 0, sizeof(VkIcdSurfaceAndroid));
     m_window = 0;
 #else
+#if defined VKREPLAY_USE_WSI_XCB
     memset(&m_surface, 0, sizeof(VkIcdSurfaceXcb));
     m_pXcbConnection = NULL;
     m_pXcbScreen = NULL;
     m_XcbWindow = 0;
+#elif defined VKREPLAY_USE_WSI_XLIB
+    memset(&m_surface, 0, sizeof(VkIcdSurfaceXlib));
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    memset(&m_surface, 0, sizeof(VkIcdSurfaceWayland));
+#endif
 #endif
 #elif defined(WIN32)
     memset(&m_surface, 0, sizeof(VkIcdSurfaceWin32));
@@ -47,12 +58,26 @@ vkDisplay::vkDisplay() : m_initedVK(false), m_windowWidth(0), m_windowHeight(0),
 
 vkDisplay::~vkDisplay() {
 #if defined(PLATFORM_LINUX) && !defined(ANDROID)
+#if defined VKREPLAY_USE_WSI_XCB
     if (m_XcbWindow != 0) {
         xcb_destroy_window(m_pXcbConnection, m_XcbWindow);
     }
     if (m_pXcbConnection != NULL) {
         xcb_disconnect(m_pXcbConnection);
     }
+#elif defined VKREPLAY_USE_WSI_XLIB
+
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    if (m_keyboard) wl_keyboard_destroy(m_keyboard);
+    if (m_pointer) wl_pointer_destroy(m_pointer);
+    if (m_seat) wl_seat_destroy(m_seat);
+    if (m_shell_surface) wl_shell_surface_destroy(m_shell_surface);
+    if (m_wl_surface) wl_surface_destroy(m_wl_surface);
+    if (m_shell) wl_shell_destroy(m_shell);
+    if (m_compositor) wl_compositor_destroy(m_compositor);
+    if (m_registry) wl_registry_destroy(m_registry);
+    if (m_display) wl_display_disconnect(m_display);
+#endif
 #endif
 }
 
@@ -137,6 +162,7 @@ int vkDisplay::init(const unsigned int gpu_idx) {
     }
 #endif
 #if defined(PLATFORM_LINUX) && !defined(ANDROID)
+#if defined VKREPLAY_USE_WSI_XCB
     const xcb_setup_t *setup;
     xcb_screen_iterator_t iter;
     int scr;
@@ -145,6 +171,31 @@ int vkDisplay::init(const unsigned int gpu_idx) {
     iter = xcb_setup_roots_iterator(setup);
     while (scr-- > 0) xcb_screen_next(&iter);
     m_pXcbScreen = iter.data;
+#elif defined VKREPLAY_USE_WSI_XLIB
+// TODO
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    try {
+        m_display = wl_display_connect(NULL);
+        if (!m_display) throw std::runtime_error("failed to connect to the display server");
+
+        m_registry = wl_display_get_registry(m_display);
+        if (!m_registry) throw std::runtime_error("failed to get registry");
+
+        wl_registry_add_listener(m_registry, &vkDisplay::registry_listener, this);
+        wl_display_roundtrip(m_display);
+
+        if (!m_compositor) throw std::runtime_error("failed to bind compositor");
+
+        if (!m_shell) throw std::runtime_error("failed to bind shell");
+    } catch (...) {
+        if (m_shell) wl_shell_destroy(m_shell);
+        if (m_compositor) wl_compositor_destroy(m_compositor);
+        if (m_registry) wl_registry_destroy(m_registry);
+        if (m_display) wl_display_disconnect(m_display);
+
+        throw;
+    }
+#endif
 #endif
     set_pause_status(false);
     set_quit_status(false);
@@ -172,7 +223,13 @@ int vkDisplay::set_window(vktrace_window_handle hWindow, unsigned int width, uns
     m_window = hWindow;
     m_surface.window = hWindow;
 #else
+#if defined VKREPLAY_USE_WSI_XCB
     m_XcbWindow = hWindow;
+#elif defined VKREPLAY_USE_WSI_XLIB
+// TODO
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    m_display = hWindow;
+#endif
 #endif
 #elif defined(WIN32)
     m_windowHandle = hWindow;
@@ -185,9 +242,8 @@ int vkDisplay::set_window(vktrace_window_handle hWindow, unsigned int width, uns
 int vkDisplay::create_window(const unsigned int width, const unsigned int height) {
 #if defined(PLATFORM_LINUX)
 #if defined(ANDROID)
-    return 0;
 #else
-
+#if defined VKREPLAY_USE_WSI_XCB
     uint32_t value_mask, value_list[32];
     m_XcbWindow = xcb_generate_id(m_pXcbConnection);
 
@@ -215,7 +271,24 @@ int vkDisplay::create_window(const unsigned int width, const unsigned int height
     m_surface.base.platform = VK_ICD_WSI_PLATFORM_XCB;
     m_surface.connection = m_pXcbConnection;
     m_surface.window = m_XcbWindow;
-    return 0;
+#elif defined VKREPLAY_USE_WSI_XLIB
+// TODO
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    m_wl_surface = wl_compositor_create_surface(m_compositor);
+    if (!m_wl_surface) throw std::runtime_error("failed to create surface");
+
+    m_shell_surface = wl_shell_get_shell_surface(m_shell, m_wl_surface);
+    if (!m_shell_surface) throw std::runtime_error("failed to shell_surface");
+
+    wl_shell_surface_add_listener(m_shell_surface, &vkDisplay::shell_surface_listener, this);
+    // set title
+    // wl_shell_surface_set_title(m_shell_surface, "");
+    wl_shell_surface_set_toplevel(m_shell_surface);
+
+    m_surface.base.platform = VK_ICD_WSI_PLATFORM_WAYLAND;
+    m_surface.display = m_display;
+    m_surface.surface = m_wl_surface;
+#endif
 #endif
 #elif defined(WIN32)
     // Register Window class
@@ -255,24 +328,21 @@ int vkDisplay::create_window(const unsigned int width, const unsigned int height
     m_surface.base.platform = VK_ICD_WSI_PLATFORM_WIN32;
     m_surface.hinstance = wcex.hInstance;
     m_surface.hwnd = m_windowHandle;
-    return 0;
 #endif
+    return 0;
 }
 
 void vkDisplay::resize_window(const unsigned int width, const unsigned int height) {
-#if defined(PLATFORM_LINUX)
-#if defined(ANDROID)
-    m_windowWidth = width;
-    m_windowHeight = height;
-#else
     if (width != m_windowWidth || height != m_windowHeight) {
+        m_windowWidth = width;
+        m_windowHeight = height;
+#if defined(PLATFORM_LINUX) && !defined(ANDROID)
+#if defined VKREPLAY_USE_WSI_XCB
         uint32_t values[2];
         values[0] = width;
         values[1] = height;
         xcb_configure_window(m_pXcbConnection, m_XcbWindow, XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT, values);
         xcb_flush(m_pXcbConnection);
-        m_windowWidth = width;
-        m_windowHeight = height;
 
         // Make sure window is visible.
         // xcb doesn't have the equivalent of XSync, so we need to sleep
@@ -282,20 +352,20 @@ void vkDisplay::resize_window(const unsigned int width, const unsigned int heigh
         xcb_map_window(m_pXcbConnection, m_XcbWindow);
         xcb_flush(m_pXcbConnection);
         usleep(50000);  // 0.05 seconds
-    }
+#elif defined VKREPLAY_USE_WSI_XLIB
+// TODO
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+// In Wayland, the shell_surface should resize based on the Vulkan surface automagically
 #endif
 #elif defined(WIN32)
-    if (width != m_windowWidth || height != m_windowHeight) {
         RECT wr = {0, 0, width, height};
         AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);
         SetWindowPos(get_window_handle(), HWND_TOP, 0, 0, wr.right - wr.left, wr.bottom - wr.top, SWP_NOMOVE);
-        m_windowWidth = width;
-        m_windowHeight = height;
 
         // Make sure window is visible.
         ShowWindow(m_windowHandle, SW_SHOWDEFAULT);
-    }
 #endif
+    }
 }
 
 void vkDisplay::process_event() {
@@ -303,6 +373,7 @@ void vkDisplay::process_event() {
 #if defined(ANDROID)
 // TODO
 #else
+#if defined VKREPLAY_USE_WSI_XCB
     xcb_connection_t *xcb_conn = this->get_connection_handle();
     xcb_generic_event_t *event = xcb_poll_for_event(xcb_conn);
     xcb_flush(xcb_conn);
@@ -326,7 +397,7 @@ void vkDisplay::process_event() {
                     case 0x9:  // Escape
                         this->set_quit_status(true);
                         break;
-                    case 0x41:
+                    case 0x41:  // Space
                         this->set_pause_status(!(this->get_pause_status()));
                         break;
                 }
@@ -338,6 +409,12 @@ void vkDisplay::process_event() {
         free(event);
         event = xcb_poll_for_event(xcb_conn);
     }
+#elif defined VKREPLAY_USE_WSI_XLIB
+// TODO
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    // Interaction is handled in the callbacks
+    wl_display_dispatch_pending(m_display);
+#endif
 #endif
 #elif defined(WIN32)
     MSG msg = {};
@@ -350,3 +427,114 @@ void vkDisplay::process_event() {
     }
 #endif
 }
+
+#if defined(PLATFORM_LINUX) && !defined(ANDROID) && defined VKREPLAY_USE_WSI_WAYLAND
+// Wayland callbacks, needed to handle events from the display manager.
+// Some stubs here that could be potentially removed
+void vkDisplay::handle_ping(void *data, wl_shell_surface *shell_surface, uint32_t serial) {
+    wl_shell_surface_pong(shell_surface, serial);
+}
+
+void vkDisplay::handle_configure(void *data, wl_shell_surface *shell_surface, uint32_t edges, int32_t width, int32_t height) {}
+
+void vkDisplay::handle_popup_done(void *data, wl_shell_surface *shell_surface) {}
+
+const struct wl_shell_surface_listener vkDisplay::shell_surface_listener = {vkDisplay::handle_ping, vkDisplay::handle_configure,
+                                                                            vkDisplay::handle_popup_done};
+
+void vkDisplay::pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface,
+                                     wl_fixed_t sx, wl_fixed_t sy) {}
+
+void vkDisplay::pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface) {}
+
+void vkDisplay::pointer_handle_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {}
+
+void vkDisplay::pointer_handle_button(void *data, struct wl_pointer *wl_pointer, uint32_t serial, uint32_t time, uint32_t button,
+                                      uint32_t state) {
+    if (button == BTN_LEFT && state == WL_POINTER_BUTTON_STATE_PRESSED) {
+        vkDisplay *display = (vkDisplay *)data;
+        wl_shell_surface_move(display->m_shell_surface, display->m_seat, serial);
+    }
+}
+
+void vkDisplay::pointer_handle_axis(void *data, struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {}
+
+const struct wl_pointer_listener vkDisplay::pointer_listener = {vkDisplay::pointer_handle_enter,
+                                                                vkDisplay::pointer_handle_leave,
+                                                                vkDisplay::pointer_handle_motion,
+                                                                vkDisplay::pointer_handle_button,
+                                                                vkDisplay::pointer_handle_axis,
+                                                                nullptr,
+                                                                nullptr,
+                                                                nullptr,
+                                                                nullptr};
+
+void vkDisplay::keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard, uint32_t format, int fd, uint32_t size) {}
+
+void vkDisplay::keyboard_handle_enter(void *data, struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface,
+                                      struct wl_array *keys) {}
+
+void vkDisplay::keyboard_handle_leave(void *data, struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface) {}
+
+void vkDisplay::keyboard_handle_key(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key,
+                                    uint32_t state) {
+    if (state != WL_KEYBOARD_KEY_STATE_RELEASED) return;
+    vkDisplay *display = (vkDisplay *)data;
+    switch (key) {
+        case KEY_ESC:
+            display->set_quit_status(true);
+            break;
+        case KEY_SPACE:
+            display->set_pause_status(true);
+            break;
+    }
+}
+
+void vkDisplay::keyboard_handle_modifiers(void *data, wl_keyboard *keyboard, uint32_t serial, uint32_t mods_depressed,
+                                          uint32_t mods_latched, uint32_t mods_locked, uint32_t group) {}
+
+const struct wl_keyboard_listener vkDisplay::keyboard_listener = {
+    vkDisplay::keyboard_handle_keymap, vkDisplay::keyboard_handle_enter,     vkDisplay::keyboard_handle_leave,
+    vkDisplay::keyboard_handle_key,    vkDisplay::keyboard_handle_modifiers, nullptr};
+
+void vkDisplay::seat_handle_capabilities(void *data, wl_seat *seat, uint32_t caps) {
+    // Subscribe to pointer events
+    vkDisplay *display = (vkDisplay *)data;
+    if ((caps & WL_SEAT_CAPABILITY_POINTER) && !display->m_pointer) {
+        display->m_pointer = wl_seat_get_pointer(seat);
+        wl_pointer_add_listener(display->m_pointer, &pointer_listener, display);
+    } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && display->m_pointer) {
+        wl_pointer_destroy(display->m_pointer);
+        display->m_pointer = NULL;
+    }
+    // Subscribe to keyboard events
+    if (caps & WL_SEAT_CAPABILITY_KEYBOARD) {
+        display->m_keyboard = wl_seat_get_keyboard(seat);
+        wl_keyboard_add_listener(display->m_keyboard, &keyboard_listener, display);
+    } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
+        wl_keyboard_destroy(display->m_keyboard);
+        display->m_keyboard = NULL;
+    }
+}
+
+const struct wl_seat_listener vkDisplay::seat_listener = {vkDisplay::seat_handle_capabilities, nullptr};
+
+void vkDisplay::registry_handle_global(void *data, wl_registry *registry, uint32_t id, const char *interface, uint32_t version) {
+    // pickup wayland objects when they appear
+    vkDisplay *display = (vkDisplay *)data;
+    if (strcmp(interface, "wl_compositor") == 0) {
+        display->m_compositor = (wl_compositor *)wl_registry_bind(registry, id, &wl_compositor_interface, 1);
+    } else if (strcmp(interface, "wl_shell") == 0) {
+        display->m_shell = (wl_shell *)wl_registry_bind(registry, id, &wl_shell_interface, 1);
+    } else if (strcmp(interface, "wl_seat") == 0) {
+        display->m_seat = (wl_seat *)wl_registry_bind(registry, id, &wl_seat_interface, 1);
+        wl_seat_add_listener(display->m_seat, &seat_listener, display);
+    }
+}
+
+void vkDisplay::registry_handle_global_remove(void *data, wl_registry *registry, uint32_t name) {}
+
+const struct wl_registry_listener vkDisplay::registry_listener = {vkDisplay::registry_handle_global,
+                                                                  vkDisplay::registry_handle_global_remove};
+
+#endif

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.h
@@ -1,7 +1,7 @@
 /*
  *
- * Copyright (C) 2015-2016 Valve Corporation
- * Copyright (C) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2017 Valve Corporation
+ * Copyright (C) 2015-2017 LunarG, Inc.
  * All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +20,16 @@
  * Author: Jon Ashburn <jon@lunarg.com>
  * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
  * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Joey Bzdek <joey@lunarg.com>
  */
 
 #pragma once
 
-#include "vkreplay_vkreplay.h"
-#include "vk_icd.h"
+#include <stdexcept>
+#include <vector>
+
+#include "vktrace_multiplatform.h"
+#include "vkreplay_window.h"
 
 class vkDisplay : public vktrace_replay::ReplayDisplayImp {
     friend class vkReplay;
@@ -48,9 +52,15 @@ class vkDisplay : public vktrace_replay::ReplayDisplayImp {
 #if defined(ANDROID)
     ANativeWindow* get_window_handle() { return m_window; }
 #else
+#if defined VKREPLAY_USE_WSI_XCB
     xcb_window_t get_window_handle() { return m_XcbWindow; }
     xcb_connection_t* get_connection_handle() { return m_pXcbConnection; }
     xcb_screen_t* get_screen_handle() { return m_pXcbScreen; }
+#elif defined VKREPLAY_USE_WSI_XLIB
+// TODO
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    wl_display* get_window_handle() { return m_display; }
+#endif
 #endif
 #elif defined(WIN32)
     HWND get_window_handle() { return m_windowHandle; }
@@ -64,12 +74,54 @@ class vkDisplay : public vktrace_replay::ReplayDisplayImp {
     VkIcdSurfaceAndroid m_surface;
     ANativeWindow* m_window;
 #else
+#if defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb m_surface;
     xcb_connection_t *m_pXcbConnection;
     xcb_screen_t *m_pXcbScreen;
     xcb_window_t m_XcbWindow;
     xcb_intern_atom_reply_t *atom_wm_delete_window;
 // VkPlatformHandleXcbKHR m_XcbPlatformHandle;
+#elif defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib m_surface;
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland m_surface;
+    struct wl_display *m_display;
+    struct wl_registry *m_registry;
+    struct wl_compositor *m_compositor;
+    struct wl_shell *m_shell;
+    struct wl_surface *m_wl_surface;
+    struct wl_shell_surface *m_shell_surface;
+    struct wl_seat *m_seat;
+    struct wl_pointer *m_pointer;
+    struct wl_keyboard *m_keyboard;
+
+    static void handle_ping(void *data, wl_shell_surface *shell_surface, uint32_t serial);
+    static void handle_configure(void *data, wl_shell_surface *shell_surface, uint32_t edges, int32_t width, int32_t height);
+    static void handle_popup_done(void *data, wl_shell_surface *shell_surface);
+    static const struct wl_shell_surface_listener shell_surface_listener;
+    static void pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface,
+                                     wl_fixed_t sx, wl_fixed_t sy);
+    static void pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface);
+    static void pointer_handle_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy);
+    static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer, uint32_t serial, uint32_t time, uint32_t button,
+                                      uint32_t state);
+    static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer, uint32_t time, uint32_t axis, wl_fixed_t value);
+    static const struct wl_pointer_listener pointer_listener;
+    static void keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard, uint32_t format, int fd, uint32_t size);
+    static void keyboard_handle_enter(void *data, struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface,
+                                      struct wl_array *keys);
+    static void keyboard_handle_leave(void *data, struct wl_keyboard *keyboard, uint32_t serial, struct wl_surface *surface);
+    static void keyboard_handle_key(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time, uint32_t key,
+                                    uint32_t state);
+    static void keyboard_handle_modifiers(void *data, wl_keyboard *keyboard, uint32_t serial, uint32_t mods_depressed,
+                                          uint32_t mods_latched, uint32_t mods_locked, uint32_t group);
+    static const struct wl_keyboard_listener keyboard_listener;
+    static void seat_handle_capabilities(void *data, wl_seat *seat, uint32_t caps);
+    static const struct wl_seat_listener seat_listener;
+    static void registry_handle_global(void *data, wl_registry *registry, uint32_t id, const char *interface, uint32_t version);
+    static void registry_handle_global_remove(void *data, wl_registry *registry, uint32_t name);
+    static const struct wl_registry_listener registry_listener;
+#endif
 #endif
 #elif defined(WIN32)
     VkIcdSurfaceWin32 m_surface;

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -210,7 +210,13 @@ VkResult vkReplay::manually_replay_vkCreateInstance(packet_vkCreateInstance *pPa
 
 #if defined(PLATFORM_LINUX)
 #if !defined(ANDROID)
+#if defined VKREPLAY_USE_WSI_XCB
         extension_names.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+        extension_names.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
+#endif
+        outlist.push_back("VK_KHR_xlib_surface");
+        outlist.push_back("VK_KHR_wayland_surface");
         outlist.push_back("VK_KHR_win32_surface");
 #else
         extension_names.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
@@ -228,6 +234,7 @@ VkResult vkReplay::manually_replay_vkCreateInstance(packet_vkCreateInstance *pPa
         outlist.push_back("VK_KHR_mir_surface");
 #endif
 
+        // Add any extensions that are both replayable and in the packet
         for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
             if (find(outlist.begin(), outlist.end(), pCreateInfo->ppEnabledExtensionNames[i]) == outlist.end()) {
                 extension_names.push_back(pCreateInfo->ppEnabledExtensionNames[i]);
@@ -3206,6 +3213,7 @@ VkResult vkReplay::manually_replay_vkCreateXcbSurfaceKHR(packet_vkCreateXcbSurfa
     }
 
 #if defined(PLATFORM_LINUX) && !defined(ANDROID)
+#if defined VK_USE_PLATFORM_XCB_KHR && defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
     VkXcbSurfaceCreateInfoKHR createInfo;
     createInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
@@ -3214,6 +3222,25 @@ VkResult vkReplay::manually_replay_vkCreateXcbSurfaceKHR(packet_vkCreateXcbSurfa
     createInfo.connection = pSurf->connection;
     createInfo.window = pSurf->window;
     replayResult = m_vkFuncs.real_vkCreateXcbSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined VK_USE_PLATFORM_XLIB_KHR && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    VkXlibSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.dpy = pSurf->dpy;
+    createInfo.window = pSurf->window;
+    replayResult = m_vkFuncs.real_vkCreateXlibSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined VK_USE_PLATFORM_WAYLAND_KHR && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    VkWaylandSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.display = pSurf->display;
+    createInfo.surface = pSurf->surface;
+    replayResult = m_vkFuncs.real_vkCreateWaylandSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#endif
 #elif defined WIN32
     VkIcdSurfaceWin32 *pSurf = (VkIcdSurfaceWin32 *)m_display->get_surface();
     VkWin32SurfaceCreateInfoKHR createInfo;
@@ -3243,7 +3270,7 @@ VkResult vkReplay::manually_replay_vkCreateXlibSurfaceKHR(packet_vkCreateXlibSur
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
-#if defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XLIB_KHR
+#if defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XLIB_KHR && defined VKREPLAY_USE_WSI_XLIB
     VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
     VkXlibSurfaceCreateInfoKHR createInfo;
     createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
@@ -3252,7 +3279,7 @@ VkResult vkReplay::manually_replay_vkCreateXlibSurfaceKHR(packet_vkCreateXlibSur
     createInfo.dpy = pSurf->dpy;
     createInfo.window = pSurf->window;
     replayResult = m_vkFuncs.real_vkCreateXlibSurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
-#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XCB_KHR
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XCB_KHR && defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
     VkXcbSurfaceCreateInfoKHR createInfo;
     createInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
@@ -3261,6 +3288,15 @@ VkResult vkReplay::manually_replay_vkCreateXlibSurfaceKHR(packet_vkCreateXlibSur
     createInfo.connection = pSurf->connection;
     createInfo.window = pSurf->window;
     replayResult = m_vkFuncs.real_vkCreateXcbSurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_WAYLAND_KHR && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    VkWaylandSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.display = pSurf->display;
+    createInfo.surface = pSurf->surface;
+    replayResult = m_vkFuncs.real_vkCreateWaylandSurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
 #elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_ANDROID_KHR
 // TODO
 #elif defined PLATFORM_LINUX
@@ -3276,6 +3312,65 @@ VkResult vkReplay::manually_replay_vkCreateXlibSurfaceKHR(packet_vkCreateXlibSur
     replayResult = m_vkFuncs.real_vkCreateWin32SurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
 #else
     vktrace_LogError("manually_replay_vkCreateXlibSurfaceKHR not implemented on this playback platform");
+    replayResult = VK_ERROR_FEATURE_NOT_PRESENT;
+#endif
+    if (replayResult == VK_SUCCESS) {
+        m_objMapper.add_to_surfacekhrs_map(*(pPacket->pSurface), local_pSurface);
+    }
+    return replayResult;
+}
+
+VkResult vkReplay::manually_replay_vkCreateWaylandSurfaceKHR(packet_vkCreateWaylandSurfaceKHR *pPacket) {
+    VkResult replayResult = VK_SUCCESS;
+    VkSurfaceKHR local_pSurface = VK_NULL_HANDLE;
+    VkInstance remappedinstance = m_objMapper.remap_instances(pPacket->instance);
+
+    if (pPacket->instance != VK_NULL_HANDLE && remappedinstance == VK_NULL_HANDLE) {
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
+#if defined PLATFORM_LINUX && defined VK_USE_PLATFORM_WAYLAND_KHR && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    VkWaylandSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.display = pSurf->display;
+    createInfo.surface = pSurf->surface;
+    replayResult = m_vkFuncs.real_vkCreateWaylandSurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XCB_KHR && defined VKREPLAY_USE_WSI_XCB
+    VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
+    VkXcbSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.connection = pSurf->connection;
+    createInfo.window = pSurf->window;
+    replayResult = m_vkFuncs.real_vkCreateXcbSurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XLIB_KHR && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    VkXlibSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.dpy = pSurf->dpy;
+    createInfo.window = pSurf->window;
+    replayResult = m_vkFuncs.real_vkCreateXlibSurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_ANDROID_KHR
+// TODO
+#elif defined PLATFORM_LINUX
+#error manually_replay_vkCreateWaylandSurfaceKHR on PLATFORM_LINUX requires one of VK_USE_PLATFORM_WAYLAND_KHR or VK_USE_PLATFORM_XLIB_KHR or VK_USE_PLATFORM_XCB_KHR or VK_USE_PLATFORM_ANDROID_KHR
+#elif defined WIN32
+    VkIcdSurfaceWin32 *pSurf = (VkIcdSurfaceWin32 *)m_display->get_surface();
+    VkWin32SurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.hinstance = pSurf->hinstance;
+    createInfo.hwnd = pSurf->hwnd;
+    replayResult = m_vkFuncs.real_vkCreateWin32SurfaceKHR(remappedinstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#else
+    vktrace_LogError("manually_replay_vkCreateWaylandSurfaceKHR not implemented on this playback platform");
     replayResult = VK_ERROR_FEATURE_NOT_PRESENT;
 #endif
     if (replayResult == VK_SUCCESS) {
@@ -3303,6 +3398,7 @@ VkResult vkReplay::manually_replay_vkCreateWin32SurfaceKHR(packet_vkCreateWin32S
     createInfo.hwnd = pSurf->hwnd;
     replayResult = m_vkFuncs.real_vkCreateWin32SurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
 #elif defined(PLATFORM_LINUX) && !defined(ANDROID)
+#if defined VK_USE_PLATFORM_XCB_KHR && defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
     VkXcbSurfaceCreateInfoKHR createInfo;
     createInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
@@ -3311,6 +3407,25 @@ VkResult vkReplay::manually_replay_vkCreateWin32SurfaceKHR(packet_vkCreateWin32S
     createInfo.connection = pSurf->connection;
     createInfo.window = pSurf->window;
     replayResult = m_vkFuncs.real_vkCreateXcbSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined VK_USE_PLATFORM_XLIB_KHR && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    VkXlibSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.dpy = pSurf->dpy;
+    createInfo.window = pSurf->window;
+    replayResult = m_vkFuncs.real_vkCreateXlibSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined VK_USE_PLATFORM_WAYLAND_KHR && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    VkWaylandSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.display = pSurf->display;
+    createInfo.surface = pSurf->surface;
+    replayResult = m_vkFuncs.real_vkCreateWaylandSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#endif
 #else
     vktrace_LogError("manually_replay_vkCreateWin32SurfaceKHR not implemented on this playback platform");
     replayResult = VK_ERROR_FEATURE_NOT_PRESENT;
@@ -3341,14 +3456,34 @@ VkResult vkReplay::manually_replay_vkCreateAndroidSurfaceKHR(packet_vkCreateAndr
     replayResult = m_vkFuncs.real_vkCreateWin32SurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
 #elif defined(PLATFORM_LINUX)
 #if !defined(ANDROID)
+#if defined VK_USE_PLATFORM_XCB_KHR && defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
     VkXcbSurfaceCreateInfoKHR createInfo;
-    createInfo.sType = pPacket->pCreateInfo->sType;
+    createInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
     createInfo.pNext = pPacket->pCreateInfo->pNext;
     createInfo.flags = pPacket->pCreateInfo->flags;
     createInfo.connection = pSurf->connection;
     createInfo.window = pSurf->window;
     replayResult = m_vkFuncs.real_vkCreateXcbSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined VK_USE_PLATFORM_XLIB_KHR && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    VkXlibSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.dpy = pSurf->dpy;
+    createInfo.window = pSurf->window;
+    replayResult = m_vkFuncs.real_vkCreateXlibSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#elif defined VK_USE_PLATFORM_WAYLAND_KHR && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    VkWaylandSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = pPacket->pCreateInfo->pNext;
+    createInfo.flags = pPacket->pCreateInfo->flags;
+    createInfo.display = pSurf->display;
+    createInfo.surface = pSurf->surface;
+    replayResult = m_vkFuncs.real_vkCreateWaylandSurfaceKHR(remappedInstance, &createInfo, pPacket->pAllocator, &local_pSurface);
+#endif
 #else
     VkIcdSurfaceAndroid *pSurf = (VkIcdSurfaceAndroid *)m_display->get_surface();
     VkAndroidSurfaceCreateInfoKHR createInfo;
@@ -3456,11 +3591,23 @@ VkBool32 vkReplay::manually_replay_vkGetPhysicalDeviceXcbPresentationSupportKHR(
         return VK_FALSE;
     }
 
-#if defined(PLATFORM_LINUX) && !defined(ANDROID)
+#if defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
-    m_display->get_window_handle();
     return (m_vkFuncs.real_vkGetPhysicalDeviceXcbPresentationSupportKHR(
         remappedphysicalDevice, pPacket->queueFamilyIndex, pSurf->connection, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceXlibPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                         pSurf->dpy, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceWaylandPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                            pSurf->display));
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_ANDROID_KHR
+    // This is not defined for anndroid
+    return VK_TRUE;
+#elif defined PLATFORM_LINUX
+#error manually_replay_vkGetPhysicalDeviceXcbPresentationSupportKHR on PLATFORM_LINUX requires one of VKREPLAY_USE_WSI_XCB or VKREPLAY_USE_WSI_XLIB or VKREPLAY_USE_WSI_WAYLAND or VK_USE_PLATFORM_ANDROID_KHR
 #elif defined WIN32
     return (m_vkFuncs.real_vkGetPhysicalDeviceWin32PresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex));
 #else
@@ -3474,29 +3621,65 @@ VkBool32 vkReplay::manually_replay_vkGetPhysicalDeviceXlibPresentationSupportKHR
     VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
     if (remappedphysicalDevice == VK_NULL_HANDLE) {
         vktrace_LogError(
-            "Error detected in vkGetPhysicalDeviceXcbPresentationSupportKHR() due to invalid remapped VkPhysicalDevice.");
+            "Error detected in vkGetPhysicalDeviceWaylandPresentationSupportKHR() due to invalid remapped VkPhysicalDevice.");
         return VK_FALSE;
     }
 
-#if defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XLIB_KHR
-    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
-    m_display->get_window_handle();
-    return (m_vkFuncs.real_vkGetPhysicalDeviceXlibPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
-                                                                         pSurf->dpy, m_display->get_screen_handle()->root_visual));
-#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_XCB_KHR
+#if defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
-    m_display->get_window_handle();
     return (m_vkFuncs.real_vkGetPhysicalDeviceXcbPresentationSupportKHR(
         remappedphysicalDevice, pPacket->queueFamilyIndex, pSurf->connection, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceXlibPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                         pSurf->dpy, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceWaylandPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                            pSurf->display));
 #elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_ANDROID_KHR
     // This is not defined for Android
     return VK_TRUE;
 #elif defined PLATFORM_LINUX
-#error manually_replay_vkGetPhysicalDeviceXlibPresentationSupportKHR on PLATFORM_LINUX requires one of VK_USE_PLATFORM_XLIB_KHR or VK_USE_PLATFORM_XCB_KHR or VK_USE_PLATFORM_ANDROID_KHR
+#error manually_replay_vkGetPhysicalDeviceXlibPresentationSupportKHR on PLATFORM_LINUX requires one of VKREPLAY_USE_WSI_XCB or VKREPLAY_USE_WSI_XLIB or VKREPLAY_USE_WSI_WAYLAND or VK_USE_PLATFORM_ANDROID_KHR
 #elif defined WIN32
     return (m_vkFuncs.real_vkGetPhysicalDeviceWin32PresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex));
 #else
     vktrace_LogError("manually_replay_vkGetPhysicalDeviceXlibPresentationSupportKHR not implemented on this playback platform");
+    return VK_FALSE;
+#endif
+}
+
+VkBool32 vkReplay::manually_replay_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+    packet_vkGetPhysicalDeviceWaylandPresentationSupportKHR *pPacket) {
+    VkPhysicalDevice remappedphysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
+    if (remappedphysicalDevice == VK_NULL_HANDLE) {
+        vktrace_LogError(
+            "Error detected in vkGetPhysicalDeviceWaylandPresentationSupportKHR() due to invalid remapped VkPhysicalDevice.");
+        return VK_FALSE;
+    }
+
+#if defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XCB
+    VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceXcbPresentationSupportKHR(
+        remappedphysicalDevice, pPacket->queueFamilyIndex, pSurf->connection, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceXlibPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                         pSurf->dpy, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceWaylandPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                            pSurf->display));
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_ANDROID_KHR
+    // This is not defined for Android
+    return VK_TRUE;
+#elif defined PLATFORM_LINUX
+#error manually_replay_vkGetPhysicalDeviceWaylandPresentationSupportKHR on PLATFORM_LINUX requires one of VKREPLAY_USE_WSI_XCB or VKREPLAY_USE_WSI_XLIB or VKREPLAY_USE_WSI_WAYLAND or VK_USE_PLATFORM_ANDROID_KHR
+#elif defined WIN32
+    return (m_vkFuncs.real_vkGetPhysicalDeviceWin32PresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex));
+#else
+    vktrace_LogError("manually_replay_vkGetPhysicalDeviceWaylandPresentationSupportKHR not implemented on this playback platform");
     return VK_FALSE;
 #endif
 }
@@ -3510,11 +3693,23 @@ VkBool32 vkReplay::manually_replay_vkGetPhysicalDeviceWin32PresentationSupportKH
 
 #if defined WIN32
     return (m_vkFuncs.real_vkGetPhysicalDeviceWin32PresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex));
-#elif defined(PLATFORM_LINUX) && !defined(ANDROID)
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb *pSurf = (VkIcdSurfaceXcb *)m_display->get_surface();
-    m_display->get_window_handle();
     return (m_vkFuncs.real_vkGetPhysicalDeviceXcbPresentationSupportKHR(
         remappedphysicalDevice, pPacket->queueFamilyIndex, pSurf->connection, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_XLIB
+    VkIcdSurfaceXlib *pSurf = (VkIcdSurfaceXlib *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceXlibPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                         pSurf->dpy, m_display->get_screen_handle()->root_visual));
+#elif defined PLATFORM_LINUX && defined VKREPLAY_USE_WSI_WAYLAND
+    VkIcdSurfaceWayland *pSurf = (VkIcdSurfaceWayland *)m_display->get_surface();
+    return (m_vkFuncs.real_vkGetPhysicalDeviceWaylandPresentationSupportKHR(remappedphysicalDevice, pPacket->queueFamilyIndex,
+                                                                            pSurf->display));
+#elif defined PLATFORM_LINUX && defined VK_USE_PLATFORM_ANDROID_KHR
+    // This is not defined for Android
+    return VK_TRUE;
+#elif defined PLATFORM_LINUX
+#error manually_replay_vkGetPhysicalDeviceWin32PresentationSupportKHR on PLATFORM_LINUX requires one of VKREPLAY_USE_WSI_XCB or VKREPLAY_USE_WSI_XLIB or VKREPLAY_USE_WSI_WAYLAND or VK_USE_PLATFORM_ANDROID_KHR
 #else
     vktrace_LogError("manually_replay_vkGetPhysicalDeviceWin32PresentationSupportKHR not implemented on this playback platform");
     return VK_FALSE;

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -1,7 +1,7 @@
 /*
  *
- * Copyright (C) 2015-2016 Valve Corporation
- * Copyright (C) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2017 Valve Corporation
+ * Copyright (C) 2015-2017 LunarG, Inc.
  * All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -176,6 +176,9 @@ class vkReplay {
     VkResult manually_replay_vkCreateXlibSurfaceKHR(packet_vkCreateXlibSurfaceKHR* pPacket);
     VkBool32 manually_replay_vkGetPhysicalDeviceXlibPresentationSupportKHR(
         packet_vkGetPhysicalDeviceXlibPresentationSupportKHR* pPacket);
+    VkResult manually_replay_vkCreateWaylandSurfaceKHR(packet_vkCreateWaylandSurfaceKHR* pPacket);
+    VkBool32 manually_replay_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+        packet_vkGetPhysicalDeviceWaylandPresentationSupportKHR* pPacket);
     VkResult manually_replay_vkCreateWin32SurfaceKHR(packet_vkCreateWin32SurfaceKHR* pPacket);
     VkBool32 manually_replay_vkGetPhysicalDeviceWin32PresentationSupportKHR(
         packet_vkGetPhysicalDeviceWin32PresentationSupportKHR* pPacket);

--- a/vktrace/vktrace_replay/vkreplay_window.h
+++ b/vktrace/vktrace_replay/vkreplay_window.h
@@ -29,8 +29,15 @@ extern "C" {
 #include <android_native_app_glue.h>
 typedef ANativeWindow* vktrace_window_handle;
 #else
+#if defined VKREPLAY_USE_WSI_XCB
 #include <xcb/xcb.h>
 typedef xcb_window_t vktrace_window_handle;
+#elif defined VKREPLAY_USE_WSI_XLIB
+// TODO
+#elif defined VKREPLAY_USE_WSI_WAYLAND
+#include <wayland-client.h>
+typedef wl_display* vktrace_window_handle;
+#endif
 #endif
 #elif defined(WIN32)
 typedef HWND vktrace_window_handle;


### PR DESCRIPTION
In CMake, define VKREPLAY_WSI_SELECTION=<XCB/XLIB/WAYLAND> to choose which windowing system vkreplay will use.