### PR TITLE
vkreplay: terminate early if xcb_connect fails

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkdisplay_xcb.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay_xcb.cpp
@@ -47,6 +47,10 @@ int vkDisplayXcb::init(const unsigned int gpu_idx) {
     xcb_screen_iterator_t iter;
     int scr;
     m_pXcbConnection = xcb_connect(NULL, &scr);
+    if (xcb_connection_has_error(m_pXcbConnection)) {
+        vktrace_LogError("failed to connect to X11 server");
+        return -1;
+    }
     setup = xcb_get_setup(m_pXcbConnection);
     iter = xcb_setup_roots_iterator(setup);
     while (scr-- > 0) xcb_screen_next(&iter);


### PR DESCRIPTION
If vkreplay fails to establish a connection to the X server for whatever reason it will currently crash with a segmentation fault without providing the user with any indication as to the cause. With this change, it will check immediately whether the connection was established successfully and if not, terminate with a more informative error message.