### PR TITLE
vktrace: Fix a typo in android-generate.sh

### DIFF
--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -66,6 +66,6 @@ REGISTRY=${REGISTRY_PATH}/vk.xml
 ( cd generated/include; python3 ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} vkreplay_vk_objmapper.h )
 
 ( pushd ${LVL_BASE}/build-android; rm -rf generated; mkdir -p generated/include generated/common; popd )
-( cd generated/include; cp -rf * ../../${LVL_BASE}/build-android/generated/include )
+( cd generated/include; cp -rf * ${LVL_BASE}/build-android/generated/include )
 
 exit 0


### PR DESCRIPTION
This change fixes an error when copying files from generate/include to
Vulkan Validation Layer directory.  Because ${LVL_BASE} is absolute
path.