### PR TITLE
vktrace: fix error for trim snapshot state tracker

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -3418,8 +3418,13 @@ void write_all_referenced_object_calls() {
         for (auto setObj = stateTracker.createdDescriptorSets.begin(); setObj != stateTracker.createdDescriptorSets.end();
              setObj++) {
             if (setObj->second.belongsToDevice == (VkDevice)deviceObj->first) {
-                uint32_t descriptorWriteCount = setObj->second.ObjectInfo.DescriptorSet.writeDescriptorCount;
-                uint32_t descriptorCopyCount = setObj->second.ObjectInfo.DescriptorSet.copyDescriptorCount;
+                // when trim track vkAllocateDescriptorSets, it create numBindings
+                // WriteDescriptorSets and CopyDescriptorSets to record the binding
+                // change, here we will use these recorded data to generate
+                // vkUpdateDescriptorSets packet for playback to
+                // update/restore the descriptorSets state when starting trim.
+                uint32_t descriptorWriteCount = setObj->second.ObjectInfo.DescriptorSet.numBindings;
+                uint32_t descriptorCopyCount = setObj->second.ObjectInfo.DescriptorSet.numBindings;
                 VkWriteDescriptorSet *pDescriptorWrites = setObj->second.ObjectInfo.DescriptorSet.pWriteDescriptorSets;
                 VkCopyDescriptorSet *pDescriptorCopies = setObj->second.ObjectInfo.DescriptorSet.pCopyDescriptorSets;
 


### PR DESCRIPTION
When saving tracked state for DescriptorSets in trim
starting process, it use wrong number of descriptorWrite and
descriptorCopy and cause some title crash during tracing with
trim, the change fix the problem.

XCAP-759
Change-Id: I8459328b3dd35720611ceb02fb8182b2037313b7