### PR TITLE
vktrace: Adjust Android screen orientation for replay

### DIFF
--- a/build-android/vkreplay/AndroidManifest.xml
+++ b/build-android/vkreplay/AndroidManifest.xml
@@ -13,7 +13,12 @@
 
         <!-- Our activity is the built-in NativeActivity framework class.
              This will take care of integrating with our NDK code. -->
-        <activity android:name="android.app.NativeActivity" android:label="@string/app_name" android:exported="true">
+        <activity android:name="android.app.NativeActivity"
+                  android:label="@string/app_name"
+                  android:exported="true"
+                  android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
+                  android:screenOrientation="unspecified">
+
             <!-- Tell NativeActivity the name of or .so -->
             <meta-data android:name="android.app.lib_name" android:value="vkreplay"/>
             <intent-filter>

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -719,7 +719,7 @@ void android_main(struct android_app* app) {
             // sleep(10);
 
             // Call into common code
-            int err = vkreplay_main(argc, argv, app->window);
+            int err = vkreplay_main(argc, argv, app);
             __android_log_print(ANDROID_LOG_DEBUG, appTag, "vkreplay_main returned %i", err);
 
             ANativeActivity_finish(app->activity);

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <android/log.h>
 #include <android_native_app_glue.h>
+#include "vkreplay_vkdisplay.h"
 #endif
 #include "vktrace_common.h"
 #include "vktrace_tracelog.h"
@@ -651,7 +652,20 @@ std::vector<std::string> get_args(android_app& app, const char* intent_extra_dat
     return args;
 }
 
-static int32_t processInput(struct android_app* app, AInputEvent* event) { return 0; }
+static int32_t processInput(struct android_app* app, AInputEvent* event) {
+    if ((app->userData != nullptr) && (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION)) {
+        vkDisplay* display = reinterpret_cast<vkDisplay*>(app->userData);
+
+        // TODO: Distinguish between tap and swipe actions; swipe to advance to next frame when paused.
+        int32_t action = AMotionEvent_getAction(event);
+        if (action == AMOTION_EVENT_ACTION_UP) {
+            display->set_pause_status(!display->get_pause_status());
+            return 1;
+        }
+    }
+
+    return 0;
+}
 
 static void processCommand(struct android_app* app, int32_t cmd) {
     switch (cmd) {
@@ -675,6 +689,9 @@ static void processCommand(struct android_app* app, int32_t cmd) {
 // Start with carbon copy of main() and convert it to support Android, then diff them and move common code to helpers.
 void android_main(struct android_app* app) {
     const char* appTag = "vkreplay";
+
+    // This will be set by the vkDisplay object.
+    app->userData = nullptr;
 
     int vulkanSupport = InitVulkan();
     if (vulkanSupport == 0) {

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
@@ -386,6 +386,8 @@ void vkDisplay::resize_window(const unsigned int width, const unsigned int heigh
                 m_jni_vm->DetachCurrentThread();
             }
         }
+
+        ANativeWindow_setBuffersGeometry(m_window, width, height, ANativeWindow_getFormat(m_window));
 #else
 #if defined VKREPLAY_USE_WSI_XCB
         uint32_t values[2];

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
@@ -249,6 +249,7 @@ int vkDisplay::set_window(vktrace_window_handle hWindow, unsigned int width, uns
     m_window = hWindow->window;
     m_surface.window = hWindow->window;
     m_android_app = hWindow;
+    m_android_app->userData = this;
 #else
 #if defined VKREPLAY_USE_WSI_XCB
     m_XcbWindow = hWindow;

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.h
@@ -31,6 +31,10 @@
 #include "vktrace_multiplatform.h"
 #include "vkreplay_window.h"
 
+#if defined(PLATFORM_LINUX) && defined(ANDROID)
+#include <jni.h>
+#endif
+
 class vkDisplay : public vktrace_replay::ReplayDisplayImp {
     friend class vkReplay;
 
@@ -73,6 +77,8 @@ class vkDisplay : public vktrace_replay::ReplayDisplayImp {
 #if defined(ANDROID)
     VkIcdSurfaceAndroid m_surface;
     ANativeWindow* m_window;
+    JavaVM* m_jni_vm;
+    jobject m_jni_activity;
 #else
 #if defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb m_surface;

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.h
@@ -31,10 +31,6 @@
 #include "vktrace_multiplatform.h"
 #include "vkreplay_window.h"
 
-#if defined(PLATFORM_LINUX) && defined(ANDROID)
-#include <jni.h>
-#endif
-
 class vkDisplay : public vktrace_replay::ReplayDisplayImp {
     friend class vkReplay;
 
@@ -77,8 +73,7 @@ class vkDisplay : public vktrace_replay::ReplayDisplayImp {
 #if defined(ANDROID)
     VkIcdSurfaceAndroid m_surface;
     ANativeWindow* m_window;
-    JavaVM* m_jni_vm;
-    jobject m_jni_activity;
+    struct android_app* m_android_app;
 #else
 #if defined VKREPLAY_USE_WSI_XCB
     VkIcdSurfaceXcb m_surface;

--- a/vktrace/vktrace_replay/vkreplay_window.h
+++ b/vktrace/vktrace_replay/vkreplay_window.h
@@ -27,7 +27,7 @@ extern "C" {
 #if defined(PLATFORM_LINUX) || defined(XCB_NVIDIA)
 #if defined(ANDROID)
 #include <android_native_app_glue.h>
-typedef ANativeWindow* vktrace_window_handle;
+typedef struct android_app* vktrace_window_handle;
 #else
 #if defined VKREPLAY_USE_WSI_XCB
 #include <xcb/xcb.h>


### PR DESCRIPTION
Implements vkDisplay::resize_window for Android, to adjust the
screen orientation based on the requested window width and height.
Screen orientation is changed by invoking Activity.setRequestedOrientation
through JNI.