### PR TITLE
layersvt: Fix access mask in screenshot layer

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -732,7 +732,7 @@ static void writePPM(const char *filename, VkImage image1) {
     // This barrier is used to transition from/to present Layout
     VkImageMemoryBarrier presentMemoryBarrier = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                                  NULL,
-                                                 VK_ACCESS_TRANSFER_WRITE_BIT,
+                                                 VK_ACCESS_MEMORY_WRITE_BIT,
                                                  VK_ACCESS_TRANSFER_READ_BIT,
                                                  VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
                                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
@@ -758,7 +758,7 @@ static void writePPM(const char *filename, VkImage image1) {
     VkImageMemoryBarrier generalMemoryBarrier = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                                  NULL,
                                                  VK_ACCESS_TRANSFER_WRITE_BIT,
-                                                 VK_ACCESS_TRANSFER_READ_BIT,
+                                                 VK_ACCESS_MEMORY_READ_BIT,
                                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                                  VK_IMAGE_LAYOUT_GENERAL,
                                                  VK_QUEUE_FAMILY_IGNORED,


### PR DESCRIPTION
This change fixes two access mask issues in screenshot layer:

1. The pipeline barrier which used to transition from present layout
for swapchain image should use VK_ACCESS_MEMORY_WRITE_BIT as
srcAccessMask to make sure all writes that are performed by entities
known to the Vulkan device are made available before read happens.

2. The pipeline barrier which used to transition a dest layout to
general layout should have dstAccessMask for CPU to read memory.