### PR TITLE
vktrace: Fix aligment fault on ARMv8 platform

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -174,7 +174,7 @@ vktrace_trace_packet_header* vktrace_create_trace_packet(uint8_t tracer_id, uint
                                                          uint64_t additional_buffers_size) {
     // Always allocate at least enough space for the packet header
     uint64_t total_packet_size =
-        ROUNDUP_TO_4(sizeof(vktrace_trace_packet_header) + ROUNDUP_TO_8(packet_size) + additional_buffers_size);
+        ROUNDUP_TO_8(sizeof(vktrace_trace_packet_header) + ROUNDUP_TO_8(packet_size) + additional_buffers_size);
     void* pMemory = vktrace_malloc((size_t)total_packet_size);
     memset(pMemory, 0, (size_t)total_packet_size);
 

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -173,7 +173,8 @@ uint64_t get_os() {
 vktrace_trace_packet_header* vktrace_create_trace_packet(uint8_t tracer_id, uint16_t packet_id, uint64_t packet_size,
                                                          uint64_t additional_buffers_size) {
     // Always allocate at least enough space for the packet header
-    uint64_t total_packet_size = ROUNDUP_TO_4(sizeof(vktrace_trace_packet_header) + packet_size + additional_buffers_size);
+    uint64_t total_packet_size =
+        ROUNDUP_TO_4(sizeof(vktrace_trace_packet_header) + ROUNDUP_TO_8(packet_size) + additional_buffers_size);
     void* pMemory = vktrace_malloc((size_t)total_packet_size);
     memset(pMemory, 0, (size_t)total_packet_size);
 
@@ -187,8 +188,13 @@ vktrace_trace_packet_header* vktrace_create_trace_packet(uint8_t tracer_id, uint
     pHeader->entrypoint_begin_time = pHeader->vktrace_begin_time;
     pHeader->entrypoint_end_time = 0;
     pHeader->vktrace_end_time = 0;
-    pHeader->next_buffers_offset =
-        sizeof(vktrace_trace_packet_header) + packet_size;  // initial offset is from start of header to after the packet body
+    pHeader->next_buffers_offset = sizeof(vktrace_trace_packet_header) +
+                                   ROUNDUP_TO_8(packet_size);  // Initial offset is from start of header to after the packet body.
+                                                               // Make the initial offset to 64-bit aligned to make it meets the
+                                                               // alignement requirement of instruction vst1.64 which may be used
+                                                               // by a 32-bit GPU driver on ARMv8 platform.
+                                                               // Assuming the content of the buffer has expected alignment of the
+                                                               // tracing platform.
     if (total_packet_size > sizeof(vktrace_trace_packet_header)) {
         pHeader->pBody = (uintptr_t)(((char*)pMemory) + sizeof(vktrace_trace_packet_header));
     }


### PR DESCRIPTION
This change fixes aligment fault when replaying a 32-bit trace file
on ARMv8 platform by making sure the additional data are stored with
64-bit aligned initial offset.

There's a possibility that a 32-bit GPU driver on ARMv8 platform
using instruction "vst1.64" which requires 64-bit alignment.