### PR TITLE
android: vktracereplay.sh: Stop timed out app

### DIFF
--- a/build-android/vktracereplay.sh
+++ b/build-android/vktracereplay.sh
@@ -343,6 +343,10 @@ do
     then
         echo "vktrace timeout reached: $vktrace_seconds seconds"
         echo "No vktrace screenshot, closing down"
+        # Cleanup
+        adb $serialFlag shell am force-stop $package
+        adb $serialFlag shell setprop debug.vulkan.layer.1 '""'
+        adb $serialFlag shell setprop debug.vulkan.layer.2 '""'
         exit 1
     fi
 
@@ -400,6 +404,9 @@ do
     then
         echo "vkreplay timeout reached: $vkreplay_seconds seconds"
         echo "No vkreplay screenshot, closing down"
+        # Cleanup
+        adb $serialFlag shell am force-stop com.example.vkreplay
+        adb $serialFlag shell setprop debug.vulkan.layer.1 '""'
         exit 1
     fi
     sleep 5


### PR DESCRIPTION
When running vktracereplay.sh, if the screenshot image is never received,
kill the app.

Change-Id: I292fb91e1ed35063032e443eefc113a0602f4dda