### PR TITLE
Add libxcb-randr0-dev dependency to BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ Ubuntu 14.04.3 LTS, 14.10, 15.04,15.10, and 16.04 LTS have been tested with this
 These additional packages are needed for building the components in this repo.
 ```
 # Dependencies from included submodule components
-sudo apt-get install git cmake build-essential bison libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev
+sudo apt-get install git cmake build-essential bison libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev libxcb-randr0-dev
 # Additional dependencies for this repo:
 sudo apt-get install wget autotools-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev
 # If performing 32-bit builds, you will also need:


### PR DESCRIPTION
Package libxcb-randr0-dev was required to build VulkanTools on my Ubuntu 18.04 machine.