### PR TITLE
vktrace: Fix lock on locked mutex lock

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -494,15 +494,14 @@ VkResult vkFlushMappedMemoryRangesWithoutAPICall(VkDevice device, uint32_t memor
     if (!g_trimEnabled) {
         // trim not enabled, send packet as usual
         FINISH_TRACE_PACKET();
-    } else if (g_trimIsPreTrim) {
+    } else {
         vktrace_finalize_trace_packet(pHeader);
-    } else if (g_trimIsInTrim) {
-        // Currently tracing the frame, so need to track references & store packet to write post-tracing.
-        vktrace_finalize_trace_packet(pHeader);
-        trim::write_packet(pHeader);
-    } else  // g_trimIsPostTrim
-    {
-        vktrace_delete_trace_packet(&pHeader);
+        if (g_trimIsInTrim) {
+            // Currently tracing the frame, so need to track references & store packet to write post-tracing.
+            trim::write_packet(pHeader);
+        } else {
+            vktrace_delete_trace_packet(&pHeader);
+        }
     }
     return result;
 }

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -854,7 +854,8 @@ void generateMapUnmap(bool makeCalls, VkDevice device, VkDeviceMemory memory, Vk
         // unmap for it.
         vktrace_delete_trace_packet(&pMapMemory);
     } else {
-        *ppMapMemoryPacket = pMapMemory;
+        *ppMapMemoryPacket = trim::copy_packet(pMapMemory);
+        vktrace_delete_trace_packet(&pMapMemory);
 
         // By creating the packet for UnmapMemory, we'll be adding the pData
         // buffer to it, which inherently copies it.
@@ -873,7 +874,9 @@ void generateMapUnmap(bool makeCalls, VkDevice device, VkDeviceMemory memory, Vk
 
         // Actually unmap the memory if it wasn't already mapped by the
         // application
-        *ppUnmapMemoryPacket = generate::vkUnmapMemory(makeCalls, size, bufferAddress, device, memory);
+        vktrace_trace_packet_header *pUnmapMemory = generate::vkUnmapMemory(makeCalls, size, bufferAddress, device, memory);
+        *ppUnmapMemoryPacket = trim::copy_packet(pUnmapMemory);
+        vktrace_delete_trace_packet(&pUnmapMemory);
     }
 }
 
@@ -1476,7 +1479,8 @@ void snapshot_state_tracker() {
             if (size != 0) {
                 vktrace_trace_packet_header *pPersistentlyMapMemory =
                     generate::vkMapMemory(false, device, deviceMemory, offset, size, flags, &pData);
-                iter->second.ObjectInfo.DeviceMemory.pPersistentlyMapMemoryPacket = pPersistentlyMapMemory;
+                iter->second.ObjectInfo.DeviceMemory.pPersistentlyMapMemoryPacket = trim::copy_packet(pPersistentlyMapMemory);
+                vktrace_delete_trace_packet(&pPersistentlyMapMemory);
             }
         }
     }


### PR DESCRIPTION
vktrace_delete_trace_packet() which will leave critical section
s_trace_lock is not always being called after CREATE_TRACE_PACKET
which will enter critical section s_trace_lock in:

1. vkFlushMappedMemoryRangesWithoutAPICall()
2. generateMapUnmap()
3. generate a vkMapMemory to recreate the persistently mapped buffers
in snapshot_state_tracker()

This will cause missing "leave critical section" or lock on an already
locked mutex lock.

This change fixed it by always call vktrace_delete_trace_packet() after
CREATE_TRACE_PACKET.