### PR TITLE
build: Update V-VL submodule

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_helpers.h
+++ b/vktrace/vktrace_layer/vktrace_lib_helpers.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include "vktrace_vk_vk.h"
 #include "vulkan/vk_layer.h"
+#include "vk_layer_dispatch_table.h"
 #include "vktrace_platform.h"
 
 #include "vk_struct_size_helper.h"


### PR DESCRIPTION
Also fix vktrace header to take into account that vk_layer.h
no longer includes vk_layer_dispatch_table.h.
This change required coordination between Vulkan-Loader and
Vulkan-ValidationLayers, and so the V-VL submodule needed updating.