### PR TITLE
vktrace: GH500, Fix deadlock in vktrace

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -208,6 +208,9 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
     vktrace_trace_packet_header* pHeader;
     packet_vkMapMemory* pPacket = NULL;
     VKAllocInfo* entry;
+#ifdef USE_PAGEGUARD_SPEEDUP
+    pageguardEnter();
+#endif
     CREATE_TRACE_PACKET(vkMapMemory, sizeof(void*));
     result = mdd(device)->devTable.MapMemory(device, memory, offset, size, flags, ppData);
     vktrace_set_packet_entrypoint_end_time(pHeader);
@@ -219,9 +222,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
     }
 
 #ifdef USE_PAGEGUARD_SPEEDUP
-    pageguardEnter();
     getPageGuardControlInstance().vkMapMemoryPageGuardHandle(device, memory, offset, size, flags, ppData);
-    pageguardExit();
 #endif
     pPacket = interpret_body_as_vkMapMemory(pHeader);
     pPacket->device = device;
@@ -254,6 +255,9 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
             vktrace_delete_trace_packet(&pHeader);
         }
     }
+#ifdef USE_PAGEGUARD_SPEEDUP
+    pageguardExit();
+#endif
     return result;
 }
 


### PR DESCRIPTION
This change fixes deadlock when tracing a multithread application by
making sure the locks in an API call are acquired in a consistent order.