### PR TITLE
Devsim 1.2.1 multiple input files

### DIFF
--- a/BUILDVT.md
+++ b/BUILDVT.md
@@ -255,16 +255,16 @@ Result screenshot will be in:
 /sdcard/Android/<framenumber>.ppm
 ```
 ### device_simulation
-To enable, set a property with the path of configuration file to load:
+To enable, use a setting with the path of configuration file to load:
 ```
-adb shell setprop debug.vulkan.devsim.filepath <path/to/DevSim/JSON/configuration/file>
+adb shell settings put global debug.vulkan.devsim.filepath <path/to/DevSim/JSON/configuration/file>
 ```
 Example of a DevSim JSON configuration file: [tiny1.json](https://github.com/LunarG/VulkanTools/blob/master/layersvt/device_simulation_examples/tiny1.json)
 
-Optional: set properties to enable debugging output and exit-on-error:
+Optional: use settings to enable debugging output and exit-on-error:
 ```
-adb shell setprop debug.vulkan.devsim.debugenable 1
-adb shell setprop debug.vulkan.devsim.exitonerror 1
+adb shell settings put global debug.vulkan.devsim.debugenable 1
+adb shell settings put global debug.vulkan.devsim.exitonerror 1
 ```
 Run your application with the following layer enabled:
 ```

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -286,7 +286,7 @@ const uint32_t MAX_BUFFER_SIZE = 255;
 typedef enum { VK_LOG_NONE = 0, VK_LOG_ERROR, VK_LOG_WARNING, VK_LOG_VERBOSE, VK_LOG_DEBUG } VkLogLevel;
 
 const char *AndroidGetEnv(const char *key) {
-    std::string command("getprop ");
+    std::string command("settings get global ");
     command += key;
 
     std::string android_env;

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -84,7 +84,9 @@ If you wish DevSim to terminate on errors, set the `VK_DEVSIM_EXIT_ON_ERROR` env
 
 ## Environment variables used by DevSim layer.
 
-* `VK_DEVSIM_FILENAME` - Name of the configuration file to load.
+* `VK_DEVSIM_FILENAME` - Name of one or more configuration file(s) to load.
+  _Added in v1.2.1:_ This variable can have a delimited list of files to be loaded.  On Windows, the delimiter is `;` else it is `:`.
+  Files are loaded in order.  Later files can override settings from earlier files.
 * `VK_DEVSIM_DEBUG_ENABLE` - A non-zero integer enables debug message output.
 * `VK_DEVSIM_EXIT_ON_ERROR` - A non-zero integer enables exit-on-error.
 
@@ -99,6 +101,8 @@ export VK_INSTANCE_LAYERS="VK_LAYER_LUNARG_device_simulation"
 
 # Specify the simulated device's configuration file.
 export VK_DEVSIM_FILENAME="${VulkanTools}/layersvt/device_simulation_examples/tiny1.json" 
+# A list of files could look like:
+# export VK_DEVSIM_FILENAME="/home/foo/first.json:/home/foo/second.json"
 
 # Enable verbose messages from the DevSim layer.
 export VK_DEVSIM_DEBUG_ENABLE="1"

--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
         "api_version": "1.0.65",
-        "implementation_version": "1.2.0",
+        "implementation_version": "1.2.1",
         "description": "LunarG device simulation layer"
     }
 }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
         "api_version": "1.0.65",
-        "implementation_version": "1.2.0",
+        "implementation_version": "1.2.1",
         "description": "LunarG device simulation layer"
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,7 +86,8 @@ if (NOT WIN32)
             # Files unique to VulkanTools go below this line
             COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/vktracereplay.sh
             COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_layer_test.sh
-            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_test1.json
+            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_test1_in.json
+            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_test1_in_ArrayOfVkFormatProperties.json
             COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_test1_gold.json
             VERBATIM
             )

--- a/tests/devsim_layer_test.sh
+++ b/tests/devsim_layer_test.sh
@@ -34,7 +34,7 @@ VKJSON_INFO="../libs/vkjson/vkjson_info"
 #############################################################################
 # Test #1 input datafile, and filename of output.
 
