### PR TITLE
vktrace: use absolute program path on Linux

### DIFF
--- a/vktrace/vktrace_common/vktrace_process.c
+++ b/vktrace/vktrace_common/vktrace_process.c
@@ -25,10 +25,10 @@
 BOOL vktrace_process_spawn(vktrace_process_info* pInfo) {
     assert(pInfo != NULL);
 
+    char fullExePath[_MAX_PATH];
 #if defined(WIN32)
     {
         unsigned long processCreateFlags = CREATE_DEFAULT_ERROR_MODE | CREATE_SUSPENDED;
-        char fullExePath[_MAX_PATH];
         PROCESS_INFORMATION processInformation;
         STARTUPINFO si = {0};
         si.cb = sizeof(si);
@@ -65,6 +65,8 @@ BOOL vktrace_process_spawn(vktrace_process_info* pInfo) {
         const char delim[] = " \t";
         unsigned int idx;
 
+        realpath(pInfo->exeName, fullExePath);
+
         // Change process name so the the tracer DLLs will behave as expected when loaded.
         // NOTE: Must be 15 characters or less.
         const char* tmpProcName = "vktraceChildProcess";
@@ -75,7 +77,7 @@ BOOL vktrace_process_spawn(vktrace_process_info* pInfo) {
             vktrace_LogError("Failed to set working directory.");
         }
 
-        args[0] = pInfo->exeName;
+        args[0] = fullExePath;
         args[127] = NULL;
         idx = 1;
         args[idx] = pInfo->processArgs ? strtok(pInfo->processArgs, delim) : NULL;
@@ -83,7 +85,7 @@ BOOL vktrace_process_spawn(vktrace_process_info* pInfo) {
             idx++;
             args[idx] = strtok(NULL, delim);
         }
-        vktrace_LogDebug("exec process=%s argc=%u\n", pInfo->exeName, idx);
+        vktrace_LogDebug("exec process=%s argc=%u\n", fullExePath, idx);
 #if 0  // uncoment to print out list of env vars
         char *env = environ[0];
         idx = 0;
@@ -95,8 +97,9 @@ BOOL vktrace_process_spawn(vktrace_process_info* pInfo) {
             env = environ[idx];
         }
 #endif
-        if (execv(pInfo->exeName, args) < 0) {
+        if (execv(fullExePath, args) < 0) {
             vktrace_LogError("Failed to spawn process.");
+            perror(NULL);
             exit(1);
         }
     }


### PR DESCRIPTION
Currently, relative paths as arguments to vktrace's "-p" option
do not work on Linux because the working directory is changed
before execv is called, rendering it unable to find the program.

This change fully cannonicalizes these paths before changing the
working directory, similarly to the current behaviour on Windows.