### PR TITLE
vktrace: Fix endianess

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_identifiers.h
+++ b/vktrace/vktrace_common/vktrace_trace_packet_identifiers.h
@@ -255,8 +255,8 @@ typedef enum _VKTRACE_TRACE_PACKET_ID_VK {
     VKTRACE_TPI_VK_vkGetPhysicalDeviceWaylandPresentationSupportKHR = 180
 } VKTRACE_TRACE_PACKET_ID_VK;
 
-#define VKTRACE_BIG_ENDIAN 0
-#define VKTRACE_LITTLE_ENDIAN 1
+#define VKTRACE_BIG_ENDIAN 1
+#define VKTRACE_LITTLE_ENDIAN 0
 
 typedef struct {
     uint8_t id;

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -116,7 +116,7 @@ uint64_t vktrace_get_time() { return 0; }
 
 uint64_t get_endianess() {
     uint32_t x = 1;
-    return *((char*)&x) ? VKTRACE_BIG_ENDIAN : VKTRACE_LITTLE_ENDIAN;
+    return *((char*)&x) ? VKTRACE_LITTLE_ENDIAN : VKTRACE_BIG_ENDIAN;
 }
 
 uint64_t get_arch() {


### PR DESCRIPTION
This change fixed the return value of get_endianess() to represent the
correct endianess.