### PR TITLE
layersvt: Add index to draw call in api dump

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -328,7 +328,7 @@ const char *const ApiDumpSettings::TABS = "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
 
 class ApiDumpInstance {
    public:
-    inline ApiDumpInstance() : dump_settings(NULL), frame_count(0), thread_count(0) {
+    inline ApiDumpInstance() : dump_settings(NULL), frame_count(0), thread_count(0), draw_call_count(0) {
         loader_platform_thread_create_mutex(&output_mutex);
         loader_platform_thread_create_mutex(&frame_mutex);
         loader_platform_thread_create_mutex(&thread_mutex);
@@ -364,6 +364,8 @@ class ApiDumpInstance {
 
         return *dump_settings;
     }
+
+    uint32_t nextDrawcall() { return draw_call_count++; }
 
     // Only used in vktracedump to print thread id in trace file
     void setThreadID(uint64_t trace_thread_id) { thread_id = trace_thread_id; }
@@ -467,6 +469,7 @@ class ApiDumpInstance {
     loader_platform_thread_id thread_map[MAX_THREADS];
     uint32_t thread_count;
     uint64_t thread_id = UINT64_MAX;
+    uint32_t draw_call_count;
 
     loader_platform_thread_mutex cmd_buffer_state_mutex;
     std::map<std::pair<VkDevice, VkCommandPool>, std::unordered_set<VkCommandBuffer> > cmd_buffer_pools;

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -630,8 +630,11 @@ std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} resu
 std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
-    settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount() << ":\\n";
-    settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn}:\\n";
+    settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
+    @if('{funcName}' in ['vkCmdDraw', 'vkCmdDrawIndexed', 'vkCmdDrawIndirect', 'vkCmdDrawIndexedIndirect'])
+    settings.stream() << ", Drawcall " << dump_inst.nextDrawcall();
+    @end if
+    settings.stream() << ":\\n{funcName}({funcNamedParams}) returns {funcReturn}:\\n";
 
     if(settings.showParams())
     {{
@@ -981,7 +984,11 @@ std::ostream& dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams}
         settings.stream() << "<details class='frm'><summary>Frame " << current_frame << "</summary>";
         next_frame++;
     }}
-    settings.stream() << "<div class='thd'>Thread " << dump_inst.threadID() << ":</div>";
+    settings.stream() << "<div class='thd'>Thread " << dump_inst.threadID();
+    @if('{funcName}' in ['vkCmdDraw', 'vkCmdDrawIndexed', 'vkCmdDrawIndirect', 'vkCmdDrawIndexedIndirect'])
+    settings.stream() << ", Drawcall " << dump_inst.nextDrawcall();
+    @end if
+    settings.stream() << ":</div>";
     settings.stream() << "<details class='fn'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), "{funcName}({funcNamedParams})", "{funcReturn}");
     settings.stream() << "</summary>";


### PR DESCRIPTION
This change adds index of draw call to api dump layer's output.
Draw call index will be shown in vkCmdDraw, vkCmdDrawIndexed,
vkCmdDrawIndirect, and vkCmdDrawIndexedIndirect calls in the output of
api dump layer.