### PR TITLE
vkreplay: Add option to pre-load trace file

### DIFF
--- a/vktrace/README.md
+++ b/vktrace/README.md
@@ -268,6 +268,17 @@ The `vkreplay` options are:
 
 <tr>
 
+<td>-pltf &lt;bool&gt;<br/>
+‑‑PreloadTraceFile &lt;bool&gt;</td>
+
+<td>Preload tracefile to memory before replay (NumLoops need to be 1)</td>
+
+<td>off</td>
+
+</tr>
+
+<tr>
+
 <td>-s &lt;string&gt;<br/>
 ‑‑Screenshot &lt;string&gt;</td>
 

--- a/vktrace/vktrace_common/vktrace_filelike.c
+++ b/vktrace/vktrace_common/vktrace_filelike.c
@@ -69,7 +69,7 @@ uint64_t vktrace_FileLike_GetFileLength(FILE* fp) {
     // Get file length
     int64_t length = 0;
     if (Fseek(fp, 0, SEEK_END) != 0) {
-        vktrace_LogError("Failed to fseek to the end of tracefile for replaying.");
+        vktrace_LogError("Failed to Fseek to the end of tracefile for replaying.");
     } else {
         length = Ftell(fp);
         if (length == -1L) {
@@ -88,14 +88,57 @@ uint64_t vktrace_FileLike_GetFileLength(FILE* fp) {
 }
 
 // ------------------------------------------------------------------------------------------------
-FileLike* vktrace_FileLike_create_file(FILE* fp) {
+FileLike* vktrace_FileLike_create_file(FILE* fp, BOOL preload) {
     FileLike* pFile = NULL;
     if (fp != NULL) {
         pFile = VKTRACE_NEW(FileLike);
-        pFile->mMode = File;
-        pFile->mFile = fp;
-        pFile->mMessageStream = NULL;
+        pFile->mFile = NULL;
         pFile->mFileLen = vktrace_FileLike_GetFileLength(fp);
+        pFile->mMessageStream = NULL;
+        pFile->mMemAddr = NULL;
+        pFile->mMemCurrAddr = NULL;
+
+        if (pFile->mFileLen == 0) {
+            vktrace_LogError("Failed to create FileLike, file length is 0!");
+            return pFile;
+        }
+
+        if (preload) {
+            vktrace_LogDebug("Preload trace file to memory.");
+            pFile->mMode = Memory;
+            char* addr = NULL;
+
+#if !defined(WIN32)
+            // mmap does not work on Windows
+            addr = (char*)mmap(NULL, pFile->mFileLen, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_POPULATE, fileno(fp), 0);
+            if (addr == MAP_FAILED) {
+                vktrace_LogError("Failed to mmap tracefile for replaying.");
+                addr = NULL;
+            }
+#else
+            // TODO: Find a better solution to make it work with a large trace file
+            addr = VKTRACE_NEW_ARRAY(char, pFile->mFileLen);
+            if (addr == NULL) {
+                vktrace_LogError("Failed to malloc memory to load tracefile for replaying.");
+            } else {
+                if (1 != fread(addr, (size_t)pFile->mFileLen, 1, fp)) {
+                    if (ferror(fp) != 0) {
+                        perror("fread error");
+                    } else if (feof(fp) != 0) {
+                        vktrace_LogVerbose("Reached end of file.");
+                    }
+                    VKTRACE_DELETE(addr);
+                    addr = NULL;
+                }
+            }
+#endif
+            pFile->mMemAddr = addr;
+            pFile->mMemCurrAddr = addr;
+        } else {
+            vktrace_LogDebug("Do not preload trace file.");
+            pFile->mMode = File;
+            pFile->mFile = fp;
+        }
     }
     return pFile;
 }
@@ -109,8 +152,22 @@ FileLike* vktrace_FileLike_create_msg(MessageStream* _msgStream) {
         pFile->mFile = NULL;
         pFile->mMessageStream = _msgStream;
         pFile->mFileLen = 0;
+        pFile->mMemAddr = NULL;
+        pFile->mMemCurrAddr = NULL;
     }
     return pFile;
+}
+
+// ------------------------------------------------------------------------------------------------
+void vktrace_FileLike_free(FileLike* pFileLike) {
+    if (pFileLike->mMemAddr) {
+#if !defined(WIN32)
+        munmap(pFileLike->mMemAddr, pFileLike->mFileLen);
+#else
+        vktrace_free(pFileLike->mMemAddr);
+#endif
+    }
+    vktrace_free(pFileLike);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -131,22 +188,38 @@ uint64_t vktrace_FileLike_Read(FileLike* pFileLike, void* _bytes, uint64_t _len)
 // ------------------------------------------------------------------------------------------------
 BOOL vktrace_FileLike_ReadRaw(FileLike* pFileLike, void* _bytes, uint64_t _len) {
     BOOL result = TRUE;
-    assert((pFileLike->mFile != 0) ^ (pFileLike->mMessageStream != 0));
+    assert((pFileLike->mFile != 0) ^ (pFileLike->mMessageStream != 0) ^ (pFileLike->mMemAddr != NULL));
 
     switch (pFileLike->mMode) {
         case File: {
-            if (1 != fread(_bytes, (size_t)_len, 1, pFileLike->mFile)) {
-                if (ferror(pFileLike->mFile) != 0) {
-                    perror("fread error");
-                } else if (feof(pFileLike->mFile) != 0) {
-                    vktrace_LogVerbose("Reached end of file.");
+            if (pFileLike->mFile != NULL) {
+                if (1 != fread(_bytes, (size_t)_len, 1, pFileLike->mFile)) {
+                    if (ferror(pFileLike->mFile) != 0) {
+                        perror("fread error");
+                    } else if (feof(pFileLike->mFile) != 0) {
+                        vktrace_LogVerbose("Reached end of file.");
+                    }
+                    result = FALSE;
                 }
+            } else {
                 result = FALSE;
             }
             break;
         }
         case Socket: {
             result = vktrace_MessageStream_BlockingRecv(pFileLike->mMessageStream, _bytes, _len);
+            break;
+        }
+        case Memory: {
+            if (pFileLike->mMemAddr == NULL) {
+                result = FALSE;
+            } else if (pFileLike->mMemCurrAddr + _len > pFileLike->mMemAddr + pFileLike->mFileLen) {
+                vktrace_LogVerbose("Reached end of file.");
+                result = FALSE;
+            } else {
+                memcpy(_bytes, pFileLike->mMemCurrAddr, _len);
+                pFileLike->mMemCurrAddr += _len;
+            }
             break;
         }
 
@@ -188,11 +261,15 @@ BOOL vktrace_FileLike_WriteRaw(FileLike* pFile, const void* _bytes, uint64_t _le
 // ------------------------------------------------------------------------------------------------
 uint64_t vktrace_FileLike_GetCurrentPosition(FileLike* pFileLike) {
     uint64_t offset = 0;
-    assert((pFileLike->mFile != 0));
+    assert((pFileLike->mFile != 0) ^ (pFileLike->mMemAddr != NULL));
 
     switch (pFileLike->mMode) {
         case File: {
             offset = Ftell(pFileLike->mFile);
+            break;
+        }
+        case Memory: {
+            offset = pFileLike->mMemCurrAddr - pFileLike->mMemAddr;
             break;
         }
 
@@ -205,11 +282,18 @@ uint64_t vktrace_FileLike_GetCurrentPosition(FileLike* pFileLike) {
 // ------------------------------------------------------------------------------------------------
 BOOL vktrace_FileLike_SetCurrentPosition(FileLike* pFileLike, uint64_t offset) {
     BOOL ret = FALSE;
-    assert((pFileLike->mFile != 0));
+    assert((pFileLike->mFile != 0) ^ (pFileLike->mMemAddr != NULL));
 
     switch (pFileLike->mMode) {
         case File: {
             if (Fseek(pFileLike->mFile, offset, SEEK_SET) == 0) {
+                ret = TRUE;
+            }
+            break;
+        }
+        case Memory: {
+            pFileLike->mMemCurrAddr = pFileLike->mMemAddr + offset;
+            if (pFileLike->mMemCurrAddr <= (pFileLike->mMemAddr + pFileLike->mFileLen)) {
                 ret = TRUE;
             }
             break;

--- a/vktrace/vktrace_common/vktrace_filelike.c
+++ b/vktrace/vktrace_common/vktrace_filelike.c
@@ -69,7 +69,7 @@ uint64_t vktrace_FileLike_GetFileLength(FILE* fp) {
     // Get file length
     int64_t length = 0;
     if (Fseek(fp, 0, SEEK_END) != 0) {
-        vktrace_LogError("Failed to Fseek to the end of tracefile for replaying.");
+        vktrace_LogError("Failed to fseek to the end of tracefile for replaying.");
     } else {
         length = Ftell(fp);
         if (length == -1L) {
@@ -99,12 +99,12 @@ FileLike* vktrace_FileLike_create_file(FILE* fp, BOOL preload) {
         pFile->mMemCurrAddr = NULL;
 
         if (pFile->mFileLen == 0) {
-            vktrace_LogError("Failed to create FileLike, file length is 0!");
+            vktrace_LogError("Failed to read trace file, file length is 0!");
             return pFile;
         }
 
         if (preload) {
-            vktrace_LogDebug("Preload trace file to memory.");
+            vktrace_LogAlways("Preloading trace file...");
             pFile->mMode = Memory;
             char* addr = NULL;
 
@@ -124,18 +124,19 @@ FileLike* vktrace_FileLike_create_file(FILE* fp, BOOL preload) {
                 if (1 != fread(addr, (size_t)pFile->mFileLen, 1, fp)) {
                     if (ferror(fp) != 0) {
                         perror("fread error");
-                    } else if (feof(fp) != 0) {
-                        vktrace_LogVerbose("Reached end of file.");
                     }
+                    vktrace_LogError("Failed to read trace file!");
                     VKTRACE_DELETE(addr);
                     addr = NULL;
                 }
             }
 #endif
+            if (addr != NULL) {
+                vktrace_LogAlways("Preloading trace file completed.");
+            }
             pFile->mMemAddr = addr;
             pFile->mMemCurrAddr = addr;
         } else {
-            vktrace_LogDebug("Do not preload trace file.");
             pFile->mMode = File;
             pFile->mFile = fp;
         }

--- a/vktrace/vktrace_common/vktrace_filelike.h
+++ b/vktrace/vktrace_common/vktrace_filelike.h
@@ -35,10 +35,12 @@ typedef struct MessageStream MessageStream;
 struct FileLike;
 typedef struct FileLike FileLike;
 typedef struct FileLike {
-    enum { File, Socket } mMode;
+    enum { File, Socket, Memory } mMode;
     FILE* mFile;
     uint64_t mFileLen;
     MessageStream* mMessageStream;
+    char* mMemAddr;
+    char* mMemCurrAddr;
 } FileLike;
 
 // For creating checkpoints (consistency checks) in the various streams we're interacting with.
@@ -60,10 +62,13 @@ BOOL vktrace_Checkpoint_read(Checkpoint* pCheckpoint, FileLike* _in);
 // reads and writes.
 
 // create a filelike interface for file streaming
-FileLike* vktrace_FileLike_create_file(FILE* fp);
+FileLike* vktrace_FileLike_create_file(FILE* fp, BOOL preload);
 
 // create a filelike interface for network streaming
 FileLike* vktrace_FileLike_create_msg(MessageStream* _msgStream);
+
+// free filelike interface
+void vktrace_FileLike_free(FileLike* pFileLike);
 
 // read a size and then a buffer of that size
 uint64_t vktrace_FileLike_Read(FileLike* pFileLike, void* _bytes, uint64_t _len);

--- a/vktrace/vktrace_replay/vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay.cpp
@@ -26,7 +26,7 @@
 #include "vktrace_vk_packet_id.h"
 #include "vktrace_tracelog.h"
 
-static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, -1, -1, NULL, NULL, NULL};
+static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, -1, -1, NULL, NULL, NULL, FALSE};
 
 vkReplay* g_pReplayer = NULL;
 VKTRACE_CRITICAL_SECTION g_handlerLock;

--- a/vktrace/vktrace_replay/vkreplay_main.h
+++ b/vktrace/vktrace_replay/vkreplay_main.h
@@ -30,6 +30,7 @@ typedef struct vkreplayer_settings {
     const char* screenshotList;
     const char* screenshotColorFormat;
     const char* verbosity;
+    BOOL preloadTraceFile;
 } vkreplayer_settings;
 
 #include <vector>

--- a/vktrace/vktrace_replay/vkreplay_seq.cpp
+++ b/vktrace/vktrace_replay/vkreplay_seq.cpp
@@ -27,7 +27,9 @@ extern "C" {
 namespace vktrace_replay {
 
 vktrace_trace_packet_header *Sequencer::get_next_packet() {
-    vktrace_free(m_lastPacket);
+    if (m_pFile->mMode != FileLike::Memory) {
+        vktrace_free(m_lastPacket);
+    }
     if (!m_pFile) return (NULL);
     m_lastPacket = vktrace_read_trace_packet(m_pFile);
     return (m_lastPacket);

--- a/vktrace/vktrace_replay/vkreplay_seq.h
+++ b/vktrace/vktrace_replay/vkreplay_seq.h
@@ -50,7 +50,9 @@ class Sequencer : public AbstractSequencer {
 
     void clean_up() {
         if (m_lastPacket) {
-            free(m_lastPacket);
+            if (m_pFile->mMode != FileLike::Memory) {
+                free(m_lastPacket);
+            }
             m_lastPacket = NULL;
         }
     }

--- a/vktrace/vktrace_replay/vkreplay_settings.cpp
+++ b/vktrace/vktrace_replay/vkreplay_settings.cpp
@@ -26,7 +26,7 @@
 // declared as extern in header
 vkreplayer_settings g_vkReplaySettings;
 
-static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, -1, -1, NULL, NULL, NULL};
+static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, -1, -1, NULL, NULL, NULL, FALSE};
 
 vktrace_SettingInfo g_vk_settings_info[] = {
     {"o",
@@ -43,6 +43,13 @@ vktrace_SettingInfo g_vk_settings_info[] = {
      {&s_defaultVkReplaySettings.pTraceFilePath},
      TRUE,
      "(Deprecated, use -o or --Open instead) The trace file to replay."},
+    {"pltf",
+     "PreloadTraceFile",
+     VKTRACE_SETTING_BOOL,
+     {&g_vkReplaySettings.preloadTraceFile},
+     {&s_defaultVkReplaySettings.preloadTraceFile},
+     TRUE,
+     "Preload tracefile to memory before replay."},
     {"l",
      "NumLoops",
      VKTRACE_SETTING_UINT,


### PR DESCRIPTION
This change adds a new option "-pltf" to help user to pre-load trace
file to memory when running vkreplay. (with "-pltf true")

It helps to replay a trace file faster especially on a system with slow
file I/O.

But the pre-load requires NumLoops to be 1 because the memory
pre-loaded with a trace file may be overwritten during replay in the
first loop which will cause problem in the second or later loops.