### PR TITLE
Fix compiler errors with vktraceviewer and new WSI selection

### DIFF
--- a/vktrace/vktrace_replay/CMakeLists.txt
+++ b/vktrace/vktrace_replay/CMakeLists.txt
@@ -42,12 +42,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     )
 endif()
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR
-    ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(OS_REPLAYER_LIBS ${LIBRARIES})
-endif()
-
-
 
 set(SRC_LIST
     ${SRC_LIST}
@@ -92,7 +86,7 @@ add_executable(${PROJECT_NAME} ${SRC_LIST} ${HDR_LIST})
 add_dependencies(${PROJECT_NAME} vktrace_generate_helper_files)
 
 target_link_libraries(${PROJECT_NAME}
-    ${OS_REPLAYER_LIBS}
+    ${LIBRARIES}
     ${LIBVK}
     vktrace_common
 )

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay_wayland.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay_wayland.cpp
@@ -1,3 +1,24 @@
+/*
+ *
+ * Copyright (C) 2015-2018 Valve Corporation
+ * Copyright (C) 2015-2018 LunarG, Inc.
+ * All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Joey Bzdek <joey@lunarg.com>
+ */
+
 #include "vkreplay_vkdisplay.h"
 #include <linux/input.h>
 

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay_xcb.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay_xcb.cpp
@@ -1,3 +1,24 @@
+/*
+ *
+ * Copyright (C) 2015-2018 Valve Corporation
+ * Copyright (C) 2015-2018 LunarG, Inc.
+ * All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Joey Bzdek <joey@lunarg.com>
+ */
+
 #include "vkreplay_vkdisplay.h"
 
 extern "C" {

--- a/vktrace/vktrace_viewer/main.cpp
+++ b/vktrace/vktrace_viewer/main.cpp
@@ -21,8 +21,8 @@
 
 #include <QApplication>
 
-#include "vktraceviewer.h"
 #include "vktraceviewer_settings.h"
+#include "vktraceviewer.h"
 
 #if defined(WIN32)
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)

--- a/vktrace/vktrace_viewer/vktraceviewer.cpp
+++ b/vktrace/vktrace_viewer/vktraceviewer.cpp
@@ -33,9 +33,9 @@
 #include <QAbstractProxyModel>
 #include <qwindow.h>
 
+#include "vktraceviewer_settings.h"
 #include "ui_vktraceviewer.h"
 #include "vktraceviewer.h"
-#include "vktraceviewer_settings.h"
 #include "vktraceviewer_output.h"
 
 #include "vktraceviewer_controller_factory.h"

--- a/vktrace/vktrace_viewer/vktraceviewer.h
+++ b/vktrace/vktrace_viewer/vktraceviewer.h
@@ -26,9 +26,6 @@
 #include <QString>
 #include <QThread>
 
-#include "vkreplay_seq.h"
-#include "vkreplay_factory.h"
-
 #include "vktraceviewer_view.h"
 #include "vktraceviewer_trace_file_utils.h"
 #include "vktraceviewer_qtimelineview.h"
@@ -38,6 +35,11 @@
 #include "vktraceviewer_qgeneratetracedialog.h"
 #include "vktraceviewer_qsettingsdialog.h"
 #include "vktraceviewer_settings.h"
+
+#include "vkreplay_seq.h"
+#include "vkreplay_factory.h"
+
+#undef Bool  // Xlib defines this, will not be compatible with QT
 
 namespace Ui {
 class vktraceviewer;

--- a/vktrace/vktrace_viewer/vktraceviewer_QReplayWidget.h
+++ b/vktrace/vktrace_viewer/vktraceviewer_QReplayWidget.h
@@ -30,6 +30,8 @@
 
 #include "vktraceviewer_QReplayWorker.h"
 
+#undef Bool  // Xlib defines this, will not be compatible with QT
+
 class vktraceviewer_QReplayWidget : public QWidget {
     Q_OBJECT
    public:

--- a/vktrace/vktrace_viewer/vktraceviewer_QReplayWorker.cpp
+++ b/vktrace/vktrace_viewer/vktraceviewer_QReplayWorker.cpp
@@ -19,9 +19,11 @@
  * Author: Peter Lohrmann <peterl@valvesoftware.com> <plohrmann@gmail.com>
  **************************************************************************/
 
-#include "vktraceviewer_QReplayWorker.h"
 #include <QAction>
 #include <QCoreApplication>
+
+#include "vktraceviewer_QReplayWorker.h"
+
 #include "vktraceviewer_trace_file_utils.h"
 
 vktraceviewer_QReplayWorker* g_pWorker;

--- a/vktrace/vktrace_viewer/vktraceviewer_QReplayWorker.h
+++ b/vktrace/vktrace_viewer/vktraceviewer_QReplayWorker.h
@@ -25,6 +25,8 @@
 #include "vktraceviewer_view.h"
 #include "vkreplay_factory.h"
 
+#undef Bool  // Xlib defines this, will not be compatible with QT
+
 // Replay from vktraceviewer doesn't work yet. Disable it for now.
 #define ENABLE_REPLAY false
 


### PR DESCRIPTION
Fixed incompatibilities between XLib and QT for vktraceviewer, now that all WSIs are included in the build.

Added headers to new cpp files and cleaned up CMake.