### PR TITLE
vktrace: trace/replay pNext structs

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -16,6 +16,7 @@
 LOCAL_PATH := $(call my-dir)
 SRC_DIR := ../..
 LAYER_DIR := ../generated
+ANDROID_DIR := $(SRC_DIR)/build-android
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := layer_utils
@@ -120,13 +121,14 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_api_dump
 LOCAL_SRC_FILES += $(LAYER_DIR)/include/api_dump.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/layersvt \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils
-LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
 include $(BUILD_SHARED_LIBRARY)
 
@@ -135,13 +137,14 @@ LOCAL_MODULE := VkLayer_screenshot
 LOCAL_SRC_FILES += $(SRC_DIR)/layersvt/screenshot.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layersvt/screenshot_parsing.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/layersvt \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils
-LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
 include $(BUILD_SHARED_LIBRARY)
 
@@ -149,63 +152,18 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_device_simulation
 LOCAL_SRC_FILES += $(SRC_DIR)/layersvt/device_simulation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_SRC_FILES += $(ANDROID_DIR)/external/jsoncpp/dist/jsoncpp.cpp
-LOCAL_C_INCLUDES += $(ANDROID_DIR)/external/jsoncpp/dist \
-                    $(SRC_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/layersvt \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/loader
+LOCAL_SRC_FILES += $(ANDROID_DIR)/third_party/jsoncpp/dist/jsoncpp.cpp
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(ANDROID_DIR)/third_party/jsoncpp/dist \
+                    $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fexceptions
 LOCAL_LDLIBS    := -llog
 include $(BUILD_SHARED_LIBRARY)
-
-# Pull in prebuilt shaderc
-include $(CLEAR_VARS)
-LOCAL_MODULE := shaderc-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libshaderc.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := glslang-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libglslang.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := OGLCompiler-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libOGLCompiler.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := OSDependent-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libOSDependent.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := HLSL-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libHLSL.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := shaderc_util-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libshaderc_util.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := SPIRV-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libSPIRV.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := SPIRV-Tools-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libSPIRV-Tools.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := SPIRV-Tools-opt-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libSPIRV-Tools-opt.a
-include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayerValidationTests
@@ -271,19 +229,20 @@ LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_trim.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
 
-LOCAL_C_INCLUDES += $(SRC_DIR)/vktrace/include \
-		    $(SRC_DIR)/include \
-		    $(SRC_DIR)/include/vulkan \
-                    $(SRC_DIR)/layers \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/vktrace/vktrace_common \
-                    $(SRC_DIR)/vktrace/vktrace_layer \
-                    $(SRC_DIR)/loader \
-                    $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h \
-                    $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h \
-                    $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pageguard.h \
-                    $(SRC_DIR)/vktrace/vktrace_common/vktrace_pageguard_memorycopy.h
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/vktrace/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/include/vulkan \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_common \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_layer \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pageguard.h \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_common/vktrace_pageguard_memorycopy.h
 LOCAL_STATIC_LIBRARIES += layer_utils
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR
 LOCAL_CPPFLAGS += -DPLATFORM_LINUX=1
 LOCAL_CPPFLAGS += -DPAGEGUARD_MEMCPY_USE_PPL_LIB
@@ -312,17 +271,18 @@ LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/common/vulkan_wrapper.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layersvt/screenshot_parsing.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/vktrace/include \
-                    $(SRC_DIR)/include \
-                    $(SRC_DIR)/include/vulkan \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/layersvt \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/vktrace/vktrace_common \
-                    $(SRC_DIR)/vktrace/vktrace_layer \
-                    $(SRC_DIR)/vktrace/vktrace_replay \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/vktrace/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/include/vulkan \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_common \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_layer \
+                    $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_replay \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils android_native_app_glue
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DAPI_LOWERCASE=\"vulkan\" --include=$(SRC_DIR)/common/vulkan_wrapper.h -fexceptions
 LOCAL_CPPFLAGS += -DPLATFORM_LINUX=1
 LOCAL_CPPFLAGS += -DPAGEGUARD_MEMCPY_USE_PPL_LIB

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -16,6 +16,22 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64 mips mips64
 APP_PLATFORM := android-22
 APP_STL := gnustl_static
-APP_MODULES := layer_utils VkLayer_core_validation VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_unique_objects VkLayer_api_dump VkLayer_screenshot VkLayerValidationTests VulkanLayerValidationTests VkLayer_vktrace_layer vkreplay VkLayer_device_simulation vkjson_info
-APP_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
+APP_MODULES := \
+layer_utils \
+VkLayer_core_validation \
+VkLayer_parameter_validation \
+VkLayer_object_tracker \
+VkLayer_threading \
+VkLayer_unique_objects \
+VkLayerValidationTests \
+VulkanLayerValidationTests \
+vkjson_info
+# The following are in addition to upstream modules
+APP_MODULES += \
+VkLayer_api_dump \
+VkLayer_screenshot \
+VkLayer_vktrace_layer \
+vkreplay \
+VkLayer_device_simulation
 NDK_TOOLCHAIN_VERSION := clang
+NDK_MODULE_PATH := .

--- a/build-android/update_external_sources_android.bat
+++ b/build-android/update_external_sources_android.bat
@@ -160,15 +160,6 @@ if %sync-spirv-headers% equ 1 (
    if %errorCode% neq 0 (goto:error)
 )
 
-if %sync-shaderc% equ 1 (
-   if not exist %SHADERC_DIR% (
-      call:create_shaderc
-   )
-   if %errorCode% neq 0 (goto:error)
-   call:update_shaderc
-   if %errorCode% neq 0 (goto:error)
-)
-
 if %sync-jsoncpp% equ 1 (
    if exist %JSONCPP_DIR% (
       rd /S /Q %JSONCPP_DIR%

--- a/vktrace/vktrace_common/CMakeLists.txt
+++ b/vktrace/vktrace_common/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)
 
 include_directories(
+    ${PROJECT_BINARY_DIR}/../..
     ${SRC_DIR}/vktrace_common
     ${SRC_DIR}/thirdparty
 )

--- a/vktrace/vktrace_common/CMakeLists.txt
+++ b/vktrace/vktrace_common/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 add_library(${PROJECT_NAME} STATIC ${SRC_LIST} ${CXX_SRC_LIST} ${HDRS})
 
+add_dependencies(${PROJECT_NAME} generate_helper_files)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 target_link_libraries(${PROJECT_NAME}

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -663,6 +663,7 @@ VkDeviceGroupDeviceCreateInfoKHX* interpret_VkDeviceGroupDeviceCreateInfoKHX(vkt
     } while (0)
 
 void vktrace_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void* struct_ptr) {
+    uint32_t i;
     if (!struct_ptr) return;
 
     while (((VkApplicationInfo*)struct_ptr)->pNext) {
@@ -677,7 +678,7 @@ void vktrace_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void
                     (VkDescriptorSetLayoutCreateInfo*)(((VkApplicationInfo*)struct_ptr)->pNext);
                 struct_ptr_cur->pBindings = (VkDescriptorSetLayoutBinding*)vktrace_trace_packet_interpret_buffer_pointer(
                     pHeader, (intptr_t)struct_ptr_cur->pBindings);
-                for (uint32_t i = 0; i < struct_ptr_cur->bindingCount; i++) {
+                for (i = 0; i < struct_ptr_cur->bindingCount; i++) {
                     VkSampler** ppSamplers = (VkSampler**)&(struct_ptr_cur->pBindings[i].pImmutableSamplers);
                     *ppSamplers = (VkSampler*)vktrace_trace_packet_interpret_buffer_pointer(
                         pHeader, (intptr_t)struct_ptr_cur->pBindings[i].pImmutableSamplers);

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -19,6 +19,7 @@
  *
  * Author: Jon Ashburn <jon@lunarg.com>
  * Author: Peter Lohrmann <peterl@valvesoftware.com>
+ * Author: David Pinedo <david@lunarg.com>
  **************************************************************************/
 #include "vktrace_trace_packet_utils.h"
 #include "vktrace_interconnect.h"
@@ -41,6 +42,7 @@
 #include <mach/mach.h>
 #endif
 
+#include "vk_struct_size_helper.c"
 #include "vktrace_pageguard_memorycopy.h"
 
 static VKTRACE_CRITICAL_SECTION s_packet_index_lock;
@@ -253,6 +255,139 @@ void vktrace_finalize_buffer_address(vktrace_trace_packet_header* pHeader, void*
     }
 }
 
+#define AddPointerWithCountToTracebuffer(_sName, _sType, _sPtr, _sCount)                 \
+    do {                                                                                 \
+        void* pSrc = (void*)(((_sName*)pInNext)->_sPtr);                                 \
+        void** pDst = (void**)&(((_sName*)*ppOutNext)->_sPtr);                           \
+        uint32_t count = ((_sName*)*ppOutNext)->_sCount;                                 \
+        vktrace_add_buffer_to_trace_packet(pHeader, pDst, sizeof(_sType) * count, pSrc); \
+        vktrace_finalize_buffer_address(pHeader, pDst);                                  \
+    } while (0)
+
+void vktrace_add_pnext_structs_to_trace_packet(vktrace_trace_packet_header* pHeader, void* pOut, const void* pIn) {
+    void** ppOutNext;
+    const void* pInNext;
+    if (!pIn) return;
+    // Add the pNext chain to trace packet.
+    while (((VkApplicationInfo*)pIn)->pNext) {
+        ppOutNext = (void**)&(((VkApplicationInfo*)pOut)->pNext);
+        pInNext = (void*)((VkApplicationInfo*)pIn)->pNext;
+        size_t size = get_struct_size(pInNext);
+        if (size > 0) {
+            vktrace_add_buffer_to_trace_packet(pHeader, ppOutNext, size, pInNext);
+            // TODO: Might be able codegen this switch statement
+            switch (((VkApplicationInfo*)*ppOutNext)->sType) {
+                case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHX:
+                    AddPointerWithCountToTracebuffer(VkDeviceGroupDeviceCreateInfoKHX, VkPhysicalDevice, pPhysicalDevices,
+                                                     physicalDeviceCount);
+                    break;
+                case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO_KHX:
+                    AddPointerWithCountToTracebuffer(VkDeviceGroupRenderPassBeginInfoKHX, VkRect2D, pDeviceRenderAreas,
+                                                     deviceRenderAreaCount);
+                    break;
+                case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO_KHX:
+                    AddPointerWithCountToTracebuffer(VkDeviceGroupSubmitInfoKHX, uint32_t, pWaitSemaphoreDeviceIndices,
+                                                     waitSemaphoreCount);
+                    AddPointerWithCountToTracebuffer(VkDeviceGroupSubmitInfoKHX, uint32_t, pCommandBufferDeviceMasks,
+                                                     commandBufferCount);
+                    AddPointerWithCountToTracebuffer(VkDeviceGroupSubmitInfoKHX, uint32_t, pSignalSemaphoreDeviceIndices,
+                                                     signalSemaphoreCount);
+                    break;
+                case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO_KHX:
+                    AddPointerWithCountToTracebuffer(VkBindBufferMemoryDeviceGroupInfoKHX, uint32_t, pDeviceIndices,
+                                                     deviceIndexCount);
+                    break;
+                case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO_KHX:
+                    AddPointerWithCountToTracebuffer(VkBindImageMemoryDeviceGroupInfoKHX, uint32_t, pDeviceIndices,
+                                                     deviceIndexCount);
+                    AddPointerWithCountToTracebuffer(VkBindImageMemoryDeviceGroupInfoKHX, VkRect2D, pSFRRects, SFRRectCount);
+                    break;
+                case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
+                    AddPointerWithCountToTracebuffer(VkValidationFlagsEXT, VkValidationCheckEXT, pDisabledValidationChecks,
+                                                     disabledValidationCheckCount);
+                    break;
+                case VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX:
+                    AddPointerWithCountToTracebuffer(VkIndirectCommandsLayoutCreateInfoNVX, VkIndirectCommandsLayoutTokenNVX,
+                                                     pTokens, tokenCount);
+                    break;
+                case VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX:
+                    AddPointerWithCountToTracebuffer(VkCmdProcessCommandsInfoNVX, VkIndirectCommandsTokenNVX,
+                                                     pIndirectCommandsTokens, indirectCommandsTokenCount);
+                    break;
+                case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
+                    AddPointerWithCountToTracebuffer(VkPipelineViewportWScalingStateCreateInfoNV, VkViewportWScalingNV,
+                                                     pViewportWScalings, viewportCount);
+                    break;
+                case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
+                    AddPointerWithCountToTracebuffer(VkPipelineViewportSwizzleStateCreateInfoNV, VkViewportSwizzleNV,
+                                                     pViewportSwizzles, viewportCount);
+                    break;
+                case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
+                    AddPointerWithCountToTracebuffer(VkPipelineDiscardRectangleStateCreateInfoEXT, VkRect2D, pDiscardRectangles,
+                                                     discardRectangleCount);
+                    break;
+                case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
+                    AddPointerWithCountToTracebuffer(VkSampleLocationsInfoEXT, VkSampleLocationEXT, pSampleLocations,
+                                                     sampleLocationsCount);
+                    break;
+                case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
+                    AddPointerWithCountToTracebuffer(VkRenderPassSampleLocationsBeginInfoEXT, VkAttachmentSampleLocationsEXT,
+                                                     pAttachmentInitialSampleLocations, attachmentInitialSampleLocationsCount);
+                    AddPointerWithCountToTracebuffer(VkRenderPassSampleLocationsBeginInfoEXT, VkSubpassSampleLocationsEXT,
+                                                     pPostSubpassSampleLocations, postSubpassSampleLocationsCount);
+                    break;
+                case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
+                    AddPointerWithCountToTracebuffer(VkPipelineCoverageModulationStateCreateInfoNV, VkCoverageModulationModeNV,
+                                                     pCoverageModulationTable, coverageModulationTableCount);
+                    break;
+                case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR:
+                    AddPointerWithCountToTracebuffer(VkImageFormatListCreateInfoKHR, VkFormat, pViewFormats, viewFormatCount);
+                    break;
+                case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHX:
+                    AddPointerWithCountToTracebuffer(VkRenderPassMultiviewCreateInfoKHX, uint32_t, pViewMasks, subpassCount);
+                    AddPointerWithCountToTracebuffer(VkRenderPassMultiviewCreateInfoKHX, int32_t, pViewOffsets, dependencyCount);
+                    AddPointerWithCountToTracebuffer(VkRenderPassMultiviewCreateInfoKHX, uint32_t, pCorrelationMasks,
+                                                     correlationMaskCount);
+                    break;
+#ifdef WIN32
+                case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoKHR, VkDeviceMemory, pAcquireSyncs,
+                                                     acquireCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoKHR, uint64_t, pAcquireKeys, acquireCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoKHR, uint32_t, pAcquireTimeouts,
+                                                     acquireCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoKHR, VkDeviceMemory, pReleaseSyncs,
+                                                     releaseCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoKHR, uint64_t, pReleaseKeys, releaseCount);
+                    break;
+                case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoNV, VkDeviceMemory, pAcquireSyncs,
+                                                     acquireCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoNV, uint64_t, pAcquireKeys, acquireCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoNV, uint32_t, pAcquireTimeoutMilliseconds,
+                                                     acquireCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoNV, VkDeviceMemory, pReleaseSyncs,
+                                                     releaseCount);
+                    AddPointerWithCountToTracebuffer(VkWin32KeyedMutexAcquireReleaseInfoNV, uint64_t, pReleaseKeys, releaseCount);
+                    break;
+#endif
+                default:
+                    // The cases in this switch statement are only those pnext struct types that have
+                    // pointers inside them that need to be added. The pnext list may contain
+                    // struct types that don't have pointers in them, which we skip and remove.
+                    break;
+            }
+            pOut = *ppOutNext;
+            pIn = pInNext;
+            vktrace_finalize_buffer_address(pHeader, ppOutNext);
+        } else {
+            // Skip and remove from chain, must be an unknown type
+            ((VkApplicationInfo*)pOut)->pNext = *ppOutNext ? ((VkApplicationInfo*)*ppOutNext)->pNext : NULL;
+            pIn = pInNext;  // Should not remove from original struct, just skip
+        }
+    }
+}
+
 void vktrace_set_packet_entrypoint_end_time(vktrace_trace_packet_header* pHeader) {
     pHeader->entrypoint_end_time = vktrace_get_time();
 }
@@ -321,6 +456,7 @@ void* vktrace_trace_packet_interpret_buffer_pointer(vktrace_trace_packet_header*
 void add_VkApplicationInfo_to_packet(vktrace_trace_packet_header* pHeader, VkApplicationInfo** ppStruct,
                                      const VkApplicationInfo* pInStruct) {
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)ppStruct, sizeof(VkApplicationInfo), pInStruct);
+    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)ppStruct, (void*)pInStruct);
     vktrace_add_buffer_to_trace_packet(
         pHeader, (void**)&((*ppStruct)->pApplicationName),
         (pInStruct->pApplicationName != NULL) ? ROUNDUP_TO_4(strlen(pInStruct->pApplicationName) + 1) : 0,
@@ -336,6 +472,7 @@ void add_VkApplicationInfo_to_packet(vktrace_trace_packet_header* pHeader, VkApp
 void add_VkInstanceCreateInfo_to_packet(vktrace_trace_packet_header* pHeader, VkInstanceCreateInfo** ppStruct,
                                         VkInstanceCreateInfo* pInStruct) {
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)ppStruct, sizeof(VkInstanceCreateInfo), pInStruct);
+    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)ppStruct, (void*)pInStruct);
     if (pInStruct->pApplicationInfo)
         add_VkApplicationInfo_to_packet(pHeader, (VkApplicationInfo**)&((*ppStruct)->pApplicationInfo),
                                         pInStruct->pApplicationInfo);
