### PR TITLE
vktrace: Remove buffer size assert from data copy

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -233,9 +233,8 @@ void* vktrace_trace_packet_get_new_buffer_address(vktrace_trace_packet_header* p
 // pBuffer in the function.
 void vktrace_add_buffer_to_trace_packet(vktrace_trace_packet_header* pHeader, void** ptr_address, uint64_t size,
                                         const void* pBuffer) {
-    // Make sure we have valid pointers and sizes. All pointers and sizes must be 4 byte aligned.
+    // Make sure we have a valid pointer.
     assert(ptr_address != NULL);
-    assert((size & 0x3) == 0);
 
     if (pBuffer == NULL || size == 0) {
         *ptr_address = NULL;


### PR DESCRIPTION
Removes an assert from vktrace_add_buffer_to_trace_packet() that
required the buffer size to be a multiple of 4. This function handles
buffers with sizes that are not multiples of 4, and the unnecessary
assert is causing some traces to fail.
