### PR TITLE
vktrace: Fix copy descriptor sets recording in trim

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -1946,6 +1946,12 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
         }
 
         for (uint32_t i = 0; i < descriptorCopyCount; i++) {
+            // Reset copyDescriptorCount for each dstSet in this UpdateDescriptorSets call to only record the latest data.
+            trim::ObjectInfo* pInfo = trim::get_DescriptorSet_objectInfo(pDescriptorCopies[i].dstSet);
+            pInfo->ObjectInfo.DescriptorSet.copyDescriptorCount = 0;
+        }
+
+        for (uint32_t i = 0; i < descriptorCopyCount; i++) {
             trim::ObjectInfo* pInfo = trim::get_DescriptorSet_objectInfo(pDescriptorCopies[i].dstSet);
             if (pInfo != NULL) {
                 // find existing CopyDescriptorSet info to update, or allocate space for a new one.


### PR DESCRIPTION
Reset copyDescriptorCount for each DescriptorSet before processing
copy descriptor sets in __HOOKED_vkUpdateDescriptorSets in trim. This
is to make sure copyDescriptorCount is consistent with the number of
pCopyDescriptorSets for each descriptor set in the latest call of
vkUpdateDescriptorSets for each descriptor set.