### PR TITLE
Update VulkanTools to 1.0.69 Vulkan Header

### DIFF
--- a/layer_factory/layer_factory_linux.json
+++ b/layer_factory/layer_factory_linux.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_layer_factory",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_layer_factory.so",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "LunarG Validation Layer Factory Layer",
         "instance_extensions": [

--- a/layer_factory/layer_factory_windows.json
+++ b/layer_factory/layer_factory_windows.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_layer_factory",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_layer_factory.dll",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "LunarG Validation Factory Layer",
         "instance_extensions": [

--- a/layersvt/linux/VkLayer_api_dump.json
+++ b/layersvt/linux/VkLayer_api_dump.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_api_dump.so",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "2",
         "description": "LunarG debug layer"
     }

--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_device_simulation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1.2.1",
         "description": "LunarG device simulation layer"
     }

--- a/layersvt/linux/VkLayer_monitor.json
+++ b/layersvt/linux/VkLayer_monitor.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_monitor",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_monitor.so",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "Execution Monitoring Layer"
     }

--- a/layersvt/linux/VkLayer_screenshot.json
+++ b/layersvt/linux/VkLayer_screenshot.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_screenshot",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_screenshot.so",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "LunarG image capture layer"
     }

--- a/layersvt/windows/VkLayer_api_dump.json
+++ b/layersvt/windows/VkLayer_api_dump.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_api_dump.dll",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "2",
         "description": "LunarG debug layer"
     }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_device_simulation",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1.2.1",
         "description": "LunarG device simulation layer"
     }

--- a/layersvt/windows/VkLayer_monitor.json
+++ b/layersvt/windows/VkLayer_monitor.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_monitor",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_monitor.dll",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "Execution Monitoring Layer"
     }

--- a/layersvt/windows/VkLayer_screenshot.json
+++ b/layersvt/windows/VkLayer_screenshot.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_screenshot",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_screenshot.dll",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "LunarG image capture layer"
     }

--- a/vktrace/vktrace_layer/linux/VkLayer_vktrace_layer.json
+++ b/vktrace/vktrace_layer/linux/VkLayer_vktrace_layer.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_vktrace",
         "type": "GLOBAL",
         "library_path": "../vktrace/libVkLayer_vktrace_layer.so",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "Vktrace tracing library",
         "functions" : {

--- a/vktrace/vktrace_layer/windows/VkLayer_vktrace_layer.json
+++ b/vktrace/vktrace_layer/windows/VkLayer_vktrace_layer.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_vktrace",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_vktrace_layer.dll",
-        "api_version": "1.0.68",
+        "api_version": "1.0.69",
         "implementation_version": "1",
         "description": "Vktrace tracing library",
         "functions" : {


### PR DESCRIPTION
- updated layer json files
- updated LVL submodule to TOT, including 69 header changes

