### PR TITLE
vktrace: assign dispatch table for created objects

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -936,6 +936,10 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDevice(VkPhysica
                     VkQueue queue = VK_NULL_HANDLE;
                     mdd(*pDevice)->devTable.GetDeviceQueue(*pDevice, queueFamilyIndex, q, &queue);
                     info.ObjectInfo.Device.pQueueFamilies[queueFamilyIndex].queues[q] = queue;
+
+                    // Because this queue was not retrieved through the loader's
+                    // trampoile function, we need to assign the dispatch table here
+                    *(void**)queue = *(void**)*pDevice;
                 }
             }
         }

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -641,6 +641,10 @@ VkCommandBuffer getCommandBufferFromDevice(VkDevice device, VkCommandPool comman
         if (result == VK_SUCCESS) {
             s_deviceToCommandBufferMap[device] = commandBuffer;
         }
+
+        // Because this commandBuffer was not allocated through the loader's
+        // trampoile function, we need to assign the dispatch table here
+        *(void **)commandBuffer = *(void **)device;
     } else {
         commandBuffer = s_deviceToCommandBufferMap[device];
 


### PR DESCRIPTION
The vktrace layer can sometimes create new dispatchable
vulkan objects, specifically VkCommandBuffers and VkQueues.
As per the loader's documentation, if this is done within a
layer it is the layer's responsibility to assign the
dispatch table for the object as this is normally done in
the top level trampoline function which is bypassed in this
case.

However, the vktrace layer currently does not do so. This can
result in problems if it is used on top of other layers. For
example, if the validation layers are enabled and an application
is traced with the trim option it causes a segmentation fault.

Hence, this change ensures the dispatch table is correctly
assigned for these objects.