### PR TITLE
vktrace: Fix error in trim 3d image handling

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -1009,7 +1009,7 @@ void snapshot_state_tracker() {
                         // buffer memory size.
 
                         copyRegion.bufferOffset = layout.offset;
-                        copyRegion.imageExtent.depth = 1;
+                        copyRegion.imageExtent.depth = imageIter->second.ObjectInfo.Image.extent.depth;
                         copyRegion.imageExtent.width = imageIter->second.ObjectInfo.Image.extent.width;
                         copyRegion.imageExtent.height = imageIter->second.ObjectInfo.Image.extent.height;
                         copyRegion.imageOffset.x = 0;
@@ -1036,7 +1036,7 @@ void snapshot_state_tracker() {
                         // copy to be tightly packed according to the imageExtent.
 
                         copyRegion.bufferOffset = layout.offset;
-                        copyRegion.imageExtent.depth = 1;
+                        copyRegion.imageExtent.depth = imageIter->second.ObjectInfo.Image.extent.depth;
                         copyRegion.imageExtent.width = imageIter->second.ObjectInfo.Image.extent.width;
                         copyRegion.imageExtent.height = imageIter->second.ObjectInfo.Image.extent.height;
                         copyRegion.imageOffset.x = 0;
@@ -1066,7 +1066,7 @@ void snapshot_state_tracker() {
                         copyRegion.bufferRowLength = 0;    //< tightly packed texels
                         copyRegion.bufferImageHeight = 0;  //< tightly packed texels
                         copyRegion.bufferOffset = lay.offset;
-                        copyRegion.imageExtent.depth = 1;
+                        copyRegion.imageExtent.depth = imageIter->second.ObjectInfo.Image.extent.depth >> i;
                         copyRegion.imageExtent.width = (imageIter->second.ObjectInfo.Image.extent.width >> i);
                         copyRegion.imageExtent.height = (imageIter->second.ObjectInfo.Image.extent.height >> i);
                         copyRegion.imageOffset.x = 0;


### PR DESCRIPTION
There's an error in trim saving data to staging buffer if the image is
a 3d image. It cause the trimmed trace file playback missing objects in
image. The change fix the problem.

XCAP-1019

Change-Id: I3f6bded038830aa890c2ac7ff8e248ebfb385130