### PR TITLE
vktrace: add lock/unlock to trim transition handling

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -2100,6 +2100,9 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue queue, uint32_t submitCount,
                                                                       const VkSubmitInfo* pSubmits, VkFence fence) {
+    if ((g_trimEnabled) && (pSubmits != NULL)) {
+        vktrace_enter_critical_section(&trim::trimTransitionMapLock);
+    }
 #if defined(USE_PAGEGUARD_SPEEDUP)
     pageguardEnter();
     flushAllChangedMappedMemory(&vkFlushMappedMemoryRangesWithoutAPICall);
@@ -2234,6 +2237,11 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
             vktrace_delete_trace_packet(&pHeader);
         }
     }
+
+    if ((g_trimEnabled) && (pSubmits != NULL)) {
+        vktrace_leave_critical_section(&trim::trimTransitionMapLock);
+    }
+
     return result;
 }
 


### PR DESCRIPTION
Some title hang randomly when capture with trim, the reason
is no lock/unlock protection for trim transition map access
in image and buffer handling of vkQueueSubmit, the change
fix the problem.

XCAP-952

Change-Id: If24750e5eb562503a24985cade531a9804cd1335