### PR TITLE
layersvt: DevSim 1.2.0 add new features

### DIFF
--- a/build-android/devsim_layer_test_android.sh
+++ b/build-android/devsim_layer_test_android.sh
@@ -162,12 +162,10 @@ else
     NC=''
 fi
 
-# compare vkjson output against gold for the #lines of input
-# echo will trim any leading whitespace
-NUM_LINES=$(cut -f1 -d ' ' <(echo $(wc -l ${goldJSON})))
-diff ${goldJSON} <(head -n ${NUM_LINES} ${resultJSON}) #>/dev/null
+# reformat/extract/sort vkjson output using jq, then compare against gold.
+diff ${goldJSON} \
+    <(jq -S '{properties,features,memory,queues,formats}' ${resultJSON})
 RES=$?
-#rm ${FILENAME_01_OUT}
 
 if [ "$RES" -eq 0 ] ; then
    printf "$GREEN[  PASSED  ]$NC ${PGM}\n"

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -62,7 +62,7 @@ namespace {
 // For any changes, at least increment the patch level.
 // When making ANY changes to the version, be sure to also update layersvt/{linux|windows}/VkLayer_device_simulation.json
 const uint32_t kVersionDevsimMajor = 1;
-const uint32_t kVersionDevsimMinor = 1;
+const uint32_t kVersionDevsimMinor = 2;
 const uint32_t kVersionDevsimPatch = 0;
 const uint32_t kVersionDevsimImplementation = VK_MAKE_VERSION(kVersionDevsimMajor, kVersionDevsimMinor, kVersionDevsimPatch);
 
@@ -77,6 +77,194 @@ const char *kOurLayerName = kLayerProperties[0].layerName;
 
 const VkExtensionProperties *kExtensionProperties = nullptr;
 const uint32_t kExtensionPropertiesCount = 0;
+
+// The "standard" VkFormat enum values (not including extension enums)
+const VkFormat StandardVkFormatEnumList[] = {
+    VK_FORMAT_R4G4_UNORM_PACK8,
+    VK_FORMAT_R4G4B4A4_UNORM_PACK16,
+    VK_FORMAT_B4G4R4A4_UNORM_PACK16,
+    VK_FORMAT_R5G6B5_UNORM_PACK16,
+    VK_FORMAT_B5G6R5_UNORM_PACK16,
+    VK_FORMAT_R5G5B5A1_UNORM_PACK16,
+    VK_FORMAT_B5G5R5A1_UNORM_PACK16,
+    VK_FORMAT_A1R5G5B5_UNORM_PACK16,
+    VK_FORMAT_R8_UNORM,
+    VK_FORMAT_R8_SNORM,
+    VK_FORMAT_R8_USCALED,
+    VK_FORMAT_R8_SSCALED,
+    VK_FORMAT_R8_UINT,
+    VK_FORMAT_R8_SINT,
+    VK_FORMAT_R8_SRGB,
+    VK_FORMAT_R8G8_UNORM,
+    VK_FORMAT_R8G8_SNORM,
+    VK_FORMAT_R8G8_USCALED,
+    VK_FORMAT_R8G8_SSCALED,
+    VK_FORMAT_R8G8_UINT,
+    VK_FORMAT_R8G8_SINT,
+    VK_FORMAT_R8G8_SRGB,
+    VK_FORMAT_R8G8B8_UNORM,
+    VK_FORMAT_R8G8B8_SNORM,
+    VK_FORMAT_R8G8B8_USCALED,
+    VK_FORMAT_R8G8B8_SSCALED,
+    VK_FORMAT_R8G8B8_UINT,
+    VK_FORMAT_R8G8B8_SINT,
+    VK_FORMAT_R8G8B8_SRGB,
+    VK_FORMAT_B8G8R8_UNORM,
+    VK_FORMAT_B8G8R8_SNORM,
+    VK_FORMAT_B8G8R8_USCALED,
+    VK_FORMAT_B8G8R8_SSCALED,
+    VK_FORMAT_B8G8R8_UINT,
+    VK_FORMAT_B8G8R8_SINT,
+    VK_FORMAT_B8G8R8_SRGB,
+    VK_FORMAT_R8G8B8A8_UNORM,
+    VK_FORMAT_R8G8B8A8_SNORM,
+    VK_FORMAT_R8G8B8A8_USCALED,
+    VK_FORMAT_R8G8B8A8_SSCALED,
+    VK_FORMAT_R8G8B8A8_UINT,
+    VK_FORMAT_R8G8B8A8_SINT,
+    VK_FORMAT_R8G8B8A8_SRGB,
+    VK_FORMAT_B8G8R8A8_UNORM,
+    VK_FORMAT_B8G8R8A8_SNORM,
+    VK_FORMAT_B8G8R8A8_USCALED,
+    VK_FORMAT_B8G8R8A8_SSCALED,
+    VK_FORMAT_B8G8R8A8_UINT,
+    VK_FORMAT_B8G8R8A8_SINT,
+    VK_FORMAT_B8G8R8A8_SRGB,
+    VK_FORMAT_A8B8G8R8_UNORM_PACK32,
+    VK_FORMAT_A8B8G8R8_SNORM_PACK32,
+    VK_FORMAT_A8B8G8R8_USCALED_PACK32,
+    VK_FORMAT_A8B8G8R8_SSCALED_PACK32,
+    VK_FORMAT_A8B8G8R8_UINT_PACK32,
+    VK_FORMAT_A8B8G8R8_SINT_PACK32,
+    VK_FORMAT_A8B8G8R8_SRGB_PACK32,
+    VK_FORMAT_A2R10G10B10_UNORM_PACK32,
+    VK_FORMAT_A2R10G10B10_SNORM_PACK32,
+    VK_FORMAT_A2R10G10B10_USCALED_PACK32,
+    VK_FORMAT_A2R10G10B10_SSCALED_PACK32,
+    VK_FORMAT_A2R10G10B10_UINT_PACK32,
+    VK_FORMAT_A2R10G10B10_SINT_PACK32,
+    VK_FORMAT_A2B10G10R10_UNORM_PACK32,
+    VK_FORMAT_A2B10G10R10_SNORM_PACK32,
+    VK_FORMAT_A2B10G10R10_USCALED_PACK32,
+    VK_FORMAT_A2B10G10R10_SSCALED_PACK32,
+    VK_FORMAT_A2B10G10R10_UINT_PACK32,
+    VK_FORMAT_A2B10G10R10_SINT_PACK32,
+    VK_FORMAT_R16_UNORM,
+    VK_FORMAT_R16_SNORM,
+    VK_FORMAT_R16_USCALED,
+    VK_FORMAT_R16_SSCALED,
+    VK_FORMAT_R16_UINT,
+    VK_FORMAT_R16_SINT,
+    VK_FORMAT_R16_SFLOAT,
+    VK_FORMAT_R16G16_UNORM,
+    VK_FORMAT_R16G16_SNORM,
+    VK_FORMAT_R16G16_USCALED,
+    VK_FORMAT_R16G16_SSCALED,
+    VK_FORMAT_R16G16_UINT,
+    VK_FORMAT_R16G16_SINT,
+    VK_FORMAT_R16G16_SFLOAT,
+    VK_FORMAT_R16G16B16_UNORM,
+    VK_FORMAT_R16G16B16_SNORM,
+    VK_FORMAT_R16G16B16_USCALED,
+    VK_FORMAT_R16G16B16_SSCALED,
+    VK_FORMAT_R16G16B16_UINT,
+    VK_FORMAT_R16G16B16_SINT,
+    VK_FORMAT_R16G16B16_SFLOAT,
+    VK_FORMAT_R16G16B16A16_UNORM,
+    VK_FORMAT_R16G16B16A16_SNORM,
+    VK_FORMAT_R16G16B16A16_USCALED,
+    VK_FORMAT_R16G16B16A16_SSCALED,
+    VK_FORMAT_R16G16B16A16_UINT,
+    VK_FORMAT_R16G16B16A16_SINT,
+    VK_FORMAT_R16G16B16A16_SFLOAT,
+    VK_FORMAT_R32_UINT,
+    VK_FORMAT_R32_SINT,
+    VK_FORMAT_R32_SFLOAT,
+    VK_FORMAT_R32G32_UINT,
+    VK_FORMAT_R32G32_SINT,
+    VK_FORMAT_R32G32_SFLOAT,
+    VK_FORMAT_R32G32B32_UINT,
+    VK_FORMAT_R32G32B32_SINT,
+    VK_FORMAT_R32G32B32_SFLOAT,
+    VK_FORMAT_R32G32B32A32_UINT,
+    VK_FORMAT_R32G32B32A32_SINT,
+    VK_FORMAT_R32G32B32A32_SFLOAT,
+    VK_FORMAT_R64_UINT,
+    VK_FORMAT_R64_SINT,
+    VK_FORMAT_R64_SFLOAT,
+    VK_FORMAT_R64G64_UINT,
+    VK_FORMAT_R64G64_SINT,
+    VK_FORMAT_R64G64_SFLOAT,
+    VK_FORMAT_R64G64B64_UINT,
+    VK_FORMAT_R64G64B64_SINT,
+    VK_FORMAT_R64G64B64_SFLOAT,
+    VK_FORMAT_R64G64B64A64_UINT,
+    VK_FORMAT_R64G64B64A64_SINT,
+    VK_FORMAT_R64G64B64A64_SFLOAT,
+    VK_FORMAT_B10G11R11_UFLOAT_PACK32,
+    VK_FORMAT_E5B9G9R9_UFLOAT_PACK32,
+    VK_FORMAT_D16_UNORM,
+    VK_FORMAT_X8_D24_UNORM_PACK32,
+    VK_FORMAT_D32_SFLOAT,
+    VK_FORMAT_S8_UINT,
+    VK_FORMAT_D16_UNORM_S8_UINT,
+    VK_FORMAT_D24_UNORM_S8_UINT,
+    VK_FORMAT_D32_SFLOAT_S8_UINT,
+    VK_FORMAT_BC1_RGB_UNORM_BLOCK,
+    VK_FORMAT_BC1_RGB_SRGB_BLOCK,
+    VK_FORMAT_BC1_RGBA_UNORM_BLOCK,
+    VK_FORMAT_BC1_RGBA_SRGB_BLOCK,
+    VK_FORMAT_BC2_UNORM_BLOCK,
+    VK_FORMAT_BC2_SRGB_BLOCK,
+    VK_FORMAT_BC3_UNORM_BLOCK,
+    VK_FORMAT_BC3_SRGB_BLOCK,
+    VK_FORMAT_BC4_UNORM_BLOCK,
+    VK_FORMAT_BC4_SNORM_BLOCK,
+    VK_FORMAT_BC5_UNORM_BLOCK,
+    VK_FORMAT_BC5_SNORM_BLOCK,
+    VK_FORMAT_BC6H_UFLOAT_BLOCK,
+    VK_FORMAT_BC6H_SFLOAT_BLOCK,
+    VK_FORMAT_BC7_UNORM_BLOCK,
+    VK_FORMAT_BC7_SRGB_BLOCK,
+    VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK,
+    VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK,
+    VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK,
+    VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK,
+    VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK,
+    VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK,
+    VK_FORMAT_EAC_R11_UNORM_BLOCK,
+    VK_FORMAT_EAC_R11_SNORM_BLOCK,
+    VK_FORMAT_EAC_R11G11_UNORM_BLOCK,
+    VK_FORMAT_EAC_R11G11_SNORM_BLOCK,
+    VK_FORMAT_ASTC_4x4_UNORM_BLOCK,
+    VK_FORMAT_ASTC_4x4_SRGB_BLOCK,
+    VK_FORMAT_ASTC_5x4_UNORM_BLOCK,
+    VK_FORMAT_ASTC_5x4_SRGB_BLOCK,
+    VK_FORMAT_ASTC_5x5_UNORM_BLOCK,
+    VK_FORMAT_ASTC_5x5_SRGB_BLOCK,
+    VK_FORMAT_ASTC_6x5_UNORM_BLOCK,
+    VK_FORMAT_ASTC_6x5_SRGB_BLOCK,
+    VK_FORMAT_ASTC_6x6_UNORM_BLOCK,
+    VK_FORMAT_ASTC_6x6_SRGB_BLOCK,
+    VK_FORMAT_ASTC_8x5_UNORM_BLOCK,
+    VK_FORMAT_ASTC_8x5_SRGB_BLOCK,
+    VK_FORMAT_ASTC_8x6_UNORM_BLOCK,
+    VK_FORMAT_ASTC_8x6_SRGB_BLOCK,
+    VK_FORMAT_ASTC_8x8_UNORM_BLOCK,
+    VK_FORMAT_ASTC_8x8_SRGB_BLOCK,
+    VK_FORMAT_ASTC_10x5_UNORM_BLOCK,
+    VK_FORMAT_ASTC_10x5_SRGB_BLOCK,
+    VK_FORMAT_ASTC_10x6_UNORM_BLOCK,
+    VK_FORMAT_ASTC_10x6_SRGB_BLOCK,
+    VK_FORMAT_ASTC_10x8_UNORM_BLOCK,
+    VK_FORMAT_ASTC_10x8_SRGB_BLOCK,
+    VK_FORMAT_ASTC_10x10_UNORM_BLOCK,
+    VK_FORMAT_ASTC_10x10_SRGB_BLOCK,
+    VK_FORMAT_ASTC_12x10_UNORM_BLOCK,
+    VK_FORMAT_ASTC_12x10_SRGB_BLOCK,
+    VK_FORMAT_ASTC_12x12_UNORM_BLOCK,
+    VK_FORMAT_ASTC_12x12_SRGB_BLOCK,
+};
 
 // Environment variables defined by this layer ///////////////////////////////////////////////////////////////////////////////////
 
@@ -236,6 +424,24 @@ std::mutex global_lock;  // Enforce thread-safety for this layer's containers.
 uint32_t loader_layer_iface_version = CURRENT_LOADER_LAYER_INTERFACE_VERSION;
 
 typedef std::vector<VkQueueFamilyProperties> ArrayOfVkQueueFamilyProperties;
+typedef std::unordered_map<uint32_t /*VkFormat*/, VkFormatProperties> ArrayOfVkFormatProperties;
+
+// FormatProperties utilities ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// This is the structure of format property data used in JSON, as defined by the Devsim schema.
+// It will be split to create a VkFormat value and a VkFormatProperties structure after reading from JSON.
+struct DevsimFormatProperties {
+    VkFormat formatID;
+    VkFormatFeatureFlags linearTilingFeatures;
+    VkFormatFeatureFlags optimalTilingFeatures;
+    VkFormatFeatureFlags bufferFeatures;
+};
+
+bool IsFormatSupported(const VkFormatProperties &props) {
+    // Per [SPEC] section 30.3.2 "Format Properties":
+    // "... if no format feature flags are supported, the format itself is not supported ..."
+    return !(!props.linearTilingFeatures && !props.optimalTilingFeatures && !props.bufferFeatures);
+}
 
 // PhysicalDeviceData : creates and manages the simulated device configurations //////////////////////////////////////////////////
 
@@ -265,6 +471,7 @@ class PhysicalDeviceData {
     VkPhysicalDeviceFeatures physical_device_features_;
     VkPhysicalDeviceMemoryProperties physical_device_memory_properties_;
     ArrayOfVkQueueFamilyProperties arrayof_queue_family_properties_;
+    ArrayOfVkFormatProperties arrayof_format_properties_;
 
    private:
     PhysicalDeviceData() = delete;
@@ -311,6 +518,7 @@ class JsonLoader {
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceMemoryProperties *dest);
     void GetValue(const Json::Value &parent, const char *name, VkExtent3D *dest);
     void GetValue(const Json::Value &parent, int index, VkQueueFamilyProperties *dest);
+    void GetValue(const Json::Value &parent, int index, DevsimFormatProperties *dest);
 
     // For use as warn_func in GET_VALUE_WARN().  Return true if warning occurred.
     static bool WarnIfGreater(const char *name, const uint64_t new_value, const uint64_t old_value) {
@@ -433,7 +641,7 @@ class JsonLoader {
         int count = 0;
         dest[0] = '\0';
         if (new_value) {
-            count = strlen(new_value);
+            count = static_cast<int>(strlen(new_value));
             strcpy(dest, new_value);
         }
         return count;
@@ -476,7 +684,32 @@ class JsonLoader {
             GetValue(value, i, &queue_family_properties);
             dest->push_back(queue_family_properties);
         }
-        return dest->size();
+        return static_cast<int>(dest->size());
+    }
+
+    int GetArray(const Json::Value &parent, const char *name, ArrayOfVkFormatProperties *dest) {
+        DebugPrintf("\t\tJsonLoader::GetArray(ArrayOfVkFormatProperties)\n");
+        const Json::Value value = parent[name];
+        if (value.type() != Json::arrayValue) {
+            return -1;
+        }
+        dest->clear();
+        const int count = static_cast<int>(value.size());
+        for (int i = 0; i < count; ++i) {
+            // Get a format structure from JSON.
+            DevsimFormatProperties devsim_format_properties = {};
+            GetValue(value, i, &devsim_format_properties);
+            // Split the JSON-acquired data into VkFormat and VkFormatProperties.
+            const VkFormat format = devsim_format_properties.formatID;
+            VkFormatProperties vk_format_properties = {};
+            vk_format_properties.linearTilingFeatures = devsim_format_properties.linearTilingFeatures;
+            vk_format_properties.optimalTilingFeatures = devsim_format_properties.optimalTilingFeatures;
+            vk_format_properties.bufferFeatures = devsim_format_properties.bufferFeatures;
+            if (IsFormatSupported(vk_format_properties)) {
+                dest->insert({format, vk_format_properties});
+            }
+        }
+        return static_cast<int>(dest->size());
     }
 
     PhysicalDeviceData &pdd_;
@@ -513,6 +746,7 @@ bool JsonLoader::LoadFile(const char *filename) {
             GetValue(root, "VkPhysicalDeviceFeatures", &pdd_.physical_device_features_);
             GetValue(root, "VkPhysicalDeviceMemoryProperties", &pdd_.physical_device_memory_properties_);
             GetArray(root, "ArrayOfVkQueueFamilyProperties", &pdd_.arrayof_queue_family_properties_);
+            GetArray(root, "ArrayOfVkFormatProperties", &pdd_.arrayof_format_properties_);
             break;
         case SchemaId::kUnknown:
         default:
@@ -756,7 +990,6 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysica
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkExtent3D *dest) {
-    DebugPrintf("\t\tJsonLoader::GetValue(VkExtent3D)\n");
     const Json::Value value = parent[name];
     if (value.type() != Json::objectValue) {
         return;
@@ -767,7 +1000,6 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkExtent3
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, int index, VkQueueFamilyProperties *dest) {
-    DebugPrintf("\t\tJsonLoader::GetValue(VkQueueFamilyProperties)\n");
     const Json::Value value = parent[index];
     if (value.type() != Json::objectValue) {
         return;
@@ -779,7 +1011,6 @@ void JsonLoader::GetValue(const Json::Value &parent, int index, VkQueueFamilyPro
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, int index, VkMemoryType *dest) {
-    DebugPrintf("\t\tJsonLoader::GetValue(VkMemoryType %d)\n", index);
     const Json::Value value = parent[index];
     if (value.type() != Json::objectValue) {
         return;
@@ -789,7 +1020,6 @@ void JsonLoader::GetValue(const Json::Value &parent, int index, VkMemoryType *de
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, int index, VkMemoryHeap *dest) {
-    DebugPrintf("\t\tJsonLoader::GetValue(VkMemoryHeap %d)\n", index);
     const Json::Value value = parent[index];
     if (value.type() != Json::objectValue) {
         return;
@@ -820,6 +1050,17 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysica
     }
 }
 
+void JsonLoader::GetValue(const Json::Value &parent, int index, DevsimFormatProperties *dest) {
+    const Json::Value value = parent[index];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    GET_VALUE(formatID);
+    GET_VALUE(linearTilingFeatures);
+    GET_VALUE(optimalTilingFeatures);
+    GET_VALUE(bufferFeatures);
+}
+
 #undef GET_VALUE
 #undef GET_ARRAY
 
@@ -848,6 +1089,13 @@ VkResult LayerSetupCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
                                               VkInstance *pInstance) {
     DebugPrintf("CreateInstance START {\n");
+    DebugPrintf("%s version %d.%d.%d\n", kOurLayerName, kVersionDevsimMajor, kVersionDevsimMinor, kVersionDevsimPatch);
+
+    const VkApplicationInfo *app_info = pCreateInfo->pApplicationInfo;
+    const uint32_t requested_version = (app_info && app_info->apiVersion) ? app_info->apiVersion : VK_API_VERSION_1_0;
+    if (requested_version != VK_API_VERSION_1_0) {
+        ErrorPrintf("%s currently supports only VK_API_VERSION_1_0\n", kOurLayerName);
+    }
 
     std::lock_guard<std::mutex> lock(global_lock);
 
@@ -857,8 +1105,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     }
 
     // Our layer-specific initialization...
-
-    DebugPrintf("%s version %d.%d.%d\n", kOurLayerName, kVersionDevsimMajor, kVersionDevsimMinor, kVersionDevsimPatch);
 
     // Get the name of our configuration file.
     std::string filename = GetEnvarValue(kEnvarDevsimFilename);
@@ -890,6 +1136,14 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
                                                   dt->GetPhysicalDeviceQueueFamilyProperties(physical_device, count, results);
                                                   return VK_SUCCESS;
                                               });
+        // Query every standard VkFormat's properties.
+        for (const VkFormat format : StandardVkFormatEnumList) {
+            VkFormatProperties format_properties = {};
+            dt->GetPhysicalDeviceFormatProperties(physical_device, format, &format_properties);
+            if (IsFormatSupported(format_properties)) {
+                pdd.arrayof_format_properties_.insert({format, format_properties});
+            }
+        }
 
         // Override PDD members with values from the configuration file.
         JsonLoader json_loader(pdd);
@@ -1001,12 +1255,25 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevi
     const auto dt = instance_dispatch_table(physicalDevice);
 
     PhysicalDeviceData *pdd = PhysicalDeviceData::Find(physicalDevice);
-    DebugPrintf("GetPhysicalDeviceQueueFamilyProperties physicalDevice %p pdd %p\n", physicalDevice, pdd);
     if (pdd) {
-        EnumerateProperties(pdd->arrayof_queue_family_properties_.size(), pdd->arrayof_queue_family_properties_.data(),
-                            pQueueFamilyPropertyCount, pQueueFamilyProperties);
+        EnumerateProperties(static_cast<uint32_t>(pdd->arrayof_queue_family_properties_.size()),
+                            pdd->arrayof_queue_family_properties_.data(), pQueueFamilyPropertyCount, pQueueFamilyProperties);
     } else {
         dt->GetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                             VkFormatProperties *pFormatProperties) {
+    std::lock_guard<std::mutex> lock(global_lock);
+    const auto dt = instance_dispatch_table(physicalDevice);
+
+    PhysicalDeviceData *pdd = PhysicalDeviceData::Find(physicalDevice);
+    if (pdd) {
+        const auto iter = pdd->arrayof_format_properties_.find(format);
+        *pFormatProperties = (iter != pdd->arrayof_format_properties_.end()) ? iter->second : VkFormatProperties{};
+    } else {
+        dt->GetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties);
     }
 }
 
@@ -1024,6 +1291,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
     GET_PROC_ADDR(GetPhysicalDeviceFeatures);
     GET_PROC_ADDR(GetPhysicalDeviceMemoryProperties);
     GET_PROC_ADDR(GetPhysicalDeviceQueueFamilyProperties);
+    GET_PROC_ADDR(GetPhysicalDeviceFormatProperties);
 #undef GET_PROC_ADDR
 
     if (!instance) {

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -48,6 +48,7 @@ The top-level sections of a configuration file are specified by the DevSim JSON 
 * `VkPhysicalDeviceFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceMemoryProperties` - Optional.  Only values specified in the JSON will be modified.
 * `ArrayOfVkQueueFamilyProperties` - Optional.  If present, all values of all elements must be specified.
+* `ArrayOfVkFormatProperties` - Optional.  If present, all values of all elements must be specified.
 * The remaining top-level sections of the schema are not yet supported by DevSim.
 
 The schema permits additional top-level sections to be optionally included in configuration files;
@@ -56,6 +57,10 @@ any additional top-level sections will be ignored by DevSim.
 The schema defines basic range checking for common Vulkan data types, but it cannot detect if a particular configuration makes no sense.
 If a configuration defines capabilities beyond what the actual device is natively capable of providing, the results are undefined.
 DevSim has some simple checking of configuration values and writes debug messages (if enabled) for values that are incompatible with the capabilities of the actual device.
+
+This version of DevSim currently supports only Vulkan v1.0.
+If the application requests an unsupported version of the Vulkan API, DevSim will emit an error message.
+If you wish DevSim to terminate on errors, set the `VK_DEVSIM_EXIT_ON_ERROR` environment variable (see below).
 
 ## Example of a DevSim JSON configuration file
 ```json

--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
         "api_version": "1.0.65",
-        "implementation_version": "1.1.0",
+        "implementation_version": "1.2.0",
         "description": "LunarG device simulation layer"
     }
 }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
         "api_version": "1.0.65",
-        "implementation_version": "1.1.0",
+        "implementation_version": "1.2.0",
         "description": "LunarG device simulation layer"
     }
 }

--- a/tests/devsim_layer_test.sh
+++ b/tests/devsim_layer_test.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
-# simple test of devsim layer
+# Simple test of devsim layer
+# Uses 'jq' v1.5 (https://stedolan.github.io/jq/) to extract sections of
+# test's JSON output and reformat for consistent comparison with gold file.
 
 set errexit
 set nounset
@@ -40,9 +42,10 @@ FILENAME_01_STDOUT="device_simulation_layer_test_1.txt"
 export VK_DEVSIM_FILENAME="${FILENAME_01_IN}"
 ${VKJSON_INFO} > ${FILENAME_01_STDOUT}
 
-# compare vkjson output against gold
-NUM_LINES=$(cut -f1 -d' ' <(wc -l ${FILENAME_01_GOLD}))
-diff ${FILENAME_01_GOLD} <(head -n ${NUM_LINES} ${FILENAME_01_RESULT}) >> ${FILENAME_01_STDOUT}
+# reformat/extract/sort vkjson output using jq, then compare against gold.
+diff ${FILENAME_01_GOLD} \
+    <(jq -S '{properties,features,memory,queues,formats}' ${FILENAME_01_RESULT}) \
+    >> ${FILENAME_01_STDOUT}
 RES=$?
 rm ${FILENAME_01_RESULT}
 rm ${FILENAME_01_STDOUT}

--- a/tests/devsim_test1.json
+++ b/tests/devsim_test1.json
@@ -256,5 +256,37 @@
 	    "queueFlags": 900004017,
 	    "timestampValidBits": 900004018
 	}
+    ],
+    "ArrayOfVkFormatProperties": [
+        {
+            "formatID": 100,
+            "linearTilingFeatures": 900005004,
+            "optimalTilingFeatures": 900005005,
+            "bufferFeatures": 900005006
+        },
+        {
+            "formatID": 4,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 3,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 900005003
+        },
+        {
+            "formatID": 2,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 900005002,
+            "bufferFeatures": 0
+        },
+        {
+            "formatID": 1,
+            "linearTilingFeatures": 900005001,
+            "optimalTilingFeatures": 0,
+            "bufferFeatures": 0
+        }
     ]
 }

--- a/tests/devsim_test1_gold.json
+++ b/tests/devsim_test1_gold.json
@@ -1,240 +1,326 @@
 {
-	"properties":	{
-		"apiVersion":	1,
-		"driverVersion":	2,
-		"vendorID":	0,
-		"deviceID":	0,
-		"deviceType":	0,
-		"deviceName":	"device_simulation_layer_test_1",
-		"pipelineCacheUUID":	[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-		"limits":	{
-			"maxImageDimension1D":	900001000,
-			"maxImageDimension2D":	900001001,
-			"maxImageDimension3D":	900001002,
-			"maxImageDimensionCube":	900001003,
-			"maxImageArrayLayers":	900001004,
-			"maxTexelBufferElements":	900001005,
-			"maxUniformBufferRange":	900001006,
-			"maxStorageBufferRange":	900001007,
-			"maxPushConstantsSize":	900001008,
-			"maxMemoryAllocationCount":	900001009,
-			"maxSamplerAllocationCount":	900001010,
-			"bufferImageGranularity":	"0x00000012a05f23f3",
-			"sparseAddressSpaceSize":	"0x00000012a05f23f4",
-			"maxBoundDescriptorSets":	900001013,
-			"maxPerStageDescriptorSamplers":	900001014,
-			"maxPerStageDescriptorUniformBuffers":	900001015,
-			"maxPerStageDescriptorStorageBuffers":	900001016,
-			"maxPerStageDescriptorSampledImages":	900001017,
-			"maxPerStageDescriptorStorageImages":	900001018,
-			"maxPerStageDescriptorInputAttachments":	900001019,
-			"maxPerStageResources":	900001020,
-			"maxDescriptorSetSamplers":	900001021,
-			"maxDescriptorSetUniformBuffers":	900001022,
-			"maxDescriptorSetUniformBuffersDynamic":	900001023,
-			"maxDescriptorSetStorageBuffers":	900001024,
-			"maxDescriptorSetStorageBuffersDynamic":	900001025,
-			"maxDescriptorSetSampledImages":	900001026,
-			"maxDescriptorSetStorageImages":	900001027,
-			"maxDescriptorSetInputAttachments":	900001028,
-			"maxVertexInputAttributes":	900001029,
-			"maxVertexInputBindings":	900001030,
-			"maxVertexInputAttributeOffset":	900001031,
-			"maxVertexInputBindingStride":	900001032,
-			"maxVertexOutputComponents":	900001033,
-			"maxTessellationGenerationLevel":	900001034,
-			"maxTessellationPatchSize":	900001035,
-			"maxTessellationControlPerVertexInputComponents":	900001036,
-			"maxTessellationControlPerVertexOutputComponents":	900001037,
-			"maxTessellationControlPerPatchOutputComponents":	900001038,
-			"maxTessellationControlTotalOutputComponents":	900001039,
-			"maxTessellationEvaluationInputComponents":	900001040,
-			"maxTessellationEvaluationOutputComponents":	900001041,
-			"maxGeometryShaderInvocations":	900001042,
-			"maxGeometryInputComponents":	900001043,
-			"maxGeometryOutputComponents":	900001044,
-			"maxGeometryOutputVertices":	900001045,
-			"maxGeometryTotalOutputComponents":	900001046,
-			"maxFragmentInputComponents":	900001047,
-			"maxFragmentOutputAttachments":	900001048,
-			"maxFragmentDualSrcAttachments":	900001049,
-			"maxFragmentCombinedOutputResources":	900001050,
-			"maxComputeSharedMemorySize":	900001051,
-			"maxComputeWorkGroupCount":	[900001052, 900001053, 900001054],
-			"maxComputeWorkGroupInvocations":	900001055,
-			"maxComputeWorkGroupSize":	[900001056, 900001057, 900001058],
-			"subPixelPrecisionBits":	900001059,
-			"subTexelPrecisionBits":	900001060,
-			"mipmapPrecisionBits":	900001061,
-			"maxDrawIndexedIndexValue":	31062,
-			"maxDrawIndirectCount":	31063,
-			"maxSamplerLodBias":	900001088,
-			"maxSamplerAnisotropy":	900001088,
-			"maxViewports":	900001066,
-			"maxViewportDimensions":	[900001067, 900001068],
-			"viewportBoundsRange":	[-900001088, 900001088],
-			"viewportSubPixelBits":	900001071,
-			"minMemoryMapAlignment":	"0x0000000035a4ed30",
-			"minTexelBufferOffsetAlignment":	"0x00000012a05f2431",
-			"minUniformBufferOffsetAlignment":	"0x00000012a05f2432",
-			"minStorageBufferOffsetAlignment":	"0x00000012a05f2433",
-			"minTexelOffset":	-900001076,
-			"maxTexelOffset":	900001077,
-			"minTexelGatherOffset":	-900001078,
-			"maxTexelGatherOffset":	900001079,
-			"minInterpolationOffset":	201.500000,
-			"maxInterpolationOffset":	-202.500000,
-			"subPixelInterpolationOffsetBits":	900001080,
-			"maxFramebufferWidth":	900001081,
-			"maxFramebufferHeight":	900001082,
-			"maxFramebufferLayers":	900001083,
-			"framebufferColorSampleCounts":	900001084,
-			"framebufferDepthSampleCounts":	900001085,
-			"framebufferStencilSampleCounts":	900001086,
-			"framebufferNoAttachmentsSampleCounts":	900001087,
-			"maxColorAttachments":	900001088,
-			"sampledImageColorSampleCounts":	900001089,
-			"sampledImageIntegerSampleCounts":	900001090,
-			"sampledImageDepthSampleCounts":	900001091,
-			"sampledImageStencilSampleCounts":	900001092,
-			"storageImageSampleCounts":	900001093,
-			"maxSampleMaskWords":	900001094,
-			"timestampComputeAndGraphics":	900001095,
-			"timestampPeriod":	900001088,
-			"maxClipDistances":	900001097,
-			"maxCullDistances":	900001098,
-			"maxCombinedClipAndCullDistances":	900001099,
-			"discreteQueuePriorities":	900001100,
-			"pointSizeRange":	[-203.500000, -204.500000],
-			"lineWidthRange":	[-205.500000, -206.500000],
-			"pointSizeGranularity":	-207.500000,
-			"lineWidthGranularity":	-208.500000,
-			"strictLines":	900001101,
-			"standardSampleLocations":	900001102,
-			"optimalBufferCopyOffsetAlignment":	"0x00000001dcd6544f",
-			"optimalBufferCopyRowPitchAlignment":	"0x00000012a05f2450",
-			"nonCoherentAtomSize":	"0x00000012a05f2451"
-		},
-		"sparseProperties":	{
-			"residencyStandard2DBlockShape":	900001106,
-			"residencyStandard2DMultisampleBlockShape":	900001107,
-			"residencyStandard3DBlockShape":	900001108,
-			"residencyAlignedMipSize":	900001109,
-			"residencyNonResidentStrict":	900001110
-		}
-	},
-	"features":	{
-		"robustBufferAccess":	101,
-		"fullDrawIndexUint32":	102,
-		"imageCubeArray":	103,
-		"independentBlend":	104,
-		"geometryShader":	105,
-		"tessellationShader":	106,
-		"sampleRateShading":	107,
-		"dualSrcBlend":	108,
-		"logicOp":	109,
-		"multiDrawIndirect":	110,
-		"drawIndirectFirstInstance":	111,
-		"depthClamp":	112,
-		"depthBiasClamp":	113,
-		"fillModeNonSolid":	114,
-		"depthBounds":	115,
-		"wideLines":	116,
-		"largePoints":	117,
-		"alphaToOne":	118,
-		"multiViewport":	119,
-		"samplerAnisotropy":	120,
-		"textureCompressionETC2":	121,
-		"textureCompressionASTC_LDR":	122,
-		"textureCompressionBC":	123,
-		"occlusionQueryPrecise":	124,
-		"pipelineStatisticsQuery":	125,
-		"vertexPipelineStoresAndAtomics":	126,
-		"fragmentStoresAndAtomics":	127,
-		"shaderTessellationAndGeometryPointSize":	128,
-		"shaderImageGatherExtended":	129,
-		"shaderStorageImageExtendedFormats":	130,
-		"shaderStorageImageMultisample":	131,
-		"shaderStorageImageReadWithoutFormat":	132,
-		"shaderStorageImageWriteWithoutFormat":	133,
-		"shaderUniformBufferArrayDynamicIndexing":	134,
-		"shaderSampledImageArrayDynamicIndexing":	135,
-		"shaderStorageBufferArrayDynamicIndexing":	136,
-		"shaderStorageImageArrayDynamicIndexing":	137,
-		"shaderClipDistance":	138,
-		"shaderCullDistance":	139,
-		"shaderFloat64":	140,
-		"shaderInt64":	141,
-		"shaderInt16":	142,
-		"shaderResourceResidency":	143,
-		"shaderResourceMinLod":	144,
-		"sparseBinding":	145,
-		"sparseResidencyBuffer":	146,
-		"sparseResidencyImage2D":	147,
-		"sparseResidencyImage3D":	148,
-		"sparseResidency2Samples":	149,
-		"sparseResidency4Samples":	150,
-		"sparseResidency8Samples":	151,
-		"sparseResidency16Samples":	152,
-		"sparseResidencyAliased":	153,
-		"variableMultisampleRate":	154,
-		"inheritedQueries":	155
-	},
-	"memory":	{
-		"memoryTypeCount":	5,
-		"memoryTypes":	[{
-				"propertyFlags":	900003002,
-				"heapIndex":	900003001
-			}, {
-				"propertyFlags":	900003004,
-				"heapIndex":	900003003
-			}, {
-				"propertyFlags":	900003006,
-				"heapIndex":	900003005
-			}, {
-				"propertyFlags":	900003008,
-				"heapIndex":	900003007
-			}, {
-				"propertyFlags":	900003010,
-				"heapIndex":	900003009
-			}],
-		"memoryHeapCount":	3,
-		"memoryHeaps":	[{
-				"size":	"0x00000012a05f27d1",
-				"flags":	900002000
-			}, {
-				"size":	"0x00000012a05f27d3",
-				"flags":	900002002
-			}, {
-				"size":	"0x00000012a05f27d5",
-				"flags":	900002004
-			}]
-	},
-	"queues":	[{
-			"queueFlags":	900004005,
-			"queueCount":	900004004,
-			"timestampValidBits":	900004006,
-			"minImageTransferGranularity":	{
-				"width":	900004003,
-				"height":	900004002,
-				"depth":	900004001
-			}
-		}, {
-			"queueFlags":	900004011,
-			"queueCount":	900004010,
-			"timestampValidBits":	900004012,
-			"minImageTransferGranularity":	{
-				"width":	900004009,
-				"height":	900004008,
-				"depth":	900004007
-			}
-		}, {
-			"queueFlags":	900004017,
-			"queueCount":	900004016,
-			"timestampValidBits":	900004018,
-			"minImageTransferGranularity":	{
-				"width":	900004015,
-				"height":	900004014,
-				"depth":	900004013
-			}
-		}],
+  "features": {
+    "alphaToOne": 118,
+    "depthBiasClamp": 113,
+    "depthBounds": 115,
+    "depthClamp": 112,
+    "drawIndirectFirstInstance": 111,
+    "dualSrcBlend": 108,
+    "fillModeNonSolid": 114,
+    "fragmentStoresAndAtomics": 127,
+    "fullDrawIndexUint32": 102,
+    "geometryShader": 105,
+    "imageCubeArray": 103,
+    "independentBlend": 104,
+    "inheritedQueries": 155,
+    "largePoints": 117,
+    "logicOp": 109,
+    "multiDrawIndirect": 110,
+    "multiViewport": 119,
+    "occlusionQueryPrecise": 124,
+    "pipelineStatisticsQuery": 125,
+    "robustBufferAccess": 101,
+    "sampleRateShading": 107,
+    "samplerAnisotropy": 120,
+    "shaderClipDistance": 138,
+    "shaderCullDistance": 139,
+    "shaderFloat64": 140,
+    "shaderImageGatherExtended": 129,
+    "shaderInt16": 142,
+    "shaderInt64": 141,
+    "shaderResourceMinLod": 144,
+    "shaderResourceResidency": 143,
+    "shaderSampledImageArrayDynamicIndexing": 135,
+    "shaderStorageBufferArrayDynamicIndexing": 136,
+    "shaderStorageImageArrayDynamicIndexing": 137,
+    "shaderStorageImageExtendedFormats": 130,
+    "shaderStorageImageMultisample": 131,
+    "shaderStorageImageReadWithoutFormat": 132,
+    "shaderStorageImageWriteWithoutFormat": 133,
+    "shaderTessellationAndGeometryPointSize": 128,
+    "shaderUniformBufferArrayDynamicIndexing": 134,
+    "sparseBinding": 145,
+    "sparseResidency16Samples": 152,
+    "sparseResidency2Samples": 149,
+    "sparseResidency4Samples": 150,
+    "sparseResidency8Samples": 151,
+    "sparseResidencyAliased": 153,
+    "sparseResidencyBuffer": 146,
+    "sparseResidencyImage2D": 147,
+    "sparseResidencyImage3D": 148,
+    "tessellationShader": 106,
+    "textureCompressionASTC_LDR": 122,
+    "textureCompressionBC": 123,
+    "textureCompressionETC2": 121,
+    "variableMultisampleRate": 154,
+    "vertexPipelineStoresAndAtomics": 126,
+    "wideLines": 116
+  },
+  "formats": [
+    [
+      1,
+      {
+        "bufferFeatures": 0,
+        "linearTilingFeatures": 900005001,
+        "optimalTilingFeatures": 0
+      }
+    ],
+    [
+      2,
+      {
+        "bufferFeatures": 0,
+        "linearTilingFeatures": 0,
+        "optimalTilingFeatures": 900005002
+      }
+    ],
+    [
+      3,
+      {
+        "bufferFeatures": 900005003,
+        "linearTilingFeatures": 0,
+        "optimalTilingFeatures": 0
+      }
+    ],
+    [
+      100,
+      {
+        "bufferFeatures": 900005006,
+        "linearTilingFeatures": 900005004,
+        "optimalTilingFeatures": 900005005
+      }
+    ]
+  ],
+  "memory": {
+    "memoryHeapCount": 3,
+    "memoryHeaps": [
+      {
+        "flags": 900002000,
+        "size": "0x00000012a05f27d1"
+      },
+      {
+        "flags": 900002002,
+        "size": "0x00000012a05f27d3"
+      },
+      {
+        "flags": 900002004,
+        "size": "0x00000012a05f27d5"
+      }
+    ],
+    "memoryTypeCount": 5,
+    "memoryTypes": [
+      {
+        "heapIndex": 900003001,
+        "propertyFlags": 900003002
+      },
+      {
+        "heapIndex": 900003003,
+        "propertyFlags": 900003004
+      },
+      {
+        "heapIndex": 900003005,
+        "propertyFlags": 900003006
+      },
+      {
+        "heapIndex": 900003007,
+        "propertyFlags": 900003008
+      },
+      {
+        "heapIndex": 900003009,
+        "propertyFlags": 900003010
+      }
+    ]
+  },
+  "properties": {
+    "apiVersion": 1,
+    "deviceID": 0,
+    "deviceName": "device_simulation_layer_test_1",
+    "deviceType": 0,
+    "driverVersion": 2,
+    "limits": {
+      "bufferImageGranularity": "0x00000012a05f23f3",
+      "discreteQueuePriorities": 900001100,
+      "framebufferColorSampleCounts": 900001084,
+      "framebufferDepthSampleCounts": 900001085,
+      "framebufferNoAttachmentsSampleCounts": 900001087,
+      "framebufferStencilSampleCounts": 900001086,
+      "lineWidthGranularity": -208.5,
+      "lineWidthRange": [
+        -205.5,
+        -206.5
+      ],
+      "maxBoundDescriptorSets": 900001013,
+      "maxClipDistances": 900001097,
+      "maxColorAttachments": 900001088,
+      "maxCombinedClipAndCullDistances": 900001099,
+      "maxComputeSharedMemorySize": 900001051,
+      "maxComputeWorkGroupCount": [
+        900001052,
+        900001053,
+        900001054
+      ],
+      "maxComputeWorkGroupInvocations": 900001055,
+      "maxComputeWorkGroupSize": [
+        900001056,
+        900001057,
+        900001058
+      ],
+      "maxCullDistances": 900001098,
+      "maxDescriptorSetInputAttachments": 900001028,
+      "maxDescriptorSetSampledImages": 900001026,
+      "maxDescriptorSetSamplers": 900001021,
+      "maxDescriptorSetStorageBuffers": 900001024,
+      "maxDescriptorSetStorageBuffersDynamic": 900001025,
+      "maxDescriptorSetStorageImages": 900001027,
+      "maxDescriptorSetUniformBuffers": 900001022,
+      "maxDescriptorSetUniformBuffersDynamic": 900001023,
+      "maxDrawIndexedIndexValue": 31062,
+      "maxDrawIndirectCount": 31063,
+      "maxFragmentCombinedOutputResources": 900001050,
+      "maxFragmentDualSrcAttachments": 900001049,
+      "maxFragmentInputComponents": 900001047,
+      "maxFragmentOutputAttachments": 900001048,
+      "maxFramebufferHeight": 900001082,
+      "maxFramebufferLayers": 900001083,
+      "maxFramebufferWidth": 900001081,
+      "maxGeometryInputComponents": 900001043,
+      "maxGeometryOutputComponents": 900001044,
+      "maxGeometryOutputVertices": 900001045,
+      "maxGeometryShaderInvocations": 900001042,
+      "maxGeometryTotalOutputComponents": 900001046,
+      "maxImageArrayLayers": 900001004,
+      "maxImageDimension1D": 900001000,
+      "maxImageDimension2D": 900001001,
+      "maxImageDimension3D": 900001002,
+      "maxImageDimensionCube": 900001003,
+      "maxInterpolationOffset": -202.5,
+      "maxMemoryAllocationCount": 900001009,
+      "maxPerStageDescriptorInputAttachments": 900001019,
+      "maxPerStageDescriptorSampledImages": 900001017,
+      "maxPerStageDescriptorSamplers": 900001014,
+      "maxPerStageDescriptorStorageBuffers": 900001016,
+      "maxPerStageDescriptorStorageImages": 900001018,
+      "maxPerStageDescriptorUniformBuffers": 900001015,
+      "maxPerStageResources": 900001020,
+      "maxPushConstantsSize": 900001008,
+      "maxSampleMaskWords": 900001094,
+      "maxSamplerAllocationCount": 900001010,
+      "maxSamplerAnisotropy": 900001088,
+      "maxSamplerLodBias": 900001088,
+      "maxStorageBufferRange": 900001007,
+      "maxTessellationControlPerPatchOutputComponents": 900001038,
+      "maxTessellationControlPerVertexInputComponents": 900001036,
+      "maxTessellationControlPerVertexOutputComponents": 900001037,
+      "maxTessellationControlTotalOutputComponents": 900001039,
+      "maxTessellationEvaluationInputComponents": 900001040,
+      "maxTessellationEvaluationOutputComponents": 900001041,
+      "maxTessellationGenerationLevel": 900001034,
+      "maxTessellationPatchSize": 900001035,
+      "maxTexelBufferElements": 900001005,
+      "maxTexelGatherOffset": 900001079,
+      "maxTexelOffset": 900001077,
+      "maxUniformBufferRange": 900001006,
+      "maxVertexInputAttributeOffset": 900001031,
+      "maxVertexInputAttributes": 900001029,
+      "maxVertexInputBindingStride": 900001032,
+      "maxVertexInputBindings": 900001030,
+      "maxVertexOutputComponents": 900001033,
+      "maxViewportDimensions": [
+        900001067,
+        900001068
+      ],
+      "maxViewports": 900001066,
+      "minInterpolationOffset": 201.5,
+      "minMemoryMapAlignment": "0x0000000035a4ed30",
+      "minStorageBufferOffsetAlignment": "0x00000012a05f2433",
+      "minTexelBufferOffsetAlignment": "0x00000012a05f2431",
+      "minTexelGatherOffset": -900001078,
+      "minTexelOffset": -900001076,
+      "minUniformBufferOffsetAlignment": "0x00000012a05f2432",
+      "mipmapPrecisionBits": 900001061,
+      "nonCoherentAtomSize": "0x00000012a05f2451",
+      "optimalBufferCopyOffsetAlignment": "0x00000001dcd6544f",
+      "optimalBufferCopyRowPitchAlignment": "0x00000012a05f2450",
+      "pointSizeGranularity": -207.5,
+      "pointSizeRange": [
+        -203.5,
+        -204.5
+      ],
+      "sampledImageColorSampleCounts": 900001089,
+      "sampledImageDepthSampleCounts": 900001091,
+      "sampledImageIntegerSampleCounts": 900001090,
+      "sampledImageStencilSampleCounts": 900001092,
+      "sparseAddressSpaceSize": "0x00000012a05f23f4",
+      "standardSampleLocations": 900001102,
+      "storageImageSampleCounts": 900001093,
+      "strictLines": 900001101,
+      "subPixelInterpolationOffsetBits": 900001080,
+      "subPixelPrecisionBits": 900001059,
+      "subTexelPrecisionBits": 900001060,
+      "timestampComputeAndGraphics": 900001095,
+      "timestampPeriod": 900001088,
+      "viewportBoundsRange": [
+        -900001088,
+        900001088
+      ],
+      "viewportSubPixelBits": 900001071
+    },
+    "pipelineCacheUUID": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16
+    ],
+    "sparseProperties": {
+      "residencyAlignedMipSize": 900001109,
+      "residencyNonResidentStrict": 900001110,
+      "residencyStandard2DBlockShape": 900001106,
+      "residencyStandard2DMultisampleBlockShape": 900001107,
+      "residencyStandard3DBlockShape": 900001108
+    },
+    "vendorID": 0
+  },
+  "queues": [
+    {
+      "minImageTransferGranularity": {
+        "depth": 900004001,
+        "height": 900004002,
+        "width": 900004003
+      },
+      "queueCount": 900004004,
+      "queueFlags": 900004005,
+      "timestampValidBits": 900004006
+    },
+    {
+      "minImageTransferGranularity": {
+        "depth": 900004007,
+        "height": 900004008,
+        "width": 900004009
+      },
+      "queueCount": 900004010,
+      "queueFlags": 900004011,
+      "timestampValidBits": 900004012
+    },
+    {
+      "minImageTransferGranularity": {
+        "depth": 900004013,
+        "height": 900004014,
+        "width": 900004015
+      },
+      "queueCount": 900004016,
+      "queueFlags": 900004017,
+      "timestampValidBits": 900004018
+    }
+  ]
+}


### PR DESCRIPTION
Add ability to override the results of vkGetPhysicalDeviceFormatProperties()

DevSim currently supports only Vulkan v1.0.  Check and cleanly emit an error
message if the application requests a Vulkan version other than v1.0.

Rework the test script to use 'jq' to extract sections of the test's JSON
output, sort, and reformat for consistent comparison against gold file.

Disable some of the noisier debug outputs.

Fix VisualStudio warnings

Update the .md documentation file.

Bump version to v1.2.0

Change-Id: I54deec8772056ad8649e3b0ae16a6d6c16148ba5