### PR TITLE
vkreplay: Make debug verbosity work on all builds

### DIFF
--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -16,7 +16,7 @@ Options for the `vktrace` command are:
 | -w&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;WorkingDir&nbsp;&lt;string&gt; | Alternate working directory | the application's directory |
 | -P&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PMB&nbsp;&lt;bool&gt; | Trace  persistently mapped buffers | true |
 | -tr&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TraceTrigger&nbsp;&lt;string&gt; | Start/stop trim by hotkey or frame range. String arg is one of:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hotkey-[F1-F12\|TAB\|CONTROL]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;frames-&lt;startframe&gt;-&lt;endframe&gt;| on |
-| -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
+| -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", "full", or "debug" | errors |
 
 In local tracing mode, both the `vktrace` and application executables reside on the same system.
 
@@ -110,7 +110,7 @@ The  `vkreplay` command-line  options are:
 | -c&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;CompatibilityMode&nbsp;&lt;bool&gt; | Enable compatibility mode - modify api calls as needed when replaying trace file created on different platform than replay platform. For example: Convert trace file memory indices to replay device memory indices. | true |
 | -s&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Screenshot&nbsp;&lt;string&gt; | Comma-separated list of frame numbers of which to take screen shots  | no screenshots |
 | -sf&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;ScreenshotFormat&nbsp;&lt;string&gt; | Color Space format of screenshot files. Formats are UNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB  | Format of swapchain image |
-| -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
+| -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", "full", or "debug" | errors |
 
 To replay the cube application trace captured in the example above:
 

--- a/vktrace/vktrace_common/vktrace_tracelog.c
+++ b/vktrace/vktrace_common/vktrace_tracelog.c
@@ -142,14 +142,12 @@ void vktrace_LogAlways(const char* format, ...) {
 }
 
 void vktrace_LogDebug(const char* format, ...) {
-#if defined(_DEBUG)
     if (vktrace_LogIsLogging(VKTRACE_LOG_DEBUG)) {
         va_list args;
         va_start(args, format);
         LogGuts(VKTRACE_LOG_DEBUG, format, args);
         va_end(args);
     }
-#endif
 }
 
 void vktrace_LogError(const char* format, ...) {

--- a/vktrace/vktrace_common/vktrace_tracelog.h
+++ b/vktrace/vktrace_common/vktrace_tracelog.h
@@ -64,8 +64,7 @@ BOOL vktrace_LogIsLogging(VktraceLogLevel level);
 // Always log the message, no matter what the ReportingLevel is.
 void vktrace_LogAlways(const char* format, ...);
 
-// Log debug information that is primarily helpful for Vktrace developers
-// and will only appear in _DEBUG builds.
+// Log debug information that is primarily helpful for Vktrace developers.
 // This will also always be logged, no matter what the ReportingLevel is.
 void vktrace_LogDebug(const char* format, ...);
 

--- a/vktrace/vktrace_layer/vktrace_lib.c
+++ b/vktrace/vktrace_layer/vktrace_lib.c
@@ -133,10 +133,8 @@ extern VKTRACER_ENTRY _Load(void) {
             vktrace_LogSetLevel(VKTRACE_LOG_WARNING);
         else if (verbosity && !strcmp(verbosity, "full"))
             vktrace_LogSetLevel(VKTRACE_LOG_VERBOSE);
-#ifdef _DEBUG
         else if (verbosity && !strcmp(verbosity, "debug"))
             vktrace_LogSetLevel(VKTRACE_LOG_DEBUG);
-#endif
         else
             // Either verbosity=="errors", or it wasn't specified
             vktrace_LogSetLevel(VKTRACE_LOG_ERROR);

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -111,7 +111,6 @@ vktrace_SettingInfo g_settings_info[] = {
      {&replaySettings.screenshotColorFormat},
      TRUE,
      "Color Space format of screenshot files. Formats are UNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB"},
-#if _DEBUG
     {"v",
      "Verbosity",
      VKTRACE_SETTING_STRING,
@@ -120,16 +119,6 @@ vktrace_SettingInfo g_settings_info[] = {
      TRUE,
      "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", \"full\", "
      "\"debug\"."},
-#else
-    {"v",
-     "Verbosity",
-     VKTRACE_SETTING_STRING,
-     {&replaySettings.verbosity},
-     {&replaySettings.verbosity},
-     TRUE,
-     "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", "
-     "\"full\"."},
-#endif
 };
 
 vktrace_SettingGroup g_replaySettingGroup = {"vkreplay", sizeof(g_settings_info) / sizeof(g_settings_info[0]), &g_settings_info[0]};
@@ -383,10 +372,8 @@ int vkreplay_main(int argc, char** argv, vktrace_window_handle window = 0) {
         vktrace_LogSetLevel(VKTRACE_LOG_WARNING);
     else if (!strcmp(replaySettings.verbosity, "full"))
         vktrace_LogSetLevel(VKTRACE_LOG_VERBOSE);
-#if _DEBUG
     else if (!strcmp(replaySettings.verbosity, "debug"))
         vktrace_LogSetLevel(VKTRACE_LOG_DEBUG);
-#endif
     else {
         vktrace_SettingGroup_print(&g_replaySettingGroup);
         // invalid options specified

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -93,7 +93,6 @@ vktrace_SettingInfo g_settings_info[] = {
      {&g_default_settings.enable_pmb},
      TRUE,
      "Enable tracking of persistently mapped buffers, default is TRUE."},
-#if _DEBUG
     {"v",
      "Verbosity",
      VKTRACE_SETTING_STRING,
@@ -102,17 +101,6 @@ vktrace_SettingInfo g_settings_info[] = {
      TRUE,
      "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", \"full\", "
      "\"debug\"."},
-#else
-    {"v",
-     "Verbosity",
-     VKTRACE_SETTING_STRING,
-     {&g_settings.verbosity},
-     {&g_default_settings.verbosity},
-     TRUE,
-     "Verbosity mode. Modes are \"quiet\", \"errors\", \"warnings\", "
-     "\"full\"."},
-#endif
-
     {"tr",
      "TraceTrigger",
      VKTRACE_SETTING_STRING,
@@ -347,10 +335,8 @@ int main(int argc, char* argv[]) {
             vktrace_LogSetLevel(VKTRACE_LOG_WARNING);
         else if (strcmp(g_settings.verbosity, "full") == 0)
             vktrace_LogSetLevel(VKTRACE_LOG_VERBOSE);
-#if _DEBUG
         else if (strcmp(g_settings.verbosity, "debug") == 0)
             vktrace_LogSetLevel(VKTRACE_LOG_DEBUG);
-#endif
         else {
             vktrace_LogSetLevel(VKTRACE_LOG_ERROR);
             validArgs = FALSE;


### PR DESCRIPTION
This change makes debug verbosity ("-v debug" option) work on both
_DEBUG build and non _DEBUG build.  It helps to make debug verbosity
work on Android build instead of crash when replaying with "-v debug"
option.