### PR TITLE
tests: Add more tests to positive_validation black list

### DIFF
--- a/tests/trace_positive_validation.ps1
+++ b/tests/trace_positive_validation.ps1
@@ -23,7 +23,7 @@ if ( !(Test-Path $toolsroot\$bits_build) ) {
 }
 
 $skip = @( "LongFenceChain)", "CreatePipelineCheckShaderCapabilityExtension1of2",
-    "CreatePipelineCheckShaderCapabilityExtension2of2", "ExternalFence", "ExternalMemory" )
+    "CreatePipelineCheckShaderCapabilityExtension2of2", "ExternalFence", "ExternalMemory", "ExternalSemaphore", "CreateGraphicsPipelineWithIgnoredPointers" )
 $lvlbinpath = "$toolsroot\Vulkan-ValidationLayers\$bits_build"
 $lvlcodepath = "$toolsroot\Vulkan-ValidationLayers"
 


### PR DESCRIPTION
Tests are failing trace / replay.  ExternalSemaphore is pretty much expected to fail, but some clever code could probably fix CreateGraphicsPipelineWithIgnoredPointers - issue submitted