### PR TITLE
Add install target for vktraceviewer

### DIFF
--- a/vktrace/vktrace_viewer/CMakeLists.txt
+++ b/vktrace/vktrace_viewer/CMakeLists.txt
@@ -256,4 +256,7 @@ if (MSVC)
 endif()
 
 build_options_finalize()
+if(UNIX)
+    install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 endif(NOT Qt5_FOUND)


### PR DESCRIPTION
Add a CMake install target for vktraceviewer when generating build files for CMake UNIX targets.

Addresses #468.
