### PR TITLE
vktrace: Remove trace layer warnings

### DIFF
--- a/vktrace/vktrace_common/vktrace_pageguard_memorycopy.h
+++ b/vktrace/vktrace_common/vktrace_pageguard_memorycopy.h
@@ -46,10 +46,10 @@ using namespace concurrency;
 #endif
 
 typedef struct __PageGuardChangedBlockInfo {
-    uint32_t offset;
-    uint32_t length;
-    uint32_t reserve0;
-    uint32_t reserve1;
+    size_t offset;
+    size_t length;
+    size_t reserve0;
+    size_t reserve1;
 } PageGuardChangedBlockInfo, *pPageGuardChangedBlockInfo;
 
 #if defined(WIN32)

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
@@ -357,9 +357,9 @@ void PageGuardMappedMemory::backupBlockChangedArraySnapshot() { pPageStatus->bac
 
 void PageGuardMappedMemory::backupBlockReadArraySnapshot() { pPageStatus->backupReadArray(); }
 
-DWORD PageGuardMappedMemory::getChangedBlockAmount(int useWhich) {
-    DWORD dwAmount = 0;
-    for (uint64_t i = 0; i < PageGuardAmount; i++) {
+size_t PageGuardMappedMemory::getChangedBlockAmount(int useWhich) {
+    size_t dwAmount = 0;
+    for (size_t i = 0; i < PageGuardAmount; i++) {
         if (isMappedBlockChanged(i, useWhich)) {
             dwAmount++;
         }
@@ -393,10 +393,10 @@ bool PageGuardMappedMemory::isRangeIncluded(VkDeviceSize RangeOffsetLimit, VkDev
 // VkDeviceSize RangeOffset, RangeSize, only consider the block which is in the range which start from RangeOffset and size is
 // RangeSize, if RangeOffset<0, consider whole mapped memory
 // return the amount of changed blocks.
-DWORD PageGuardMappedMemory::getChangedBlockInfo(VkDeviceSize RangeOffset, VkDeviceSize RangeSize, DWORD *pdwSaveSize,
-                                                 DWORD *pInfoSize, PBYTE pData, DWORD DataOffset, int useWhich) {
-    DWORD dwAmount = getChangedBlockAmount(useWhich), dwIndex = 0, offset = 0;
-    DWORD infosize = sizeof(PageGuardChangedBlockInfo) * (dwAmount + 1), SaveSize = 0, CurrentBlockSize = 0;
+size_t PageGuardMappedMemory::getChangedBlockInfo(VkDeviceSize RangeOffset, VkDeviceSize RangeSize, size_t *pdwSaveSize,
+                                                 size_t *pInfoSize, PBYTE pData, size_t DataOffset, int useWhich) {
+    size_t dwAmount = getChangedBlockAmount(useWhich), dwIndex = 0, offset = 0;
+    size_t infosize = sizeof(PageGuardChangedBlockInfo) * (dwAmount + 1), SaveSize = 0, CurrentBlockSize = 0;
     PBYTE pChangedData;
     PageGuardChangedBlockInfo *pChangedInfoArray = (PageGuardChangedBlockInfo *)(pData ? (pData + DataOffset) : nullptr);
     void *srcAddr;
@@ -468,7 +468,7 @@ bool PageGuardMappedMemory::vkFlushMappedMemoryRangePageGuardHandle(VkDevice dev
                                                                     VkDeviceSize size, VkDeviceSize *pChangedSize,
                                                                     VkDeviceSize *pDataPackageSize, PBYTE *ppChangedDataPackage) {
     bool handleSuccessfully = false;
-    DWORD dwSaveSize, InfoSize;
+    size_t dwSaveSize, InfoSize;
 
     backupBlockChangedArraySnapshot();
     getChangedBlockInfo(offset, size, &dwSaveSize, &InfoSize, nullptr, 0,
@@ -490,8 +490,8 @@ bool PageGuardMappedMemory::vkFlushMappedMemoryRangePageGuardHandle(VkDevice dev
     PageGuardChangedBlockInfo *pChangedInfoArray = (PageGuardChangedBlockInfo *)pChangedDataPackage;
     if (pChangedInfoArray[0].length) {
         PBYTE pChangedData = (PBYTE)pChangedDataPackage + sizeof(PageGuardChangedBlockInfo) * (pChangedInfoArray[0].offset + 1);
-        DWORD CurrentOffset = 0;
-        for (DWORD i = 0; i < pChangedInfoArray[0].offset; i++) {
+        size_t CurrentOffset = 0;
+        for (size_t i = 0; i < pChangedInfoArray[0].offset; i++) {
             vktrace_pageguard_memcpy(pRealMappedData + pChangedInfoArray[i + 1].offset, pChangedData + CurrentOffset,
                                      (size_t)pChangedInfoArray[i + 1].length);
             CurrentOffset += pChangedInfoArray[i + 1].length;

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
@@ -107,7 +107,7 @@ typedef class PageGuardMappedMemory {
 
     void backupBlockReadArraySnapshot();
 
-    DWORD getChangedBlockAmount(int useWhich);
+    size_t getChangedBlockAmount(int useWhich);
 
     /// is RangeLimit cover or partly cover Range
     bool isRangeIncluded(VkDeviceSize RangeOffsetLimit, VkDeviceSize RangeSizeLimit, VkDeviceSize RangeOffset,
@@ -125,8 +125,8 @@ typedef class PageGuardMappedMemory {
     /// VkDeviceSize RangeOffset, RangeSize, only consider the block which is in the range which start from RangeOffset and size is
     /// RangeSize, if RangeOffset<0, consider whole mapped memory
     /// return the amount of changed blocks.
-    DWORD getChangedBlockInfo(VkDeviceSize RangeOffset, VkDeviceSize RangeSize, DWORD *pdwSaveSize, DWORD *pInfoSize, PBYTE pData,
-                              DWORD DataOffset, int useWhich = BLOCK_FLAG_ARRAY_CHANGED);
+    size_t getChangedBlockInfo(VkDeviceSize RangeOffset, VkDeviceSize RangeSize, size_t *pdwSaveSize, size_t *pInfoSize, PBYTE pData,
+                              size_t DataOffset, int useWhich = BLOCK_FLAG_ARRAY_CHANGED);
 
     /// return: if memory already changed;
     ///        evenif no change to mmeory, it will still allocate memory for info array which only include one


### PR DESCRIPTION
Using size_t instead of DWORD