### PR TITLE
vkreplay: Fix verification of remapped surfaces in vkCreateSwapchain.

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -2,6 +2,7 @@
  *
  * Copyright (C) 2015-2016 Valve Corporation
  * Copyright (C) 2015-2016 LunarG, Inc.
+ * Modifications Copyright (C) 2017-2018 Advanced Micro Devices, Inc.
  * All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2985,10 +2986,15 @@ VkResult vkReplay::manually_replay_vkCreateSwapchainKHR(packet_vkCreateSwapchain
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
+    if (pPacket->pCreateInfo->surface == VK_NULL_HANDLE) {
+        vktrace_LogError("Skipping vkCreateSwapchainKHR() due to invalid traced VkSurfaceKHR (VK_NULL_HANDLE).");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     save_surface = pPacket->pCreateInfo->surface;
     VkSurfaceKHR *pSurf = (VkSurfaceKHR *)&(pPacket->pCreateInfo->surface);
     *pSurf = m_objMapper.remap_surfacekhrs(*pSurf);
-    if (*pSurf == VK_NULL_HANDLE && pPacket->pCreateInfo->surface != VK_NULL_HANDLE) {
+    if (*pSurf == VK_NULL_HANDLE && save_surface != VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkCreateSwapchainKHR() due to invalid remapped VkSurfaceKHR.");
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }


### PR DESCRIPTION
Since pSurf points to pCreateInfo->surface, and *pSurf was just
updated to the remapped surface, this conditional was previously checking
if the surface object both WAS and WAS NOT a VK_NULL_HANDLE (which is
impossible, so this error would never get reported).

For this entrypoint, the input (trace-time) surface is not allowed to be
VK_NULL_HANDLE, so this change now verifies the surface is valid, and
reports an error if not valid.

It also verifies that the remapped surface is not VK_NULL_HANDLE; and
reports an error as needed.