### PR TITLE
apidump : Display object name with handle

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -535,10 +535,6 @@ inline void dump_text_value(const T object, const ApiDumpSettings &settings, con
                             std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
     settings.formatNameType(settings.stream(), indents, name, type_string);
     dump(object, settings, indents, args...) << "\n";
-//    auto search = handles.find(std::string(type_string));
-//    if (search != handles.end()) {
-//        settings.stream() << "garbage";
-//    }
 }
 
 template <typename T, typename... Args>

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -437,6 +437,8 @@ class ApiDumpInstance {
 
     static inline ApiDumpInstance &current() { return current_instance; }
 
+    std::unordered_map<uint64_t, std::string> *objectNameMap;
+
    private:
     static ApiDumpInstance current_instance;
 
@@ -735,9 +737,4 @@ inline std::ostream &dump_html_int(int object, const ApiDumpSettings &settings, 
     settings.stream() << "<div class='val'>";
     settings.stream() << object;
     return settings.stream() << "</div>";
-}
-
-inline VkResult vkDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
-    VkResult result;
-    return result;
 }

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -736,3 +736,8 @@ inline std::ostream &dump_html_int(int object, const ApiDumpSettings &settings, 
     settings.stream() << object;
     return settings.stream() << "</div>";
 }
+
+inline VkResult vkDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+    VkResult result;
+    return result;
+}

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -16,6 +16,7 @@
  * limitations under the License.
  *
  * Author: Lenny Komow <lenny@lunarg.com>
+ * Author: Shannon McPherson <shannon@lunarg.com>
  */
 
 #pragma once
@@ -437,7 +438,7 @@ class ApiDumpInstance {
 
     static inline ApiDumpInstance &current() { return current_instance; }
 
-    std::unordered_map<uint64_t, std::string> *objectNameMap;
+    std::unordered_map<uint64_t, std::string> object_name_map;
 
    private:
     static ApiDumpInstance current_instance;
@@ -534,6 +535,10 @@ inline void dump_text_value(const T object, const ApiDumpSettings &settings, con
                             std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
     settings.formatNameType(settings.stream(), indents, name, type_string);
     dump(object, settings, indents, args...) << "\n";
+//    auto search = handles.find(std::string(type_string));
+//    if (search != handles.end()) {
+//        settings.stream() << "garbage";
+//    }
 }
 
 template <typename T, typename... Args>

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -270,7 +270,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 
 // Autogen device functions
 
-@foreach function where('{funcType}' == 'device' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkQueuePresentKHR', 'vkGetDeviceProcAddr'])
+@foreach function where('{funcType}' == 'device' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkQueuePresentKHR', 'vkGetDeviceProcAddr', 'vkDebugMarkerSetObjectNameEXT'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
     {funcReturn} result = device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
@@ -280,7 +280,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 }}
 @end function
 
-@foreach function where('{funcType}' == 'device' and '{funcReturn}' == 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkGetDeviceProcAddr'])
+@foreach function where('{funcType}' == 'device' and '{funcReturn}' == 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkGetDeviceProcAddr', 'vkDebugMarkerSetObjectNameEXT'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
     device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -94,8 +94,6 @@ inline void dump_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {fu
 @foreach function where('{funcName}' == 'vkDebugMarkerSetObjectNameEXT' and '{funcReturn}' != 'void')
 inline void dump_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 {{
-    // TODO - Remove the following stream output; How to test?
-    dump_inst.settings().stream() << "In DebugMarkerSetObjectNameEXT\\n";
     loader_platform_thread_lock_mutex(dump_inst.outputMutex());
 
     if (pNameInfo->pObjectName)
@@ -373,7 +371,6 @@ TEXT_CODEGEN = """
 
 #include "api_dump.h"
 
-std::unordered_set<std::string> handles({{@foreach handle"{hdlName}", @end handle}});
 @foreach struct
 std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars});
 @end struct
@@ -417,18 +414,18 @@ inline std::ostream& dump_text_{sysName}(const {sysType} object, const ApiDumpSe
 
 @foreach handle
 inline std::ostream& dump_text_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
-{{        
+{{
     if(settings.showAddress()) {{
-        settings.stream() << object << " " << ApiDumpInstance::current().object_name_map.size() << " "; // TODO - REMOVE THE MAP SIZE
-        
-        std::unordered_map<uint64_t, std::string>::const_iterator is_named = ApiDumpInstance::current().object_name_map.find((uint64_t) object);
-        if (is_named != ApiDumpInstance::current().object_name_map.end()) {{
-            settings.stream() << " I\\'M IN" << is_named->second;
+        settings.stream() << object;
+
+        std::unordered_map<uint64_t, std::string>::const_iterator it = ApiDumpInstance::current().object_name_map.find((uint64_t) object);
+        if (it != ApiDumpInstance::current().object_name_map.end()) {{
+            settings.stream() << " [" << it->second << "]";
         }}
     }} else {{
         settings.stream() << "address";
     }}
-        
+
     return settings.stream();
 }}
 @end handle
@@ -680,6 +677,7 @@ HTML_CODEGEN = """
  *
  * Author: Lenny Komow <lenny@lunarg.com>
  * Author: Joey Bzdek <joey@lunarg.com>
+ * Author: Shannon McPherson <shannon@lunarg.com>
  */
 
 /*
@@ -738,12 +736,11 @@ inline std::ostream& dump_html_{hdlName}(const {hdlName} object, const ApiDumpSe
 {{
     settings.stream() << "<div class='val'>";
     if(settings.showAddress()) {{
-        settings.stream() << object << "</div>";
-        
-        std::unordered_map<uint64_t, std::string>::const_iterator is_named = ApiDumpInstance::current().object_name_map.find((uint64_t) object);
-        if (is_named != ApiDumpInstance::current().object_name_map.end()) {{
-            settings.stream() << " " << is_named->second;
-            // TODO - Remove the above output
+        settings.stream() << object;
+
+        std::unordered_map<uint64_t, std::string>::const_iterator it = ApiDumpInstance::current().object_name_map.find((uint64_t) object);
+        if (it != ApiDumpInstance::current().object_name_map.end()) {{
+            settings.stream() << "</div><div class='val'>[" << it->second << "]";
         }}
     }} else {{
         settings.stream() << "address";

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -737,10 +737,17 @@ inline std::ostream& dump_html_{sysName}(const {sysType} object, const ApiDumpSe
 inline std::ostream& dump_html_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << "<div class='val'>";
-    if(settings.showAddress())
-        settings.stream() << object;
-    else
+    if(settings.showAddress()) {{
+        settings.stream() << object << "</div>";
+        
+        std::unordered_map<uint64_t, std::string>::const_iterator is_named = ApiDumpInstance::current().object_name_map.find((uint64_t) object);
+        if (is_named != ApiDumpInstance::current().object_name_map.end()) {{
+            settings.stream() << " " << is_named->second;
+            // TODO - Remove the above output
+        }}
+    }} else {{
         settings.stream() << "address";
+    }}
     return settings.stream() << "</div></summary>";
 }}
 @end handle


### PR DESCRIPTION
This change addresses LVL github issue [#2107](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/issues/2107).

VK_LAYER_LUNARG_api_dump layer now displays object handle and name if set.