### PR TITLE
vkreplay: Fix FPS calculation

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -239,11 +239,12 @@ int main_loop(vktrace_replay::ReplayDisplay display, Sequencer& seq, vktrace_tra
                         if (prevFrameNumber != frameNumber) {
                             prevFrameNumber = frameNumber;
 
-                            // Only set the loop start location in the first loop when loopStartFrame is not 0
+                            // Only set the loop start location and start_time in the first loop when loopStartFrame is not 0
                             if (frameNumber == start_frame && start_frame > 0 && replaySettings.numLoops == totalLoops) {
                                 // record the location of looping start packet
                                 seq.record_bookmark();
                                 seq.get_bookmark(startingPacket);
+                                start_time = vktrace_get_time();
                             }
 
                             if (frameNumber == replaySettings.loopEndFrame) {


### PR DESCRIPTION
This change fixes FPS calculation when loop start frame "-lsf" is
greater than 0.

Issue:
The current printed FPS and time consuming info are calculated from
frame 0 which is inconsistent with the printed frame count and frame
range info when loops start frame is greater than 0.

e.g. X fps, Y seconds, 9 frames, 1 loop, framerange 2-10
X fps and Y seconds are caclulated from frame 0 to 10 (11 frames)
instead of frame 2 to 10 (9 frames)

Fix:
Reset start_time in the loopStartFrame in the first loop when
loopStartFrame is not 0.