### PR TITLE
vkreplay: Grant SD card read permission in vkreplay APK installation

### DIFF
--- a/build-android/vkreplay/AndroidManifest.xml
+++ b/build-android/vkreplay/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.vkreplay" android:versionCode="1" android:versionName="1.0">
 
     <!-- This is the platform API where NativeActivity was introduced. -->
-    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23"/>
+    <uses-sdk android:minSdkVersion="22" android:targetSdkVersion="22"/>
 
     <!-- This allows reading trace file from sdcard -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
Set the target SDK version to a version before 23 makes it possible for
vkreplay to grant SD card read/write permission during installation on
Android.

With this change, user will not need to manually run following commands
after vkreplay installation.

* adb shell pm grant com.example.vkreplay android.permission.READ_EXTERNAL_STORAGE
* adb shell pm grant com.example.vkreplay android.permission.WRITE_EXTERNAL_STORAGE

This has been tested on Android N and Android O with vkreplay built by Android SDK Tools v24.4.1.