### PR TITLE
vkreplay: Fix pNext processing error

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -2645,7 +2645,6 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                             'pNonConst->pViewportState = (const VkPipelineViewportStateCreateInfo*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pPacket->pCreateInfos[i].pViewportState);\n',
                             '// Raster State\n',
                             'pNonConst->pRasterizationState = (const VkPipelineRasterizationStateCreateInfo*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pPacket->pCreateInfos[i].pRasterizationState);\n',
-                            'vktrace_interpret_pnext_pointers(pHeader, (void *)pNonConst->pRasterizationState);\n',
 
 
                             '// MultiSample State\n',


### PR DESCRIPTION
Fix for LunarXchange 757.

The pNext field for VkPipelineRasterizationStateCreateInfo structs was getting interpreted (converted) twice.  This would cause vkreplay to crash if this pNext pointed to something.

Can easily repro this problem by adding a struct to pNext in the cube demo.  Then create a trace and then replay.

```diff
diff --git a/demos/cube.c b/demos/cube.c
index b8b4950..4e9180f 100644
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -1971,6 +1971,10 @@ static void demo_prepare_pipeline(struct demo *demo) {
     rs.rasterizerDiscardEnable = VK_FALSE;
     rs.depthBiasEnable = VK_FALSE;
     rs.lineWidth = 1.0f;
+    VkPipelineRasterizationStateRasterizationOrderAMD a;
+    a.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD;
+    a.pNext = NULL;
+    rs.pNext = (void*)&a;

     memset(&cb, 0, sizeof(cb));
```
