### PR TITLE
vktrace: Fix mapped memory size incorrect issue in trim

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -1145,7 +1145,7 @@ void snapshot_state_tracker() {
 
             VkDeviceMemory memory = imageIter->second.ObjectInfo.Image.memory;
             VkDeviceSize offset = imageIter->second.ObjectInfo.Image.memoryOffset;
-            VkDeviceSize size = ROUNDUP_TO_4(imageIter->second.ObjectInfo.Image.memorySize);
+            VkDeviceSize size = imageIter->second.ObjectInfo.Image.memorySize;
 
             if (imageIter->second.ObjectInfo.Image.needsStagingBuffer) {
                 // Note that the staged memory object won't be in the state tracker,
@@ -1347,7 +1347,7 @@ void snapshot_state_tracker() {
 
             VkDeviceMemory memory = bufferIter->second.ObjectInfo.Buffer.memory;
             VkDeviceSize offset = bufferIter->second.ObjectInfo.Buffer.memoryOffset;
-            VkDeviceSize size = ROUNDUP_TO_4(bufferIter->second.ObjectInfo.Buffer.size);
+            VkDeviceSize size = bufferIter->second.ObjectInfo.Buffer.size;
 
             void *mappedAddress = NULL;
             VkDeviceSize mappedOffset = 0;
@@ -1472,7 +1472,7 @@ void snapshot_state_tracker() {
             VkDevice device = iter->second.belongsToDevice;
             VkDeviceMemory deviceMemory = iter->first;
             VkDeviceSize offset = 0;
-            VkDeviceSize size = ROUNDUP_TO_4(iter->second.ObjectInfo.DeviceMemory.size);
+            VkDeviceSize size = iter->second.ObjectInfo.DeviceMemory.size;
             VkMemoryMapFlags flags = 0;
             void *pData = iter->second.ObjectInfo.DeviceMemory.mappedAddress;
 

--- a/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
@@ -453,7 +453,7 @@ vktrace_trace_packet_header *vkMapMemory(bool makeCall, VkDevice device, VkDevic
 vktrace_trace_packet_header *vkUnmapMemory(bool makeCall, VkDeviceSize size, void *pData, VkDevice device, VkDeviceMemory memory) {
     vktrace_trace_packet_header *pHeader;
     packet_vkUnmapMemory *pPacket;
-    CREATE_TRACE_PACKET(vkUnmapMemory, size);
+    CREATE_TRACE_PACKET(vkUnmapMemory, ROUNDUP_TO_4(size));
     pPacket = interpret_body_as_vkUnmapMemory(pHeader);
     if (size > 0) {
         vktrace_add_buffer_to_trace_packet(pHeader, (void **)&(pPacket->pData), size, pData);


### PR DESCRIPTION
This is a follow up of #497

Whenever ROUNDUP_TO_4 is used, need to make sure that it is used to
round up the size of packet elements.

Issue:
Currently trimmed trace file has vkMapMemory being recorded with
memory size ROUNDUP_TO_4 which may cause "mapped memory size +
mapped memory offset" greater than "allocated memory size".

Fix:
This change removes ROUNDUP_TO_4 from memory size in vkMapMemory.