### PR TITLE
vktrace: Extract correct ret val of vkAllocMem on replay

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -2006,8 +2006,7 @@ VkResult vkReplay::manually_replay_vkAllocateMemory(packet_vkAllocateMemory *pPa
                 packetHeader1.packet_id == VKTRACE_TPI_VK_vkAllocateMemory) {
                 // Found it
                 // Save away the vkAM return val from the trace file
-                traceAllocateMemoryRval =
-                    *((VkDeviceMemory *)((PBYTE)pPacket->header + pPacket->header->size - sizeof(VkDeviceMemory *)));
+                traceAllocateMemoryRval = *pPacket->pMemory;
 
                 // Save the index where we will start the next search for vkAM
                 amSearchPos = amIdx + 1;


### PR DESCRIPTION
Fixes error in replay of old 32-bit trace files.

Change-Id: I5303e8dba73e30050c8b270e65be5fbdbad71d9b