### PR TITLE
layersvt: DevSim 1.0.4 GH296 Add debug msgs

### DIFF
--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -51,6 +51,7 @@ any additional top-level sections will be ignored by DevSim.
 
 The schema defines basic range checking for common Vulkan data types, but it cannot detect if a particular configuration makes no sense.
 If a configuration defines capabilities beyond what the actual device is natively capable of providing, the results are undefined.
+DevSim has some simple checking of configuration values and writes debug messages (if enabled) for values that are incompatible with the capabilities of the actual device.
 
 ## Example of a DevSim JSON configuration file
 ```json

--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.3",
+        "implementation_version": "1.0.4",
         "description": "LunarG device simulation layer"
     }
 }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.3",
+        "implementation_version": "1.0.4",
         "description": "LunarG device simulation layer"
     }
 }


### PR DESCRIPTION
Bump version to 1.0.4

See issue https://github.com/LunarG/VulkanTools/issues/296
This depends upon pull request https://github.com/LunarG/VulkanTools/pull/304

Add some informational messages to help diagnose when values of a simulated device configuration are not compatible with the VkPhysicalDeviceLimits of the underlying actual device.  Those messages are enabled, along with other debug messages, using: export VK_DEVSIM_DEBUG_ENABLE="1"
