### PR TITLE
vktrace: Check for loadable trace library

### DIFF
--- a/vktrace/vktrace_common/vktrace_platform.h
+++ b/vktrace/vktrace_common/vktrace_platform.h
@@ -165,10 +165,10 @@ void vktrace_leave_critical_section(VKTRACE_CRITICAL_SECTION* pCriticalSection);
 void vktrace_delete_critical_section(VKTRACE_CRITICAL_SECTION* pCriticalSection);
 
 #if defined(PLATFORM_LINUX) || defined(PLATFORM_OSX)
-#define VKTRACE_LIBRARY_NAME(projname) (sizeof(void*) == 4) ? "lib" #projname "32.so" : "lib" #projname ".so"
+#define VKTRACE_LIBRARY_NAME(projname) "lib" #projname ".so"
 #endif
 #if defined(WIN32)
-#define VKTRACE_LIBRARY_NAME(projname) (sizeof(void*) == 4) ? #projname "32.dll" : #projname ".dll"
+#define VKTRACE_LIBRARY_NAME(projname) #projname ".dll"
 #endif
 
 BOOL vktrace_platform_remote_load_library(vktrace_process_handle pProcessHandle, const char* dllPath,

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -390,6 +390,18 @@ int main(int argc, char* argv[]) {
             fflush(stdout);
             g_settings.arguments = NULL;
         } else {
+            // We are not in server mode.
+
+            // Verify trace layer is available.
+            void* traceLayerLibHandle;
+            traceLayerLibHandle = vktrace_platform_open_library(VKTRACE_LIBRARY_NAME(VkLayer_vktrace_layer));
+            if (!traceLayerLibHandle) {
+                vktrace_LogError("Cannot find trace layer %s", VKTRACE_LIBRARY_NAME(VkLayer_vktrace_layer));
+                return -1;
+            }
+            vktrace_platform_close_library(traceLayerLibHandle);
+
+            // Give warning if working directory is not specified
             if (g_settings.working_dir == NULL || strlen(g_settings.working_dir) == 0) {
                 CHAR* buf = VKTRACE_NEW_ARRAY(CHAR, 4096);
                 vktrace_LogVerbose("No working directory (-w) parameter found: Assuming executable's path as working directory.");


### PR DESCRIPTION
Modified vktrace when in non-server mode to checkout to see if the
trace layer library file is available and loadable, and generates an
error if is is not. This helps prevent the scenario in which vktrace
hangs or crashes when the trace layer can't be loaded.

Change-Id: I61f02f5aff9cc56b5382ef58b94351f6e9b2b928