### PR TITLE
android: Fix android build

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -58,7 +58,7 @@ echo Generating VT layer factory header/source files
 echo ********
 py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% layer_factory.h
 py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% layer_factory.cpp
-py -3 %VT_SCRIPTS%\vt_genvk.py ..\..\..\layer_factory
+py -3 %VT_SCRIPTS%\vlf_makefile_generator.py ..\..\..\layer_factory
 
 REM apidump
 echo Generating VT apidump header/source files

--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -19,9 +19,10 @@ if exist generated (
 )
 mkdir generated\include generated\common
 
-set LVL_SCRIPTS=../../../submodules/Vulkan-LoaderAndValidationLayers/scripts
-set VT_SCRIPTS=../../../scripts
-set REGISTRY=../../../submodules/Vulkan-LoaderAndValidationLayers/scripts/vk.xml
+LVL_BASE=../submodules/Vulkan-LoaderAndValidationLayers
+LVL_SCRIPTS=../../${LVL_BASE}/scripts
+VT_SCRIPTS=../../../scripts
+REGISTRY=../../${LVL_BASE}/scripts/vk.xml
 
 cd generated/include
 py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_safe_struct.h
@@ -60,5 +61,14 @@ REM vkreplay
 py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vkreplay_vk_func_ptrs.h
 py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vkreplay_vk_replay_gen.cpp
 py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vkreplay_vk_objmapper.h
+
+REM Copy over the built source files to the LVL submodule.  Otherwise,
+REM cube won't build.
+pushd ${LVL_BASE}/build-android
+RMDIR /S /Q generated
+MKDIR /S generated/include
+MKDIR /S generated/common
+popd
+XCOPY /S /Y /R /Q * ../../${LVL_BASE}/build-android/generated/include
 
 cd ../..

--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -1,6 +1,6 @@
 @echo off
-REM # Copyright 2015 The Android Open Source Project
-REM # Copyright (C) 2015 Valve Corporation
+REM # Copyright 2015-2018 The Android Open Source Project
+REM # Copyright (C) 2015-2018 Valve Corporation
 REM
 REM # Licensed under the Apache License, Version 2.0 (the "License");
 REM # you may not use this file except in compliance with the License.
@@ -14,61 +14,98 @@ REM # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 REM # See the License for the specific language governing permissions and
 REM # limitations under the License.
 
+echo Removing old generated directory in VT\build-android
+echo ********
 if exist generated (
-  rmdir /s /q generated
+    RMDIR /S /Q generated
 )
-mkdir generated\include generated\common
 
-LVL_BASE=../submodules/Vulkan-LoaderAndValidationLayers
-LVL_SCRIPTS=../../${LVL_BASE}/scripts
-VT_SCRIPTS=../../../scripts
-REGISTRY=../../${LVL_BASE}/scripts/vk.xml
+echo Creating new empty generated directories in VT\build-android
+echo ********
+MKDIR generated
+MKDIR generated\include
+MKDIR generated\common
 