@@ -367,12 +504,15 @@ void add_VkInstanceCreateInfo_to_packet(vktrace_trace_packet_header* pHeader, Vk
 
 void add_VkDeviceCreateInfo_to_packet(vktrace_trace_packet_header* pHeader, VkDeviceCreateInfo** ppStruct,
                                       const VkDeviceCreateInfo* pInStruct) {
+    uint32_t i, siz = 0;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)ppStruct, sizeof(VkDeviceCreateInfo), pInStruct);
+    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)ppStruct, (void*)pInStruct);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(*ppStruct)->pQueueCreateInfos,
                                        pInStruct->queueCreateInfoCount * sizeof(VkDeviceQueueCreateInfo),
                                        pInStruct->pQueueCreateInfos);
-    uint32_t i, siz = 0;
     for (i = 0; i < pInStruct->queueCreateInfoCount; i++) {
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)&(*ppStruct)->pQueueCreateInfos[i].pQueuePriorities,
+                                                  (void*)&pInStruct->pQueueCreateInfos[i]);
         vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(*ppStruct)->pQueueCreateInfos[i].pQueuePriorities,
                                            pInStruct->pQueueCreateInfos[i].queueCount * sizeof(float),
                                            pInStruct->pQueueCreateInfos[i].pQueuePriorities);
