### PR TITLE
vktrace: fix error in copying 1D/2D image

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -2977,6 +2977,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
 #endif  //! TRIM_USE_ORDERED_IMAGE_CREATION
         info.ObjectInfo.Image.bIsSwapchainImage = false;
         info.ObjectInfo.Image.format = pCreateInfo->format;
+        info.ObjectInfo.Image.imageType = pCreateInfo->imageType;
         info.ObjectInfo.Image.aspectMask = trim::getImageAspectFromFormat(pCreateInfo->format);
         info.ObjectInfo.Image.extent = pCreateInfo->extent;
         info.ObjectInfo.Image.mipLevels = pCreateInfo->mipLevels;

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -1066,9 +1066,21 @@ void snapshot_state_tracker() {
                         copyRegion.bufferRowLength = 0;    //< tightly packed texels
                         copyRegion.bufferImageHeight = 0;  //< tightly packed texels
                         copyRegion.bufferOffset = lay.offset;
-                        copyRegion.imageExtent.depth = imageIter->second.ObjectInfo.Image.extent.depth >> i;
+
+                        if (imageIter->second.ObjectInfo.Image.imageType == VK_IMAGE_TYPE_3D) {
+                            copyRegion.imageExtent.depth = imageIter->second.ObjectInfo.Image.extent.depth >> i;
+                        } else {
+                            copyRegion.imageExtent.depth = 1;
+                        }
+
                         copyRegion.imageExtent.width = (imageIter->second.ObjectInfo.Image.extent.width >> i);
-                        copyRegion.imageExtent.height = (imageIter->second.ObjectInfo.Image.extent.height >> i);
+
+                        if (imageIter->second.ObjectInfo.Image.imageType != VK_IMAGE_TYPE_1D) {
+                            copyRegion.imageExtent.height = (imageIter->second.ObjectInfo.Image.extent.height >> i);
+                        } else {
+                            copyRegion.imageExtent.height = 1;
+                        }
+
                         copyRegion.imageOffset.x = 0;
                         copyRegion.imageOffset.y = 0;
                         copyRegion.imageOffset.z = 0;

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
@@ -151,6 +151,7 @@ typedef struct _Trim_ObjectInfo {
             VkDeviceSize memoryOffset;
             VkDeviceSize memorySize;
             VkFormat format;
+            VkImageType imageType;
             VkExtent3D extent;
             uint32_t mipLevels;
             uint32_t arrayLayers;


### PR DESCRIPTION
Add ImageType to track info, use this info when copying
1D/2D image in trim to fix an error which may cause depth
or height be wrongly set to zero.

XCAP-1019

Change-Id: I0034f5e0cf77668c3f74d0f11ec5f743f1976603