### PR TITLE
vktrace: Add option for post process trim

### DIFF
--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -16,6 +16,7 @@ Options for the `vktrace` command are:
 | -w&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;WorkingDir&nbsp;&lt;string&gt; | Alternate working directory | the application's directory |
 | -P&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PMB&nbsp;&lt;bool&gt; | Trace  persistently mapped buffers | true |
 | -tr&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TraceTrigger&nbsp;&lt;string&gt; | Start/stop trim by hotkey or frame range. String arg is one of:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hotkey-[F1-F12\|TAB\|CONTROL]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;frames-&lt;startframe&gt;-&lt;endframe&gt;| on |
+| -tpp&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TrimPostProcessing&nbsp;&lt;bool&gt; | Enable trim post processing to make trimmed trace file smaller | false |
 | -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
 
 In local tracing mode, both the `vktrace` and application executables reside on the same system.
@@ -168,6 +169,10 @@ Several environment variables can be set to change the behavior of vktrace/vkrep
  - VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS
 
     VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS, when set to a non-null value, enables post processing  when read PMB support is enabled.  When VKTRACE_PAGEGUARD_ENABLE_READ_PMB is set, PMB processing will sometimes miss writes following reads if writes occur on the same page as a read. Set this environment variable to enable post processing to fix missed pmb writes. It is supported only on Windows.
+
+ - VKTRACE_TRIM_POST_PROCESS
+
+    VKTRACE_TRIM_POST_PROCESS enables post processing of trim if its value is 1.  Other values disable trim post processing.  Disable post processing means the trimmed trace file will record all the not destroyed objects no matter they are used/referenced in the trim frame range or not.  Enable post processing will drop most of the pre-trim objects which are not used/referenced in the trim frame range.  Set this environment variable to 1 to enable post processing of trim to generate a smaller trace file and eliminate most useless pre-trim objects and vulkan calls.  Do NOT enable trim post processing when there's a large trim frame range because both the referenced pre-trim data and in-trim data are kept in memory until writing to trace file in the trim end frame which may exceeds the system memory.
 
 ## Android
 

--- a/vktrace/vktrace_common/vktrace_common.h
+++ b/vktrace/vktrace_common/vktrace_common.h
@@ -148,6 +148,23 @@ static const uint32_t  INVALID_BINDING_INDEX = UINT32_MAX;
 // trace layer.
 #define VKTRACE_TRIM_TRIGGER_ENV "VKTRACE_TRIM_TRIGGER"
 
+// VKTRACE_TRIM_POST_PROCESS env var is an option to be configured to do write
+// all referenced object calls in either trim start frame or trim stop frame.
+//
+// When it is set to 0, write all referenced object calls will happen in trim start frame.
+// When it is set to 1, write all referenced object calls will happen in trim end frame.
+// If this var is undefined or other value, trimmed data writes will happen in the start frame.
+//
+// Setting it to 1 will reduce trimmed trace file size a lot for some vulkan titles which have
+// lots of shader modules, images and buffers NOT referenced in-trim.
+//
+// But the post processing will consume a lot of memory if there are too many in-trim frames
+// because it keeps both trimmed data and in-trim packets in memory until writting everything to
+// trace file in trim end frame which may exceeds the system memory.
+// So it is default to 0 (disabled) and should be only enabled as needed.
+// (e.g. when generating trace file with only 1 or small range of frames.)
+#define VKTRACE_TRIM_POST_PROCESS_ENV "VKTRACE_TRIM_POST_PROCESS"
+
 // _VKTRACE_VERBOSITY env var is set by the vktrace program to
 // communicate verbosity level to the trace layer. It is set to
 // one of "quiet", "errors", "warnings", "full", or "debug".

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -132,6 +132,8 @@ void remove_CommandBuffer_calls(VkCommandBuffer commandBuffer);
 void add_Image_call(vktrace_trace_packet_header *pHeader);
 #endif  // TRIM_USE_ORDERED_IMAGE_CREATION
 
+void add_InTrim_call(vktrace_trace_packet_header *pHeader);
+
 void AddImageTransition(VkCommandBuffer commandBuffer, ImageTransition transition);
 std::list<ImageTransition> GetImageTransitions(VkCommandBuffer commandBuffer);
 void ClearImageTransitions(VkCommandBuffer commandBuffer);
