### PR TITLE
tests: Fix path to validation layer test

### DIFF
--- a/tests/trace_positive_validation.ps1
+++ b/tests/trace_positive_validation.ps1
@@ -24,7 +24,7 @@ if ( !(Test-Path $toolsroot\$bits_build) ) {
 
 $skip = @( "LongFenceChain)", "CreatePipelineCheckShaderCapabilityExtension1of2",
     "CreatePipelineCheckShaderCapabilityExtension2of2", "ExternalFence", "ExternalMemory" )
-$lvlbinpath = "$toolsroot\$bits_build\Vulkan-ValidationLayers"
+$lvlbinpath = "$toolsroot\Vulkan-ValidationLayers\$bits_build"
 $lvlcodepath = "$toolsroot\Vulkan-ValidationLayers"
 
 if ( -not($toolsroot) ) { Throw "You must supply a path to a VulkanTools build via -toolsroot" }


### PR DESCRIPTION
With Vulkan-ValidationLayers no longer a submodule, this path needs to change