### PR TITLE
layersvt: DevSim 1.0.3 minor code reorgs

### DIFF
--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.2",
+        "implementation_version": "1.0.3",
         "description": "LunarG device simulation layer"
     }
 }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.2",
+        "implementation_version": "1.0.3",
         "description": "LunarG device simulation layer"
     }
 }


### PR DESCRIPTION
Bump version to 1.0.3

This commit is a collection of small changes that don't affect existing
functionality.  There are general code improvements, and some preparation
for new functionality in development.

Among minor code reorganizations, function renames, comments added, also:

1) Use JsonCpp value.type() rather than value.is*().
An old JsonCpp design decision (and tagged as will-not-change): isObject()
unfortunately returns TRUE for nullValue.  Therefore, use explicit test of
type() to ensure a value is really only an objectValue.  isArray() has same
issue.  Changing all type checks to avoid value.is*().

2) Reduce type checking code, since types are enforced by schema validation.

3) Rename ApplyOverrides() to GetValue().  Split the value argument into
separate parent and name arguments.

Change-Id: Id660685cdecd3b137ea24e269815045e0376dec3