### PR TITLE
vktrace: Fix trimming for VkFenceCreateInfo

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -3522,6 +3522,7 @@ void write_all_referenced_object_calls() {
 
         VkFenceCreateInfo createInfo;
         createInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        createInfo.pNext = nullptr;
         createInfo.flags = (obj->second.ObjectInfo.Fence.signaled) ? VK_FENCE_CREATE_SIGNALED_BIT : 0;
 
         vktrace_trace_packet_header *pCreateFence = generate::vkCreateFence(false, device, &createInfo, pAllocator, &fence);


### PR DESCRIPTION
The trace trim code was not initializing VkFenceCreateInfo::pNext to
NULL and an uninitialized value was written to the trace file.  This
would lead to replay crashes at fence creation when pNext contained
a non-zero value, such as an uninitialized memory debug pattern.
