### PR TITLE
layersvt: DevSim 1.1.0 add new features

### DIFF
--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -34,16 +34,20 @@ Please report issues to the [GitHub VulkanTools repository](https://github.com/L
 ## DevSim Layer operation and configuration
 At application startup, during vkCreateInstance(), the DevSim layer initializes its internal tables from the actual physical device in the system, then loads its configuration file, which specifies override values to apply to those internal tables.
 
-A configuration file need not specify every possible Vulkan parameter;
-a sparse set of override values is permitted.
+How the JSON configuration values are applied depends on whether the top-level section begins with "ArrayOf" or not.
+* If the section is not an array, values are applied if they appear in the JSON; if a value is not present in the JSON, the previous value is not modified.
+Therefore not every parameter needs to be specified, only a sparse set of values that need to be changed.
+* If the section defines an array (i.e.: begins with "ArrayOf"), then all previous contents of that array is cleared, and the JSON must specify all values of each desired array element.
 
 The JSON fileformat consumed by the DevSim layer is specified by a JSON schema, the canonical URI of which is "https://schema.khronos.org/vulkan/devsim_1_0_0.json#"
 
 The top-level sections of a configuration file are specified by the DevSim JSON schema, and are processed as follows:
 * `$schema` - Mandatory.  Must be the URI string referencing the JSON schema.
 * `comments` - Optional.  May contain arbitrary comments, description, copyright, etc.
-* `VkPhysicalDeviceProperties` - Optional.  May contain valid name/value overrides.
-* `VkPhysicalDeviceFeatures` - Optional.  May contain valid name/value overrides.
+* `VkPhysicalDeviceProperties` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceMemoryProperties` - Optional.  Only values specified in the JSON will be modified.
+* `ArrayOfVkQueueFamilyProperties` - Optional.  If present, all values of all elements must be specified.
 * The remaining top-level sections of the schema are not yet supported by DevSim.
 
 The schema permits additional top-level sections to be optionally included in configuration files;

--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.5",
+        "implementation_version": "1.1.0",
         "description": "LunarG device simulation layer"
     }
 }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
         "api_version": "1.0.57",
-        "implementation_version": "1.0.5",
+        "implementation_version": "1.1.0",
         "description": "LunarG device simulation layer"
     }
 }

--- a/tests/devsim_test1.json
+++ b/tests/devsim_test1.json
@@ -1,5 +1,9 @@
 {
 	"$schema":	"https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
+	"comments":	{
+		"url":	"https://github.com/LunarG/VulkanTools/blob/master/tests/devsim_test1.json",
+		"desc":	"Stimulus file for Device Simulation layer test.  By design, the DevSim layer does not enforce the use of 'sane' values; such enforcement is the job of the Validation layers.  The values in this file are deliberately 'insane', unique (to aid verification of each override) and huge (to trigger any debug warnings)."
+	},
 	"VkPhysicalDeviceProperties":	{
 		"apiVersion":	1,
 		"driverVersion":	2,
@@ -180,5 +184,77 @@
 		"sparseResidencyAliased":	153,
 		"variableMultisampleRate":	154,
 		"inheritedQueries":	155
+	},
+
+    "VkPhysicalDeviceMemoryProperties": {
+	"memoryHeaps": [
+	    {
+		"flags": 900002000,
+		"size": 80000002001
+	    },
+	    {
+		"flags": 900002002,
+		"size": 80000002003
+	    },
+	    {
+		"flags": 900002004,
+		"size": 80000002005
+	    }
+	],
+	"memoryTypes": [
+	    {
+		"heapIndex": 900003001,
+		"propertyFlags": 900003002
+	    },
+	    {
+		"heapIndex": 900003003,
+		"propertyFlags": 900003004
+	    },
+	    {
+		"heapIndex": 900003005,
+		"propertyFlags": 900003006
+	    },
+	    {
+		"heapIndex": 900003007,
+		"propertyFlags": 900003008
+	    },
+	    {
+		"heapIndex": 900003009,
+		"propertyFlags": 900003010
+	    }
+	]
+    },
+
+    "ArrayOfVkQueueFamilyProperties": [
+	{
+	    "minImageTransferGranularity": {
+		"depth": 900004001,
+		"height": 900004002,
+		"width": 900004003
+	    },
+	    "queueCount": 900004004,
+	    "queueFlags": 900004005,
+	    "timestampValidBits": 900004006
+	},
+	{
+	    "minImageTransferGranularity": {
+		"depth": 900004007,
+		"height": 900004008,
+		"width": 900004009
+	    },
+	    "queueCount": 900004010,
+	    "queueFlags": 900004011,
+	    "timestampValidBits": 900004012
+	},
+	{
+	    "minImageTransferGranularity": {
+		"depth": 900004013,
+		"height": 900004014,
+		"width": 900004015
+	    },
+	    "queueCount": 900004016,
+	    "queueFlags": 900004017,
+	    "timestampValidBits": 900004018
 	}
+    ]
 }

--- a/tests/devsim_test1_gold.json
+++ b/tests/devsim_test1_gold.json
@@ -180,3 +180,61 @@
 		"variableMultisampleRate":	154,
 		"inheritedQueries":	155
 	},
+	"memory":	{
+		"memoryTypeCount":	5,
+		"memoryTypes":	[{
+				"propertyFlags":	900003002,
+				"heapIndex":	900003001
+			}, {
+				"propertyFlags":	900003004,
+				"heapIndex":	900003003
+			}, {
+				"propertyFlags":	900003006,
+				"heapIndex":	900003005
+			}, {
+				"propertyFlags":	900003008,
+				"heapIndex":	900003007
+			}, {
+				"propertyFlags":	900003010,
+				"heapIndex":	900003009
+			}],
+		"memoryHeapCount":	3,
+		"memoryHeaps":	[{
+				"size":	"0x00000012a05f27d1",
+				"flags":	900002000
+			}, {
+				"size":	"0x00000012a05f27d3",
+				"flags":	900002002
+			}, {
+				"size":	"0x00000012a05f27d5",
+				"flags":	900002004
+			}]
+	},
+	"queues":	[{
+			"queueFlags":	900004005,
+			"queueCount":	900004004,
+			"timestampValidBits":	900004006,
+			"minImageTransferGranularity":	{
+				"width":	900004003,
+				"height":	900004002,
+				"depth":	900004001
+			}
+		}, {
+			"queueFlags":	900004011,
+			"queueCount":	900004010,
+			"timestampValidBits":	900004012,
+			"minImageTransferGranularity":	{
+				"width":	900004009,
+				"height":	900004008,
+				"depth":	900004007
+			}
+		}, {
+			"queueFlags":	900004017,
+			"queueCount":	900004016,
+			"timestampValidBits":	900004018,
+			"minImageTransferGranularity":	{
+				"width":	900004015,
+				"height":	900004014,
+				"depth":	900004013
+			}
+		}],


### PR DESCRIPTION
Add new Device Simulation layer support for the JSON sections VkPhysicalDeviceMemoryProperties and ArrayOfVkQueueFamilyProperties.

Changes include:
- Add JSON-loading and Vulkan-intercepting functions for the new sections
- Extend tests to exercise new features.
- Extend documentation.
- Some other small enhancements.
- Overall clang-format.

Change-Id: Id2327237ca61511e8efa1723e2d0d55476ae006a