### PR TITLE
Consolidate and cleanup vktracereplay tests

### DIFF
--- a/tests/_vktracereplay.ps1
+++ b/tests/_vktracereplay.ps1
@@ -43,28 +43,8 @@ cp ..\..\layersvt\$dPath\VkLayer_screenshot.json .
 cp ..\..\layersvt\$dPath\VkLayer_vktrace_layer.dll .
 cp ..\..\layersvt\$dPath\VkLayer_vktrace_layer.json .
 
-# Change PATH to the temp directory
-$oldpath = $Env:PATH
-$Env:PATH = $pwd
-
-# Set up some modified env vars
-$Env:VK_LAYER_PATH = $pwd
-
-# Do a trace and replay for cube
-& vktrace -o c01.vktrace -s 1 -p cube -a "--c 10" --PMB true > trace.sout 2> trace.serr
-rename-item -path 1.ppm -newname 1-cubetrace.ppm
-& vkreplay  -s 1 -o  c01.vktrace > replay.sout 2> replay.serr
-rename-item -path 1.ppm -newname 1-cubereplay.ppm
-
 # Replay old trace if specified.
 if ($Replay) {
-    if (Test-Path $Replay/cubeold.vktrace) {
-        & vkreplay -s 1 -o "$Replay/cubeold.vktrace" > replayold.sout 2> replayold.serr
-        rename-item -path 1.ppm -newname 1-replayold.ppm
-    }
-
-    # Restore PATH
-    $Env:PATH = $oldpath
     # Run trace/replay test on any .vktrace in this folder
     $tracedir = Join-Path -Path $PWD -ChildPath '..\vktracereplay.py'
     & python $tracedir $Replay $PWD\vktrace.exe $PWD $PWD\vkreplay.exe
@@ -75,79 +55,6 @@ if ($Replay) {
         $exitstatus = 1
     }
 }