@@ -514,4 +654,113 @@ VkDeviceGroupDeviceCreateInfoKHX* interpret_VkDeviceGroupDeviceCreateInfoKHX(vkt
         }
     }
     return pCreateInfo;
+}
+#define InterpretPointerInPNext(_sName, _sPtrType, _sPtr)                                                        \
+    do {                                                                                                         \
+        _sName* struct_ptr_cur = (_sName*)(((VkApplicationInfo*)struct_ptr)->pNext);                             \
+        struct_ptr_cur->_sPtr =                                                                                  \
+            (_sPtrType*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)struct_ptr_cur->_sPtr); \
+    } while (0)
+
+void vktrace_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void* struct_ptr) {
+    if (!struct_ptr) return;
+
+    while (((VkApplicationInfo*)struct_ptr)->pNext) {
+        // Convert the pNext pointer
+        VkApplicationInfo* pNext = (VkApplicationInfo*)((VkApplicationInfo*)struct_ptr)->pNext;
+        ((VkApplicationInfo*)struct_ptr)->pNext = (void*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pNext);
+
+        // Convert pointers in pNext structures
+        switch (((VkApplicationInfo*)(((VkApplicationInfo*)struct_ptr)->pNext))->sType) {
+            case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO: {
+                VkDescriptorSetLayoutCreateInfo* struct_ptr_cur =
+                    (VkDescriptorSetLayoutCreateInfo*)(((VkApplicationInfo*)struct_ptr)->pNext);
+                struct_ptr_cur->pBindings = (VkDescriptorSetLayoutBinding*)vktrace_trace_packet_interpret_buffer_pointer(
+                    pHeader, (intptr_t)struct_ptr_cur->pBindings);
+                for (uint32_t i = 0; i < struct_ptr_cur->bindingCount; i++) {
+                    VkSampler** ppSamplers = (VkSampler**)&(struct_ptr_cur->pBindings[i].pImmutableSamplers);
+                    *ppSamplers = (VkSampler*)vktrace_trace_packet_interpret_buffer_pointer(
+                        pHeader, (intptr_t)struct_ptr_cur->pBindings[i].pImmutableSamplers);
+                }
+            } break;
+            case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHX:
+                InterpretPointerInPNext(VkDeviceGroupDeviceCreateInfoKHX, VkPhysicalDevice, pPhysicalDevices);
+                break;
+            case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO_KHX:
+                InterpretPointerInPNext(VkDeviceGroupRenderPassBeginInfoKHX, VkRect2D, pDeviceRenderAreas);
+                break;
+            case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO_KHX:
+                InterpretPointerInPNext(VkDeviceGroupSubmitInfoKHX, uint32_t, pWaitSemaphoreDeviceIndices);
+                InterpretPointerInPNext(VkDeviceGroupSubmitInfoKHX, uint32_t, pCommandBufferDeviceMasks);
+                InterpretPointerInPNext(VkDeviceGroupSubmitInfoKHX, uint32_t, pSignalSemaphoreDeviceIndices);
+                break;
+            case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO_KHX:
+                InterpretPointerInPNext(VkBindBufferMemoryDeviceGroupInfoKHX, uint32_t, pDeviceIndices);
+                break;
+            case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO_KHX:
+                InterpretPointerInPNext(VkBindImageMemoryDeviceGroupInfoKHX, uint32_t, pDeviceIndices);
+                InterpretPointerInPNext(VkBindImageMemoryDeviceGroupInfoKHX, VkRect2D, pSFRRects);
+                break;
+            case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
+                InterpretPointerInPNext(VkValidationFlagsEXT, VkValidationCheckEXT, pDisabledValidationChecks);
+                break;
+            case VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX:
+                InterpretPointerInPNext(VkIndirectCommandsLayoutCreateInfoNVX, VkIndirectCommandsLayoutTokenNVX, pTokens);
+                break;
+            case VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX:
+                InterpretPointerInPNext(VkCmdProcessCommandsInfoNVX, VkIndirectCommandsTokenNVX, pIndirectCommandsTokens);
+                break;
+            case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
+                InterpretPointerInPNext(VkPipelineViewportWScalingStateCreateInfoNV, VkViewportWScalingNV, pViewportWScalings);
+                break;
+            case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
+                InterpretPointerInPNext(VkPipelineViewportSwizzleStateCreateInfoNV, VkViewportSwizzleNV, pViewportSwizzles);
+                break;
+            case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
+                InterpretPointerInPNext(VkPipelineDiscardRectangleStateCreateInfoEXT, VkRect2D, pDiscardRectangles);
+                break;
+            case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
+                InterpretPointerInPNext(VkSampleLocationsInfoEXT, VkSampleLocationEXT, pSampleLocations);
+                break;
+            case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
+                InterpretPointerInPNext(VkRenderPassSampleLocationsBeginInfoEXT, VkAttachmentSampleLocationsEXT,
+                                        pAttachmentInitialSampleLocations);
+                InterpretPointerInPNext(VkRenderPassSampleLocationsBeginInfoEXT, VkSubpassSampleLocationsEXT,
+                                        pPostSubpassSampleLocations);
+                break;
+            case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
+                InterpretPointerInPNext(VkPipelineCoverageModulationStateCreateInfoNV, float, pCoverageModulationTable);
+                break;
+            case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR:
+                InterpretPointerInPNext(VkImageFormatListCreateInfoKHR, VkFormat, pViewFormats);
+                break;
+            case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHX:
+                InterpretPointerInPNext(VkRenderPassMultiviewCreateInfoKHX, uint32_t, pViewMasks);
+                InterpretPointerInPNext(VkRenderPassMultiviewCreateInfoKHX, int32_t, pViewOffsets);
+                InterpretPointerInPNext(VkRenderPassMultiviewCreateInfoKHX, uint32_t, pCorrelationMasks);
+                break;
+#ifdef WIN32
+            case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoKHR, VkDeviceMemory, pAcquireSyncs);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoKHR, uint64_t, pAcquireKeys);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoKHR, uint32_t, pAcquireTimeouts);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoKHR, VkDeviceMemory, pReleaseSyncs);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoKHR, uint64_t, pReleaseKeys);
+                break;
+            case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoNV, VkDeviceMemory, pAcquireSyncs);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoNV, uint64_t, pAcquireKeys);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoNV, uint32_t, pAcquireTimeoutMilliseconds);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoNV, VkDeviceMemory, pReleaseSyncs);
+                InterpretPointerInPNext(VkWin32KeyedMutexAcquireReleaseInfoNV, uint64_t, pReleaseKeys);
+                break;
+#endif
+            default:
+                // The cases in this switch statement are only those pnext struct types that have
+                // pointers inside them that need to be interpreted. The pnext list may contain
+                // struct types that don't have pointers in them, which we simply skip over.
+                break;
+        }
+        struct_ptr = (VkApplicationInfo*)((VkApplicationInfo*)struct_ptr)->pNext;
+    }
 }

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.h
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.h
@@ -87,6 +87,9 @@ void* vktrace_trace_packet_get_new_buffer_address(vktrace_trace_packet_header* p
 void vktrace_add_buffer_to_trace_packet(vktrace_trace_packet_header* pHeader, void** ptr_address, uint64_t size,
                                         const void* pBuffer);
 
+// adds pNext structures to a trace packet
+void vktrace_add_pnext_structs_to_trace_packet(vktrace_trace_packet_header* pHeader, void* pOut, const void* pIn);
+
 // converts buffer pointers into byte offset so that pointer can be interpretted after being read into memory
 void vktrace_finalize_buffer_address(vktrace_trace_packet_header* pHeader, void** ptr_address);
 
@@ -124,6 +127,8 @@ VkDeviceCreateInfo* interpret_VkDeviceCreateInfo(vktrace_trace_packet_header* pH
 void interpret_VkPipelineShaderStageCreateInfo(vktrace_trace_packet_header* pHeader, VkPipelineShaderStageCreateInfo* pShader);
 VkDeviceGroupDeviceCreateInfoKHX* interpret_VkDeviceGroupDeviceCreateInfoKHX(vktrace_trace_packet_header* pHeader,
                                                                              intptr_t ptr_variable);
+// converts the Vulkan struct pnext chain that is currently byte offsets into pointers
+void vktrace_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void* struct_ptr);
 
 //=============================================================================
 // trace packet message

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -48,8 +48,7 @@
 #include "vktrace_lib_pageguardcapture.h"
 #include "vktrace_lib_pageguard.h"
 
-// Intentionally include the struct_size source file
-#include "vk_struct_size_helper.c"
+#include "vk_struct_size_helper.h"
 
 VKTRACER_LEAVE _Unload(void) {
     // only do the hooking and networking if the tracer is NOT loaded by vktrace
@@ -358,7 +357,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevic
     pPacket = interpret_body_as_vkAllocateMemory(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocateInfo), sizeof(VkMemoryAllocateInfo), pAllocateInfo);
-    add_alloc_memory_to_trace_packet(pHeader, (void**)&(pPacket->pAllocateInfo->pNext), pAllocateInfo->pNext);
+    if (pAllocateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pAllocateInfo, pAllocateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pMemory), sizeof(VkDeviceMemory), pMemory);
     pPacket->result = result;
