### PR TITLE
vkreplay: GH365, Fix MAILBOX present mode support

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -1586,7 +1586,8 @@ void vkReplay::manually_replay_vkCmdWaitEvents(packet_vkCmdWaitEvents *pPacket) 
     VkImage *saveImg = VKTRACE_NEW_ARRAY(VkImage, pPacket->imageMemoryBarrierCount);
     for (idx = 0; idx < pPacket->imageMemoryBarrierCount; idx++) {
         VkImageMemoryBarrier *pNextImg = (VkImageMemoryBarrier *)&(pPacket->pImageMemoryBarriers[idx]);
-        if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR && traceImageToImageIndex.find(pNextImg->image) != traceImageToImageIndex.end() &&
+        if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR &&
+            traceImageToImageIndex.find(pNextImg->image) != traceImageToImageIndex.end() &&
             traceImageIndexToImage.find(m_imageIndex) != traceImageIndexToImage.end() && m_imageIndex != UINT32_MAX) {
             pNextImg->image = traceImageIndexToImage[m_imageIndex];
         }
@@ -1676,7 +1677,8 @@ void vkReplay::manually_replay_vkCmdPipelineBarrier(packet_vkCmdPipelineBarrier 
     }
     for (idx = 0; idx < pPacket->imageMemoryBarrierCount; idx++) {
         VkImageMemoryBarrier *pNextImg = (VkImageMemoryBarrier *)&(pPacket->pImageMemoryBarriers[idx]);
-        if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR && traceImageToImageIndex.find(pNextImg->image) != traceImageToImageIndex.end() &&
+        if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR &&
+            traceImageToImageIndex.find(pNextImg->image) != traceImageToImageIndex.end() &&
             traceImageIndexToImage.find(m_imageIndex) != traceImageIndexToImage.end() && m_imageIndex != UINT32_MAX) {
             pNextImg->image = traceImageIndexToImage[m_imageIndex];
         }
