### PR TITLE
Add new Assistant Layer Check for CmdDispatch groupCounts set to Zero

### DIFF
--- a/layer_factory/assistant_layer/zero_counts.h
+++ b/layer_factory/assistant_layer/zero_counts.h
@@ -59,6 +59,16 @@ class ZeroCounts : public layer_factory {
             Warning("Warning: You are calling vkCmdDrawIndexedIndirect with a drawCount of Zero.");
         }
     };
+
+    // Intercept CmdDispatch call and check groupCounts
+    void PreCallCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ) {
+        if ((groupCountX == 0) || (groupCountY == 0) || (groupCountZ == 0)) {
+            std::stringstream message;
+            message << "Warning: You are calling vkCmdDispatch while one or more groupCounts are zero ( groupCountX = "
+                    << groupCountX << ", groupCountY = " << groupCountY << ", groupCountZ = " << groupCountZ << " ).";
+            Warning(message.str());
+        }
+    };
 };
 
 ZeroCounts warn_for_zero_counts;

--- a/layer_factory/assistant_layer/zero_counts.h
+++ b/layer_factory/assistant_layer/zero_counts.h
@@ -53,8 +53,8 @@ class ZeroCounts : public layer_factory {
     };
 
     // Intercept CmdDrawIndexedIndirect calls and check drawCount
-    void CmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
-                                uint32_t stride) {
+    void PreCallCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
+                                       uint32_t stride) {
         if (drawCount == 0) {
             Warning("Warning: You are calling vkCmdDrawIndexedIndirect with a drawCount of Zero.");
         }


### PR DESCRIPTION
From LVL issue #1912, add this to assistant layer in the existing zero_counts interceptor.  Also fixed a leftover bug in the original.