### PR TITLE
vktrace: add next n frames trim capture support

### DIFF
--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -121,6 +121,7 @@ vktrace_SettingInfo g_settings_info[] = {
      TRUE,
      "Start/stop trim by hotkey or frame range:\n\
                                          hotkey-[F1-F12|TAB|CONTROL]\n\
+                                         hotkey-[F1-F12|TAB|CONTROL]-<frameCount>\n\
                                          frames-<startFrame>-<endFrame>"},
     //{ "z", "pauze", VKTRACE_SETTING_BOOL, &g_settings.pause,
     //&g_default_settings.pause, TRUE, "Wait for a key at startup (so a debugger


### PR DESCRIPTION
Add support to capture the next n frames after pressing a trim hotkey once.

   The original command line option for trim hotkey is “hotkey-\<hotkeyname\>”, the change in this pull request is to add support for an additional format which is " hotkey-\<hotkeyname\>-\<framecount\>".  If user starts vktrace with this type of command line option or from server mode, set “ hotkey-\<hotkeyname\>-\<framenumber\> “ to  original environment variable for hotkey, once user press hotkey, trim will automatically stop capture after specified frames (framecount) . The feature also support user press hotkey to stop the trim capture before it reach the specified frames.

XCAP-729

Change-Id: I83ee50aa4c90b656b51bb6bf05c249ff7b9ff747