### PR TITLE
vktrace: add support in trim for create and destroy DescriptorUpdateTemplate

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -3935,6 +3935,32 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
         FINISH_TRACE_PACKET();
     } else {
         vktrace_finalize_trace_packet(pHeader);
+        trim::ObjectInfo& info = trim::add_DescriptorUpdateTemplate_object(*pDescriptorUpdateTemplate);
+        info.belongsToDevice = device;
+        info.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket = trim::copy_packet(pHeader);
+        info.ObjectInfo.DescriptorUpdateTemplate.flags = pCreateInfo->flags;
+        info.ObjectInfo.DescriptorUpdateTemplate.descriptorUpdateEntryCount = pCreateInfo->descriptorUpdateEntryCount;
+        if ((pCreateInfo->descriptorUpdateEntryCount != 0) && (pCreateInfo->pDescriptorUpdateEntries != nullptr)) {
+            info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries =
+                VKTRACE_NEW_ARRAY(VkDescriptorUpdateTemplateEntry, pCreateInfo->descriptorUpdateEntryCount);
+            assert(info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries != nullptr);
+            memcpy(
+                reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateEntry*>(
+                    info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries)),
+                reinterpret_cast<const void*>(const_cast<VkDescriptorUpdateTemplateEntry*>(pCreateInfo->pDescriptorUpdateEntries)),
+                pCreateInfo->descriptorUpdateEntryCount * sizeof(VkDescriptorUpdateTemplateEntry));
+        }
+        info.ObjectInfo.DescriptorUpdateTemplate.templateType = pCreateInfo->templateType;
+        info.ObjectInfo.DescriptorUpdateTemplate.descriptorSetLayout = pCreateInfo->descriptorSetLayout;
+        info.ObjectInfo.DescriptorUpdateTemplate.pipelineBindPoint = pCreateInfo->pipelineBindPoint;
+        info.ObjectInfo.DescriptorUpdateTemplate.pipelineLayout = pCreateInfo->pipelineLayout;
+        info.ObjectInfo.DescriptorUpdateTemplate.set = pCreateInfo->set;
+
+        if (pAllocator != NULL) {
+            info.ObjectInfo.DescriptorUpdateTemplate.pAllocator = pAllocator;
+            trim::add_Allocator(pAllocator);
+        }
+
         if (g_trimIsInTrim) {
             trim::write_packet(pHeader);
         } else {
@@ -3961,6 +3987,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTem
         FINISH_TRACE_PACKET();
     } else {
         vktrace_finalize_trace_packet(pHeader);
+        trim::remove_DescriptorUpdateTemplate_object(descriptorUpdateTemplate);
         if (g_trimIsInTrim) {
             trim::write_packet(pHeader);
         } else {
@@ -3995,6 +4022,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTem
         FINISH_TRACE_PACKET();
     } else {
         vktrace_finalize_trace_packet(pHeader);
+        trim::remove_DescriptorUpdateTemplate_object(descriptorUpdateTemplate);
         if (g_trimIsInTrim) {
             trim::write_packet(pHeader);
         } else {

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -3757,12 +3757,11 @@ void write_all_referenced_object_calls() {
     VKTRACE_DELETE(pSignalSemaphores);
 
     // DescriptorUpdateTemplate
-    for (auto obj = stateTracker.createdDescriptorUpdateTemplates.begin(); obj != stateTracker.createdDescriptorUpdateTemplates.end();
-        obj++) {
+    for (auto obj = stateTracker.createdDescriptorUpdateTemplates.begin();
+         obj != stateTracker.createdDescriptorUpdateTemplates.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket, vktrace_trace_get_trace_file());
         vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket));
     }
-
 
     vktrace_LogDebug("vktrace done recreating objects for trim.");
 }

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -223,6 +223,9 @@ ObjectInfo *get_Sampler_objectInfo(VkSampler var);
 ObjectInfo &add_DescriptorSetLayout_object(VkDescriptorSetLayout var);
 ObjectInfo *get_DescriptorSetLayout_objectInfo(VkDescriptorSetLayout var);
 
+ObjectInfo &add_DescriptorUpdateTemplate_object(VkDescriptorUpdateTemplate var);
+ObjectInfo *get_DescriptorUpdateTemplate_objectInfo(VkDescriptorUpdateTemplate var);
+
 ObjectInfo &add_DescriptorSet_object(VkDescriptorSet var);
 ObjectInfo *get_DescriptorSet_objectInfo(VkDescriptorSet var);
 
@@ -252,5 +255,6 @@ void remove_ShaderModule_object(const VkShaderModule var);
 void remove_PipelineLayout_object(const VkPipelineLayout var);
 void remove_Sampler_object(const VkSampler var);
 void remove_DescriptorSetLayout_object(const VkDescriptorSetLayout var);
+void remove_DescriptorUpdateTemplate_object(VkDescriptorUpdateTemplate var);
 void remove_DescriptorSet_object(const VkDescriptorSet var);
 }  // namespace trim

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
@@ -248,6 +248,18 @@ typedef struct _Trim_ObjectInfo {
                                            // sets that will need a copy update.
             VkCopyDescriptorSet *pCopyDescriptorSets;
         } DescriptorSet;