@@ -581,11 +580,12 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemory
     resetAllReadFlagAndPageGuard();
 #endif
 
-    // find out how much memory is in the ranges
+    // determine sum of sizes of memory ranges and pNext structures
     for (iter = 0; iter < memoryRangeCount; iter++) {
         VkMappedMemoryRange* pRange = (VkMappedMemoryRange*)&pMemoryRanges[iter];
         rangesSize += vk_size_vkmappedmemoryrange(pRange);
-        dataSize += (size_t)pRange->size;
+        dataSize += ROUNDUP_TO_4((size_t)pRange->size);
+        dataSize += get_struct_chain_size((void*)pRange);
     }
 
     CREATE_TRACE_PACKET(vkInvalidateMappedMemoryRanges, rangesSize + sizeof(void*) * memoryRangeCount + dataSize);
@@ -593,6 +593,11 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemory
     pPacket = interpret_body_as_vkInvalidateMappedMemoryRanges(pHeader);
 
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pMemoryRanges), rangesSize, pMemoryRanges);
+
+    // add the pnext structures to the packet
+    for (iter = 0; iter < memoryRangeCount; iter++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)&pPacket->pMemoryRanges[iter], (void*)&pMemoryRanges[iter]);
+
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pMemoryRanges));
 
     // insert into packet the data that was written by CPU between the vkMapMemory call and here
@@ -655,6 +660,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
     vktrace_trace_packet_header* pHeader;
     size_t rangesSize = 0;
     size_t dataSize = 0;
+    size_t pnextSize = 0;
     uint32_t iter;
     packet_vkFlushMappedMemoryRanges* pPacket = NULL;
 #ifdef USE_PAGEGUARD_SPEEDUP
@@ -673,7 +679,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
 #ifndef USE_PAGEGUARD_SPEEDUP
     for (iter = 0; iter < memoryRangeCount; iter++) {
         VkMappedMemoryRange* pRange = (VkMappedMemoryRange*)&pMemoryRanges[iter];
-        dataSize += ROUNDUP_TO_4(((size_t)(getPageGuardControlInstance().getMappedMemorySize(device, pRange->memory));
+        dataSize += ROUNDUP_TO_4((size_t)(getPageGuardControlInstance().getMappedMemorySize(device, pRange->memory)));
     }
 #else
     dataSize = getPageGuardControlInstance().getALLChangedPackageSizeInMappedMemory(device, memoryRangeCount, pMemoryRanges,
@@ -681,11 +687,22 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
 #endif
     rangesSize = sizeof(VkMappedMemoryRange) * memoryRangeCount;
 
-    CREATE_TRACE_PACKET(vkFlushMappedMemoryRanges, rangesSize + sizeof(void*) * memoryRangeCount + dataSize);
+    // determine size of pnext chains
+    for (iter = 0; iter < memoryRangeCount; iter++) {
+        VkMappedMemoryRange* pRange = (VkMappedMemoryRange*)&pMemoryRanges[iter];
+        pnextSize += get_struct_chain_size((void*)pRange);
+    }
+
+    CREATE_TRACE_PACKET(vkFlushMappedMemoryRanges, rangesSize + sizeof(void*) * memoryRangeCount + dataSize + pnextSize);
     pHeader->vktrace_begin_time = trace_begin_time;
     pPacket = interpret_body_as_vkFlushMappedMemoryRanges(pHeader);
 
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pMemoryRanges), rangesSize, pMemoryRanges);
+
+    // add the pnext structures to the packet
+    for (iter = 0; iter < memoryRangeCount; iter++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)&pPacket->pMemoryRanges[iter], (void*)&pMemoryRanges[iter]);
+
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pMemoryRanges));
 
     // insert into packet the data that was written by CPU between the vkMapMemory call and here
@@ -790,6 +807,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocateInfo), sizeof(VkCommandBufferAllocateInfo),
                                        pAllocateInfo);
+    if (pAllocateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pAllocateInfo, (void*)pAllocateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCommandBuffers),
                                        sizeof(VkCommandBuffer) * pAllocateInfo->commandBufferCount, pCommandBuffers);
     pPacket->result = result;
@@ -833,6 +851,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBeginCommandBuffer(VkC
     pPacket = interpret_body_as_vkBeginCommandBuffer(pHeader);
     pPacket->commandBuffer = commandBuffer;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pBeginInfo), sizeof(VkCommandBufferBeginInfo), pBeginInfo);
+    if (pBeginInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pBeginInfo, (void*)pBeginInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pBeginInfo->pInheritanceInfo),
                                        sizeof(VkCommandBufferInheritanceInfo), pBeginInfo->pInheritanceInfo);
     pPacket->result = result;
@@ -874,6 +893,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorPool(V
     pPacket = interpret_body_as_vkCreateDescriptorPool(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkDescriptorPoolCreateInfo), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, (void*)pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pPoolSizes),
                                        pCreateInfo->poolSizeCount * sizeof(VkDescriptorPoolSize), pCreateInfo->pPoolSizes);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
@@ -1000,12 +1020,25 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDevice(VkPhysica
     memcpy(&localCreateInfo, pCreateInfo, sizeof(localCreateInfo));
     localCreateInfo.pNext = strip_create_extensions(pCreateInfo->pNext);
 
-    CREATE_TRACE_PACKET(vkCreateDevice,
-                        get_struct_chain_size((void*)&localCreateInfo) + sizeof(VkAllocationCallbacks) + sizeof(VkDevice));
+    // determine size of pnext chains
+    size_t pnextSize = 0;
+    {
+        if (pCreateInfo) pnextSize = get_struct_chain_size((void*)&localCreateInfo);
+        for (uint32_t iter = 0; iter < localCreateInfo.queueCreateInfoCount; iter++) {
+            pnextSize += get_struct_chain_size((void*)&localCreateInfo.pQueueCreateInfos[iter]);
+        }
+    }
+
+    CREATE_TRACE_PACKET(vkCreateDevice, pnextSize + sizeof(VkAllocationCallbacks) + sizeof(VkDevice));
     vktrace_set_packet_entrypoint_end_time(pHeader);
     pPacket = interpret_body_as_vkCreateDevice(pHeader);
     pPacket->physicalDevice = physicalDevice;
     add_VkDeviceCreateInfo_to_packet(pHeader, (VkDeviceCreateInfo**)&(pPacket->pCreateInfo), &localCreateInfo);
+    //    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void *)&pPacket->pCreateInfo, (void *)&localCreateInfo);
+    //    for (uint32_t iter = 0; iter < localCreateInfo.queueCreateInfoCount; iter++) {
+    //        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void *)&pPacket->pCreateInfo->pQueueCreateInfos[iter],
+    //                                                  (void *)&localCreateInfo.pQueueCreateInfos[iter]);
+    //    }
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pDevice), sizeof(VkDevice), pDevice);
     pPacket->result = result;
@@ -1074,6 +1107,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateFramebuffer(VkDe
     pPacket = interpret_body_as_vkCreateFramebuffer(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkFramebufferCreateInfo), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, (void*)pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pAttachments),
                                        attachmentCount * sizeof(VkImageView), pCreateInfo->pAttachments);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
@@ -1272,10 +1306,9 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const V
         firstCreateInstance = false;
     }
 
-    // localCreateInfo.pNext = strip_create_extensions(pCreateInfo->pNext);
-    // The pNext pointer isn't getting marshalled into the trace buffer properly anyway, so
-    // set it to NULL so that replay does not trip over it.
-    localCreateInfo.pNext = NULL;
+    // Remove loader extensions
+    localCreateInfo.pNext = strip_create_extensions(pCreateInfo->pNext);
+
     CREATE_TRACE_PACKET(vkCreateInstance,
                         sizeof(VkInstance) + get_struct_chain_size((void*)&localCreateInfo) + sizeof(VkAllocationCallbacks));
     pHeader->vktrace_begin_time = vktraceStartTime;
@@ -1285,6 +1318,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const V
 
     add_VkInstanceCreateInfo_to_packet(pHeader, (VkInstanceCreateInfo**)&(pPacket->pCreateInfo),
                                        (VkInstanceCreateInfo*)&localCreateInfo);
+    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)&pPacket->pCreateInfo, (void*)&localCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pInstance), sizeof(VkInstance), pInstance);
     pPacket->result = result;
@@ -1370,6 +1404,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateRenderPass(VkDev
     pPacket = interpret_body_as_vkCreateRenderPass(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkRenderPassCreateInfo), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pAttachments),
                                        attachmentCount * sizeof(VkAttachmentDescription), pCreateInfo->pAttachments);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pDependencies),
@@ -1700,7 +1735,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateDescriptorSets
     startTime = vktrace_get_time();
     result = mdd(device)->devTable.AllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
     endTime = vktrace_get_time();
