### PR TITLE
layersvt: Devsim 1.2.3 bug fix

### DIFF
--- a/layersvt/linux/VkLayer_device_simulation.json
+++ b/layersvt/linux/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "./libVkLayer_device_simulation.so",
         "api_version": "1.1.70",
-        "implementation_version": "1.2.2",
+        "implementation_version": "1.2.3",
         "description": "LunarG device simulation layer"
     }
 }

--- a/layersvt/windows/VkLayer_device_simulation.json
+++ b/layersvt/windows/VkLayer_device_simulation.json
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_device_simulation.dll",
         "api_version": "1.1.70",
-        "implementation_version": "1.2.2",
+        "implementation_version": "1.2.3",
         "description": "LunarG device simulation layer"
     }
 }

--- a/tests/devsim_layer_test.sh
+++ b/tests/devsim_layer_test.sh
@@ -63,7 +63,7 @@ export VK_DEVSIM_FILENAME="devsim_test2_in1.json:devsim_test2_in2.json:devsim_te
 [ $? -eq 0 ] || fail_msg "test2 vulkaninfo"
 
 # Use jq to extract, reformat, and sort the output.
-JSON_SECTIONS='{VkPhysicalDeviceProperties,VkPhysicalDeviceFeatures,VkPhysicalDeviceMemoryProperties,ArrayOfVkFormatProperties}'
+JSON_SECTIONS='{VkPhysicalDeviceProperties,VkPhysicalDeviceFeatures,VkPhysicalDeviceMemoryProperties,ArrayOfVkQueueFamilyProperties,ArrayOfVkFormatProperties}'
 jq -S $JSON_SECTIONS $FILENAME_02_TEMP1 > $FILENAME_02_TEMP2
 [ $? -eq 0 ] || fail_msg "test2 jq extraction"
 

--- a/tests/devsim_test2_gold.json
+++ b/tests/devsim_test2_gold.json
@@ -25,6 +25,38 @@
       "optimalTilingFeatures": 900005005
     }
   ],
+  "ArrayOfVkQueueFamilyProperties": [
+    {
+      "minImageTransferGranularity": {
+        "depth": 900004001,
+        "height": 900004002,
+        "width": 900004003
+      },
+      "queueCount": 1,
+      "queueFlags": 900004005,
+      "timestampValidBits": 900004006
+    },
+    {
+      "minImageTransferGranularity": {
+        "depth": 900004007,
+        "height": 900004008,
+        "width": 900004009
+      },
+      "queueCount": 1,
+      "queueFlags": 900004011,
+      "timestampValidBits": 900004012
+    },
+    {
+      "minImageTransferGranularity": {
+        "depth": 900004013,
+        "height": 900004014,
+        "width": 900004015
+      },
+      "queueCount": 1,
+      "queueFlags": 900004017,
+      "timestampValidBits": 900004018
+    }
+  ],
   "VkPhysicalDeviceFeatures": {
     "alphaToOne": 118,
     "depthBiasClamp": 113,


### PR DESCRIPTION
The DevSim implementation of vkGetPhysicalDeviceQueueFamilyProperties2KHR() was incorrectly populating the destination properties array.

This also restores the QueueFamilyProperties test that was temporarily disabled to avoid breaking CI.

Change-Id: I2ff07574e7ab7502932dae86b299e7abae1d5b32