### PR TITLE
Android fixes

### DIFF
--- a/build-android/build_vktracereplay.sh
+++ b/build-android/build_vktracereplay.sh
@@ -45,7 +45,7 @@ findtool jarsigner
 set -ev
 
 LAYER_BUILD_DIR=$PWD
-DEMO_BUILD_DIR=$PWD/../demos/android
+DEMO_BUILD_DIR=$PWD/../submodules/Vulkan-LoaderAndValidationLayers/demos/android
 echo LAYER_BUILD_DIR="${LAYER_BUILD_DIR}"
 echo DEMO_BUILD_DIR="${DEMO_BUILD_DIR}"
 

--- a/build-android/install_all.sh
+++ b/build-android/install_all.sh
@@ -72,9 +72,9 @@ fi
 # Install everything built by build_all.sh
 echo "adb $serialFlag install -r bin/VulkanLayerValidationTests.apk"
 adb $serialFlag install -r bin/VulkanLayerValidationTests.apk
-echo "adb $serialFlag install -r ../demos/android/cube/bin/cube.apk"
-adb $serialFlag install -r ../demos/android/cube/bin/cube.apk
-echo "adb $serialFlag install -r ../demos/android/cube-with-layers/bin/cube-with-layers.apk"
-adb $serialFlag install -r ../demos/android/cube-with-layers/bin/cube-with-layers.apk
+echo "adb $serialFlag install -r ../submodules/Vulkan-LoaderAndValidationLayers/demos/android/cube/bin/cube.apk"
+adb $serialFlag install -r ../submodules/Vulkan-LoaderAndValidationLayers/demos/android/cube/bin/cube.apk
+echo "adb $serialFlag install -r ../submodules/Vulkan-LoaderAndValidationLayers/demos/android/cube-with-layers/bin/cube-with-layers.apk"
+adb $serialFlag install -r ../submodules/Vulkan-LoaderAndValidationLayers/demos/android/cube-with-layers/bin/cube-with-layers.apk
 
 exit $?

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -72,7 +72,9 @@ char *android_exec(const char *cmd) {
         // Do a right strip of " ", "\n", "\r", "\t" for the android_env string
         string android_env_str(android_env);
         android_env_str.erase(android_env_str.find_last_not_of(" \n\r\t") + 1);
-        return (char *)android_env_str.c_str();
+        snprintf(android_env, sizeof(android_env), "%s", android_env_str.c_str());
+        return android_env;
+
     }
 
     return nullptr;


### PR DESCRIPTION
Screenshot has been broken since end of December merge from LVL.  Found time to track it down today.  The switch from gnustl_static to c++_static STL libraries exposed a bug where a pointer to contents of a local string were being returned.  Writing the value back to our global envvar gets things working again.

Also, updated some scripts that were missed during move to submodules.

vktrace/vkreplay and screenshot are working now.  devsim has one difference I'll work with @mikew-lunarg  on.