-cd generated/include
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_safe_struct.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_safe_struct.cpp
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_enum_string_helper.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_object_types.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_dispatch_table_helper.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% thread_check.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% parameter_validation.cpp
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% unique_objects_wrappers.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_layer_dispatch_table.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_extension_helper.h
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% object_tracker.cpp
-py -3 %LVL_SCRIPTS%/lvl_genvk.py -registry %REGISTRY% vk_typemap_helper.h
-py -3 %LVL_SCRIPTS%/external_revision_generator.py --git_dir ../../third_party/shaderc/third_party/spirv-tools -s SPIRV_TOOLS_COMMIT_ID -o spirv_tools_commit_id.h
+echo Setting some environment variables
+echo ********
+set LVL_BASE=..\submodules\Vulkan-LoaderAndValidationLayers
+set LVL_SCRIPTS=..\..\%LVL_BASE%\scripts
+set VT_SCRIPTS=..\..\..\scripts
+set REGISTRY=..\..\%LVL_BASE%\scripts\vk.xml
+
+echo Entering Generated/Include Folder
+echo ********
+pushd generated\include
+
+echo Generating LVL header/source files
+echo ********
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_safe_struct.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_safe_struct.cpp
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_enum_string_helper.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_object_types.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_dispatch_table_helper.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% thread_check.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% parameter_validation.cpp
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% unique_objects_wrappers.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_layer_dispatch_table.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_extension_helper.h
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% object_tracker.cpp
+py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% vk_typemap_helper.h
+py -3 %LVL_SCRIPTS%\external_revision_generator.py --git_dir ..\..\third_party\shaderc\third_party\spirv-tools -s SPIRV_TOOLS_COMMIT_ID -o spirv_tools_commit_id.h
 
 REM layer factory
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% layer_factory.h
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% layer_factory.cpp
-py -3 %VT_SCRIPTS%/vt_genvk.py ../../../layer_factory
+echo Generating VT layer factory header/source files
+echo ********
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% layer_factory.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% layer_factory.cpp
+py -3 %VT_SCRIPTS%\vt_genvk.py ..\..\..\layer_factory
 
 REM apidump
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% api_dump.cpp
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% api_dump_text.h
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% api_dump_html.h
+echo Generating VT apidump header/source files
+echo ********
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% api_dump.cpp
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% api_dump_text.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% api_dump_html.h
 
 REM vktrace
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vktrace_vk_vk.h
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vktrace_vk_vk.cpp
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vktrace_vk_vk_packets.h
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vktrace_vk_packet_id.h
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vk_struct_size_helper.h
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vk_struct_size_helper.c
+echo Generating VT vktrace header/source files
+echo ********
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vktrace_vk_vk.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vktrace_vk_vk.cpp
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vktrace_vk_vk_packets.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vktrace_vk_packet_id.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vk_struct_size_helper.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vk_struct_size_helper.c
 
 REM vkreplay
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vkreplay_vk_func_ptrs.h
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vkreplay_vk_replay_gen.cpp
-py -3 %VT_SCRIPTS%/vt_genvk.py -registry %REGISTRY% vkreplay_vk_objmapper.h
+echo Generating VT vkreplay header/source files
+echo ********
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vkreplay_vk_func_ptrs.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vkreplay_vk_replay_gen.cpp
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% vkreplay_vk_objmapper.h
 
 REM Copy over the built source files to the LVL submodule.  Otherwise,
 REM cube won't build.
-pushd ${LVL_BASE}/build-android
-RMDIR /S /Q generated
-MKDIR /S generated/include
-MKDIR /S generated/common
-popd
-XCOPY /S /Y /R /Q * ../../${LVL_BASE}/build-android/generated/include
+echo Entering submodules\Vulkan-LoaderAndValidationLayers\build-android
+echo ********
+pushd ..\..\%LVL_BASE%\build-android
+REM Removing old generated directory in submodules\Vulkan-LoaderAndValidationLayers\build-android
+if exist generated (
+    RMDIR /S /Q generated
+)
+REM Creating new empty generated directories in submodules\Vulkan-LoaderAndValidationLayers\build-android
+MKDIR generated
+MKDIR generated\include
+MKDIR generated\common
 
-cd ../..
+echo Leaving submodules\Vulkan-LoaderAndValidationLayers\build-android
+echo ********
+popd
+
+echo Copying generated headers/source into submodules\Vulkan-LoaderAndValidationLayers\build-android
+echo ********
+COPY /Y * ..\..\%LVL_BASE%\build-android\generated\include
+
+echo leaving Generated/Include Folder
+echo ********
+popd

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -21,9 +21,10 @@ cd $dir
 rm -rf generated
 mkdir -p generated/include generated/common
 
-LVL_SCRIPTS=../../../submodules/Vulkan-LoaderAndValidationLayers/scripts
+LVL_BASE=../submodules/Vulkan-LoaderAndValidationLayers
+LVL_SCRIPTS=../../${LVL_BASE}/scripts
 VT_SCRIPTS=../../../scripts
-REGISTRY=../../../submodules/Vulkan-LoaderAndValidationLayers/scripts/vk.xml
+REGISTRY=../../${LVL_BASE}/scripts/vk.xml
 
 ( cd generated/include; python3 ${LVL_SCRIPTS}/lvl_genvk.py -registry ${REGISTRY} vk_safe_struct.h )
 ( cd generated/include; python3 ${LVL_SCRIPTS}/lvl_genvk.py -registry ${REGISTRY} vk_safe_struct.cpp )
@@ -63,5 +64,8 @@ REGISTRY=../../../submodules/Vulkan-LoaderAndValidationLayers/scripts/vk.xml
 ( cd generated/include; python3 ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} vkreplay_vk_func_ptrs.h )
 ( cd generated/include; python3 ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} vkreplay_vk_replay_gen.cpp )
 ( cd generated/include; python3 ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} vkreplay_vk_objmapper.h )
+
+( pushd ${LVL_BASE}/build-android; rm -rf generated; mkdir -p generated/include generated/common; popd )
+( cd generated/include; cp -rf * ../../${LVL_BASE}/build-android/generated/include )
 
 exit 0


### PR DESCRIPTION
build_all.sh in Android failed to build because the LVL submodule
did not have the generated include files in the proper location.

This has been verified on Linux, and needs to be verified on
Windows.