-else {
-    # Restore PATH
-    $Env:PATH = $oldpath
-}
-
-# Force a failure - for testing this script
-#cp vulkan.dll 1-cubereplay.ppm
-#rm 1-cubetrace.ppm
-#rm 1-cubereplay.ppm
-
-if ($exitstatus -eq 0) {
-   # Check that two screenshots were created, and the third if replaying an old trace
-   if (!(Test-Path 1-cubetrace.ppm) -or !(Test-Path 1-cubereplay.ppm) -or
-       #!(Test-Path 1-smoketrace.ppm) -or !(Test-Path 1-smokereplay.ppm) -or
-        ($Replay -and (Test-Path $Replay/cubeold.vktrace) -and !(Test-Path 1-replayold.ppm))) {
-           echo 'Trace file does not exist'
-           write-host -background black -foreground red "[  FAILED  ] "  -nonewline;
-           $exitstatus = 1
-   }
-}
-
-if ($exitstatus -eq 0) {
-    # ensure the trace and replay snapshots are identical
-    fc.exe /b 1-cubetrace.ppm 1-cubereplay.ppm > $null
-    if (!(Test-Path 1-cubetrace.ppm) -or !(Test-Path 1-cubereplay.ppm) -or $LastExitCode -eq 1) {
-        echo 'Cube trace files do not match'
-        write-host -background black -foreground red "[  FAILED  ] "  -nonewline;
-        $exitstatus = 1
-    }
-    if ($Replay -and (Test-Path $Replay/cubeold.vktrace)) {
-        # check old trace
-        fc.exe /b "$Replay\cubeold.ppm" 1-replayold.ppm > $null
-        if (!(Test-Path "$Replay/cubeold.ppm") -or !(Test-Path 1-replayold.ppm) -or $LastExitCode -eq 1) {
-            echo 'Old trace does not match'
-            write-host -background black -foreground red "[  FAILED  ] "  -nonewline;
-            $exitstatus = 1
-        }
-    }
-}
-
-# check the average pixel value of each screenshot to ensure something plausible was written
-#if ($exitstatus -eq 0) {
-#    $trace_mean = (convert 1-cubetrace.ppm -format "%[mean]" info:)
-#    $replay_mean = (convert 1-cubereplay.ppm -format "%[mean]" info:)
-#    $version = (identify -version)
-#
-#    # normalize the values so we can support Q8 and Q16 imagemagick installations
-#    if ($version -match "Q8") {
-#        $trace_mean = $trace_mean   / 255 # 2^8-1
-#        $replay_mean = $replay_mean / 255 # 2^8-1
-#    } else {
-#        $trace_mean = $trace_mean   / 65535 # 2^16-1
-#        $replay_mean = $replay_mean / 65535 # 2^16-1
-#    }
-#
-#    # if either screenshot is too bright or too dark, it either failed, or is a bad test
-#    if (($trace_mean -lt 0.10) -or ($trace_mean -gt 0.90)){
-#        echo ''
-#        echo 'Trace screenshot failed mean check, must be in range [0.1, 0.9]'
-#        write-host 'Detected mean:' $trace_mean
-#        echo ''
-#        write-host -background black -foreground red "[  FAILED  ] "  -nonewline;
-#        $exitstatus = 1
-#    }
-#    if (($replay_mean -lt 0.10) -or ($replay_mean -gt 0.90)){
-#        echo ''
-#        echo 'Replay screenshot failed mean check, must be in range [0.1, 0.9]'
-#        write-host 'Detected mean:' $replay_mean
-#        echo ''
-#        write-host -background black -foreground red "[  FAILED  ] "  -nonewline;
-#        $exitstatus = 1
-#    }
-#}
 
 # if we passed all the checks, the test is good
 if ($exitstatus -eq 0) {

--- a/tests/vktracereplay.py
+++ b/tests/vktracereplay.py
@@ -1,19 +1,28 @@
 # Python script for running the regression test for both trace and replay. Python version 3 or greater required.
-# This script operates by iterating through old traces in a directory specified by the user, tracing a replay of the old trace, and replaying the new trace.
-# NOTE - This is normally invoked from _vktracereplay.ps1 or vktracereplay.sh.
+# NOTES - 
+#   Cube is expected to be in the PATH or working directory.
+#   This script is normally invoked from _vktracereplay.ps1 or vktracereplay.sh.
+#
+# Cube is traced and replayed with screenshot comparison, then again with trim.
+# Also runs regression by iterating through old traces in a directory specified by the user, tracing a replay of the old trace, and replaying the new trace.
+#
 # To run this test:
 #    cd <this-dir>
 #    python ./vktracereplay.py <old-trace-directory> <vktrace-exe> <vktrace-layer-path> <vkreplay-exe>
 #
 #    <old-trace-directory> example: "C:\traces\" would result in the script testing against "C:\traces\trace1.vktrace", "C:\traces\trace2.vktrace", etc.
 
-import os, sys, subprocess, time, argparse, filecmp, time
+import os, sys, subprocess, time, argparse, filecmp, time, shutil
+
+
 
 def findnth(haystack, needle, n):
     parts= haystack.split(needle, n+1)
     if len(parts)<=n+1:
         return -1
     return len(haystack)-len(parts[-1])-len(needle)
+
+
 
 def HandleError(msg):
     # If msg is greater than 10 lines,
@@ -23,12 +32,107 @@ def HandleError(msg):
     print (msg)
     sys.exit(1)
 
+
+
 def GetErrorMessage(out):
     matched_lines = [line for line in out.split('\n') if 'error' in line]
     return ''.join(matched_lines)
 
-def TraceReplayTest(testname, traceFile, args):
-    print ('Beginning Test: %s\n' % testname)
+
+
+
+def TraceReplayProgramTest(testname, program, programArgs, args):
+    print ('Beginning Trace/Replay Test: %s\n' % program)
+
+    startTime = time.time()
+
+    # Trace. Screenshot frame 1
+    layerEnv = os.environ.copy()
+    layerEnv['VK_LAYER_PATH'] = args.VkLayerPath
+    out = subprocess.check_output([args.VkTracePath, '-o', '%s.vktrace' % testname, '-p', program, '-a', '%s' % programArgs, '-s', '1', '-w', '.'], env=layerEnv).decode('utf-8')
+
+    if 'error' in out:
+        err = GetErrorMessage(out)
+        HandleError('Errors while tracing:\n%s' % err)
+
+    # Rename 1.ppm to <testname>.trace.ppm
+    if os.path.exists('1.ppm'):
+        os.rename('1.ppm', '%s.trace.ppm' % testname)
+    else:
+        HandleError('Error: Screenshot not taken while tracing.')
+
+    # Replay
+    out = subprocess.check_output([args.VkReplayPath, '-o', '%s.vktrace' % testname, '-s', '1'], env=layerEnv).decode('utf-8')
+
+    if 'error' in out:
+        err = GetErrorMessage(out)
+        HandleError('Error while replaying:\n%s' % err)
+
+    # Rename 1.ppm to <testname>.replay.ppm
+    if os.path.exists('1.ppm'):
+        os.rename('1.ppm', '%s.replay.ppm'% testname)
+    else:
+        HandleError ('Error: Screenshot not taken while replaying.')
+
+    # Compare screenshots
+    if not filecmp.cmp('%s.trace.ppm' % testname, '%s.replay.ppm' % testname):
+        HandleError ('Error: Trace/replay screenshots do not match.')
+
+    elapsed = time.time() - startTime
+
+    print ('Success')
+    print ('Elapsed seconds: %s\n' % elapsed)
+
+
+
+
+def TrimTest(testname, program, programArgs, args):
+    print ('Beginning Trim Test: %s\n' % program)
+
+    startTime = time.time()
+
+    # Trace with trim frames 100-200. Screenshot frame 101
+    layerEnv = os.environ.copy()
+    layerEnv['VK_LAYER_PATH'] = args.VkLayerPath
+    out = subprocess.check_output([args.VkTracePath, '-o', '%s-trim.vktrace' % testname, '-p', program, '-a', '%s' % programArgs, '-tr', 'frames-100-200', '-s', '101', '-w', '.'], env=layerEnv).decode('utf-8')
+
+    if 'error' in out:
+        err = GetErrorMessage(out)
+        HandleError('Errors while tracing with trim:\n%s' % err)
+
+    # Rename 101.ppm to <testname>.trace.ppm
+    if os.path.exists('101.ppm'):
+        os.rename('101.ppm', '%s.trace.ppm' % testname)
+    else:
+        HandleError('Error: Screenshot not taken while tracing.')
+
+    # Replay
+    out = subprocess.check_output([args.VkReplayPath, '-o', '%s-trim.vktrace' % testname, '-s', '2'], env=layerEnv).decode('utf-8')
+
+    if 'error' in out:
+        err = GetErrorMessage(out)
+        HandleError('Error while replaying:\n%s' % err)
+
+    # Rename 1.ppm to <testname>.replay.ppm
+    if os.path.exists('2.ppm'):
+        os.rename('2.ppm', '%s.replay.ppm' % testname)
+    else:
+        HandleError ('Error: Screenshot not taken while replaying.')
+
+    # Compare screenshots
+    if not filecmp.cmp('%s.trace.ppm' % testname, '%s.replay.ppm' % testname):
+        HandleError ('Error: Trim Trace/replay screenshots do not match.')
+
+    elapsed = time.time() - startTime
+
+    print ('Success')
+    print ('Elapsed seconds: %s\n' % elapsed)
+
+
+
+
+def TraceReplayTraceTest(testname, traceFile, args):
+    print ('Beginning Trace/Replay Test: %s\n' % testname)
 
     startTime = time.time()
 
@@ -40,9 +144,9 @@ def TraceReplayTest(testname, traceFile, args):
             frame = configFile.read().strip()
     
     # Trace replay of <traceFile>
-    traceEnv = os.environ.copy()
-    traceEnv['VK_LAYER_PATH'] = args.VkLayerPath
-    out = subprocess.check_output([args.VkTracePath, '-o', '%s.vktrace' % testname, '-p', args.VkReplayPath, '-a', '-o %s' % traceFile, '-s', frame, '-w', '.'], env=traceEnv).decode('utf-8')
+    layerEnv = os.environ.copy()
+    layerEnv['VK_LAYER_PATH'] = args.VkLayerPath
+    out = subprocess.check_output([args.VkTracePath, '-o', '%s.vktrace' % testname, '-p', args.VkReplayPath, '-a', '-o %s' % traceFile, '-s', frame, '-w', '.'], env=layerEnv).decode('utf-8')
 
     if 'error' in out:
         err = GetErrorMessage(out)
@@ -54,7 +158,7 @@ def TraceReplayTest(testname, traceFile, args):
     else:
         HandleError('Error: Screenshot not taken while tracing.')
 
-    out = subprocess.check_output([args.VkReplayPath, '-o', '%s.vktrace' % testname, '-s', frame]).decode('utf-8')
+    out = subprocess.check_output([args.VkReplayPath, '-o', '%s.vktrace' % testname, '-s', frame], env=layerEnv).decode('utf-8')
 
     if 'error' in out:
         err = GetErrorMessage(out)
@@ -75,18 +179,34 @@ def TraceReplayTest(testname, traceFile, args):
     print ('Success')
     print ('Elapsed seconds: %s\n' % elapsed)
 
-# Load settings from command-line
-parser = argparse.ArgumentParser(description='Test vktrace and vkreplay.')
-parser.add_argument('OldTracesPath', help='directory of old traces to replay')
-parser.add_argument('VkTracePath', help='directory containing vktrace')
-parser.add_argument('VkLayerPath', help='directory containing vktrace layer')
-parser.add_argument('VkReplayPath', help='directory containing vkreplay')
-args = parser.parse_args()
 
-# Run Trace/Replay on old trace files
-directory = args.OldTracesPath
-for filename in os.listdir(directory):
-    if filename.endswith(".vktrace"):
-        TraceReplayTest(filename, os.path.join(directory, filename), args)
 
-sys.exit(0);
+if __name__ == '__main__':
+
+    # Load settings from command-line
+    parser = argparse.ArgumentParser(description='Test vktrace and vkreplay.')
+    parser.add_argument('OldTracesPath', help='directory of old traces to replay')
+    parser.add_argument('VkTracePath', help='directory containing vktrace')
+    parser.add_argument('VkLayerPath', help='directory containing vktrace layer')
+    parser.add_argument('VkReplayPath', help='directory containing vkreplay')
+    args = parser.parse_args()
+
+    # Get cube executable path from PATH
+    cubePath = shutil.which('cube')
+    if (cubePath is None):
+        HandleError('Error: Cube executable not found')
+
+    # Trace/replay test on cube
+    TraceReplayProgramTest('cube', cubePath, '--c 50', args)
+
+    # Run trim test on cube
+    TrimTest('cube-trim', cubePath, '--c 250', args)
+
+    # Run Trace/Replay on old trace files
+    directory = args.OldTracesPath
+    for filename in os.listdir(directory):
+        if filename.endswith(".vktrace"):
+            TraceReplayTraceTest(filename, os.path.join(directory, filename), args)
+
+
+    sys.exit(0)

--- a/tests/vktracereplay.py
+++ b/tests/vktracereplay.py
@@ -202,11 +202,12 @@ if __name__ == '__main__':
     # Run trim test on cube
     TrimTest('cube-trim', cubePath, '--c 250', args)
 
-    # Run Trace/Replay on old trace files
+    # Run Trace/Replay on old trace files if directory specified
     directory = args.OldTracesPath
-    for filename in os.listdir(directory):
-        if filename.endswith(".vktrace"):
-            TraceReplayTraceTest(filename, os.path.join(directory, filename), args)
+    if os.path.isdir(directory):
+        for filename in os.listdir(directory):
+            if filename.endswith(".vktrace"):
+                TraceReplayTraceTest(filename, os.path.join(directory, filename), args)
 
 
     sys.exit(0)

--- a/tests/vktracereplay.sh
+++ b/tests/vktracereplay.sh
@@ -14,40 +14,15 @@ fi
 
 printf "$GREEN[ RUN      ]$NC $0\n"
 
-export VK_LAYER_PATH=${PWD}/../layersvt
+python3 vktracereplay.py "" ${PWD}/../vktrace/vktrace ${PWD}/../layersvt ${PWD}/../vktrace/vkreplay
 
-function trace_replay {
-	PGM=`which $1`
-	PARGS=$2
-	TARGS=$3
-	VKTRACE=${PWD}/../vktrace/vktrace
-	VKREPLAY=${PWD}/../vktrace/vkreplay
-	printf "$GREEN[ TRACE    ]$NC ${PGM}\n"
-	${VKTRACE}	--Program ${PGM} \
-			--Arguments "--c 100 ${PARGS}" \
-			--WorkingDir ${PWD} \
-			--OutputTrace ${PGM}.vktrace \
-			${TARGS} \
-			-s 1
-	mv 1.ppm 1-trace.ppm
-	printf "$GREEN[ REPLAY   ]$NC ${PGM}\n"
-	${VKREPLAY}	--Open ${PGM}.vktrace \
-			-s 1
-	rm -f ${PGM}.vktrace
-	cmp -s 1.ppm 1-trace.ppm
-	RES=$?
-	rm 1.ppm 1-trace.ppm
-	if [ $RES -eq 0 ] ; then
-	   printf "$GREEN[  PASSED  ]$NC ${PGM}\n"
-	else
-	   printf "$RED[  FAILED  ]$NC screenshot file compare failed\n"
-	   printf "$RED[  FAILED  ]$NC ${PGM}\n"
-	   printf "TEST FAILED\n"
-	   exit 1
-	fi
-}
-
-trace_replay cube "" "--PMB false"
+if [ $? -eq 0 ] ; then
+	printf "$GREEN[  PASSED  ]$NC ${PGM}\n"
+else
+	printf "$RED[  FAILED  ]$NC Trace/replay tests failed.\n"
+	printf "$RED[  FAILED  ]$NC ${PGM}\n"
+	printf "TEST FAILED\n"
+	exit 1
+fi
 
 exit 0
-


### PR DESCRIPTION
Make vktrace/replay tests between Windows/Linux consistent. Added cube/trim tests to the python.

Remove redundant code from the bash and powershell scripts.

When the 'make install' functionality and pattern is established for testing, the bash and powershell scripts will be removed. Temporarily they are used to setup to gather up the dependencies for the tests on windows vs linux.