### PR TITLE
vkreplay: Kill com.example.vkreplay after everything is done

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -698,7 +698,10 @@ void android_main(struct android_app* app) {
             ANativeActivity_finish(app->activity);
             free(argv);
 
-            return;
+            // Kill the process
+            // This is not a necessarily good practice.  But it works to make sure the process is killed after replaying a trace
+            // file.  So user will not need to run "adb shell am force-stop come.example.vkreplay" afterwards.
+            exit(err);
         }
     }
 }


### PR DESCRIPTION
With this change, user will not need to run "adb shell am force-stop
com.example.vkreplay" manually after replaying a trace file.

Not sure if the "exit()" way of doing this is suggested in Android development.
But I haven't found any better way to kill the process from vkreplay itself on Android.