### PR TITLE
vktrace: fix error in trim process for staging buffer and image

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -3019,7 +3019,8 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
         info.ObjectInfo.Image.arrayLayers = pCreateInfo->arrayLayers;
         info.ObjectInfo.Image.sharingMode = pCreateInfo->sharingMode;
         info.ObjectInfo.Image.queueFamilyIndex =
-            (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT && pCreateInfo->pQueueFamilyIndices != NULL)
+            (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT && pCreateInfo->pQueueFamilyIndices != NULL &&
+             pCreateInfo->queueFamilyIndexCount != 0)
                 ? pCreateInfo->pQueueFamilyIndices[0]
                 : 0;
         info.ObjectInfo.Image.initialLayout = pCreateInfo->initialLayout;

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -643,6 +643,14 @@ VkCommandBuffer getCommandBufferFromDevice(VkDevice device, VkCommandPool comman
         }
     } else {
         commandBuffer = s_deviceToCommandBufferMap[device];
+
+        // by Doc, "Executable command buffers can be submitted, reset, or
+        // recorded to another command buffer.", the command buffer here
+        // will be reused to record command, reset is needed to make it
+        // come back to initial state. Directly using without reset is
+        // not supported by Doc, for the target title, vkBeginCommandBuffer
+        // return fail can be found on specific hardware and driver.
+        mdd(device)->devTable.ResetCommandBuffer(commandBuffer, 0);
     }
 
     return commandBuffer;


### PR DESCRIPTION
If an image or buffer bound to memory which is not host visable, trim will
use staging buffer to copy its data, the error is in the process when try
to reuse command buffer. It cause vkBeginCommandBuffer fail, the change
fix the error.

Change-Id: I03b7ef94982a9f32db113336d23b3df42afb322f