### PR TITLE
layersvt: Fix api_dump asserts

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -423,8 +423,8 @@ class ApiDumpInstance {
             loader_platform_thread_lock_mutex(&cmd_buffer_state_mutex);
 
             const auto cmd_buffers_iter = cmd_buffer_pools.find(std::make_pair(device, cmd_pool));
-            assert(cmd_buffers_iter != cmd_buffer_pools.end());
-            cmd_buffers_iter->second.clear();
+            if (cmd_buffers_iter != cmd_buffer_pools.end())
+                cmd_buffers_iter->second.clear();
 
             loader_platform_thread_unlock_mutex(&cmd_buffer_state_mutex);
         }

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -423,8 +423,13 @@ class ApiDumpInstance {
             loader_platform_thread_lock_mutex(&cmd_buffer_state_mutex);
 
             const auto cmd_buffers_iter = cmd_buffer_pools.find(std::make_pair(device, cmd_pool));
-            if (cmd_buffers_iter != cmd_buffer_pools.end())
+            if (cmd_buffers_iter != cmd_buffer_pools.end()) {
+                for (const auto cmd_buffer : cmd_buffers_iter->second) {
+                    assert(cmd_buffer_level.count(cmd_buffer) > 0);
+                    cmd_buffer_level.erase(cmd_buffer);
+                }
                 cmd_buffers_iter->second.clear();
+            }
 
             loader_platform_thread_unlock_mutex(&cmd_buffer_state_mutex);
         }


### PR DESCRIPTION
Fixes crashes caused by asserts() in api_dump layer.