-    CREATE_TRACE_PACKET(vkAllocateDescriptorSets, vk_size_vkdescriptorsetallocateinfo(pAllocateInfo) +
+    CREATE_TRACE_PACKET(vkAllocateDescriptorSets, get_struct_chain_size(pAllocateInfo) +
                                                       (pAllocateInfo->descriptorSetCount * sizeof(VkDescriptorSetLayout)) +
                                                       (pAllocateInfo->descriptorSetCount * sizeof(VkDescriptorSet)));
     pHeader->vktrace_begin_time = vktraceStartTime;
@@ -1710,6 +1745,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateDescriptorSets
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocateInfo), sizeof(VkDescriptorSetAllocateInfo),
                                        pAllocateInfo);
+    if (pAllocateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pAllocateInfo, pAllocateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocateInfo->pSetLayouts),
                                        pPacket->pAllocateInfo->descriptorSetCount * sizeof(VkDescriptorSetLayout),
                                        pAllocateInfo->pSetLayouts);
@@ -2056,6 +2092,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
             default:
                 break;
         }
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pDescriptorWrites + i), pDescriptorWrites + i);
     }
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pDescriptorWrites));
 
@@ -2170,6 +2207,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
     size_t arrayByteCount = 0;
     for (uint32_t i = 0; i < submitCount; ++i) {
         arrayByteCount += vk_size_vksubmitinfo(&pSubmits[i]);
+        arrayByteCount += get_struct_chain_size(&pSubmits[i]);
     }
     CREATE_TRACE_PACKET(vkQueueSubmit, arrayByteCount);
     result = mdd(queue)->devTable.QueueSubmit(queue, submitCount, pSubmits, fence);
@@ -2181,6 +2219,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
     pPacket->result = result;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSubmits), submitCount * sizeof(VkSubmitInfo), pSubmits);
     for (uint32_t i = 0; i < submitCount; ++i) {
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pSubmits + i), pSubmits + i);
         vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSubmits[i].pCommandBuffers),
                                            pPacket->pSubmits[i].commandBufferCount * sizeof(VkCommandBuffer),
                                            pSubmits[i].pCommandBuffers);
@@ -2290,6 +2329,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueBindSparse(VkQueu
 
     for (i = 0; i < bindInfoCount; ++i) {
         arrayByteCount += vk_size_vkbindsparseinfo(&pBindInfo[i]);
+        arrayByteCount += get_struct_chain_size(&pBindInfo[i]);
     }
 
     CREATE_TRACE_PACKET(vkQueueBindSparse, arrayByteCount + 2 * sizeof(VkDeviceMemory));
@@ -2306,6 +2346,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueBindSparse(VkQueu
         vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pBindInfo[i].pBufferBinds),
                                            pPacket->pBindInfo[i].bufferBindCount * sizeof(VkSparseBufferMemoryBindInfo),
                                            pBindInfo[i].pBufferBinds);
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pBindInfo + i), pBindInfo + i);
         for (uint32_t j = 0; j < pPacket->pBindInfo[i].bufferBindCount; j++) {
             VkSparseBufferMemoryBindInfo* pSparseBufferMemoryBindInfo =
                 (VkSparseBufferMemoryBindInfo*)&pPacket->pBindInfo[i].pBufferBinds[j];
@@ -2382,6 +2423,9 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdWaitEvents(
     customSize = (eventCount * sizeof(VkEvent)) + (memoryBarrierCount * sizeof(VkMemoryBarrier)) +
                  (bufferMemoryBarrierCount * sizeof(VkBufferMemoryBarrier)) +
                  (imageMemoryBarrierCount * sizeof(VkImageMemoryBarrier));
+    for (uint32_t i = 0; i < memoryBarrierCount; i++) customSize += get_struct_chain_size(&pMemoryBarriers[i]);
+    for (uint32_t i = 0; i < bufferMemoryBarrierCount; i++) customSize += get_struct_chain_size(&pBufferMemoryBarriers[i]);
+    for (uint32_t i = 0; i < imageMemoryBarrierCount; i++) customSize += get_struct_chain_size(&pImageMemoryBarriers[i]);
     CREATE_TRACE_PACKET(vkCmdWaitEvents, customSize);
     mdd(commandBuffer)
         ->devTable.CmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount,
@@ -2398,12 +2442,21 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdWaitEvents(
     pPacket->imageMemoryBarrierCount = imageMemoryBarrierCount;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pEvents), eventCount * sizeof(VkEvent), pEvents);
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pEvents));
+
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pMemoryBarriers), memoryBarrierCount * sizeof(VkMemoryBarrier),
                                        pMemoryBarriers);
+    for (uint32_t i = 0; i < memoryBarrierCount; i++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pMemoryBarriers + i), pMemoryBarriers + i);
+
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pBufferMemoryBarriers),
                                        bufferMemoryBarrierCount * sizeof(VkBufferMemoryBarrier), pBufferMemoryBarriers);
+    for (uint32_t i = 0; i < bufferMemoryBarrierCount; i++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pBufferMemoryBarriers + i), pBufferMemoryBarriers + i);
+
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pImageMemoryBarriers),
                                        imageMemoryBarrierCount * sizeof(VkImageMemoryBarrier), pImageMemoryBarriers);
+    for (uint32_t i = 0; i < imageMemoryBarrierCount; i++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pImageMemoryBarriers + i), pImageMemoryBarriers + i);
 
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pMemoryBarriers));
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pBufferMemoryBarriers));
@@ -2441,6 +2494,9 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
     size_t customSize;
     customSize = (memoryBarrierCount * sizeof(VkMemoryBarrier)) + (bufferMemoryBarrierCount * sizeof(VkBufferMemoryBarrier)) +
                  (imageMemoryBarrierCount * sizeof(VkImageMemoryBarrier));
+    for (uint32_t i = 0; i < memoryBarrierCount; i++) customSize = get_struct_chain_size(&pMemoryBarriers[i]);
+    for (uint32_t i = 0; i < bufferMemoryBarrierCount; i++) customSize = get_struct_chain_size(&pBufferMemoryBarriers[i]);
+    for (uint32_t i = 0; i < imageMemoryBarrierCount; i++) customSize = get_struct_chain_size(&pImageMemoryBarriers[i]);
     CREATE_TRACE_PACKET(vkCmdPipelineBarrier, customSize);
     mdd(commandBuffer)
         ->devTable.CmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount,
@@ -2455,12 +2511,21 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
     pPacket->memoryBarrierCount = memoryBarrierCount;
     pPacket->bufferMemoryBarrierCount = bufferMemoryBarrierCount;
     pPacket->imageMemoryBarrierCount = imageMemoryBarrierCount;
+
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pMemoryBarriers), memoryBarrierCount * sizeof(VkMemoryBarrier),
                                        pMemoryBarriers);
+    for (uint32_t i = 0; i < memoryBarrierCount; i++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pMemoryBarriers + i), pMemoryBarriers + i);
+
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pBufferMemoryBarriers),
                                        bufferMemoryBarrierCount * sizeof(VkBufferMemoryBarrier), pBufferMemoryBarriers);
+    for (uint32_t i = 0; i < bufferMemoryBarrierCount; i++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pBufferMemoryBarriers + i), pBufferMemoryBarriers + i);
+
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pImageMemoryBarriers),
                                        imageMemoryBarrierCount * sizeof(VkImageMemoryBarrier), pImageMemoryBarriers);
+    for (uint32_t i = 0; i < imageMemoryBarrierCount; i++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pImageMemoryBarriers + i), pImageMemoryBarriers + i);
 
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pMemoryBarriers));
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pBufferMemoryBarriers));
@@ -2575,6 +2640,34 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPipelineCacheData(V
     return result;
 }
 
+static size_t get_VkGraphicsPipelineCreateInfo_size(const VkGraphicsPipelineCreateInfo* pCreateInfos) {
+    size_t entryPointNameLength = 0;
+    size_t struct_size = get_struct_chain_size(pCreateInfos);
+
+    if ((pCreateInfos->stageCount) && (pCreateInfos->pStages != nullptr)) {
+        VkPipelineShaderStageCreateInfo* pStage = const_cast<VkPipelineShaderStageCreateInfo*>(pCreateInfos->pStages);
+        for (uint32_t i = 0; i < pCreateInfos->stageCount; i++) {
+            if (pStage->pName) {
+                entryPointNameLength = strlen(pStage->pName) + 1;
+                struct_size += ROUNDUP_TO_4(entryPointNameLength) - entryPointNameLength;
+            }
+            struct_size += get_struct_chain_size(pStage);
+            ++pStage;
+        }
+    }
+    struct_size += get_struct_chain_size(pCreateInfos->pVertexInputState);
+    struct_size += get_struct_chain_size(pCreateInfos->pVertexInputState);
+    struct_size += get_struct_chain_size(pCreateInfos->pInputAssemblyState);
+    struct_size += get_struct_chain_size(pCreateInfos->pTessellationState);
+    struct_size += get_struct_chain_size(pCreateInfos->pViewportState);
+    struct_size += get_struct_chain_size(pCreateInfos->pRasterizationState);
+    struct_size += get_struct_chain_size(pCreateInfos->pMultisampleState);
+    struct_size += get_struct_chain_size(pCreateInfos->pDepthStencilState);
+    struct_size += get_struct_chain_size(pCreateInfos->pColorBlendState);
+    struct_size += get_struct_chain_size(pCreateInfos->pDynamicState);
+    return struct_size;
+}
+
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache,
                                                                                   uint32_t createInfoCount,
                                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
