### PR TITLE
layersvt: Fix incorrect resolution in screenshot

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -1109,6 +1109,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(VkDevice device, const VkSwapc
         swapchainMapElem->device = device;
         swapchainMapElem->imageExtent = pCreateInfo->imageExtent;
         swapchainMapElem->format = pCreateInfo->imageFormat;
+        // If there's a (destroyed) swapchain with the same handle, remove it from the swapchainMap
+        if (swapchainMap.find(*pSwapchain) != swapchainMap.end()) {
+            delete swapchainMap[*pSwapchain];
+            swapchainMap.erase(*pSwapchain);
+        }
         swapchainMap.insert(make_pair(*pSwapchain, swapchainMapElem));
 
         // Create a mapping for the swapchain object into the dispatch table


### PR DESCRIPTION
This change drops the earlier swapchain info from swapchain map when
there's a new swapchain being created with the same handle.

It makes screenshot has correct resolution in following condition:
* Swapchain#1 is created with Handle#1 and Resolution#1
* Swapchain#1 is destroyed
* Swapchain#2 is created with Handle#1 (reused handle) and Resolution#2
* Screenshot#1 is taken.
Screenshot#1 will have Resolution#1 without this fix and it will have
the expected Resolution#2 with this fix.