-FILENAME_01_IN="devsim_test1.json"
+FILENAME_01_IN="devsim_test1_in_ArrayOfVkFormatProperties.json:devsim_test1_in.json"
 FILENAME_01_GOLD="devsim_test1_gold.json"
 FILENAME_01_RESULT="device_simulation_layer_test_1.json"
 FILENAME_01_STDOUT="device_simulation_layer_test_1.txt"

--- a/tests/devsim_test1_in.json
+++ b/tests/devsim_test1_in.json
@@ -1,8 +1,8 @@
 {
 	"$schema":	"https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
 	"comments":	{
-		"url":	"https://github.com/LunarG/VulkanTools/blob/master/tests/devsim_test1.json",
-		"desc":	"Stimulus file for Device Simulation layer test.  By design, the DevSim layer does not enforce the use of 'sane' values; such enforcement is the job of the Validation layers.  The values in this file are deliberately 'insane', unique (to aid verification of each override) and huge (to trigger any debug warnings)."
+		"url":	"https://github.com/LunarG/VulkanTools/blob/master/tests/devsim_test1_in.json",
+		"desc":	"A configuration file fragment for Device Simulation layer test.  By design, the DevSim layer does not enforce the use of 'sane' values; such enforcement is the job of the Validation layers.  The values in this file are deliberately 'insane', unique (to aid verification of each override) and huge (to trigger any debug warnings)."
 	},
 	"VkPhysicalDeviceProperties":	{
 		"apiVersion":	1,
@@ -185,108 +185,74 @@
 		"variableMultisampleRate":	154,
 		"inheritedQueries":	155
 	},
-
-    "VkPhysicalDeviceMemoryProperties": {
-	"memoryHeaps": [
-	    {
-		"flags": 900002000,
-		"size": 80000002001
-	    },
-	    {
-		"flags": 900002002,
-		"size": 80000002003
-	    },
-	    {
-		"flags": 900002004,
-		"size": 80000002005
-	    }
-	],
-	"memoryTypes": [
-	    {
-		"heapIndex": 900003001,
-		"propertyFlags": 900003002
-	    },
-	    {
-		"heapIndex": 900003003,
-		"propertyFlags": 900003004
-	    },
-	    {
-		"heapIndex": 900003005,
-		"propertyFlags": 900003006
-	    },
-	    {
-		"heapIndex": 900003007,
-		"propertyFlags": 900003008
-	    },
-	    {
-		"heapIndex": 900003009,
-		"propertyFlags": 900003010
-	    }
+	"VkPhysicalDeviceMemoryProperties":	{
+		"memoryHeaps":	[
+			{
+				"flags":	900002000,
+				"size":	80000002001
+			},
+			{
+				"flags":	900002002,
+				"size":	80000002003
+			},
+			{
+				"flags":	900002004,
+				"size":	80000002005
+			}
+		],
+		"memoryTypes":	[
+			{
+				"heapIndex":	900003001,
+				"propertyFlags":	900003002
+			},
+			{
+				"heapIndex":	900003003,
+				"propertyFlags":	900003004
+			},
+			{
+				"heapIndex":	900003005,
+				"propertyFlags":	900003006
+			},
+			{
+				"heapIndex":	900003007,
+				"propertyFlags":	900003008
+			},
+			{
+				"heapIndex":	900003009,
+				"propertyFlags":	900003010
+			}
+		]
+	},
+	"ArrayOfVkQueueFamilyProperties":	[
+		{
+			"minImageTransferGranularity":	{
+				"depth":	900004001,
+				"height":	900004002,
+				"width":	900004003
+			},
+			"queueCount":	900004004,
+			"queueFlags":	900004005,
+			"timestampValidBits":	900004006
+		},
+		{
+			"minImageTransferGranularity":	{
+				"depth":	900004007,
+				"height":	900004008,
+				"width":	900004009
+			},
+			"queueCount":	900004010,
+			"queueFlags":	900004011,
+			"timestampValidBits":	900004012
+		},
+		{
+			"minImageTransferGranularity":	{
+				"depth":	900004013,
+				"height":	900004014,
+				"width":	900004015
+			},
+			"queueCount":	900004016,
+			"queueFlags":	900004017,
+			"timestampValidBits":	900004018
+		}
 	]
-    },
-
-    "ArrayOfVkQueueFamilyProperties": [
-	{
-	    "minImageTransferGranularity": {
-		"depth": 900004001,
-		"height": 900004002,
-		"width": 900004003
-	    },
-	    "queueCount": 900004004,
-	    "queueFlags": 900004005,
-	    "timestampValidBits": 900004006
-	},
-	{
-	    "minImageTransferGranularity": {
-		"depth": 900004007,
-		"height": 900004008,
-		"width": 900004009
-	    },
-	    "queueCount": 900004010,
-	    "queueFlags": 900004011,
-	    "timestampValidBits": 900004012
-	},
-	{
-	    "minImageTransferGranularity": {
-		"depth": 900004013,
-		"height": 900004014,
-		"width": 900004015
-	    },
-	    "queueCount": 900004016,
-	    "queueFlags": 900004017,
-	    "timestampValidBits": 900004018
-	}
-    ],
-    "ArrayOfVkFormatProperties": [
-        {
-            "formatID": 100,
-            "linearTilingFeatures": 900005004,
-            "optimalTilingFeatures": 900005005,
-            "bufferFeatures": 900005006
-        },
-        {
-            "formatID": 4,
-            "linearTilingFeatures": 0,
-            "optimalTilingFeatures": 0,
-            "bufferFeatures": 0
-        },
-        {
-            "formatID": 3,
-            "linearTilingFeatures": 0,
-            "optimalTilingFeatures": 0,
-            "bufferFeatures": 900005003
-        },
-        {
-            "formatID": 2,
-            "linearTilingFeatures": 0,
-            "optimalTilingFeatures": 900005002,
-            "bufferFeatures": 0
-        },
-        {
-            "formatID": 1,
-            "linearTilingFeatures": 900005001,
-            "optimalTilingFeatures": 0,
-            "bufferFeatures": 0
-        }
-    ]
 }

--- a/tests/devsim_test1_in_ArrayOfVkFormatProperties.json
+++ b/tests/devsim_test1_in_ArrayOfVkFormatProperties.json
@@ -1,0 +1,39 @@
+{
+	"$schema":	"https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
+	"comments":	{
+		"url":	"https://github.com/LunarG/VulkanTools/blob/master/tests/devsim_test1_in_ArrayOfVkFormatProperties.json",
+		"desc":	"A configuration file fragment for Device Simulation layer test.  By design, the DevSim layer does not enforce the use of 'sane' values; such enforcement is the job of the Validation layers.  The values in this file are deliberately 'insane', unique (to aid verification of each override) and huge (to trigger any debug warnings)."
+	},
+	"ArrayOfVkFormatProperties":	[
+		{
+			"formatID":	100,
+			"linearTilingFeatures":	900005004,
+			"optimalTilingFeatures":	900005005,
+			"bufferFeatures":	900005006
+		},
+		{
+			"formatID":	4,
+			"linearTilingFeatures":	0,
+			"optimalTilingFeatures":	0,
+			"bufferFeatures":	0
+		},
+		{
+			"formatID":	3,
+			"linearTilingFeatures":	0,
+			"optimalTilingFeatures":	0,
+			"bufferFeatures":	900005003
+		},
+		{
+			"formatID":	2,
+			"linearTilingFeatures":	0,
+			"optimalTilingFeatures":	900005002,
+			"bufferFeatures":	0
+		},
+		{
+			"formatID":	1,
+			"linearTilingFeatures":	900005001,
+			"optimalTilingFeatures":	0,
+			"bufferFeatures":	0
+		}
+	]
+}


### PR DESCRIPTION
Device Simulation Layer can now load multiple configuration files by specifying a delimited list of filenames in the VK_DEVSIM_FILENAME environment variable.  The delimited list borrows the syntax of the PATH environment variable: on Windows, separate the filenames with ';', on Linux separate with ":".

Add documentation for the multiple configuration filename to the .md file.

Some minor rearrangement of comments and debug messages.

Restructure/rename the regression test input files to exercise and make use of the new list of configuration files feature.
    
The "test1" input configuration now consists of several file fragments that are all loaded at runtime to create the complete configuration.
    
This feature permits configuration files to be modular, with boilerplate data in separate files.
