### PR TITLE
vktrace: Fix loading of xcb/wayland libs if in other path

### DIFF
--- a/vktrace/vktrace_replay/CMakeLists.txt
+++ b/vktrace/vktrace_replay/CMakeLists.txt
@@ -40,6 +40,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         ${WAYLAND_CLIENT_LIBRARIES}
         vktrace_common
     )
+
+    # Make sure the exe directory is searched when loading libraries with dlopen
+    SET(CMAKE_EXE_LINKER_FLAGS
+        "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,'$ORIGIN'")
 endif()
 
 


### PR DESCRIPTION
When running vkreplay outside of the exe directory, the xcb and
wayland window libraries were not loading. Add $ORIGIN to the
rpath to search the exe directory.

Change-Id: Ieb0705575bb371dd8c83f215b79b72873a48da00