### PR TITLE
layersvt: Shader dump in hex format

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -507,6 +507,56 @@ inline void dump_text_array(const T *array, size_t len, const ApiDumpSettings &s
 }
 
 template <typename T, typename... Args>
+inline void dump_text_array_hex(const uint32_t *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
+                                const char *child_type, const char *name, int indents,
+                                std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+    settings.formatNameType(settings.stream(), indents, name, type_string);
+    if (array == NULL) {
+        settings.stream() << "NULL\n";
+        return;
+    }
+    if (settings.showAddress())
+        settings.stream() << (void *)array << "\n";
+    else
+        settings.stream() << "address\n";
+
+    std::stringstream stream;
+    const uint8_t *arraybyte = reinterpret_cast<const uint8_t *>(array);
+    for (size_t i = 0; i < (len * 4) && array != NULL; ++i) {
+        stream << std::hex << std::setw(2) << std::setfill('0') << (int)arraybyte[i] << " ";
+        if (i % 32 == 31) {
+            stream << "\n";
+        }
+    }
+    settings.stream() << stream.str() << "\n";
+}
+
+template <typename T, typename... Args>
+inline void dump_text_array_hex(const uint32_t *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
+                                const char *child_type, const char *name, int indents,
+                                std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+    settings.formatNameType(settings.stream(), indents, name, type_string);
+    if (array == NULL) {
+        settings.stream() << "NULL\n";
+        return;
+    }
+    if (settings.showAddress())
+        settings.stream() << (void *)array << "\n";
+    else
+        settings.stream() << "address\n";
+
+    std::stringstream stream;
+    const uint8_t *arraybyte = reinterpret_cast<const uint8_t *>(array);
+    for (size_t i = 0; i < (len * 4) && array != NULL; ++i) {
+        stream << std::hex << std::setw(2) << std::setfill('0') << (int)arraybyte[i] << " ";
+        if (i % 32 == 31) {
+            stream << "\n";
+        }
+    }
+    settings.stream() << stream.str() << "\n";
+}
+
+template <typename T, typename... Args>
 inline void dump_text_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name,
                               int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args),
                               Args... args) {

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -558,7 +558,7 @@ std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings
     @end if
     @if('{memName}' == 'pCode')
     if(settings.showShader())
-        dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions});
+        dump_text_array_hex<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions});
     else
         dump_text_special("SHADER DATA", settings, "{memType}", "{memName}", indents + 1);
     @end if


### PR DESCRIPTION
This change makes api_dump layer to dump shader in hex format which is
compatible with xxd.

With this change, user is able to copy out the shader hex data to a
file <shader_hex_file> and convert it back to binary using:

xxd -r -p <shader_hex_file>