### PR TITLE
layersvt: Fix incorrect process of taking screenshots

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -771,8 +771,8 @@ static void writePPM(const char *filename, VkImage image1) {
 
     // The source image needs to be transitioned from present to transfer
     // source.
-    pTableCommandBuffer->CmdPipelineBarrier(data.commandBuffer, srcStages, dstStages, 0, 0, NULL, 0, NULL, 1,
-                                            &presentMemoryBarrier);
+    pTableCommandBuffer->CmdPipelineBarrier(data.commandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, dstStages, 0, 0, NULL, 0,
+                                            NULL, 1, &presentMemoryBarrier);
 
     // image2 needs to be transitioned from its undefined state to transfer
     // destination.
@@ -1176,8 +1176,6 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
     }
     DeviceMapStruct *devMap = get_dev_info((VkDevice)queue);
     assert(devMap);
-    VkLayerDispatchTable *pDisp = devMap->device_dispatch_table;
-    VkResult result = pDisp->QueuePresentKHR(queue, pPresentInfo);
     loader_platform_thread_lock_mutex(&globalLock);
 
     if (!screenshotFramesReceived) {
@@ -1197,7 +1195,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
         local_free_getenv(vk_screenshot_frames);
     }
 
-    if (result == VK_SUCCESS && (!screenshotFrames.empty() || screenShotFrameRange.valid)) {
+    if (!screenshotFrames.empty() || screenShotFrameRange.valid) {
         set<int>::iterator it;
         bool inScreenShotFrames = false;
         bool inScreenShotFrameRange = false;
@@ -1252,6 +1250,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
     }
     frameNumber++;
     loader_platform_thread_unlock_mutex(&globalLock);
+    VkLayerDispatchTable *pDisp = devMap->device_dispatch_table;
+    VkResult result = pDisp->QueuePresentKHR(queue, pPresentInfo);
     return result;
 }
 


### PR DESCRIPTION
This change calls writePPM before the real vkQueuePresentKHR being
called.  Because the swapchain image (after vkQueuePresentKHR is
called) is owned at some point in time by the presentation engine which
might do things to the image like zapping memory away.

This change also makes sure everything which could affect the swapchain
image being captured has has completed before capturing it using
VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT in pipeline barrier for the
swapchain image's image layout transition.

So now the process of taking screenshot is:
1. Wait on bottom_of_pipe to complete
2. Transition the image from present_src into transfer_src
3. Copy/dump the content out
4. Transition the image back into present_src
5. Call vkQueuePresentKHR as intended/intercepted