### PR TITLE
vktrace: Fix inconsistent use of macro in trim

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -2820,14 +2820,14 @@ void write_all_referenced_object_calls() {
         }
     }
 
-#if defined(TRIM_USE_ORDERED_IMAGE_CREATION)
+#if TRIM_USE_ORDERED_IMAGE_CREATION
     for (auto iter = stateTracker.m_image_calls.begin(); iter != stateTracker.m_image_calls.end(); ++iter) {
         vktrace_write_trace_packet(*iter, vktrace_trace_get_trace_file());
         vktrace_delete_trace_packet_no_lock(&(*iter));
     }
 #endif  // TRIM_USE_ORDERED_IMAGE_CREATION
     for (auto obj = stateTracker.createdImages.begin(); obj != stateTracker.createdImages.end(); obj++) {
-#if !defined(TRIM_USE_ORDERED_IMAGE_CREATION)
+#if !TRIM_USE_ORDERED_IMAGE_CREATION
         // CreateImage
         if (obj->second.ObjectInfo.Image.pCreatePacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pCreatePacket, vktrace_trace_get_trace_file());


### PR DESCRIPTION
This change makes the use of TRIM_USE_ORDERED_IMAGE_CREATION
consistent in vktrace.

Previously it was used in two ways:
1. #if TRIM_USE_ORDERED_IMAGE_CREATION
2. #if defined(TRIM_USE_ORDERED_IMAGE_CREATION)

Now it is used in a consistent way:
1. #if TRIM_USE_ORDERED_IMAGE_CREATION

Because TRIM_USE_ORDERED_IMAGE_CREATION is defined as 1 by default. If
the allowed value of TRIM_USE_ORDERED_IMAGE_CREATION is either 1 or 0,
then only "#if TRIM_USE_ORDERED_IMAGE_CREATION" will work as expected
when TRIM_USE_ORDERED_IMAGE_CREATION is defined as 0.