### PR TITLE
vktrace/replay: Fix pageguard delta structure type

### DIFF
--- a/vktrace/vktrace_common/vktrace_pageguard_memorycopy.h
+++ b/vktrace/vktrace_common/vktrace_pageguard_memorycopy.h
@@ -46,10 +46,10 @@ using namespace concurrency;
 #endif
 
 typedef struct __PageGuardChangedBlockInfo {
-    size_t offset;
-    size_t length;
-    size_t reserve0;
-    size_t reserve1;
+    uint32_t offset;
+    uint32_t length;
+    uint32_t reserve0;
+    uint32_t reserve1;
 } PageGuardChangedBlockInfo, *pPageGuardChangedBlockInfo;
 
 #if defined(WIN32)


### PR DESCRIPTION
Made an an assumption when cleaning up warnings, undoing change.

Change-Id: If46589d893130a9e8b7fbe6b2b45dc175a04ece7