### PR TITLE
vktrace: Search for matching physical device

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -92,6 +92,7 @@ class vkReplay {
     int m_frameNumber;
     vktrace_trace_file_header* m_pFileHeader;
     struct_gpuinfo* m_pGpuinfo;
+    uint32_t m_gpu_count = 0;
 
     // Replay platform description
     uint64_t m_replay_endianess;


### PR DESCRIPTION
When enumerating physical devices in vkreplay, first check for a
matching device based on the vendor and hardware IDs. If no match is
found, map based on the indices.

Change-Id: I606886de30408380aba68a6ad3039ffa9a78420a