@@ -1799,7 +1801,8 @@ void vkReplay::manually_replay_vkCmdBeginRenderPass(packet_vkCmdBeginRenderPass 
     VkRenderPassBeginInfo local_renderPassBeginInfo;
     memcpy((void *)&local_renderPassBeginInfo, (void *)pPacket->pRenderPassBegin, sizeof(VkRenderPassBeginInfo));
     local_renderPassBeginInfo.pClearValues = (const VkClearValue *)pPacket->pRenderPassBegin->pClearValues;
-    if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR && traceFramebufferToImageIndex.find(pPacket->pRenderPassBegin->framebuffer) != traceFramebufferToImageIndex.end() &&
+    if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR &&
+        traceFramebufferToImageIndex.find(pPacket->pRenderPassBegin->framebuffer) != traceFramebufferToImageIndex.end() &&
         traceImageIndexToFramebuffer.find(m_imageIndex) != traceImageIndexToFramebuffer.end() && m_imageIndex != UINT32_MAX) {
         // Use Framebuffer mapped to the image index returned by vkAcquireNextImage()
         local_renderPassBeginInfo.framebuffer = m_objMapper.remap_framebuffers(traceImageIndexToFramebuffer[m_imageIndex]);
@@ -1838,7 +1841,8 @@ VkResult vkReplay::manually_replay_vkBeginCommandBuffer(packet_vkBeginCommandBuf
         pRP = &(pHinfo->renderPass);
         pFB = &(pHinfo->framebuffer);
         *pRP = m_objMapper.remap_renderpasss(savedRP);
-        if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR && traceFramebufferToImageIndex.find(savedFB) != traceFramebufferToImageIndex.end() &&
+        if (m_presentMode == VK_PRESENT_MODE_MAILBOX_KHR &&
+            traceFramebufferToImageIndex.find(savedFB) != traceFramebufferToImageIndex.end() &&
             traceImageIndexToFramebuffer.find(m_imageIndex) != traceImageIndexToFramebuffer.end() && m_imageIndex != UINT32_MAX) {
             // Use Framebuffer mapped to the image index returned by vkAcquireNextImage()
             *pFB = m_objMapper.remap_framebuffers(traceImageIndexToFramebuffer[m_imageIndex]);

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -608,6 +608,10 @@ void vkReplay::manually_replay_vkDestroyImage(packet_vkDestroyImage *pPacket) {
     }
     m_vkDeviceFuncs.DestroyImage(remappedDevice, remappedImage, pPacket->pAllocator);
     m_objMapper.rm_from_images_map(pPacket->image);
+    if (traceImageToImageIndex.find(pPacket->image) != traceImageToImageIndex.end()) {
+        traceImageIndexToImage.erase(traceImageToImageIndex[pPacket->image]);
+        traceImageToImageIndex.erase(pPacket->image);
+    }
     if (replayGetImageMemoryRequirements.find(remappedImage) != replayGetImageMemoryRequirements.end())
         replayGetImageMemoryRequirements.erase(remappedImage);
     return;
@@ -1582,6 +1586,10 @@ void vkReplay::manually_replay_vkCmdWaitEvents(packet_vkCmdWaitEvents *pPacket) 
     VkImage *saveImg = VKTRACE_NEW_ARRAY(VkImage, pPacket->imageMemoryBarrierCount);
     for (idx = 0; idx < pPacket->imageMemoryBarrierCount; idx++) {
         VkImageMemoryBarrier *pNextImg = (VkImageMemoryBarrier *)&(pPacket->pImageMemoryBarriers[idx]);
+        if (traceImageToImageIndex.find(pNextImg->image) != traceImageToImageIndex.end() &&
+            traceImageIndexToImage.find(m_imageIndex) != traceImageIndexToImage.end() && m_imageIndex != UINT32_MAX) {
+            pNextImg->image = traceImageIndexToImage[m_imageIndex];
+        }
         saveImg[numRemapImg++] = pNextImg->image;
         traceDevice = traceImageToDevice[pNextImg->image];
         pNextImg->image = m_objMapper.remap_images(pNextImg->image);
@@ -1668,6 +1676,10 @@ void vkReplay::manually_replay_vkCmdPipelineBarrier(packet_vkCmdPipelineBarrier 
     }
     for (idx = 0; idx < pPacket->imageMemoryBarrierCount; idx++) {
         VkImageMemoryBarrier *pNextImg = (VkImageMemoryBarrier *)&(pPacket->pImageMemoryBarriers[idx]);
+        if (traceImageToImageIndex.find(pNextImg->image) != traceImageToImageIndex.end() &&
+            traceImageIndexToImage.find(m_imageIndex) != traceImageIndexToImage.end() && m_imageIndex != UINT32_MAX) {
+            pNextImg->image = traceImageIndexToImage[m_imageIndex];
+        }
         saveImg[numRemapImg++] = pNextImg->image;
         traceDevice = traceImageToDevice[pNextImg->image];
         if (traceDevice == NULL) vktrace_LogError("DEBUG: traceDevice is NULL");
@@ -1724,6 +1736,10 @@ VkResult vkReplay::manually_replay_vkCreateFramebuffer(packet_vkCreateFramebuffe
         pAttachments = VKTRACE_NEW_ARRAY(VkImageView, pInfo->attachmentCount);
         memcpy(pAttachments, pSavedAttachments, sizeof(VkImageView) * pInfo->attachmentCount);
         for (uint32_t i = 0; i < pInfo->attachmentCount; i++) {
+            if (traceImageViewToImageIndex.find(pInfo->pAttachments[i]) != traceImageViewToImageIndex.end()) {
+                traceFramebufferToImageIndex[*(pPacket->pFramebuffer)] = traceImageViewToImageIndex[pInfo->pAttachments[i]];
+                traceImageIndexToFramebuffer[traceImageViewToImageIndex[pInfo->pAttachments[i]]] = *(pPacket->pFramebuffer);
+            }
             pAttachments[i] = m_objMapper.remap_imageviews(pInfo->pAttachments[i]);
             if (pAttachments[i] == VK_NULL_HANDLE && pInfo->pAttachments[i] != VK_NULL_HANDLE) {
                 vktrace_LogError("Skipping vkCreateFramebuffer() due to invalid remapped VkImageView.");
@@ -1783,7 +1799,13 @@ void vkReplay::manually_replay_vkCmdBeginRenderPass(packet_vkCmdBeginRenderPass 
     VkRenderPassBeginInfo local_renderPassBeginInfo;
     memcpy((void *)&local_renderPassBeginInfo, (void *)pPacket->pRenderPassBegin, sizeof(VkRenderPassBeginInfo));
     local_renderPassBeginInfo.pClearValues = (const VkClearValue *)pPacket->pRenderPassBegin->pClearValues;
-    local_renderPassBeginInfo.framebuffer = m_objMapper.remap_framebuffers(pPacket->pRenderPassBegin->framebuffer);
+    if (traceFramebufferToImageIndex.find(pPacket->pRenderPassBegin->framebuffer) != traceFramebufferToImageIndex.end() &&
+        traceImageIndexToFramebuffer.find(m_imageIndex) != traceImageIndexToFramebuffer.end() && m_imageIndex != UINT32_MAX) {
+        // Use Framebuffer mapped to the image index returned by vkAcquireNextImage()
+        local_renderPassBeginInfo.framebuffer = m_objMapper.remap_framebuffers(traceImageIndexToFramebuffer[m_imageIndex]);
+    } else {
+        local_renderPassBeginInfo.framebuffer = m_objMapper.remap_framebuffers(pPacket->pRenderPassBegin->framebuffer);
+    }
     if (local_renderPassBeginInfo.framebuffer == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkCmdBeginRenderPass() due to invalid remapped VkFramebuffer.");
         return;
@@ -1816,7 +1838,13 @@ VkResult vkReplay::manually_replay_vkBeginCommandBuffer(packet_vkBeginCommandBuf
         pRP = &(pHinfo->renderPass);
         pFB = &(pHinfo->framebuffer);
         *pRP = m_objMapper.remap_renderpasss(savedRP);
-        *pFB = m_objMapper.remap_framebuffers(savedFB);
+        if (traceFramebufferToImageIndex.find(savedFB) != traceFramebufferToImageIndex.end() &&
+            traceImageIndexToFramebuffer.find(m_imageIndex) != traceImageIndexToFramebuffer.end() && m_imageIndex != UINT32_MAX) {
+            // Use Framebuffer mapped to the image index returned by vkAcquireNextImage()
+            *pFB = m_objMapper.remap_framebuffers(traceImageIndexToFramebuffer[m_imageIndex]);
+        } else {
+            *pFB = m_objMapper.remap_framebuffers(savedFB);
+        }
     }
     replayResult = m_vkDeviceFuncs.BeginCommandBuffer(remappedCommandBuffer, pPacket->pBeginInfo);
     if (pInfo != NULL && pHinfo != NULL) {
@@ -3012,6 +3040,14 @@ void vkReplay::manually_replay_vkDestroySwapchainKHR(packet_vkDestroySwapchainKH
 
     m_vkDeviceFuncs.DestroySwapchainKHR(remappeddevice, remappedswapchain, pPacket->pAllocator);
     m_objMapper.rm_from_swapchainkhrs_map(pPacket->swapchain);
+
+    traceImageIndexToImage.clear();
+    traceImageToImageIndex.clear();
+    traceImageIndexToImageView.clear();
+    traceImageViewToImageIndex.clear();
+    traceImageIndexToFramebuffer.clear();
+    traceFramebufferToImageIndex.clear();
+    m_imageIndex = UINT32_MAX;
 }
 
 VkResult vkReplay::manually_replay_vkGetSwapchainImagesKHR(packet_vkGetSwapchainImagesKHR *pPacket) {
@@ -3037,6 +3073,8 @@ VkResult vkReplay::manually_replay_vkGetSwapchainImagesKHR(packet_vkGetSwapchain
         numImages = *(pPacket->pSwapchainImageCount);
         for (uint32_t i = 0; i < numImages; i++) {
             packetImage[i] = pPacketImages[i];
+            traceImageIndexToImage[i] = packetImage[i];
+            traceImageToImageIndex[packetImage[i]] = i;
             traceImageToDevice[packetImage[i]] = pPacket->device;
         }
     }

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -93,6 +93,7 @@ class vkReplay {
     vktrace_trace_file_header* m_pFileHeader;
     struct_gpuinfo* m_pGpuinfo;
     uint32_t m_imageIndex = UINT32_MAX;
+    VkPresentModeKHR m_presentMode;
 
     // Replay platform description
     uint64_t m_replay_endianess;

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -92,6 +92,7 @@ class vkReplay {
     int m_frameNumber;
     vktrace_trace_file_header* m_pFileHeader;
     struct_gpuinfo* m_pGpuinfo;
+    uint32_t m_imageIndex = UINT32_MAX;
 
     // Replay platform description
     uint64_t m_replay_endianess;
@@ -256,6 +257,15 @@ class vkReplay {
     // Map VkPhysicalDevice to VkPhysicalDeviceMemoryProperites
     std::unordered_map<VkPhysicalDevice, VkPhysicalDeviceMemoryProperties> traceMemoryProperties;
     std::unordered_map<VkPhysicalDevice, VkPhysicalDeviceMemoryProperties> replayMemoryProperties;
+
+    // Map swapchain image index to VkImage, VkImageView, VkFramebuffer, so we can replace swapchain image and frame buffer with the
+    // acquired ones
+    std::unordered_map<uint32_t, VkImage> traceImageIndexToImage;
+    std::unordered_map<VkImage, uint32_t> traceImageToImageIndex;
+    std::unordered_map<uint32_t, VkImageView> traceImageIndexToImageView;
+    std::unordered_map<VkImageView, uint32_t> traceImageViewToImageIndex;
+    std::unordered_map<uint32_t, VkFramebuffer> traceImageIndexToFramebuffer;
+    std::unordered_map<VkFramebuffer, uint32_t> traceFramebufferToImageIndex;
 
     // Map VkImage to VkMemoryRequirements
     std::unordered_map<VkImage, VkMemoryRequirements> replayGetImageMemoryRequirements;


### PR DESCRIPTION
This change fixes #365 "trace file with VK_PRESENT_MODE_MAILBOX_KHR
present mode is not replayed correctly".

It records the mapping between following objects:

* swapchain image <-> swapchain image index
* swapchain image view <-> swapchain image index
* swapchain framebuffer <-> swapchain image index

to replace:

* swapchain images in vkCmdWaitEvents and vkCmdPipelineBarrier
* swapchain framebuffers in vkCmdBeginRenderPass and vkBeginCommandBuffer

using the ones mapped to the image index returned by
vkAcquireNextImageKHR.