@@ -2585,7 +2678,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipeline
     packet_vkCreateGraphicsPipelines* pPacket = NULL;
     size_t total_size = 0;
     for (uint32_t i = 0; i < createInfoCount; i++) {
-        total_size += get_VkGraphicsPipelineCreateInfo_size_ROUNDUP_TO_4(&pCreateInfos[i]);
+        total_size += get_VkGraphicsPipelineCreateInfo_size(&pCreateInfos[i]);
     }
     CREATE_TRACE_PACKET(vkCreateGraphicsPipelines,
                         total_size + sizeof(VkAllocationCallbacks) + createInfoCount * sizeof(VkPipeline));
@@ -2598,6 +2691,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipeline
     pPacket->createInfoCount = createInfoCount;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfos),
                                        createInfoCount * sizeof(VkGraphicsPipelineCreateInfo), pCreateInfos);
+    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfos), pCreateInfos);
     add_VkGraphicsPipelineCreateInfos_to_trace_packet(pHeader, (VkGraphicsPipelineCreateInfo*)pPacket->pCreateInfos, pCreateInfos,
                                                       createInfoCount);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
@@ -2671,7 +2765,12 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateComputePipelines
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateComputePipelines* pPacket = NULL;
-    CREATE_TRACE_PACKET(vkCreateComputePipelines, createInfoCount * sizeof(VkComputePipelineCreateInfo) +
+    size_t pnextSize = 0;
+
+    // Determine size of pNext chain
+    for (uint32_t iter = 0; iter < createInfoCount; iter++) pnextSize += get_struct_chain_size((void*)&pCreateInfos[iter]);
+
+    CREATE_TRACE_PACKET(vkCreateComputePipelines, pnextSize + createInfoCount * sizeof(VkComputePipelineCreateInfo) +
                                                       getVkComputePipelineCreateInfosAdditionalSize(createInfoCount, pCreateInfos) +
                                                       sizeof(VkAllocationCallbacks) + createInfoCount * sizeof(VkPipeline));
 
@@ -2686,6 +2785,8 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateComputePipelines
                                        createInfoCount * sizeof(VkComputePipelineCreateInfo), pCreateInfos);
     add_VkComputePipelineCreateInfos_to_trace_packet(pHeader, (VkComputePipelineCreateInfo*)pPacket->pCreateInfos, pCreateInfos,
                                                      createInfoCount);
+    for (uint32_t iter = 0; iter < createInfoCount; iter++)
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)&pPacket->pCreateInfos[iter], (void*)&pCreateInfos[iter]);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pPipelines), createInfoCount * sizeof(VkPipeline), pPipelines);
     pPacket->result = result;
@@ -2735,14 +2836,15 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreatePipelineCache* pPacket = NULL;
-    // Need to round up the size when we create the packet because pCreateInfo->initialDataSize may not be a mult of 4
-    CREATE_TRACE_PACKET(vkCreatePipelineCache, ROUNDUP_TO_4(get_struct_chain_size((void*)pCreateInfo) +
-                                                            sizeof(VkAllocationCallbacks) + sizeof(VkPipelineCache)));
+    CREATE_TRACE_PACKET(vkCreatePipelineCache, get_struct_chain_size((void*)pCreateInfo) +
+                                                   ROUNDUP_TO_4(pCreateInfo->initialDataSize) + sizeof(VkAllocationCallbacks) +
+                                                   sizeof(VkPipelineCache));
     result = mdd(device)->devTable.CreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache);
     vktrace_set_packet_entrypoint_end_time(pHeader);
     pPacket = interpret_body_as_vkCreatePipelineCache(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkPipelineCacheCreateInfo), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pInitialData),
                                        ROUNDUP_TO_4(pPacket->pCreateInfo->initialDataSize), pCreateInfo->pInitialData);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
@@ -2778,7 +2880,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkComma
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdBeginRenderPass* pPacket = NULL;
     size_t clearValueSize = sizeof(VkClearValue) * pRenderPassBegin->clearValueCount;
-    CREATE_TRACE_PACKET(vkCmdBeginRenderPass, sizeof(VkRenderPassBeginInfo) + clearValueSize);
+    CREATE_TRACE_PACKET(vkCmdBeginRenderPass, get_struct_chain_size((void*)pRenderPassBegin) + clearValueSize);
     mdd(commandBuffer)->devTable.CmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
     vktrace_set_packet_entrypoint_end_time(pHeader);
     pPacket = interpret_body_as_vkCmdBeginRenderPass(pHeader);
@@ -2786,6 +2888,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkComma
     pPacket->contents = contents;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pRenderPassBegin), sizeof(VkRenderPassBeginInfo),
                                        pRenderPassBegin);
+    if (pRenderPassBegin) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)(pPacket->pRenderPassBegin), pRenderPassBegin);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pRenderPassBegin->pClearValues), clearValueSize,
                                        pRenderPassBegin->pClearValues);
     vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pRenderPassBegin->pClearValues));
@@ -2881,7 +2984,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkImageCreateInfo), pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pQueueFamilyIndices),
                                        sizeof(uint32_t) * pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices);
-    add_extension_to_createimage_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pNext), pCreateInfo->pNext);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pImage), sizeof(VkImage), pImage);
     pPacket->result = result;
@@ -2935,8 +3038,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
-                                                                       const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer)
-{
+                                                                       const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateBuffer* pPacket = NULL;
@@ -2959,7 +3061,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice 
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkBufferCreateInfo), pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pQueueFamilyIndices), sizeof(uint32_t) * pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices);
-    add_extension_to_createbuffer_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pNext), pCreateInfo->pNext);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pBuffer), sizeof(VkBuffer), pBuffer);
     pPacket->result = result;
@@ -3107,12 +3209,14 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateSwapchainKHR* pPacket = NULL;
-    CREATE_TRACE_PACKET(vkCreateSwapchainKHR,
-                        vk_size_vkswapchaincreateinfokhr(pCreateInfo) + sizeof(VkSwapchainKHR) + sizeof(VkAllocationCallbacks));
+    CREATE_TRACE_PACKET(vkCreateSwapchainKHR, vk_size_vkswapchaincreateinfokhr(pCreateInfo) +
+                                                  get_struct_chain_size((void*)pCreateInfo) + sizeof(VkSwapchainKHR) +
+                                                  sizeof(VkAllocationCallbacks));
     result = mdd(device)->devTable.CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
     pPacket = interpret_body_as_vkCreateSwapchainKHR(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkSwapchainCreateInfoKHR), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSwapchain), sizeof(VkSwapchainKHR), pSwapchain);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pQueueFamilyIndices),
@@ -3208,7 +3312,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueuePresentKHR(VkQueu
     size_t indexSize = pPresentInfo->swapchainCount * sizeof(uint32_t);
     size_t semaSize = pPresentInfo->waitSemaphoreCount * sizeof(VkSemaphore);
     size_t resultsSize = pPresentInfo->swapchainCount * sizeof(VkResult);
-    size_t totalSize = sizeof(VkPresentInfoKHR) + swapchainSize + indexSize + semaSize;
+    size_t totalSize = sizeof(VkPresentInfoKHR) + get_struct_chain_size((void*)pPresentInfo) + swapchainSize + indexSize + semaSize;
     if (pPresentInfo->pResults != NULL) {
         totalSize += resultsSize;
     }
@@ -3218,6 +3322,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueuePresentKHR(VkQueu
     pPacket = interpret_body_as_vkQueuePresentKHR(pHeader);
     pPacket->queue = queue;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pPresentInfo), sizeof(VkPresentInfoKHR), pPresentInfo);
+    if (pPresentInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pPresentInfo, pPresentInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pPresentInfo->pSwapchains), swapchainSize,
                                        pPresentInfo->pSwapchains);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pPresentInfo->pImageIndices), indexSize,
@@ -3318,12 +3423,14 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateWin32SurfaceKHR* pPacket = NULL;
     // don't bother with copying the actual win32 hinstance, hwnd into the trace packet, vkreplay has to use it's own anyway
-    CREATE_TRACE_PACKET(vkCreateWin32SurfaceKHR,
-                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + sizeof(VkWin32SurfaceCreateInfoKHR));
+    CREATE_TRACE_PACKET(vkCreateWin32SurfaceKHR, sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) +
+                                                     sizeof(VkWin32SurfaceCreateInfoKHR) +
+                                                     get_struct_chain_size((void*)pCreateInfo));
     result = mid(instance)->instTable.CreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     pPacket = interpret_body_as_vkCreateWin32SurfaceKHR(pHeader);
     pPacket->instance = instance;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkWin32SurfaceCreateInfoKHR), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSurface), sizeof(VkSurfaceKHR), pSurface);
     pPacket->result = result;
