### PR TITLE
Revert "synchronize window sizes on Linux"

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
@@ -277,7 +277,9 @@ int vkDisplay::create_window(const unsigned int width, const unsigned int height
 
     value_mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
     value_list[0] = m_pXcbScreen->black_pixel;
-    value_list[1] = XCB_EVENT_MASK_KEY_RELEASE | XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_STRUCTURE_NOTIFY;
+    value_list[1] = XCB_EVENT_MASK_KEY_RELEASE |
+                    XCB_EVENT_MASK_EXPOSURE |
+                    XCB_EVENT_MASK_STRUCTURE_NOTIFY;
 
     xcb_create_window(m_pXcbConnection, XCB_COPY_FROM_PARENT, m_XcbWindow, m_pXcbScreen->root, 0, 0, width, height, 0,
                       XCB_WINDOW_CLASS_INPUT_OUTPUT, m_pXcbScreen->root_visual, value_mask, value_list);
@@ -485,11 +487,11 @@ void vkDisplay::process_event() {
                     set_quit_status(true);
                 }
             } break;
-            case XCB_MAP_NOTIFY: {
-                // If we were waiting for a MapWindow request to be processed,
-                // we can now continue
-                set_pause_status(false);
-            } break;
+            case XCB_MAP_NOTIFY:
+            // If we were waiting for a MapWindow request to be processed,
+            // we can now continue
+            set_pause_status(false);
+            break;
         }
         free(event);
         event = xcb_poll_for_event(xcb_conn);

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
@@ -277,9 +277,7 @@ int vkDisplay::create_window(const unsigned int width, const unsigned int height
 
     value_mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
     value_list[0] = m_pXcbScreen->black_pixel;
-    value_list[1] = XCB_EVENT_MASK_KEY_RELEASE |
-                    XCB_EVENT_MASK_EXPOSURE |
-                    XCB_EVENT_MASK_STRUCTURE_NOTIFY;
+    value_list[1] = XCB_EVENT_MASK_KEY_RELEASE | XCB_EVENT_MASK_EXPOSURE;
 
     xcb_create_window(m_pXcbConnection, XCB_COPY_FROM_PARENT, m_XcbWindow, m_pXcbScreen->root, 0, 0, width, height, 0,
                       XCB_WINDOW_CLASS_INPUT_OUTPUT, m_pXcbScreen->root_visual, value_mask, value_list);
@@ -410,13 +408,13 @@ void vkDisplay::resize_window(const unsigned int width, const unsigned int heigh
         xcb_flush(m_pXcbConnection);
 
         // Make sure window is visible.
+        // xcb doesn't have the equivalent of XSync, so we need to sleep
+        // for a while to make sure the X server received and processed
+        // the map window request. This is a kludge, but without the sleep,
+        // the window doesn't get mapped for a long time.
         xcb_map_window(m_pXcbConnection, m_XcbWindow);
         xcb_flush(m_pXcbConnection);
-
-        // Pause the replay until we receive a MapNotify event from the
-        // server indicating that our request has been processed
-        set_pause_status(true);
-
+        usleep(50000);  // 0.05 seconds
 #elif defined(VKREPLAY_USE_WSI_XLIB)
 // TODO
 #elif defined(VKREPLAY_USE_WSI_WAYLAND)
@@ -479,19 +477,8 @@ void vkDisplay::process_event() {
                 }
             } break;
             case XCB_CONFIGURE_NOTIFY: {
-                xcb_configure_notify_event_t *cne = (xcb_configure_notify_event_t *)event;
-                if (cne->width != m_windowWidth || cne->height != m_windowHeight) {
-                    // Our window has been resized, probably by the window manager.
-                    // There's not really anything we can do here other than abort.
-                    vktrace_LogError("bad window size, aborting!");
-                    set_quit_status(true);
-                }
+                // TODO resize here too
             } break;
-            case XCB_MAP_NOTIFY:
-            // If we were waiting for a MapWindow request to be processed,
-            // we can now continue
-            set_pause_status(false);
-            break;
         }
         free(event);
         event = xcb_poll_for_event(xcb_conn);


### PR DESCRIPTION
Reverts this commit:
https://github.com/LunarG/VulkanTools/commit/8664ed77230bafadc42c3495c4c9b962a8aed2dd

Due to "bad window size" error when vktrace/replay run in quick succession and preventing tests from passing.