### PR TITLE
vktrace: fix trim pnext handling error in vkCreateGraphicsPipelines

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
@@ -1125,6 +1125,7 @@ vktrace_trace_packet_header *vkCreateGraphicsPipelines(bool makeCall, VkDevice d
     pPacket->createInfoCount = createInfoCount;
     vktrace_add_buffer_to_trace_packet(pHeader, (void **)&(pPacket->pCreateInfos),
                                        createInfoCount * sizeof(VkGraphicsPipelineCreateInfo), pCreateInfos);
+    vktrace_add_pnext_structs_to_trace_packet(pHeader, (void **)&(pPacket->pCreateInfos), pCreateInfos);
     add_VkGraphicsPipelineCreateInfos_to_trace_packet(pHeader, (VkGraphicsPipelineCreateInfo *)pPacket->pCreateInfos, pCreateInfos,
                                                       createInfoCount);
     vktrace_add_buffer_to_trace_packet(pHeader, (void **)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);


### PR DESCRIPTION
vkCreateGraphicsPipelines lack pnext handling for trim, it cause generate
wrong trimmed trace file and crash when playback the trace file. The
change fix the error.

XCAP-952

Change-Id: Ic1c83c1509479ee0b26fad5eb8fb9cc12371eed6