@@ -3386,11 +3493,12 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateXcbSurfaceKHR(Vk
     trim::set_keyboard_connection(pCreateInfo->connection);
     // don't bother with copying the actual xcb window and connection into the trace packet, vkreplay has to use it's own anyway
     CREATE_TRACE_PACKET(vkCreateXcbSurfaceKHR,
-                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + sizeof(VkXcbSurfaceCreateInfoKHR));
+                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + get_struct_chain_size((void*)pCreateInfo));
     result = mid(instance)->instTable.CreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     pPacket = interpret_body_as_vkCreateXcbSurfaceKHR(pHeader);
     pPacket->instance = instance;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkXcbSurfaceCreateInfoKHR), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pNext), pCreateInfo->pNext);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSurface), sizeof(VkSurfaceKHR), pSurface);
     pPacket->result = result;
@@ -3456,11 +3564,12 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateXlibSurfaceKHR(V
     packet_vkCreateXlibSurfaceKHR* pPacket = NULL;
     // don't bother with copying the actual xlib window and connection into the trace packet, vkreplay has to use it's own anyway
     CREATE_TRACE_PACKET(vkCreateXlibSurfaceKHR,
-                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + sizeof(VkXlibSurfaceCreateInfoKHR));
+                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + get_struct_chain_size((void*)pCreateInfo));
     result = mid(instance)->instTable.CreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     pPacket = interpret_body_as_vkCreateXlibSurfaceKHR(pHeader);
     pPacket->instance = instance;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkXlibSurfaceCreateInfoKHR), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pNext), pCreateInfo->pNext);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSurface), sizeof(VkSurfaceKHR), pSurface);
     pPacket->result = result;
@@ -3593,12 +3702,13 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWaylandSurfaceKH
     packet_vkCreateWaylandSurfaceKHR* pPacket = NULL;
     // don't bother with copying the actual wayland window and connection into the trace packet, vkreplay has to use it's own anyway
     CREATE_TRACE_PACKET(vkCreateWaylandSurfaceKHR,
-                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + sizeof(VkWaylandSurfaceCreateInfoKHR));
+                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + get_struct_chain_size((void*)pCreateInfo));
     result = mid(instance)->instTable.CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     pPacket = interpret_body_as_vkCreateWaylandSurfaceKHR(pHeader);
     pPacket->instance = instance;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkWaylandSurfaceCreateInfoKHR),
                                        pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pNext), pCreateInfo->pNext);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSurface), sizeof(VkSurfaceKHR), pSurface);
     pPacket->result = result;
@@ -3665,12 +3775,13 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateAndroidSurfaceKH
     packet_vkCreateAndroidSurfaceKHR* pPacket = NULL;
     // don't bother with copying the actual native window into the trace packet, vkreplay has to use it's own anyway
     CREATE_TRACE_PACKET(vkCreateAndroidSurfaceKHR,
-                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + sizeof(VkAndroidSurfaceCreateInfoKHR));
+                        sizeof(VkSurfaceKHR) + sizeof(VkAllocationCallbacks) + get_struct_chain_size((void*)pCreateInfo));
     result = mid(instance)->instTable.CreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     pPacket = interpret_body_as_vkCreateAndroidSurfaceKHR(pHeader);
     pPacket->instance = instance;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkAndroidSurfaceCreateInfoKHR),
                                        pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pNext), pCreateInfo->pNext);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pSurface), sizeof(VkSurfaceKHR), pSurface);
     pPacket->result = result;
@@ -3710,7 +3821,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
     packet_vkCreateDescriptorUpdateTemplateKHR* pPacket = NULL;
 
     CREATE_TRACE_PACKET(vkCreateDescriptorUpdateTemplateKHR,
-                        sizeof(VkDescriptorUpdateTemplateCreateInfoKHR) + sizeof(VkAllocationCallbacks) +
+                        get_struct_chain_size((void*)pCreateInfo) + sizeof(VkAllocationCallbacks) +
                             sizeof(VkDescriptorUpdateTemplateKHR) +
                             sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount);
     result = mdd(device)->devTable.CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -3732,6 +3843,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
 
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkDescriptorUpdateTemplateCreateInfoKHR),
                                        pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pDescriptorUpdateEntries),
                                        sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount,
                                        pCreateInfo->pDescriptorUpdateEntries);
@@ -3925,6 +4037,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
     pPacket = interpret_body_as_vkCreateObjectTableNVX(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkObjectTableCreateInfoNVX), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pObjectTable), sizeof(VkObjectTableNVX), pObjectTable);
     if (pCreateInfo) {
@@ -3978,6 +4091,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
     pPacket->commandBuffer = commandBuffer;
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pProcessCommandsInfo), sizeof(VkCmdProcessCommandsInfoNVX), pProcessCommandsInfo);
     if (pProcessCommandsInfo) {
+        vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pProcessCommandsInfo, pProcessCommandsInfo);
         vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pProcessCommandsInfo->pIndirectCommandsTokens),
                                            pProcessCommandsInfo->indirectCommandsTokenCount * sizeof(VkIndirectCommandsTokenNVX), pProcessCommandsInfo->pIndirectCommandsTokens);
         vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pProcessCommandsInfo->pIndirectCommandsTokens));
@@ -4020,6 +4134,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateIndirectCommands
     pPacket->device = device;
 
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkIndirectCommandsLayoutCreateInfoNVX), pCreateInfo);
+    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pIndirectCommandsLayout), sizeof(VkIndirectCommandsLayoutNVX), pIndirectCommandsLayout);
     if (pCreateInfo)

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -638,7 +638,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemory
     pPacket->device = device;
     pPacket->memoryRangeCount = memoryRangeCount;
     pPacket->result = result;
