### PR TITLE
vkreplay: Fix reset frame number when loopStartFrame is given.

### DIFF
--- a/vktrace/vktrace_replay/vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay.cpp
@@ -150,8 +150,8 @@ int VKTRACER_CDECL VkReplayGetFrameNumber() {
     return -1;
 }
 
-void VKTRACER_CDECL VkReplayResetFrameNumber() {
+void VKTRACER_CDECL VkReplayResetFrameNumber(int frameNumber) {
     if (g_pReplayer != NULL) {
-        g_pReplayer->reset_frame_number();
+        g_pReplayer->reset_frame_number(frameNumber);
     }
 }

--- a/vktrace/vktrace_replay/vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay.h
@@ -36,6 +36,6 @@ extern vktrace_trace_packet_header* VKTRACER_CDECL VkReplayInterpret(vktrace_tra
 extern vktrace_replay::VKTRACE_REPLAY_RESULT VKTRACER_CDECL VkReplayReplay(vktrace_trace_packet_header* pPacket);
 extern int VKTRACER_CDECL VkReplayDump();
 extern int VKTRACER_CDECL VkReplayGetFrameNumber();
-extern void VKTRACER_CDECL VkReplayResetFrameNumber();
+extern void VKTRACER_CDECL VkReplayResetFrameNumber(int frameNumber);
 
 extern PFN_vkDebugReportCallbackEXT g_fpDbgMsgCallback;

--- a/vktrace/vktrace_replay/vkreplay_factory.h
+++ b/vktrace/vktrace_replay/vkreplay_factory.h
@@ -65,7 +65,7 @@ typedef vktrace_trace_packet_header *(VKTRACER_CDECL *funcptr_vkreplayer_interpr
 typedef vktrace_replay::VKTRACE_REPLAY_RESULT(VKTRACER_CDECL *funcptr_vkreplayer_replay)(vktrace_trace_packet_header *pPacket);
 typedef int(VKTRACER_CDECL *funcptr_vkreplayer_dump)();
 typedef int(VKTRACER_CDECL *funcptr_vkreplayer_getframenumber)();
-typedef void(VKTRACER_CDECL *funcptr_vkreplayer_resetframenumber)();
+typedef void(VKTRACER_CDECL *funcptr_vkreplayer_resetframenumber)(int frameNumber);
 }
 
 struct vktrace_trace_packet_replay_library {

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -224,7 +224,7 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
         seq.set_bookmark(startingPacket);
         trace_running = true;
         if (replayer != NULL) {
-            replayer->ResetFrameNumber();
+            replayer->ResetFrameNumber(settings.loopStartFrame);
         }
     }
 

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -132,6 +132,7 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
     // record the location of looping start packet
     seq.record_bookmark();
     seq.get_bookmark(startingPacket);
+    unsigned int totalLoops = settings.numLoops;
     while (settings.numLoops > 0) {
         while (trace_running) {
             display.process_event();
@@ -192,7 +193,9 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
                         if (prevFrameNumber != frameNumber) {
                             prevFrameNumber = frameNumber;
 
-                            if (frameNumber == settings.loopStartFrame) {
+                            // Only set the loop start location in the first loop when loopStartFrame is not 0
+                            if (frameNumber == settings.loopStartFrame && settings.loopStartFrame > 0 &&
+                                settings.numLoops == totalLoops) {
                                 // record the location of looping start packet
                                 seq.record_bookmark();
                                 seq.get_bookmark(startingPacket);

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -74,7 +74,7 @@ class vkReplay {
     vktrace_replay::VKTRACE_REPLAY_RESULT pop_validation_msgs();
     int dump_validation_data();
     int get_frame_number() { return m_frameNumber; }
-    void reset_frame_number() { m_frameNumber = 0; }
+    void reset_frame_number(int frameNumber) { m_frameNumber = frameNumber > 0 ? frameNumber : 0; }
 
    private:
     struct vkFuncs m_vkFuncs;


### PR DESCRIPTION
This change sets m_frameNumber to loopStartFrame after each loop to
make the frame number counter m_frameNumber consistent with the frame
which startingPacket belongs to.

Otherwise the vkreplay will replay frames starts from loopStartFrame to
(loopStartFrame + loopEndFrame) in the second or later loop.  Because
the startingPacket is set to the first packet of frame "loopStartFrame"
but the m_frameNumber is reset to 0 which means the replayed content is
starts from the expected loopStartFrame but the internal frame counter
is starts from 0 instead of loopStartFrame.