+        struct _DescriptorUpdateTemplate {  // VkDescriptorSet
+            vktrace_trace_packet_header *pCreatePacket;
+            const VkAllocationCallbacks *pAllocator;
+            VkDescriptorUpdateTemplateCreateFlags flags;
+            uint32_t descriptorUpdateEntryCount;
+            const VkDescriptorUpdateTemplateEntry *pDescriptorUpdateEntries;
+            VkDescriptorUpdateTemplateType templateType;
+            VkDescriptorSetLayout descriptorSetLayout;
+            VkPipelineBindPoint pipelineBindPoint;
+            VkPipelineLayout pipelineLayout;
+            uint32_t set;
+        } DescriptorUpdateTemplate;
         struct _Framebuffer {  // VkFramebuffer
             vktrace_trace_packet_header *pCreatePacket;
             const VkAllocationCallbacks *pAllocator;
@@ -338,6 +350,7 @@ class StateTracker {
     ObjectInfo &add_Sampler(VkSampler var);
     ObjectInfo &add_DescriptorSetLayout(VkDescriptorSetLayout var);
     ObjectInfo &add_DescriptorSet(VkDescriptorSet var);
+    ObjectInfo &add_DescriptorUpdateTemplate(VkDescriptorUpdateTemplate var);
 
     ObjectInfo *get_Instance(VkInstance var);
     ObjectInfo *get_PhysicalDevice(VkPhysicalDevice var);
@@ -365,6 +378,7 @@ class StateTracker {
     ObjectInfo *get_PipelineLayout(VkPipelineLayout var);
     ObjectInfo *get_Sampler(VkSampler var);
     ObjectInfo *get_DescriptorSetLayout(VkDescriptorSetLayout var);
+    ObjectInfo * get_DescriptorUpdateTemplate(VkDescriptorUpdateTemplate var);
     ObjectInfo *get_DescriptorSet(VkDescriptorSet var);
 
     void remove_Instance(const VkInstance var);
@@ -393,6 +407,7 @@ class StateTracker {
     void remove_PipelineLayout(const VkPipelineLayout var);
     void remove_Sampler(const VkSampler var);
     void remove_DescriptorSetLayout(const VkDescriptorSetLayout var);
+    void remove_DescriptorUpdateTemplate(const VkDescriptorUpdateTemplate var);
     void remove_DescriptorSet(const VkDescriptorSet var);
 
     static void copy_VkRenderPassCreateInfo(VkRenderPassCreateInfo *pDst, const VkRenderPassCreateInfo &src);
@@ -446,6 +461,7 @@ class StateTracker {
     std::unordered_map<VkPipelineLayout, ObjectInfo> createdPipelineLayouts;
     std::unordered_map<VkSampler, ObjectInfo> createdSamplers;
     std::unordered_map<VkDescriptorSetLayout, ObjectInfo> createdDescriptorSetLayouts;
+    std::unordered_map<VkDescriptorUpdateTemplate, ObjectInfo> createdDescriptorUpdateTemplates;
     std::unordered_map<VkDescriptorSet, ObjectInfo> createdDescriptorSets;
 };
 }

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
@@ -378,7 +378,7 @@ class StateTracker {
     ObjectInfo *get_PipelineLayout(VkPipelineLayout var);
     ObjectInfo *get_Sampler(VkSampler var);
     ObjectInfo *get_DescriptorSetLayout(VkDescriptorSetLayout var);
-    ObjectInfo * get_DescriptorUpdateTemplate(VkDescriptorUpdateTemplate var);
+    ObjectInfo *get_DescriptorUpdateTemplate(VkDescriptorUpdateTemplate var);
     ObjectInfo *get_DescriptorSet(VkDescriptorSet var);
 
     void remove_Instance(const VkInstance var);


### PR DESCRIPTION
Adding track info and corresponding handling for DescriptorUpdateTemplate,
the change fix command queue submission fail for some title.

VKTRACE-13

Change-Id: I1a0d6453f53abb39ecda6b066744a99c1f871009