### PR TITLE
vktrace: Fix trim trace file playback crash

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -2266,6 +2266,14 @@ void write_all_referenced_object_calls() {
 
     // PhysicalDevice memory and queue family properties
     for (auto obj = stateTracker.createdPhysicalDevices.begin(); obj != stateTracker.createdPhysicalDevices.end(); obj++) {
+        if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDevicePropertiesPacket != nullptr) {
+            // Generate GetPhysicalDeviceProperties Packet. It's needed by portability
+            // process in vkAllocateMemory during playback.
+            vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDevicePropertiesPacket,
+                                       vktrace_trace_get_trace_file());
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDevicePropertiesPacket));
+        }
+
         if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceMemoryPropertiesPacket != nullptr) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceMemoryPropertiesPacket,
                                        vktrace_trace_get_trace_file());

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
@@ -398,6 +398,7 @@ StateTracker &StateTracker::operator=(const StateTracker &other) {
 
     createdPhysicalDevices = other.createdPhysicalDevices;
     for (auto obj = createdPhysicalDevices.begin(); obj != createdPhysicalDevices.end(); obj++) {
+        COPY_PACKET(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDevicePropertiesPacket);
         COPY_PACKET(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceMemoryPropertiesPacket);
         COPY_PACKET(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesCountPacket);
         COPY_PACKET(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesPacket);

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
@@ -80,6 +80,7 @@ typedef struct _Trim_ObjectInfo {
             vktrace_trace_packet_header *pEnumeratePhysicalDevicesPacket;
         } Instance;
         struct _PhysicalDevice {  // VkPhysicalDevice
+            vktrace_trace_packet_header *pGetPhysicalDevicePropertiesPacket;
             vktrace_trace_packet_header *pGetPhysicalDeviceMemoryPropertiesPacket;
             vktrace_trace_packet_header *pGetPhysicalDeviceQueueFamilyPropertiesCountPacket;
             vktrace_trace_packet_header *pGetPhysicalDeviceQueueFamilyPropertiesPacket;


### PR DESCRIPTION
vkreplay crash during playback trimmed trace file for some title. The
change fixes the problem by adding process in vktrace trim module to
record vkGetPhysicalDeviceProperties packet, the packet is needed by
portability process during playback.

Change-Id: I9692a99614818679123cdd1bbbca0db56da58434