### PR TITLE
vkreplay: GH446, Auto reorient to fit surface extent

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -277,6 +277,9 @@ class vkReplay {
     // Map device to extension property count, for device extension property queries
     std::unordered_map<VkPhysicalDevice, uint32_t> replayDeviceExtensionPropertyCount;
 
+    // Map VkSurfaceKHR to VkSurfaceCapabilitiesKHR
+    std::unordered_map<VkSurfaceKHR, VkSurfaceCapabilitiesKHR> replaySurfaceCapabilities;
+
     bool modifyMemoryTypeIndexInAllocateMemoryPacket(VkDevice remappedDevice, packet_vkAllocateMemory* pPacket);
 
     bool getMemoryTypeIdx(VkDevice traceDevice, VkDevice replayDevice, uint32_t traceIdx, VkMemoryRequirements* memRequirements,


### PR DESCRIPTION
This change is comparing content's orientation with surface's
orientation, if they are not match, vkreplay will rotate the content 90
degrees to make the content shown in expected orientation.

It is implemented by setting VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR to
pCreateInfo->preTransform in vkCreateSwapchainKHR() when the content's
orientation does not match surface's orientation retrieved via
vkGetPhysicalDeviceSurfaceCapabilitiesKHR().