### PR TITLE
vkreplay: Print frame per second

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -130,6 +130,13 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
     bool trace_running = true;
     int prevFrameNumber = -1;
 
+    if (settings.loopEndFrame != -1) {
+        // Increase by 1 because it is comparing with the frame number which is increased right after vkQueuePresentKHR being
+        // called.
+        // e.g. when frame number is 3, maybe frame 2 is just finished replaying and frame 3 is not started yet.
+        settings.loopEndFrame += 1;
+    }
+
     // record the location of looping start packet
     seq.record_bookmark();
     seq.get_bookmark(startingPacket);
@@ -224,8 +231,8 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
                                                         : std::min(replayer->GetFrameNumber(), settings.loopEndFrame);
             int frame_number = end_frame - start_frame;
             double fps = static_cast<double>(frame_number) / (end_time - start_time) * 1000000000;
-            vktrace_LogAlways("fps %f (loop duration(ns) %llu, frame number %d (%d , %d))", fps, end_time - start_time,
-                              frame_number, start_frame, end_frame - 1);
+            vktrace_LogAlways("fps %f (loop duration(seconds) %f, frame number %d (%d , %d))", fps,
+                              static_cast<double>(end_time - start_time) / 1000000000, frame_number, start_frame, end_frame - 1);
         } else {
             vktrace_LogError("fps error!");
         }

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -230,9 +230,15 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
             int end_frame = settings.loopEndFrame == -1 ? replayer->GetFrameNumber()
                                                         : std::min(replayer->GetFrameNumber(), settings.loopEndFrame);
             int frame_number = end_frame - start_frame;
-            double fps = static_cast<double>(frame_number) / (end_time - start_time) * 1000000000;
-            vktrace_LogAlways("%f fps, %f seconds, %d frames, framerange %d-%d", fps,
-                              static_cast<double>(end_time - start_time) / 1000000000, frame_number, start_frame, end_frame - 1);
+            if (frame_number <= 0) {
+                vktrace_LogError("Loop start frame is greater than loop end frame!");
+                err = -1;
+                goto out;
+            } else {
+                double fps = static_cast<double>(frame_number) / (end_time - start_time) * 1000000000;
+                vktrace_LogAlways("%f fps, %f seconds, %d frames, framerange %d-%d", fps,
+                                  static_cast<double>(end_time - start_time) / 1000000000, frame_number, start_frame, end_frame - 1);
+            }
         } else {
             vktrace_LogError("fps error!");
         }

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <string>
+#include <algorithm>
 #if defined(ANDROID)
 #include <sstream>
 #include <android/log.h>

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -231,7 +231,7 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
                                                         : std::min(replayer->GetFrameNumber(), settings.loopEndFrame);
             int frame_number = end_frame - start_frame;
             double fps = static_cast<double>(frame_number) / (end_time - start_time) * 1000000000;
-            vktrace_LogAlways("fps %f (loop duration(seconds) %f, frame number %d (%d , %d))", fps,
+            vktrace_LogAlways("%f fps, %f seconds, %d frames, framerange %d-%d", fps,
                               static_cast<double>(end_time - start_time) / 1000000000, frame_number, start_frame, end_frame - 1);
         } else {
             vktrace_LogError("fps error!");


### PR DESCRIPTION
This change prints frame per second after finish replaying a trace file
for user to easily measure the performance.

If a trace file is replayed with multiple loops "NumLoops > 1", the
frame per second will be printed after each loop.