### PR TITLE
Fix vkreplay arg processing to reject negative values for unsigned settings.

### DIFF
--- a/vktrace/vktrace_common/vktrace_settings.c
+++ b/vktrace/vktrace_common/vktrace_settings.c
@@ -77,6 +77,15 @@ BOOL vktrace_SettingInfo_parse_value(vktrace_SettingInfo* pSetting, const char* 
             if (sscanf(arg, "%u", pSetting->Data.pUint) != 1) {
                 vktrace_LogWarning("Invalid unsigned int setting: '%s'. Resetting to default value instead.", arg);
                 *(pSetting->Data.pUint) = *(pSetting->Default.pUint);
+            } else {
+                // sscanf() happily parses negative numbers into unsigned ints without any indication.
+                // Look for a leading '-' to detect a negative number.
+                // Using sscanf() with a %d and signed int allows an easy way to check for negative values,
+                // but misses the range between INT_MAX and UINT_MAX.
+                if (arg[0] == '-') {
+                    vktrace_LogError("Invalid unsigned int setting: '%s'.", arg);
+                    return FALSE;
+                }
             }
         } break;
         case VKTRACE_SETTING_INT: {

--- a/vktrace/vktrace_replay/vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay.cpp
@@ -26,7 +26,7 @@
 #include "vktrace_vk_packet_id.h"
 #include "vktrace_tracelog.h"
 
-static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, -1, -1, NULL, NULL, NULL};
+static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, UINT_MAX, UINT_MAX, NULL, NULL, NULL};
 
 vkReplay* g_pReplayer = NULL;
 VKTRACE_CRITICAL_SECTION g_handlerLock;

--- a/vktrace/vktrace_replay/vkreplay_main.h
+++ b/vktrace/vktrace_replay/vkreplay_main.h
@@ -25,8 +25,8 @@
 typedef struct vkreplayer_settings {
     char* pTraceFilePath;
     unsigned int numLoops;
-    int loopStartFrame;
-    int loopEndFrame;
+    unsigned int loopStartFrame;
+    unsigned int loopEndFrame;
     const char* screenshotList;
     const char* screenshotColorFormat;
     const char* verbosity;

--- a/vktrace/vktrace_replay/vkreplay_settings.cpp
+++ b/vktrace/vktrace_replay/vkreplay_settings.cpp
@@ -26,7 +26,7 @@
 // declared as extern in header
 vkreplayer_settings g_vkReplaySettings;
 
-static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, -1, -1, NULL, NULL, NULL};
+static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, UINT_MAX, UINT_MAX, NULL, NULL, NULL};
 
 vktrace_SettingInfo g_vk_settings_info[] = {
     {"o",
@@ -52,14 +52,14 @@ vktrace_SettingInfo g_vk_settings_info[] = {
      "The number of times to replay the trace file or loop range."},
     {"lsf",
      "LoopStartFrame",
-     VKTRACE_SETTING_INT,
+     VKTRACE_SETTING_UINT,
      {&g_vkReplaySettings.loopStartFrame},
      {&s_defaultVkReplaySettings.loopStartFrame},
      TRUE,
      "The start frame number of the loop range."},
     {"lef",
      "LoopEndFrame",
-     VKTRACE_SETTING_INT,
+     VKTRACE_SETTING_UINT,
      {&g_vkReplaySettings.loopEndFrame},
      {&s_defaultVkReplaySettings.loopEndFrame},
      TRUE,


### PR DESCRIPTION
Fixes #395 

and addresses a similar problem with the -lsf and -lef settings.