### PR TITLE
vktrace: fix trim copy image error for optimal tiling mode

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -1845,6 +1845,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
             trim_instructions.append('            vktrace_delete_trace_packet(&pHeader);')
             trim_instructions.append('        }')
         elif 'vkDestroyImage' == proto.name:
+            trim_instructions.append("        trim::deleteImageSubResourceSizes(image);")
             trim_instructions.append("#if TRIM_USE_ORDERED_IMAGE_CREATION")
             trim_instructions.append("        trim::add_Image_call(trim::copy_packet(pHeader));")
             trim_instructions.append("#endif //TRIM_USE_ORDERED_IMAGE_CREATION")

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -127,7 +127,6 @@ VkDeviceSize calculateImageSubResourceSize(VkDevice device, VkImageCreateInfo im
 
     if (result == VK_SUCCESS) {
         VkMemoryRequirements memoryRequirements;
-        VkDeviceMemory memory;
 
         mdd(device)->devTable.GetImageMemoryRequirements(device, image, &memoryRequirements);
         imageSubResourceSize = memoryRequirements.size;
@@ -138,7 +137,7 @@ VkDeviceSize calculateImageSubResourceSize(VkDevice device, VkImageCreateInfo im
 
 bool calculateImageAllSubResourceSize(VkDevice device, VkImageCreateInfo imageCreateInfo, const VkAllocationCallbacks *pAllocator,
                                       std::vector<VkDeviceSize> &subResourceSizes) {
-    uint32_t mipLevel, wholeSize = 0;
+    uint32_t wholeSize = 0;
     subResourceSizes.push_back(0);
     for (uint32_t i = 0; i < imageCreateInfo.mipLevels; i++) {
         subResourceSizes.push_back(calculateImageSubResourceSize(device, imageCreateInfo, pAllocator, i));

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -16,11 +16,13 @@
 #pragma once
 #include <list>
 #include <map>
+#include <algorithm>
 #include "vktrace_trace_packet_identifiers.h"
 
 #include "vktrace_lib_trim_generate.h"
 #include "vktrace_lib_trim_statetracker.h"
 #include "vulkan/vulkan.h"
+#include <mutex>
 
 #if defined(PLATFORM_LINUX)  // VK_USE_PLATFORM_XCB_KHR
 #if defined(ANDROID)
@@ -89,6 +91,21 @@ enum enum_key_state {
 
 // return if hotkey triggered;
 bool is_hotkey_trim_triggered();
+
+VkDeviceSize calculateImageSubResourceSize(VkDevice device, VkImageCreateInfo imageCreateInfo,
+                                           const VkAllocationCallbacks *pAllocator, uint32_t subresourceIndex);
+bool calculateImageAllSubResourceSize(VkDevice device, VkImageCreateInfo imageCreateInfo, const VkAllocationCallbacks *pAllocator,
+                                      std::vector<VkDeviceSize> &subResourceSizes);
+
+void addImageSubResourceSizes(VkImage image, std::vector<VkDeviceSize> subResourceSizes);
+
+bool getImageSubResourceSizes(VkImage image, std::vector<VkDeviceSize> *pSubresourceSizes);
+
+void deleteImageSubResourceSizes(VkImage image);
+
+VkDeviceSize getImageSize(VkImage image);
+
+VkDeviceSize getImageSubResourceOffset(VkImage image, uint32_t mipLevel);
 
 // Use this to snapshot the global state tracker at the start of the trim
 // frames.


### PR DESCRIPTION
trim need vkGetImageSubresourceLayout when copy image to staging buffer,
but it's not valid usage if the image created without linear tiling mode.
it cause image difference when playback trimmed trace file for some title.
The change fix the problem.

VKTRACE-13

Change-Id: I52cbc7cb1503aa0258097873afcd2238adea4ba9