### PR TITLE
via: Quiet annoying GCC warning message

### DIFF
--- a/via/via.cpp
+++ b/via/via.cpp
@@ -3939,7 +3939,7 @@ int RunTestInDirectory(std::string path, std::string test, std::string cmd_line)
             // Path doesn't exist at all
             err_code = 1;
         }
-        chdir(orig_dir);
+        err = chdir(orig_dir);
     }
     return err_code;
 }


### PR DESCRIPTION
For gcc version 5.4.0 of Ubuntu 16.04.3 LTS, resolve this compilation message:
warning: ignoring return value of ‘int chdir(const char*)’, declared with attribute warn_unused_result [-Wunused-result]

Change-Id: Idcc2f867d997d96e28c4109e62f9efbd61eca87b