### PR TITLE
Add VLF test scripts

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,9 +17,11 @@ else()
     if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
         FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/_vktracereplay.ps1 VKTRACEREPLAY)
         FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/trace_positive_validation.ps1 VKTRACEPOSITIVE)
+        FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/vlf_test.ps1 VKVLFTEST)
         add_custom_target(vt_test-dir-symlinks ALL
             COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VKTRACEREPLAY} _vktracereplay.ps1
             COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VKTRACEPOSITIVE} trace_positive_validation.ps1
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VKVLFTEST} vlf_test.ps1
             VERBATIM
             )
     endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ if (NOT WIN32)
             COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_test1_in.json
             COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_test1_in_ArrayOfVkFormatProperties.json
             COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/devsim_test1_gold.json
+            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/vlf_test.sh
             VERBATIM
             )
         set_target_properties(vt_test-dir-symlinks PROPERTIES FOLDER ${VULKANTOOLS_TARGET_FOLDER})

--- a/tests/vlf_test.ps1
+++ b/tests/vlf_test.ps1
@@ -1,0 +1,72 @@
+# Powershell script for running the Vulkan Layer Factory sanity test
+
+# vlf_test.ps1
+# This script will run the demo vulkaninfo with the demo_layer and capture the output.
+# This layer will output all of the API names used by the application, and this script
+# will search the output for a certain amount of APIs that are known to be used by this
+# demo.  If the threshold is met, the test will indicate PASS, else FAILURE.
+#
+# To run this test:
+#    Change to the repo build tests directory, run the script:
+#         powershell vlf_test.ps1 [-Debug]
+#
+#    Specify -Debug for debug builds
+
+Param(
+    [switch]$Debug
+)
+
+if ($Debug) {
+    $dPath = "Debug"
+} else {
+    $dPath = "Release"
+}
+
+$exitstatus = 0
+
+write-host -background black -foreground green "[  RUN     ] " -nonewline
+write-host "vlf_test.ps1: Vulkan Layer Factory Sanity Test"
+
+# Save current directory
+$current_directory = $pwd
+
+cd "..\demos"
+
+# Set up some modified env vars
+$Env:VK_LAYER_PATH = "$pwd\..\layers\$dPath"
+$Env:VK_ICD_FILENAMES = "$pwd\..\submodules\Vulkan-LoaderAndValidationLayers\icd\$dPath\VkICD_mock_icd.json"
+$Env:VK_INSTANCE_LAYERS = "VK_LAYER_LUNARG_demo_layer"
+
+# Run vulkaninfo with mock ICD and demo layer, capturing output
+& vulkaninfo > temp_output_file
+
+# Fail if temp file is not present, or if results do not match expectations
+if (!(Test-Path temp_output_file)) {
+    echo 'Output file does not exist'
+    write-host -background black -foreground red "[  FAILED  ] "  -nonewline;
+    $exitstatus = 1
+} else {
+    # Look for sensible results in output file
+    $count = (Select-String -Path .\temp_output_file -Pattern "vkGetPhysicalDeviceFormatProperties").length
+    if ($count -lt 200) {
+        $exitstatus = 1
+    }
+}
+
+# Output pass/fail result
+if ($exitstatus -eq 0) {
+    write-host -background black -foreground green "[  PASSED  ] " -nonewline;
+} else {
+    write-host -background black -foreground red "[  FAILED  ] "
+}
+
+# Clean up env, files, path
+Remove-Item Env:\VK_INSTANCE_LAYERS
+Remove-Item Env:\VK_ICD_FILENAMES
+Remove-Item Env:\VK_LAYER_PATH
+
+Remove-Item -Path .\temp_output_file
+
+cd $current_directory
+
+exit $exitstatus

--- a/tests/vlf_test.sh
+++ b/tests/vlf_test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# vlf_test.sh
+# This script will run the demo vulkaninfo with the demo_layer and capture the output.
+# This layer will output all of the API names used by the application, and this script
+# will search the output for a certain amount of APIs that are known to be used by this
+# demo.  If the threshold is met, the test will indicate PASS, else FAILURE.
+
+if [ -t 1 ] ; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    GREEN=''
+    NC=''
+fi
+
+pushd ../submodules/Vulkan-LoaderAndValidationLayers/demos
+
+VK_ICD_FILENAMES=../icd/VkICD_mock_icd.json VK_LAYER_PATH=../../../layers VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_demo_layer ./vulkaninfo > file.tmp
+
+printf "$GREEN[ RUNNING VLF TEST ]$NC $0\n"
+if [ -f file.tmp ]
+then
+    count=$(grep vkGetPhysicalDeviceFormatProperties file.tmp | wc -l)
+    if [ $count -gt 100 ]
+    then
+        printf "$GREEN[ PASS             ]$NC $0\n"
+    else
+        printf "$RED[ FAIL             ]$NC $0\n"
+        rm file.tmp
+        popd
+        exit 1
+    fi
+fi
+
+rm file.tmp
+popd
+
+exit 0


### PR DESCRIPTION
These powershell and bash scripts will set up and excute vulkaninfo with the demo_layer and check the output for correctness.  Need to add one for api_dump soon, and to fix the currently busted vktrace_replay test scripts.