### PR TITLE
layersvt: DevSim to verify schema is acceptable

### DIFF
--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.1",
+        "implementation_version": "1.0.2",
         "description": "LunarG device simulation layer"
     }
 }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.1",
+        "implementation_version": "1.0.2",
         "description": "LunarG device simulation layer"
     }
 }


### PR DESCRIPTION
DevSim now verifies the contents of the "$schema" property and can
use that to determine how to parse the config file.
Bump version to 1.0.2.
A couple other minor tweaks and clang-format.

Change-Id: I68cf6adb948bc648e3d5da1612517dd880a6f1c9