### PR TITLE
vkreplay: Replace map with unordered_map

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -489,7 +489,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
         replay_objmapper_header  = '\n'
         replay_objmapper_header += '#pragma once\n\n'
         replay_objmapper_header += '#include <set>\n'
-        replay_objmapper_header += '#include <map>\n'
+        replay_objmapper_header += '#include <unordered_map>\n'
         replay_objmapper_header += '#include <list>\n'
         replay_objmapper_header += '#include <vector>\n'
         replay_objmapper_header += '#include <string>\n'
@@ -519,7 +519,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 obj_name = item[2:].lower() + 'Obj'
             else:
                 obj_name = item
-            replay_objmapper_header += '    std::map<%s, %s> %s;\n' % (item, obj_name, mangled_name)
+            replay_objmapper_header += '    std::unordered_map<%s, %s> %s;\n' % (item, obj_name, mangled_name)
             replay_objmapper_header += '    void add_to_%s_map(%s pTraceVal, %s pReplayVal) {\n' % (map_name, item, obj_name)
             replay_objmapper_header += '        %s[pTraceVal] = pReplayVal;\n' % mangled_name
             replay_objmapper_header += '    }\n\n'
@@ -531,14 +531,14 @@ class VkTraceFileOutputGenerator(OutputGenerator):
             replay_objmapper_header += '    %s remap_%s(const %s& value) {\n' % (item, map_name, item)
             replay_objmapper_header += '        if (value == 0) { return 0; }\n'
             if item in remapped_objects:
-                replay_objmapper_header += '        std::map<%s, %s>::const_iterator q = %s.find(value);\n' % (item, obj_name, mangled_name)
+                replay_objmapper_header += '        std::unordered_map<%s, %s>::const_iterator q = %s.find(value);\n' % (item, obj_name, mangled_name)
                 if item == 'VkDeviceMemory':
                     replay_objmapper_header += '        if (q == %s.end()) { vktrace_LogError("Failed to remap %s."); return VK_NULL_HANDLE; }\n' % (mangled_name, item)
                 else:
                     replay_objmapper_header += '        if (q == %s.end()) return VK_NULL_HANDLE;\n' % mangled_name
                 replay_objmapper_header += '        return q->second.replay%s;\n' % item[2:]
             else:
-                replay_objmapper_header += '        std::map<%s, %s>::const_iterator q = %s.find(value);\n' % (item, obj_name, mangled_name)
+                replay_objmapper_header += '        std::unordered_map<%s, %s>::const_iterator q = %s.find(value);\n' % (item, obj_name, mangled_name)
                 replay_objmapper_header += '        if (q == %s.end()) { vktrace_LogError("Failed to remap %s."); return VK_NULL_HANDLE; }\n' % (mangled_name, item)
                 replay_objmapper_header += '        return q->second;\n'
             replay_objmapper_header += '    }\n\n'

--- a/vktrace/vktrace_replay/vkreplay_objmapper_class_defs.h
+++ b/vktrace/vktrace_replay/vkreplay_objmapper_class_defs.h
@@ -170,7 +170,7 @@ class vkReplayObjMapper {
     void init_objMemCount(const uint64_t handle, const VkDebugReportObjectTypeEXT objectType, const uint32_t &num) {
         switch (objectType) {
             case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT: {
-                std::map<VkBuffer, bufferObj>::iterator it = m_buffers.find((VkBuffer)handle);
+                std::unordered_map<VkBuffer, bufferObj>::iterator it = m_buffers.find((VkBuffer)handle);
                 if (it != m_buffers.end()) {
                     objMemory obj = it->second.bufferMem;
                     obj.setCount(num);
@@ -179,7 +179,7 @@ class vkReplayObjMapper {
                 break;
             }
             case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT: {
-                std::map<VkImage, imageObj>::iterator it = m_images.find((VkImage)handle);
+                std::unordered_map<VkImage, imageObj>::iterator it = m_images.find((VkImage)handle);
                 if (it != m_images.end()) {
                     objMemory obj = it->second.imageMem;
                     obj.setCount(num);
@@ -197,7 +197,7 @@ class vkReplayObjMapper {
                          const unsigned int num) {
         switch (objectType) {
             case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT: {
-                std::map<VkBuffer, bufferObj>::iterator it = m_buffers.find((VkBuffer)handle);
+                std::unordered_map<VkBuffer, bufferObj>::iterator it = m_buffers.find((VkBuffer)handle);
                 if (it != m_buffers.end()) {
                     objMemory obj = it->second.bufferMem;
                     obj.setReqs(pMemReqs, num);
@@ -206,7 +206,7 @@ class vkReplayObjMapper {
                 break;
             }
             case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT: {
-                std::map<VkImage, imageObj>::iterator it = m_images.find((VkImage)handle);
+                std::unordered_map<VkImage, imageObj>::iterator it = m_images.find((VkImage)handle);
                 if (it != m_images.end()) {
                     objMemory obj = it->second.imageMem;
                     obj.setReqs(pMemReqs, num);


### PR DESCRIPTION
This change replaces std::map with std::unordered_map in vkreplay to
have better performance when looking up elements from objmapper.