### PR TITLE
scripts: Extend scope of LaTeX handling

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1536,6 +1536,7 @@ class VulkanVariable:
             code = re.sub('{|}', '', code)
             code = re.sub('\\\\mathit', '', code)
             code = re.sub('\\\\over', '/', code)
+            code = re.sub('\\\\textrm', '', code)
             self.arrayLength = code
 
         # Dereference if necessary and handle members of variables

--- a/scripts/tool_helper_file_generator.py
+++ b/scripts/tool_helper_file_generator.py
@@ -262,9 +262,9 @@ class ToolHelperFileOutputGenerator(OutputGenerator):
                 decoratedName = '{}/{}'.format(*match.group(2, 3))
         else:
             # Matches expressions similar to 'latexmath : [dataSize \over 4]'
-            match = re.match(r'latexmath\s*\:\s*\[\s*(\w+)\s*\\over\s*(\d+)\s*\]', source)
-            name = match.group(1)
-            decoratedName = '{}/{}'.format(*match.group(1, 2))
+            match = re.match(r'latexmath\s*\:\s*\[\s*(\\textrm\{)?(\w+)\}?\s*\\over\s*(\d+)\s*\]', source)
+            name = match.group(2)
+            decoratedName = '{}/{}'.format(*match.group(2, 3))
         return name, decoratedName
     #
     # Retrieve the value of the len tag
@@ -490,4 +490,3 @@ class ToolHelperFileOutputGenerator(OutputGenerator):
             return self.GenerateStructSizeHelperSource()
         else:
             return 'Bad Tools Helper File Generator Option %s' % self.helper_file_type
-

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -340,9 +340,9 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 decoratedName = '{}/{}'.format(*match.group(2, 3))
         else:
             # Matches expressions similar to 'latexmath : [dataSize \over 4]'
-            match = re.match(r'latexmath\s*\:\s*\[\s*(\w+)\s*\\over\s*(\d+)\s*\]', source)
-            name = match.group(1)
-            decoratedName = '{}/{}'.format(*match.group(1, 2))
+            match = re.match(r'latexmath\s*\:\s*\[\s*(\\textrm\{)?(\w+)\}?\s*\\over\s*(\d+)\s*\]', source)
+            name = match.group(2)
+            decoratedName = '{}/{}'.format(*match.group(2, 3))
         return name, decoratedName
     #
     # Retrieve the value of the len tag
@@ -2999,4 +2999,3 @@ class VkTraceFileOutputGenerator(OutputGenerator):
             return self.GenerateTraceVkPacketsHeader()
         else:
             return 'Bad VkTrace File Generator Option %s' % self.vktrace_file_type
-


### PR DESCRIPTION
The 1.1.90 header introduced the use of "\textrm" in `vk.xml`, requiring
changes to:
- scripts/api_dump_generator.py
- scripts/tool_helper_file_generator.py
- scripts/vktrace_file_generator.py