-    if (g_trimEnabled) {
+    if (!g_trimEnabled) {
         FINISH_TRACE_PACKET();
     } else {
         vktrace_finalize_trace_packet(pHeader);

--- a/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
@@ -536,7 +536,7 @@ vktrace_trace_packet_header *vkAllocateMemory(bool makeCall, VkDevice device, co
     pPacket = interpret_body_as_vkAllocateMemory(pHeader);
     pPacket->device = device;
     vktrace_add_buffer_to_trace_packet(pHeader, (void **)&(pPacket->pAllocateInfo), sizeof(VkMemoryAllocateInfo), pAllocateInfo);
-    add_alloc_memory_to_trace_packet(pHeader, (void **)&(pPacket->pAllocateInfo->pNext), pAllocateInfo->pNext);
+    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void *)pPacket->pAllocateInfo, (void *)pAllocateInfo);
     vktrace_add_buffer_to_trace_packet(pHeader, (void **)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
     vktrace_add_buffer_to_trace_packet(pHeader, (void **)&(pPacket->pMemory), sizeof(VkDeviceMemory), pMemory);
     pPacket->result = result;

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -360,6 +360,8 @@ bool vkReplay::getQueueFamilyIdx(VkDevice traceDevice, VkDevice replayDevice, ui
 
 VkResult vkReplay::manually_replay_vkCreateDevice(packet_vkCreateDevice *pPacket) {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
+    for (uint32_t i = 0; i < pPacket->pCreateInfo->queueCreateInfoCount; i++)
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pPacket->pCreateInfo->pQueueCreateInfos[i]);
     if (!m_display->m_initedVK) {
         VkDevice device;
         VkPhysicalDevice remappedPhysicalDevice = m_objMapper.remap_physicaldevices(pPacket->physicalDevice);
@@ -627,6 +629,7 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit *pPacket) 
     remappedSubmits = VKTRACE_NEW_ARRAY(VkSubmitInfo, pPacket->submitCount);
     VkCommandBuffer *pRemappedBuffers = NULL;
     VkSemaphore *pRemappedWaitSems = NULL, *pRemappedSignalSems = NULL;
+
     for (uint32_t submit_idx = 0; submit_idx < pPacket->submitCount; submit_idx++) {
         const VkSubmitInfo *submit = &pPacket->pSubmits[submit_idx];
         VkSubmitInfo *remappedSubmit = &remappedSubmits[submit_idx];
@@ -692,7 +695,6 @@ VkResult vkReplay::manually_replay_vkQueueSubmit(packet_vkQueueSubmit *pPacket) 
 
 VkResult vkReplay::manually_replay_vkQueueBindSparse(packet_vkQueueBindSparse *pPacket) {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
-
     VkQueue remappedQueue = m_objMapper.remap_queues(pPacket->queue);
     if (remappedQueue == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkQueueBindSparse() due to invalid remapped VkQueue.");
@@ -718,6 +720,8 @@ VkResult vkReplay::manually_replay_vkQueueBindSparse(packet_vkQueueBindSparse *p
     memcpy((void *)remappedBindSparseInfos, (void *)(pPacket->pBindInfo), sizeof(VkBindSparseInfo) * pPacket->bindInfoCount);
 
     for (uint32_t bindInfo_idx = 0; bindInfo_idx < pPacket->bindInfoCount; bindInfo_idx++) {
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&remappedBindSparseInfos[bindInfo_idx]);
+
         if (remappedBindSparseInfos[bindInfo_idx].pBufferBinds) {
             sBMBinf = VKTRACE_NEW_ARRAY(VkSparseBufferMemoryBindInfo, remappedBindSparseInfos[bindInfo_idx].bufferBindCount);
             remappedBindSparseInfos[bindInfo_idx].pBufferBinds =
@@ -869,12 +873,18 @@ void vkReplay::manually_replay_vkUpdateDescriptorSets(packet_vkUpdateDescriptorS
     }
 
     // allocate a new array for the writes and clear the memory, we'll update the contents further down
-    VkWriteDescriptorSet *pRemappedWrites = VKTRACE_NEW_ARRAY(VkWriteDescriptorSet, pPacket->descriptorWriteCount);
-    memset(pRemappedWrites, 0, pPacket->descriptorWriteCount * sizeof(VkWriteDescriptorSet));
+    VkWriteDescriptorSet *pRemappedWrites = NULL;
+    if (pPacket->descriptorWriteCount > 0) {
+        pRemappedWrites = VKTRACE_NEW_ARRAY(VkWriteDescriptorSet, pPacket->descriptorWriteCount);
+        memset(pRemappedWrites, 0, pPacket->descriptorWriteCount * sizeof(VkWriteDescriptorSet));
+    }
 
     // allocate a new array for the copies, and simply copy the original data in since there are no pointers to update.
-    VkCopyDescriptorSet *pRemappedCopies = VKTRACE_NEW_ARRAY(VkCopyDescriptorSet, pPacket->descriptorCopyCount);
-    memcpy(pRemappedCopies, pPacket->pDescriptorCopies, pPacket->descriptorCopyCount * sizeof(VkCopyDescriptorSet));
+    VkCopyDescriptorSet *pRemappedCopies = NULL;
+    if (pPacket->descriptorCopyCount > 0) {
+        pRemappedCopies = VKTRACE_NEW_ARRAY(VkCopyDescriptorSet, pPacket->descriptorCopyCount);
+        memcpy(pRemappedCopies, pPacket->pDescriptorCopies, pPacket->descriptorCopyCount * sizeof(VkCopyDescriptorSet));
+    }
 
     bool errorBadRemap = false;
 
@@ -1068,6 +1078,8 @@ VkResult vkReplay::manually_replay_vkCreateDescriptorSetLayout(packet_vkCreateDe
     VkDescriptorSetLayoutCreateInfo *pInfo = (VkDescriptorSetLayoutCreateInfo *)pPacket->pCreateInfo;
     if (pInfo != NULL) {
         if (pInfo->pBindings != NULL) {
+            pInfo->pBindings = (VkDescriptorSetLayoutBinding *)vktrace_trace_packet_interpret_buffer_pointer(
+                pPacket->header, (intptr_t)pInfo->pBindings);
             for (unsigned int i = 0; i < pInfo->bindingCount; i++) {
                 VkDescriptorSetLayoutBinding *pBindings = (VkDescriptorSetLayoutBinding *)&pInfo->pBindings[i];
                 if (pBindings->pImmutableSamplers != NULL) {
@@ -1300,6 +1312,8 @@ VkResult vkReplay::manually_replay_vkCreateComputePipelines(packet_vkCreateCompu
 
     // Fix up stage sub-elements
     for (i = 0; i < pPacket->createInfoCount; i++) {
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pLocalCIs[i]);
+
         pLocalCIs[i].stage.module = m_objMapper.remap_shadermodules(pLocalCIs[i].stage.module);
 
         if (pLocalCIs[i].stage.pName)
@@ -1345,7 +1359,6 @@ VkResult vkReplay::manually_replay_vkCreateComputePipelines(packet_vkCreateCompu
 
 VkResult vkReplay::manually_replay_vkCreateGraphicsPipelines(packet_vkCreateGraphicsPipelines *pPacket) {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
-
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkCreateGraphicsPipelines() due to invalid remapped VkDevice.");
@@ -1378,6 +1391,19 @@ VkResult vkReplay::manually_replay_vkCreateGraphicsPipelines(packet_vkCreateGrap
                 return VK_ERROR_VALIDATION_FAILED_EXT;
             }
         }
+
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pLocalCIs[i]);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pStages);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pVertexInputState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pInputAssemblyState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pTessellationState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pViewportState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pRasterizationState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pMultisampleState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pDepthStencilState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pColorBlendState);
+        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pDynamicState);
+
         VkPipelineShaderStageCreateInfo **ppSSCI = (VkPipelineShaderStageCreateInfo **)&(pLocalCIs[i].pStages);
         *ppSSCI = pRemappedStages;
 
@@ -1679,7 +1705,6 @@ void vkReplay::manually_replay_vkCmdPipelineBarrier(packet_vkCmdPipelineBarrier 
 
 VkResult vkReplay::manually_replay_vkCreateFramebuffer(packet_vkCreateFramebuffer *pPacket) {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
-
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkCreateFramebuffer() due to invalid remapped VkDevice.");
@@ -1728,7 +1753,6 @@ VkResult vkReplay::manually_replay_vkCreateFramebuffer(packet_vkCreateFramebuffe
 
 VkResult vkReplay::manually_replay_vkCreateRenderPass(packet_vkCreateRenderPass *pPacket) {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
-
     VkDevice remappedDevice = m_objMapper.remap_devices(pPacket->device);
     if (remappedDevice == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkCreateRenderPass() due to invalid remapped VkDevice.");
@@ -1745,10 +1769,12 @@ VkResult vkReplay::manually_replay_vkCreateRenderPass(packet_vkCreateRenderPass 
 
 void vkReplay::manually_replay_vkCmdBeginRenderPass(packet_vkCmdBeginRenderPass *pPacket) {
     VkCommandBuffer remappedCommandBuffer = m_objMapper.remap_commandbuffers(pPacket->commandBuffer);
+
     if (remappedCommandBuffer == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkCmdBeginRenderPass() due to invalid remapped VkCommandBuffer.");
         return;
     }
+
     VkRenderPassBeginInfo local_renderPassBeginInfo;
     memcpy((void *)&local_renderPassBeginInfo, (void *)pPacket->pRenderPassBegin, sizeof(VkRenderPassBeginInfo));
     local_renderPassBeginInfo.pClearValues = (const VkClearValue *)pPacket->pRenderPassBegin->pClearValues;
@@ -1768,7 +1794,6 @@ void vkReplay::manually_replay_vkCmdBeginRenderPass(packet_vkCmdBeginRenderPass 
 
 VkResult vkReplay::manually_replay_vkBeginCommandBuffer(packet_vkBeginCommandBuffer *pPacket) {
     VkResult replayResult = VK_ERROR_VALIDATION_FAILED_EXT;
-
     VkCommandBuffer remappedCommandBuffer = m_objMapper.remap_commandbuffers(pPacket->commandBuffer);
     if (remappedCommandBuffer == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkBeginCommandBuffer() due to invalid remapped VkCommandBuffer.");
@@ -1930,14 +1955,18 @@ VkResult vkReplay::manually_replay_vkAllocateMemory(packet_vkAllocateMemory *pPa
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
-    if (pPacket->pAllocateInfo->pNext) {
-        VkDedicatedAllocationMemoryAllocateInfoNV *x = (VkDedicatedAllocationMemoryAllocateInfoNV *)(pPacket->pAllocateInfo->pNext);
-
-        if (x->sType == VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV) {
-            x->image = m_objMapper.remap_images(x->image);
-            x->buffer = m_objMapper.remap_buffers(x->buffer);
-            if (!(x->image == VK_NULL_HANDLE || x->buffer == VK_NULL_HANDLE))
-                vktrace_LogError("Invalid handle in vkAllocateMemory pAllocate->pNext structure.");
+    if (pPacket->pAllocateInfo) {
+        const void *pNext = pPacket->pAllocateInfo->pNext;
+        while (pNext) {
+            VkDedicatedAllocationMemoryAllocateInfoNV *x =
+                (VkDedicatedAllocationMemoryAllocateInfoNV *)(pPacket->pAllocateInfo->pNext);
+            if (x->sType == VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV) {
+                x->image = m_objMapper.remap_images(x->image);
+                x->buffer = m_objMapper.remap_buffers(x->buffer);
+                if (!(x->image == VK_NULL_HANDLE || x->buffer == VK_NULL_HANDLE))
+                    vktrace_LogError("Invalid handle in vkAllocateMemory pAllocate->pNext structure.");
+            }
+            pNext = x->pNext;
         }
     }
 
@@ -3663,13 +3692,13 @@ void vkReplay::manually_replay_vkCmdPushDescriptorSetWithTemplateKHR(packet_vkCm
     m_vkDeviceFuncs.CmdPushDescriptorSetWithTemplateKHR(remappedcommandBuffer, remappedDescriptorUpdateTemplate, remappedlayout,
                                                         pPacket->set, pPacket->pData);
 }
-
 VkResult vkReplay::manually_replay_vkRegisterDeviceEventEXT(packet_vkRegisterDeviceEventEXT *pPacket) {
     VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
     if (pPacket->device != VK_NULL_HANDLE && remappeddevice == VK_NULL_HANDLE) {
         vktrace_LogError("Error detected in RegisterDeviceEventEXT() due to invalid remapped VkDevice.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
+
     // No need to remap pDeviceEventInfo
     // No need to remap pAllocator
     VkFence fence;
@@ -3691,6 +3720,7 @@ VkResult vkReplay::manually_replay_vkRegisterDisplayEventEXT(packet_vkRegisterDi
         vktrace_LogError("Error detected in RegisterDisplayEventEXT() due to invalid remapped VkDisplayKHR.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
+
     // No need to remap pDisplayEventInfo
     // No need to remap pAllocator
     VkFence fence;


### PR DESCRIPTION
Added support during trace for adding all pNext structs in api
calls to the trace file, and for unpacking them and including
them in api calls during replay.

Change-Id: I3c31ba96411e6a9d1c470c8d9a7f751f3e660496