### PR TITLE
vktrace: add next n frames trim capture support

### DIFF
--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -120,7 +120,7 @@ vktrace_SettingInfo g_settings_info[] = {
      {&g_default_settings.traceTrigger},
      TRUE,
      "(Alpha) Start/stop trim by hotkey or frame range:\n\
-                                         hotkey-<keyname>\n\
+                                         hotkey-<keyname>-<frameCount>\n\
                                          frames-<startFrame>-<endFrame>"},
     //{ "z", "pauze", VKTRACE_SETTING_BOOL, &g_settings.pause,
     //&g_default_settings.pause, TRUE, "Wait for a key at startup (so a debugger


### PR DESCRIPTION
Add support to capture the next n frames after pressing a trim hotkey once.

   The original command line option for trim hotkey is “hotkey-\<hotkeyname\>”, the change in this pull request is to add support for an additional format which is " hotkey-\<hotkeyname\>-\<framecount\>".  If user starts vktrace with this type of command line option or from server mode, set “ hotkey-\<hotkeyname\>-\<framenumber\> “ to  original environment variable for hotkey, once user press hotkey, trim will automatically stop capture after specified frames (framecount) . The feature also support user press hotkey to stop the trim capture before it reach the specified frames.

XCAP-729

Change-Id: I28c98011f2a04a552201aac0345c918e8b781f60