### PR TITLE
vktrace: fix error in vkUpdateDescriptorSets trim tracking

### DIFF
--- a/vktrace/vktrace_common/vktrace_common.h
+++ b/vktrace/vktrace_common/vktrace_common.h
@@ -67,6 +67,8 @@
 #define U_ASSERT_ONLY
 #endif
 
+static const uint32_t  INVALID_BINDING_INDEX = UINT32_MAX;
+
 // Enviroment variables used by vktrace/replay
 
 // VKTRACE_PMB_ENABLE env var enables tracking of PMB if the value is 1.

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -1829,7 +1829,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateDescriptorSets
 // numbers between 0 and the maximum binding number. the function is used to
 // convert the binding number to binding index starting from 0.
 uint32_t get_binding_index(VkDescriptorSet dstSet, uint32_t binding) {
-    uint32_t binding_index = trim::INVALID_BINDING_INDEX;
+    uint32_t binding_index = INVALID_BINDING_INDEX;
     trim::ObjectInfo* pInfo = trim::get_DescriptorSet_objectInfo(dstSet);
     for (uint32_t i = 0; i < pInfo->ObjectInfo.DescriptorSet.numBindings; i++) {
         if (binding == pInfo->ObjectInfo.DescriptorSet.pWriteDescriptorSets[i].dstBinding) {
@@ -1837,7 +1837,7 @@ uint32_t get_binding_index(VkDescriptorSet dstSet, uint32_t binding) {
             break;
         }
     }
-    if (binding_index == trim::INVALID_BINDING_INDEX) {
+    if (binding_index == INVALID_BINDING_INDEX) {
         vktrace_LogWarning(
             "The binding is invalid when the app tries to update the bindings of the DescriptorSet using "
             "vkUpdateDescriptorSets.");
@@ -1885,7 +1885,7 @@ bool isUpdateDescriptorSetBindingNeeded(const VkWriteDescriptorSet* pDescriptorW
         pDescriptorWrites[WriteDescriptorIndex].dstSet;  // the DescriptorSet that we are going to update its bindings
     trim::ObjectInfo* pInfo = trim::get_DescriptorSet_objectInfo(dstSet);
     uint32_t initial_binding_index = get_binding_index(dstSet, pDescriptorWrites[WriteDescriptorIndex].dstBinding);
-    if (initial_binding_index == trim::INVALID_BINDING_INDEX) {
+    if (initial_binding_index == INVALID_BINDING_INDEX) {
         vktrace_LogWarning(
             "The binding is invalid when the app tries to update the bindings of the DescriptorSet using "
             "vkUpdateDescriptorSets.");

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -3420,11 +3420,16 @@ void write_all_referenced_object_calls() {
             if (setObj->second.belongsToDevice == (VkDevice)deviceObj->first) {
                 // when trim track vkAllocateDescriptorSets, it create numBindings
                 // WriteDescriptorSets and CopyDescriptorSets to record the binding
-                // change, here we will use these recorded data to generate
-                // vkUpdateDescriptorSets packet for playback to
+                // change, here we will use these recorded data of changed binding
+                // to generate vkUpdateDescriptorSets packet for playback to
                 // update/restore the descriptorSets state when starting trim.
-                uint32_t descriptorWriteCount = setObj->second.ObjectInfo.DescriptorSet.numBindings;
-                uint32_t descriptorCopyCount = setObj->second.ObjectInfo.DescriptorSet.numBindings;
+                // descriptorWriteCount and descriptorCopyCount all <= numBindings.
+                // they are used to indicate so far how many bindings of this
+                // descriptorset has been updated, if we start to trim at a location
+                // close to title's beginning, that's very possible not all bindings
+                // has been updated.
+                uint32_t descriptorWriteCount = setObj->second.ObjectInfo.DescriptorSet.writeDescriptorCount;
+                uint32_t descriptorCopyCount = setObj->second.ObjectInfo.DescriptorSet.copyDescriptorCount;
                 VkWriteDescriptorSet *pDescriptorWrites = setObj->second.ObjectInfo.DescriptorSet.pWriteDescriptorSets;
                 VkCopyDescriptorSet *pDescriptorCopies = setObj->second.ObjectInfo.DescriptorSet.pCopyDescriptorSets;
 

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -16,7 +16,6 @@
 #pragma once
 #include <list>
 #include <map>
-#include <limits>
 #include "vktrace_trace_packet_identifiers.h"
 
 #include "vktrace_lib_trim_generate.h"
@@ -90,8 +89,6 @@ enum enum_key_state {
 
 // return if hotkey triggered;
 bool is_hotkey_trim_triggered();
-
-static const uint32_t INVALID_BINDING_INDEX = std::numeric_limits<uint32_t>::max();
 
 // Use this to snapshot the global state tracker at the start of the trim
 // frames.

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -16,6 +16,7 @@
 #pragma once
 #include <list>
 #include <map>
+#include <limits>
 #include "vktrace_trace_packet_identifiers.h"
 
 #include "vktrace_lib_trim_generate.h"
@@ -89,6 +90,8 @@ enum enum_key_state {
 
 // return if hotkey triggered;
 bool is_hotkey_trim_triggered();
+
+static const uint32_t INVALID_BINDING_INDEX = std::numeric_limits<uint32_t>::max();
 
 // Use this to snapshot the global state tracker at the start of the trim
 // frames.


### PR DESCRIPTION
The current process cannot handle multiple bindings update in pDescriptorWrites,
the change fix the error.

XCAP-759
Change-Id: I4ba297e1171c652b59527d405bfba60e2be7a9a1