### PR TITLE
Fix compile on archlinux.

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -48,6 +48,7 @@
 #include <vector>
 #include <fstream>
 #include <mutex>
+#include <sstream>
 
 #include <json/json.h>  // https://github.com/open-source-parsers/jsoncpp
 


### PR DESCRIPTION
Fixes

../layersvt/device_simulation.cpp: In member function ‘bool {anonymous}::JsonLoader::LoadFiles(const char*)’:
../layersvt/device_simulation.cpp:725:44: error: variable ‘std::stringstream ss_list’ has initializer but incomplete type
     std::stringstream ss_list(filename_list);
                                            ^