### PR TITLE
vktrace: Fix descriptor sets recording in trim

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -1901,6 +1901,11 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
     } else {
         vktrace_finalize_trace_packet(pHeader);
         for (uint32_t i = 0; i < descriptorWriteCount; i++) {
+            // Reset writeDescriptorCount for each dstSet in this UpdateDescriptorSets call to only record the latest data.
+            trim::ObjectInfo* pInfo = trim::get_DescriptorSet_objectInfo(pDescriptorWrites[i].dstSet);
+            pInfo->ObjectInfo.DescriptorSet.writeDescriptorCount = 0;
+        }
+        for (uint32_t i = 0; i < descriptorWriteCount; i++) {
             trim::ObjectInfo* pInfo = trim::get_DescriptorSet_objectInfo(pDescriptorWrites[i].dstSet);
             if (pInfo != NULL) {
                 // find existing writeDescriptorSet info to update.
@@ -1913,21 +1918,21 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
                         pInfo->ObjectInfo.DescriptorSet.writeDescriptorCount++;
 
                         pWriteDescriptorSet->dstArrayElement = pDescriptorWrites[i].dstArrayElement;
-                        if (pDescriptorWrites[i].pImageInfo != nullptr) {
+                        if (pDescriptorWrites[i].pImageInfo != nullptr && pWriteDescriptorSet->pImageInfo != nullptr) {
                             memcpy(const_cast<VkDescriptorImageInfo*>(pWriteDescriptorSet->pImageInfo),
                                    pDescriptorWrites[i].pImageInfo,
                                    sizeof(VkDescriptorImageInfo) * pWriteDescriptorSet->descriptorCount);
                             pWriteDescriptorSet->pBufferInfo = nullptr;
                             pWriteDescriptorSet->pTexelBufferView = nullptr;
                         }
-                        if (pDescriptorWrites[i].pBufferInfo != nullptr) {
+                        if (pDescriptorWrites[i].pBufferInfo != nullptr && pWriteDescriptorSet->pBufferInfo != nullptr) {
                             memcpy(const_cast<VkDescriptorBufferInfo*>(pWriteDescriptorSet->pBufferInfo),
                                    pDescriptorWrites[i].pBufferInfo,
                                    sizeof(VkDescriptorBufferInfo) * pWriteDescriptorSet->descriptorCount);
                             pWriteDescriptorSet->pImageInfo = nullptr;
                             pWriteDescriptorSet->pTexelBufferView = nullptr;
                         }
-                        if (pDescriptorWrites[i].pTexelBufferView != nullptr) {
+                        if (pDescriptorWrites[i].pTexelBufferView != nullptr && pWriteDescriptorSet->pTexelBufferView != nullptr) {
                             memcpy(const_cast<VkBufferView*>(pWriteDescriptorSet->pTexelBufferView),
                                    pDescriptorWrites[i].pTexelBufferView,
                                    sizeof(VkBufferView) * pWriteDescriptorSet->descriptorCount);

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
@@ -600,7 +600,7 @@ StateTracker &StateTracker::operator=(const StateTracker &other) {
             memcpy(tmp, obj->second.ObjectInfo.DescriptorSet.pWriteDescriptorSets, numBindings * sizeof(VkWriteDescriptorSet));
             obj->second.ObjectInfo.DescriptorSet.pWriteDescriptorSets = tmp;
 
-            for (uint32_t s = 0; s < obj->second.ObjectInfo.DescriptorSet.writeDescriptorCount; s++) {
+            for (uint32_t s = 0; s < numBindings; s++) {
                 uint32_t count = obj->second.ObjectInfo.DescriptorSet.pWriteDescriptorSets[s].descriptorCount;
 
                 if (obj->second.ObjectInfo.DescriptorSet.pWriteDescriptorSets[s].pImageInfo != nullptr) {


### PR DESCRIPTION
This change fixes three minor issues related to recording write descriptor
sets in trim.

* Reset writeDescriptorCount for each DescriptorSet before processing
write descriptor sets in __HOOKED_vkUpdateDescriptorSets in trim. This
is to make sure writeDescriptorCount is consistent with the number of
pWriteDescriptorSets for each descriptor set in the latest call of
vkUpdateDescriptorSets for each descriptor set.

* Add check for the destination address (it should not be nullptr) when
recording ImageInfo, BufferInfo or TexelBufferView for each write
descriptor set via memcpy.

* Go through all the WriteDescriptorSets to copy their valid ImageInfo,
BufferInfo and TexelBufferView data in StateTracker::operator=().