### PR TITLE
vkreplay: Remap memoryOffset for vkBindImageMemory

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -631,6 +631,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                  'UpdateDescriptorSetWithTemplateKHR',
                                  'CmdPushDescriptorSetWithTemplateKHR',
                                  'BindBufferMemory',
+                                 'BindImageMemory',
                                  # VK_EXT_display_control
                                  'RegisterDeviceEventEXT',
                                  'RegisterDisplayEventEXT',

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -203,7 +203,7 @@ class vkReplay {
     void manually_replay_vkUpdateDescriptorSetWithTemplateKHR(packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket);
     void manually_replay_vkCmdPushDescriptorSetWithTemplateKHR(packet_vkCmdPushDescriptorSetWithTemplateKHR* pPacket);
     VkResult manually_replay_vkBindBufferMemory(packet_vkBindBufferMemory* pPacket);
-    VkResult manually_replay_vkBindImageMemory(packet_vkBindImageMemory *pPacket);
+    VkResult manually_replay_vkBindImageMemory(packet_vkBindImageMemory* pPacket);
     VkResult manually_replay_vkRegisterDeviceEventEXT(packet_vkRegisterDeviceEventEXT *pPacket);
     VkResult manually_replay_vkRegisterDisplayEventEXT(packet_vkRegisterDisplayEventEXT *pPacket);
     VkResult manually_replay_vkCreateObjectTableNVX(packet_vkCreateObjectTableNVX *pPacket);

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -203,6 +203,7 @@ class vkReplay {
     void manually_replay_vkUpdateDescriptorSetWithTemplateKHR(packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket);
     void manually_replay_vkCmdPushDescriptorSetWithTemplateKHR(packet_vkCmdPushDescriptorSetWithTemplateKHR* pPacket);
     VkResult manually_replay_vkBindBufferMemory(packet_vkBindBufferMemory* pPacket);
+    VkResult manually_replay_vkBindImageMemory(packet_vkBindImageMemory *pPacket);
     VkResult manually_replay_vkRegisterDeviceEventEXT(packet_vkRegisterDeviceEventEXT *pPacket);
     VkResult manually_replay_vkRegisterDisplayEventEXT(packet_vkRegisterDisplayEventEXT *pPacket);
     VkResult manually_replay_vkCreateObjectTableNVX(packet_vkCreateObjectTableNVX *pPacket);


### PR DESCRIPTION
This change remaps the memoryOffset in vkBindImageMemory when the
aligment on replay platform is different from the trace platform.

It only takes effect when portability table is being used and the
alignment in vkGBMR on replay platform is different from the
trace platform.