### PR TITLE
vktrace: fix trim vkCreateGraphicsPipelines tracking error

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_helpers.h
+++ b/vktrace/vktrace_layer/vktrace_lib_helpers.h
@@ -351,6 +351,26 @@ static void add_create_ds_layout_to_trace_packet(vktrace_trace_packet_header *pH
     return;
 }
 
+// The accurate size of VkGraphicsPipelineCreateInfo can be got from
+// get_struct_chain_size, but it's needed to ROUNDUP_TO_4 because
+// VkGraphicsPipelineCreateInfo might include valid entry point name of shader.
+static size_t get_VkGraphicsPipelineCreateInfo_size_ROUNDUP_TO_4(const VkGraphicsPipelineCreateInfo *pCreateInfos) {
+    size_t entryPointNameLength = 0;
+    size_t struct_size = get_struct_chain_size(pCreateInfos);
+
+    if ((pCreateInfos->stageCount) && (pCreateInfos->pStages != nullptr)) {
+        VkPipelineShaderStageCreateInfo *pStage = const_cast<VkPipelineShaderStageCreateInfo *>(pCreateInfos->pStages);
+        for (uint32_t i = 0; i < pCreateInfos->stageCount; i++) {
+            if (pStage->pName) {
+                entryPointNameLength = strlen(pStage->pName) + 1;
+                struct_size += ROUNDUP_TO_4(entryPointNameLength) - entryPointNameLength;
+            }
+            ++pStage;
+        }
+    }
+    return struct_size;
+}
+
 static void add_VkGraphicsPipelineCreateInfos_to_trace_packet(vktrace_trace_packet_header *pHeader,
                                                               VkGraphicsPipelineCreateInfo *pPacket,
                                                               const VkGraphicsPipelineCreateInfo *pParam, uint32_t count) {

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -2575,26 +2575,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPipelineCacheData(V
     return result;
 }
 
-// The accurate size of VkGraphicsPipelineCreateInfo can be got from
-// get_struct_chain_size, but it's needed to ROUNDUP_TO_4 because
-// VkGraphicsPipelineCreateInfo might include valid entry point name of shader.
-size_t get_VkGraphicsPipelineCreateInfo_size_ROUNDUP_TO_4(const VkGraphicsPipelineCreateInfo* pCreateInfos) {
-    size_t entryPointNameLength = 0;
-    size_t struct_size = get_struct_chain_size(pCreateInfos);
-
-    if ((pCreateInfos->stageCount) && (pCreateInfos->pStages != nullptr)) {
-        VkPipelineShaderStageCreateInfo* pStage = const_cast<VkPipelineShaderStageCreateInfo*>(pCreateInfos->pStages);
-        for (uint32_t i = 0; i < pCreateInfos->stageCount; i++) {
-            if (pStage->pName) {
-                entryPointNameLength = strlen(pStage->pName) + 1;
-                struct_size += ROUNDUP_TO_4(entryPointNameLength) - entryPointNameLength;
-            }
-            ++pStage;
-        }
-    }
-    return struct_size;
-}
-
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache,
                                                                                   uint32_t createInfoCount,
                                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,

--- a/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
@@ -1110,7 +1110,7 @@ vktrace_trace_packet_header *vkCreateGraphicsPipelines(bool makeCall, VkDevice d
     size_t total_size = 0;
     uint32_t i;
     for (i = 0; i < createInfoCount; i++) {
-        total_size += get_struct_chain_size((void *)&pCreateInfos[i]);
+        total_size += get_VkGraphicsPipelineCreateInfo_size_ROUNDUP_TO_4(&pCreateInfos[i]);
     }
     CREATE_TRACE_PACKET(vkCreateGraphicsPipelines,
                         total_size + sizeof(VkAllocationCallbacks) + createInfoCount * sizeof(VkPipeline));

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
@@ -473,10 +473,19 @@ StateTracker &StateTracker::operator=(const StateTracker &other) {
         // note: Using the same memory as both the destination and the source.
         // We're copying what is currently there, which will properly result in
         // new copies of any pointed-to objects and arrays.
-        copy_VkGraphicsPipelineCreateInfo(pCreateInfo, obj->second.ObjectInfo.Pipeline.graphicsPipelineCreateInfo);
-        copy_VkComputePipelineCreateInfo(
-            const_cast<VkComputePipelineCreateInfo *>(&obj->second.ObjectInfo.Pipeline.computePipelineCreateInfo),
-            obj->second.ObjectInfo.Pipeline.computePipelineCreateInfo);
+        if (obj->second.ObjectInfo.Pipeline.isGraphicsPipeline) {
+            // here we keep the original value of source to a copy, so we can
+            // change the destination value in pCreateInfo and make it a
+            // deepcopy of the source. note: src parameter in the define of
+            // copy_VkGraphicsPipelineCreateInfo function is a reference.
+            VkGraphicsPipelineCreateInfo createInfoCopy = obj->second.ObjectInfo.Pipeline.graphicsPipelineCreateInfo;
+            copy_VkGraphicsPipelineCreateInfo(pCreateInfo, createInfoCopy);
+        } else {
+            VkComputePipelineCreateInfo createInfoCopy = obj->second.ObjectInfo.Pipeline.computePipelineCreateInfo;
+            copy_VkComputePipelineCreateInfo(
+                const_cast<VkComputePipelineCreateInfo *>(&obj->second.ObjectInfo.Pipeline.computePipelineCreateInfo),
+                createInfoCopy);
+        }
     }
 
     createdQueues = other.createdQueues;


### PR DESCRIPTION
There are two errors in vkCreateGraphicsPipelines tracking and generating
trace packet, it cause replay crash for target title of xcap-759 when
playback the trimmed trace file, the change fix the problem.

XCAP-759
Change-Id: I08c435447d2c31815fb6a49edcf863d5e12a1179