@@ -158,7 +160,21 @@ VkImageAspectFlags getImageAspectFromFormat(VkFormat format);
 void add_Allocator(const VkAllocationCallbacks *pAllocator);
 VkAllocationCallbacks *get_Allocator(const VkAllocationCallbacks *pAllocator);
 
-void mark_CommandBuffer_reference(VkCommandBuffer commandbuffer);
+void mark_Device_reference(VkDevice var);
+void mark_CommandBuffer_reference(VkCommandBuffer var);
+void mark_CommandPool_reference(VkCommandPool var);
+void mark_ShaderModule_reference(VkShaderModule var);
+void mark_Pipeline_reference(VkPipeline var);
+void mark_PipelineCache_reference(VkPipelineCache var);
+void mark_DescriptorPool_reference(VkDescriptorPool var);
+void mark_DescriptorSet_reference(VkDescriptorSet var);
+void mark_Image_reference(VkImage var);
+void mark_ImageView_reference(VkImageView var);
+void mark_Framebuffer_reference(VkFramebuffer var);
+void mark_QueryPool_reference(VkQueryPool var);
+void mark_DeviceMemory_reference(VkDeviceMemory var);
+void mark_Buffer_reference(VkBuffer var);
+void mark_BufferView_reference(VkBufferView var);
 
 ObjectInfo &add_Instance_object(VkInstance var);
 ObjectInfo *get_Instance_objectInfo(VkInstance var);

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.cpp
@@ -101,6 +101,8 @@ void StateTracker::remove_CommandBuffer_calls(VkCommandBuffer commandBuffer) {
 void StateTracker::add_Image_call(vktrace_trace_packet_header *pHeader) { m_image_calls.push_back(pHeader); }
 #endif  // TRIM_USE_ORDERED_IMAGE_CREATION
 
+void StateTracker::add_InTrim_call(vktrace_trace_packet_header *pHeader) { m_inTrim_calls.push_back(pHeader); }
+
 //-------------------------------------------------------------------------
 void StateTracker::clear() {
     seqInstances.clear();
@@ -229,6 +231,12 @@ void StateTracker::clear() {
         vktrace_delete_trace_packet(&pHeader);
     }
     m_image_calls.clear();
+
+    for (auto packet = m_inTrim_calls.begin(); packet != m_inTrim_calls.end(); ++packet) {
+        vktrace_trace_packet_header *pHeader = *packet;
+        vktrace_delete_trace_packet(&pHeader);
+    }
+    m_inTrim_calls.clear();
 
     for (auto renderPassIter = m_renderPassVersions.begin(); renderPassIter != m_renderPassVersions.end(); ++renderPassIter) {
         std::vector<VkRenderPassCreateInfo *> versions = renderPassIter->second;

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
@@ -70,6 +70,8 @@ typedef struct _Trim_ObjectInfo {
     uint64_t vkObject;                         // object handle
     bool bReferencedInTrim;                    // True if the object was referenced during the trim
                                                // frames
+    bool bReferencedInTrimChecked;             // True if the object has been checked if it was referenced
+                                               // during the trim frames
     VkInstance belongsToInstance;              // owning Instance
     VkPhysicalDevice belongsToPhysicalDevice;  // owning PhysicalDevice
     VkDevice belongsToDevice;                  // owning Device
@@ -185,6 +187,7 @@ typedef struct _Trim_ObjectInfo {
         struct _BufferView {  // VkBufferView
             vktrace_trace_packet_header *pCreatePacket;
             const VkAllocationCallbacks *pAllocator;
+            VkBuffer buffer;
         } BufferView;
         struct _Sampler {  // VkSampler
             vktrace_trace_packet_header *pCreatePacket;
@@ -347,6 +350,8 @@ class StateTracker {
     void add_Image_call(vktrace_trace_packet_header *pHeader);
 #endif  // TRIM_USE_ORDERED_IMAGE_CREATION
 
+    void add_InTrim_call(vktrace_trace_packet_header *pHeader);
+
     StateTracker &operator=(const StateTracker &other);
 
     ObjectInfo &add_Instance(VkInstance var);
@@ -463,6 +468,8 @@ class StateTracker {
     // We need to recreate them in the same order to ensure they will have the
     // same size requirements as they had a trace-time.
     std::list<vktrace_trace_packet_header *> m_image_calls;
+
+    std::list<vktrace_trace_packet_header *> m_inTrim_calls;
 
     std::unordered_map<VkInstance, ObjectInfo> createdInstances;
     std::vector<VkInstance> seqInstances;

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -123,6 +123,13 @@ vktrace_SettingInfo g_settings_info[] = {
                                          hotkey-[F1-F12|TAB|CONTROL]\n\
                                          hotkey-[F1-F12|TAB|CONTROL]-<frameCount>\n\
                                          frames-<startFrame>-<endFrame>"},
+    {"tpp",
+     "TrimPostProcessing",
+     VKTRACE_SETTING_BOOL,
+     {&g_settings.enable_trim_post_processing},
+     {&g_default_settings.enable_trim_post_processing},
+     TRUE,
+     "Enable trim post processing to make trimmed trace file smaller, default is FALSE."},
     //{ "z", "pauze", VKTRACE_SETTING_BOOL, &g_settings.pause,
     //&g_default_settings.pause, TRUE, "Wait for a key at startup (so a debugger
     // can be attached)" },
@@ -319,12 +326,21 @@ int main(int argc, char* argv[]) {
     g_default_settings.screenshotList = NULL;
     g_default_settings.screenshotColorFormat = NULL;
     g_default_settings.enable_pmb = true;
+    g_default_settings.enable_trim_post_processing = false;
 
     // Check to see if the PAGEGUARD_PAGEGUARD_ENABLE_ENV env var is set.
     // If it is set to anything but "1", set the default to false.
     // Note that the command line option will override the env variable.
     char* pmbEnableEnv = vktrace_get_global_var(VKTRACE_PMB_ENABLE_ENV);
     if (pmbEnableEnv && strcmp(pmbEnableEnv, "1")) g_default_settings.enable_pmb = false;
+
+    // Check to see if the VKTRACE_TRIM_POST_PROCESS_ENV env var is set.
+    // If it is set to "1", set it to true.
+    // If it is set to anything but "1", set it to false.
+    // Note that the command line option will override the env variable.
+    char* tppEnableEnv = vktrace_get_global_var(VKTRACE_TRIM_POST_PROCESS_ENV);
+    if (tppEnableEnv && strcmp(tppEnableEnv, "1")) g_default_settings.enable_trim_post_processing = false;
+    if (tppEnableEnv && !strcmp(tppEnableEnv, "1")) g_default_settings.enable_trim_post_processing = true;
 
     if (vktrace_SettingGroup_init(&g_settingGroup, NULL, argc, argv, &g_settings.arguments) != 0) {
         // invalid cmd-line parameters
@@ -406,6 +422,7 @@ int main(int argc, char* argv[]) {
     }
 
     vktrace_set_global_var(VKTRACE_PMB_ENABLE_ENV, g_settings.enable_pmb ? "1" : "0");
+    vktrace_set_global_var(VKTRACE_TRIM_POST_PROCESS_ENV, g_settings.enable_trim_post_processing ? "1" : "0");
 
     if (g_settings.traceTrigger) {
         // Export list to screenshot layer

--- a/vktrace/vktrace_trace/vktrace.h
+++ b/vktrace/vktrace_trace/vktrace.h
@@ -44,7 +44,7 @@ typedef struct vktrace_settings {
     BOOL enable_pmb;
     const char* verbosity;
     const char* traceTrigger;
-
+    BOOL enable_trim_post_processing;
 } vktrace_settings;
 
 extern vktrace_settings g_settings;


### PR DESCRIPTION
This PR adds a environment variable VKTRACE_TRIM_POST_PROCESS and a vktrace option "-tpp" to enable/disable trim post processing.
Disable post processing means "write all referenced object calls" will happen in the trim start frame.
Enable post processing means "write all referenced object calls" will happen in the trim end frame and will NOT save objects NOT referenced in-trim.

- When VKTRACE_TRIM_POST_PROCESS is set to 1, trim post processing is enabled and the "write all referenced object calls" will happen in trim end frame.
- When VKTRACE_TRIM_POST_PROCESS is set to 0, trim post processing is disabled and the "write all referenced object calls" will happen in trim start frame.
- When VKTRACE_TRIM_POST_PROCESS is NOT set or set with other value, the "write all referenced object calls" will happen in trim start frame.

(The same as the behavior without this change.)

This change helps to reduce the trimmed trace file size.
It saves around 30% file size in average in our testing but it depends on the number of objects (especially shader modules, images and buffers) NOT referenced in-trim.