### PR TITLE
vkreplay: Encapsulate direct file read calls and fix alignment in vkBBM

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -614,6 +614,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                  'DestroyDescriptorUpdateTemplateKHR',
                                  'UpdateDescriptorSetWithTemplateKHR',
                                  'CmdPushDescriptorSetWithTemplateKHR',
+                                 'BindBufferMemory',
                                  ]
         # Map APIs to functions if body is fully custom
         custom_body_dict = {'CreateInstance': self.GenReplayCreateInstance,

--- a/vktrace/vktrace_common/vktrace_filelike.c
+++ b/vktrace/vktrace_common/vktrace_filelike.c
@@ -65,8 +65,12 @@ BOOL vktrace_Checkpoint_read(Checkpoint* pCheckpoint, FileLike* _in) {
 // ------------------------------------------------------------------------------------------------
 size_t vktrace_FileLike_GetFileLength(FILE* fp) {
     size_t byte_length = 0;
-
     long length = 0;
+
+    // Save file position before getting file length
+    size_t savedFilePosition = ftell(fp);
+
+    // Get file length
     if (fseek(fp, 0, SEEK_END) != 0) {
         vktrace_LogError("Failed to fseek to the end of tracefile for replaying.");
     } else {
@@ -76,7 +80,9 @@ size_t vktrace_FileLike_GetFileLength(FILE* fp) {
             length = 0;
         }
     }
-    rewind(fp);
+
+    // Reset file position after getting file length
+    fseek(fp, savedFilePosition, SEEK_SET);
 
     byte_length = length;
     return byte_length;
@@ -90,7 +96,7 @@ FileLike* vktrace_FileLike_create_file(FILE* fp) {
         pFile->mMode = File;
         pFile->mFile = fp;
         pFile->mMessageStream = NULL;
-        pFile->mMemLen = vktrace_FileLike_GetFileLength(fp);
+        pFile->mFileLen = vktrace_FileLike_GetFileLength(fp);
     }
     return pFile;
 }
@@ -103,7 +109,7 @@ FileLike* vktrace_FileLike_create_msg(MessageStream* _msgStream) {
         pFile->mMode = Socket;
         pFile->mFile = NULL;
         pFile->mMessageStream = _msgStream;
-        pFile->mMemLen = 0;
+        pFile->mFileLen = 0;
     }
     return pFile;
 }

--- a/vktrace/vktrace_common/vktrace_filelike.c
+++ b/vktrace/vktrace_common/vktrace_filelike.c
@@ -65,12 +65,9 @@ BOOL vktrace_Checkpoint_read(Checkpoint* pCheckpoint, FileLike* _in) {
 // ------------------------------------------------------------------------------------------------
 size_t vktrace_FileLike_GetFileLength(FILE* fp) {
     size_t byte_length = 0;
-    long length = 0;
-
-    // Save file position before getting file length
-    size_t savedFilePosition = ftell(fp);
 
     // Get file length
+    long length = 0;
     if (fseek(fp, 0, SEEK_END) != 0) {
         vktrace_LogError("Failed to fseek to the end of tracefile for replaying.");
     } else {
@@ -81,8 +78,10 @@ size_t vktrace_FileLike_GetFileLength(FILE* fp) {
         }
     }
 
-    // Reset file position after getting file length
-    fseek(fp, savedFilePosition, SEEK_SET);
+    // WARNING: Reset file position to the beginning of the file
+    // Because this function is only called from vktrace_FileLike_create_file,
+    // the file position should always be the beginning of the file before getting file length.
+    rewind(fp);
 
     byte_length = length;
     return byte_length;

--- a/vktrace/vktrace_common/vktrace_filelike.h
+++ b/vktrace/vktrace_common/vktrace_filelike.h
@@ -37,7 +37,7 @@ typedef struct FileLike FileLike;
 typedef struct FileLike {
     enum { File, Socket } mMode;
     FILE* mFile;
-    size_t mMemLen;
+    size_t mFileLen;
     MessageStream* mMessageStream;
 } FileLike;
 

--- a/vktrace/vktrace_common/vktrace_filelike.h
+++ b/vktrace/vktrace_common/vktrace_filelike.h
@@ -37,6 +37,7 @@ typedef struct FileLike FileLike;
 typedef struct FileLike {
     enum { File, Socket } mMode;
     FILE* mFile;
+    size_t mMemLen;
     MessageStream* mMessageStream;
 } FileLike;
 
@@ -77,6 +78,12 @@ void vktrace_FileLike_Write(FileLike* pFileLike, const void* _bytes, size_t _len
 // Normally, Write outputs the _len to the stream first--with WriteRaw the bytes are simply written,
 // no size parameter first.
 BOOL vktrace_FileLike_WriteRaw(FileLike* pFile, const void* _bytes, size_t _len);
+
+// Get the starting position for the next vktrace_FileLike_ReadRaw
+size_t vktrace_FileLike_GetCurrentPosition(FileLike* pFile);
+
+// Set the starting position for the next vktrace_FileLike_ReadRaw
+BOOL vktrace_FileLike_SetCurrentPosition(FileLike* pFile, size_t offset);
 
 #ifdef __cplusplus
 }

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -298,10 +298,10 @@ static bool readPortabilityTable() {
 
     originalFilePos = vktrace_FileLike_GetCurrentPosition(traceFile);
     if (-1 == originalFilePos) return false;
-    if (!vktrace_FileLike_SetCurrentPosition(traceFile, traceFile->mMemLen - sizeof(size_t))) return false;
+    if (!vktrace_FileLike_SetCurrentPosition(traceFile, traceFile->mFileLen - sizeof(size_t))) return false;
     if (!vktrace_FileLike_ReadRaw(traceFile, &tableSize, sizeof(size_t))) return false;
     if (tableSize == 0) return true;
-    if (!vktrace_FileLike_SetCurrentPosition(traceFile, traceFile->mMemLen - ((tableSize + 1) * sizeof(size_t)))) return false;
+    if (!vktrace_FileLike_SetCurrentPosition(traceFile, traceFile->mFileLen - ((tableSize + 1) * sizeof(size_t)))) return false;
     portabilityTable.resize(tableSize);
     if (!vktrace_FileLike_ReadRaw(traceFile, &portabilityTable[0], sizeof(size_t) * tableSize)) return false;
     if (!vktrace_FileLike_SetCurrentPosition(traceFile, originalFilePos)) return false;

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -296,15 +296,15 @@ static bool readPortabilityTable() {
     size_t tableSize;
     int originalFilePos;
 
-    originalFilePos = ftell(tracefp);
+    originalFilePos = vktrace_FileLike_GetCurrentPosition(traceFile);
     if (-1 == originalFilePos) return false;
-    if (0 != fseek(tracefp, -sizeof(size_t), SEEK_END)) return false;
-    if (1 != fread(&tableSize, sizeof(size_t), 1, tracefp)) return false;
+    if (!vktrace_FileLike_SetCurrentPosition(traceFile, traceFile->mMemLen - sizeof(size_t))) return false;
+    if (!vktrace_FileLike_ReadRaw(traceFile, &tableSize, sizeof(size_t))) return false;
     if (tableSize == 0) return true;
-    if (0 != fseek(tracefp, -(tableSize + 1) * sizeof(size_t), SEEK_END)) return false;
+    if (!vktrace_FileLike_SetCurrentPosition(traceFile, traceFile->mMemLen - ((tableSize + 1) * sizeof(size_t)))) return false;
     portabilityTable.resize(tableSize);
-    if (tableSize != fread(&portabilityTable[0], sizeof(size_t), tableSize, tracefp)) return false;
-    if (0 != fseek(tracefp, originalFilePos, SEEK_SET)) return false;
+    if (!vktrace_FileLike_ReadRaw(traceFile, &portabilityTable[0], sizeof(size_t) * tableSize)) return false;
+    if (!vktrace_FileLike_SetCurrentPosition(traceFile, originalFilePos)) return false;
 
     vktrace_LogDebug("portabilityTable size=%ld\n", tableSize);
     for (size_t i = 0; i < tableSize; i++) vktrace_LogDebug("   %p %ld", &portabilityTable[i], portabilityTable[i]);
@@ -387,6 +387,8 @@ int vkreplay_main(int argc, char** argv, vktrace_window_handle window = 0) {
     vktrace_trace_file_header fileHeader;
     vktrace_trace_file_header* pFileHeader;  // File header, including gpuinfo structs
 
+    FILE* tracefp;
+
     if (pTraceFile != NULL && strlen(pTraceFile) > 0) {
         tracefp = fopen(pTraceFile, "rb");
         if (tracefp == NULL) {
@@ -408,7 +410,7 @@ int vkreplay_main(int argc, char** argv, vktrace_window_handle window = 0) {
     }
 
     // read the header
-    FileLike* traceFile = vktrace_FileLike_create_file(tracefp);
+    traceFile = vktrace_FileLike_create_file(tracefp);
     if (vktrace_FileLike_ReadRaw(traceFile, &fileHeader, sizeof(fileHeader)) == false) {
         vktrace_LogError("Unable to read header from file.");
         if (pAllSettings != NULL) {

--- a/vktrace/vktrace_replay/vkreplay_main.h
+++ b/vktrace/vktrace_replay/vkreplay_main.h
@@ -34,6 +34,6 @@ typedef struct vkreplayer_settings {
 
 #include <vector>
 extern std::vector<size_t> portabilityTable;
-extern FILE* tracefp;
+extern FileLike* traceFile;
 
 #endif  // VKREPLAY__MAIN_H

--- a/vktrace/vktrace_replay/vkreplay_seq.cpp
+++ b/vktrace/vktrace_replay/vkreplay_seq.cpp
@@ -35,8 +35,8 @@ vktrace_trace_packet_header *Sequencer::get_next_packet() {
 
 void Sequencer::get_bookmark(seqBookmark &bookmark) { bookmark.file_offset = m_bookmark.file_offset; }
 
-void Sequencer::set_bookmark(const seqBookmark &bookmark) { fseek(m_pFile->mFile, m_bookmark.file_offset, SEEK_SET); }
+void Sequencer::set_bookmark(const seqBookmark &bookmark) { vktrace_FileLike_SetCurrentPosition(m_pFile, m_bookmark.file_offset); }
 
-void Sequencer::record_bookmark() { m_bookmark.file_offset = ftell(m_pFile->mFile); }
+void Sequencer::record_bookmark() { m_bookmark.file_offset = vktrace_FileLike_GetCurrentPosition(m_pFile); }
 
 } /* namespace vktrace_replay */

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -104,7 +104,8 @@ int vkReplay::init(vktrace_replay::ReplayDisplay &disp) {
 
     // 32bit/64bit trace file is not supported by 64bit/32bit vkreplay
     if (m_replay_ptrsize != m_pFileHeader->ptrsize) {
-        vktrace_LogError("%d-bit trace file is not supported by %d-bit vkreplay.", m_pFileHeader->ptrsize * 8, m_replay_ptrsize * 8);
+        vktrace_LogError("%d-bit trace file is not supported by %d-bit vkreplay.", m_pFileHeader->ptrsize * 8,
+                         m_replay_ptrsize * 8);
         return -1;
     }
 

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -2306,7 +2306,8 @@ VkResult vkReplay::manually_replay_vkAllocateMemory(packet_vkAllocateMemory *pPa
                         }
                         if ((packetHeader2.packet_id == VKTRACE_TPI_VK_vkGetImageMemoryRequirements ||
                              packetHeader2.packet_id == VKTRACE_TPI_VK_vkGetBufferMemoryRequirements) &&
-                            gimrPacket.image == bimPacket.image) {
+                            (gimrPacket.image == bimPacket.image) &&
+                            (packetHeader2.global_packet_index < pPacket->header->global_packet_index)) {
                             // Found the corresponding gimr/gbmr packet
                             FSEEK(traceFile,
                                   (long)portabilityTable[j] + sizeof(packetHeader2) + (long)gimrPacket.pMemoryRequirements,

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -105,6 +105,7 @@ int vkReplay::init(vktrace_replay::ReplayDisplay &disp) {
     // 32bit/64bit trace file is not supported by 64bit/32bit vkreplay
     if (m_replay_ptrsize != m_pFileHeader->ptrsize) {
         vktrace_LogError("%d-bit trace file is not supported by %d-bit vkreplay.", m_pFileHeader->ptrsize * 8, m_replay_ptrsize * 8);
+        return -1;
     }
 
     return 0;

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -190,6 +190,7 @@ class vkReplay {
     void manually_replay_vkDestroyDescriptorUpdateTemplateKHR(packet_vkDestroyDescriptorUpdateTemplateKHR* pPacket);
     void manually_replay_vkUpdateDescriptorSetWithTemplateKHR(packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket);
     void manually_replay_vkCmdPushDescriptorSetWithTemplateKHR(packet_vkCmdPushDescriptorSetWithTemplateKHR* pPacket);
+    VkResult manually_replay_vkBindBufferMemory(packet_vkBindBufferMemory* pPacket);
 
     void process_screenshot_list(const char* list) {
         std::string spec(list), word;


### PR DESCRIPTION
* Encapsulate all the direct calls of fread/ftell/fseek with FileLike

* Do alignment for the memory size needed in vkAM call to make sure it
allocates memory with the expected size during replay.  Only works when
portability table is being used and the alignment in vkGBMR is
different in trace platform and replay platform.
(Haven't met the alignment issue in vkBIM, so leave vkBIM unchanged)

* Print useful info when user tries to replay a 32bit trace file using
64bit vkreplay and vice versa.