### PR TITLE
vktrace: add env variable for page guard lazy copy process

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.h
@@ -97,6 +97,7 @@
 VkDeviceSize& ref_target_range_size();
 bool getPageGuardEnableFlag();
 bool getEnableReadPMBFlag();
+bool getEnablePageGuardLazyCopyFlag();
 #if defined(WIN32)
 void setPageGuardExceptionHandler();
 void removePageGuardExceptionHandler();

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
@@ -282,6 +282,10 @@ bool PageGuardMappedMemory::vkMapMemoryPageGuardHandle(VkDevice device, VkDevice
     // for non-win32 platforms, so far we haven't found similiar page guard handler, so need
     // to keep this memcpy.
     vktrace_pageguard_memcpy(pMappedData, pRealMappedData, size);
+#else
+    if (!getEnablePageGuardLazyCopyFlag()) {
+        vktrace_pageguard_memcpy(pMappedData, pRealMappedData, size);
+    }
 #endif
     *ppData = pMappedData;
 #else


### PR DESCRIPTION
Add env variable VKTRACE_PAGEGUARD_ENABLE_LAZY_COPY to enable/disable
pageguard lazycopy process.

Change-Id: I0415505a2c78359fa4ad40907d6e1d7e39a3531f