### PR TITLE
vktrace: Fix trim swapchain image remap error

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -1485,6 +1485,7 @@ void snapshot_state_tracker() {
 }
 
 //=========================================================================
+#if TRIM_USE_ORDERED_IMAGE_CREATION
 void add_Image_call(vktrace_trace_packet_header *pHeader) {
     if (pHeader != NULL) {
         vktrace_enter_critical_section(&trimStateTrackerLock);
@@ -1492,7 +1493,7 @@ void add_Image_call(vktrace_trace_packet_header *pHeader) {
         vktrace_leave_critical_section(&trimStateTrackerLock);
     }
 }
-
+#endif  // TRIM_USE_ORDERED_IMAGE_CREATION
 //=========================================================================
 ObjectInfo &add_Instance_object(VkInstance var) {
     vktrace_enter_critical_section(&trimStateTrackerLock);
@@ -2776,19 +2777,6 @@ void write_all_referenced_object_calls() {
         }
     }
 
-    // SwapchainKHR
-    for (auto obj = stateTracker.createdSwapchainKHRs.begin(); obj != stateTracker.createdSwapchainKHRs.end(); obj++) {
-        vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket));
-
-        vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImageCountPacket,
-                                   vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImageCountPacket));
-
-        vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImagesPacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImagesPacket));
-    }
-
     // DeviceMemory
     for (auto obj = stateTracker.createdDeviceMemorys.begin(); obj != stateTracker.createdDeviceMemorys.end(); obj++) {
         // AllocateMemory
@@ -2822,6 +2810,49 @@ void write_all_referenced_object_calls() {
         vktrace_delete_trace_packet_no_lock(&(*iter));
     }
 #endif  // TRIM_USE_ORDERED_IMAGE_CREATION
+
+    // The location of following code block which is used to recreate
+    // Swapchain must be put before ordered image creation if
+    // TRIM_USE_ORDERED_IMAGE_CREATION is enabled. the reason:
+    // Let's consider the following calls during capture a title:
+    //
+    //      vkCreateImage --->the handle value of created image is A
+    //      ......
+    //      vkDestroyImage ----> destroy A
+    //      ......
+    //      vkGetSwapchainImagesKHR ----> get an array B of swapchain images
+    //
+    // for some titles on specific hardware/driver, we can found
+    // sometimes A is same value with one element of B. It caused crash
+    // problem for trimmed trace file playback if we keep Swapchain recreation
+    // before ordered image creation, that's because trim generate following
+    // calls:
+    //
+    //      vkGetSwapchainImagesKHR ----> get an array B of swapchain images
+    //      ......
+    //      vkCreateImage --->created image handle value is A
+    //      ......
+    //      vkDestroyImage ----> destroy A
+    //
+    // During playback, swapchain images will be first put in map, and then
+    // A will be put in map, then map item will be deleted when meet
+    // vkDestroyImage A, after here, any call which need remap A will get
+    // error, but compared with original title, the remap should return that
+    // swapchain image.
+
+    // SwapchainKHR
+    for (auto obj = stateTracker.createdSwapchainKHRs.begin(); obj != stateTracker.createdSwapchainKHRs.end(); obj++) {
+        vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket, vktrace_trace_get_trace_file());
+        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket));
+
+        vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImageCountPacket,
+                                   vktrace_trace_get_trace_file());
+        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImageCountPacket));
+
+        vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImagesPacket, vktrace_trace_get_trace_file());
+        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImagesPacket));
+    }
+
     for (auto obj = stateTracker.createdImages.begin(); obj != stateTracker.createdImages.end(); obj++) {
 #ifndef TRIM_USE_ORDERED_IMAGE_CREATION
         // CreateImage

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -2804,7 +2804,7 @@ void write_all_referenced_object_calls() {
         }
     }
 
-#ifdef TRIM_USE_ORDERED_IMAGE_CREATION
+#if TRIM_USE_ORDERED_IMAGE_CREATION
     for (auto iter = stateTracker.m_image_calls.begin(); iter != stateTracker.m_image_calls.end(); ++iter) {
         vktrace_write_trace_packet(*iter, vktrace_trace_get_trace_file());
         vktrace_delete_trace_packet_no_lock(&(*iter));
@@ -2812,7 +2812,7 @@ void write_all_referenced_object_calls() {
 #endif  // TRIM_USE_ORDERED_IMAGE_CREATION
 
     // The location of following code block which is used to recreate
-    // Swapchain must be put before ordered image creation if
+    // Swapchain must be put after ordered image creation if
     // TRIM_USE_ORDERED_IMAGE_CREATION is enabled. the reason:
     // Let's consider the following calls during capture a title:
     //
@@ -2854,7 +2854,7 @@ void write_all_referenced_object_calls() {
     }
 
     for (auto obj = stateTracker.createdImages.begin(); obj != stateTracker.createdImages.end(); obj++) {
-#ifndef TRIM_USE_ORDERED_IMAGE_CREATION
+#if !TRIM_USE_ORDERED_IMAGE_CREATION
         // CreateImage
         if (obj->second.ObjectInfo.Image.pCreatePacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pCreatePacket, vktrace_trace_get_trace_file());


### PR DESCRIPTION
When trim generate trace file, ordered image calls recreation may
overwrite swapchain image in map. It cause swapchain image remap
error amd make trimmed trace file playback crash for some title,
the change fix the problem.

XCAP-1019

Change-Id: I52bdf906a9ab69d2fd5a5d8fbc3f643682b45b4b