### PR TITLE
vkreplay: Re-implement cross platform replay

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -688,7 +688,8 @@ class VkTraceFileOutputGenerator(OutputGenerator):
             if cmdname in temp_exclude: # TODO verify this needs to be here
                 continue
             protect = cmd_protect_dict[api.name]
-            if protect is not None:
+            do_protect = (protect != None and protect != "VK_USE_PLATFORM_XLIB_KHR" and protect != "VK_USE_PLATFORM_XCB" and protect != "VK_USE_PLATFORM_WAYLAND_KHR" and protect != "VK_USE_PLATFORM_WIN32_KHR")
+            if do_protect:
                 replay_gen_source += '#ifdef %s\n' % protect
             disp_table = ""
             if isInstanceCmd(api):
@@ -699,7 +700,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 replay_gen_source += '    %s.%s = (PFN_vk%s)(vktrace_platform_get_library_entrypoint(handle, "vk%s"));\n' % (disp_table, cmdname, cmdname, cmdname)
             else: # These func ptrs get assigned at GetProcAddr time
                 replay_gen_source += '    %s.%s = (PFN_vk%s)NULL;\n' % (disp_table, cmdname, cmdname)
-            if protect is not None:
+            if do_protect:
                 replay_gen_source += '#endif // %s\n' % protect
         replay_gen_source += '}\n\n'
         replay_gen_source += 'vktrace_replay::VKTRACE_REPLAY_RESULT vkReplay::replay(vktrace_trace_packet_header *packet) { \n'
@@ -720,7 +721,8 @@ class VkTraceFileOutputGenerator(OutputGenerator):
 
             cmdinfo = cmd_info_dict[vk_cmdname]
             protect = cmd_protect_dict[vk_cmdname]
-            if protect is not None:
+            do_protect = (protect != None and protect != "VK_USE_PLATFORM_XLIB_KHR" and protect != "VK_USE_PLATFORM_XCB" and protect != "VK_USE_PLATFORM_WAYLAND_KHR" and protect != "VK_USE_PLATFORM_WIN32_KHR")
+            if do_protect:
                 replay_gen_source += '#ifdef %s\n' % protect
             # TODO : How to handle void* return of GetProcAddr?
             # TODO : Make sure vkDestroy object functions really do clean up the object maps
@@ -959,7 +961,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 replay_gen_source += '            CHECK_RETURN_VALUE(vk%s);\n' % cmdname
             replay_gen_source += '            break;\n'
             replay_gen_source += '        }\n'
-            if protect is not None:
+            if do_protect:
                 replay_gen_source += '#endif // %s\n' % protect
         replay_gen_source += '        default:\n'
         replay_gen_source += '            vktrace_LogWarning("Unrecognized packet_id %u, skipping.", packet->packet_id);\n'

--- a/vktrace/vktrace_common/vktrace_multiplatform.h
+++ b/vktrace/vktrace_common/vktrace_multiplatform.h
@@ -144,10 +144,6 @@ typedef struct VkWin32SurfaceCreateInfoKHR {
     HINSTANCE hinstance;
     HWND window;
 } VkWin32SurfaceCreateInfoKHR;
-typedef VkResult(VKAPI_PTR* PFN_vkCreateWin32SurfaceKHR)(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
-                                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
-typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR)(VkPhysicalDevice physicalDevice,
-                                                                                uint32_t queueFamilyIndex);
 
 typedef struct VkMemoryWin32HandlePropertiesKHR {
     VkStructureType sType;
@@ -195,6 +191,28 @@ typedef struct VkFenceGetWin32HandleInfoKHR {
     VkFence fence;
     VkExternalFenceHandleTypeFlagBitsKHR handleType;
 } VkFenceGetWin32HandleInfoKHR;
+
+typedef VkResult(VKAPI_PTR* PFN_vkCreateWin32SurfaceKHR)(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR)(VkPhysicalDevice physicalDevice,
+                                                                                uint32_t queueFamilyIndex);
+typedef VkResult(VKAPI_PTR* PFN_vkGetMemoryWin32HandleKHR)(VkDevice device,
+                                                           const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                           HANDLE* pHandle);
+typedef VkResult(VKAPI_PTR* PFN_vkGetMemoryWin32HandlePropertiesKHR)(
+    VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, HANDLE handle,
+    VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties);
+typedef VkResult(VKAPI_PTR* PFN_vkImportSemaphoreWin32HandleKHR)(
+    VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo);
+typedef VkResult(VKAPI_PTR* PFN_vkGetSemaphoreWin32HandleKHR)(VkDevice device,
+                                                              const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                              HANDLE* pHandle);
+typedef VkResult(VKAPI_PTR* PFN_vkImportFenceWin32HandleKHR)(VkDevice device,
+                                                             const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo);
+typedef VkResult(VKAPI_PTR* PFN_vkGetFenceWin32HandleKHR)(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                          HANDLE* pHandle);
+typedef VkResult(VKAPI_PTR* PFN_vkGetMemoryWin32HandleNV)(VkDevice device, VkDeviceMemory memory,
+                                                          VkExternalMemoryHandleTypeFlagsNV handleType, HANDLE* pHandle);
 
 #endif
 

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -49,7 +49,26 @@ extern "C" {
 
 #include "vulkan/vulkan.h"
 
+#if defined(PLATFORM_LINUX)
+#define VK_USE_PLATFORM_WIN32_KHR
+#endif
+#if defined(PLATFORM_WINDOWS)
+#define VK_USE_PLATFORM_XLIB_KHR
+#define VK_USE_PLATFORM_XCB_KHR
+#define VK_USE_PLATFORM_WAYLAND_KHR
+#endif
+
 #include "vk_layer_dispatch_table.h"
+
+#if defined(PLATFORM_LINUX)
+#undef VK_USE_PLATFORM_WIN32_KHR
+#endif
+#if defined(PLATFORM_WINDOWS)
+#undef VK_USE_PLATFORM_XLIB_KHR
+#undef VK_USE_PLATFORM_XCB_KHR
+#undef VK_USE_PLATFORM_WAYLAND_KHR
+#endif
+
 #include "vk_dispatch_table_helper.h"
 
 #include "vkreplay_vkdisplay.h"


### PR DESCRIPTION
Allow traces created on Windows to be replayed on Linux, and vise-versa.
Cross platform replay probably requires that GPUs be from the same vendor
and that the driver versions be close.

Tested by tracing a simple program (cube) on Linux and replaying on
Windows using nVidia GPUs, and vise-versa.  This worked, but many
configurations will not work because of inherent differences in
GPUs and driver implementations.

This used to work many commits ago, got broken sometime in the past,
and it has been fixed to work again.