### PR TITLE
vkreplay: Fix issues replaying 32-bit large file

### DIFF
--- a/vktrace/vktrace_common/vktrace_common.h
+++ b/vktrace/vktrace_common/vktrace_common.h
@@ -72,9 +72,12 @@ static const uint32_t  INVALID_BINDING_INDEX = UINT32_MAX;
 #if defined(WIN32)
 #define Ftell _ftelli64
 #define Fseek _fseeki64
+#elif defined(ANDROID)
+#define Ftell vktrace_ftell
+#define Fseek vktrace_fseek
 #else
-#define Ftell ftell
-#define Fseek fseek
+#define Ftell ftello
+#define Fseek fseeko
 #endif
 
 // Enviroment variables used by vktrace/replay

--- a/vktrace/vktrace_common/vktrace_platform.c
+++ b/vktrace/vktrace_common/vktrace_platform.c
@@ -498,3 +498,29 @@ BOOL vktrace_platform_remote_load_library(vktrace_process_handle pProcessHandle,
 
     return TRUE;
 }
+
+#if defined(ANDROID)
+int vktrace_fseek(FILE* stream, int64_t offset, int whence) {
+    if (sizeof(void*) == 8) {
+        // use native fseek on 64 bit Android
+        return fseek(stream, offset, whence);
+    } else {
+        // disable buffering
+        setbuf(stream, NULL);
+        if (lseek64(fileno(stream), offset, whence) == -1) {
+            return -1;
+        }
+        return 0;
+    }
+}
+int64_t vktrace_ftell(FILE* stream) {
+    if (sizeof(void*) == 8) {
+        // use native ftell on 64 bit Android
+        return ftell(stream);
+    } else {
+        // disable buffering
+        setbuf(stream, NULL);
+        return lseek64(fileno(stream), 0L, SEEK_CUR);
+    }
+}
+#endif

--- a/vktrace/vktrace_common/vktrace_platform.h
+++ b/vktrace/vktrace_common/vktrace_platform.h
@@ -174,6 +174,12 @@ void vktrace_delete_critical_section(VKTRACE_CRITICAL_SECTION* pCriticalSection)
 BOOL vktrace_platform_remote_load_library(vktrace_process_handle pProcessHandle, const char* dllPath,
                                           vktrace_thread* pTracingThread, char** ldPreload);
 
+#if defined(ANDROID)
+#include <stdio.h>
+int vktrace_fseek(FILE* stream, int64_t offset, int whence);
+int64_t vktrace_ftell(FILE* stream);
+#endif
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
On 32-bit Linux/Android, fseek and ftell only works well for trace file
smaller than 2GB which will cause problem when geting file length and
using portability table on a large trace file.

This change fixes the issue by:

* x86 version:
** Use fseeko and ftello instead of fseek and ftell.
"-D_FILE_OFFSET_BITS=64" has been defined in vktrace's CMakeList.txt to
make those functions support large file.

* 32-bit Android version:
** Implement vktrace_fseek and vktrace_ftell using lseek64 which is
available in NDK.

For the NDK problem of using fseeko and ftello, refer to
https://github.com/android-ndk/ndk/issues/480