### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1191,7 +1191,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
         gen.OutputGenerator.beginFile(self, genOpts)
         self.format = genOpts.input
 
-        if self.registryFile != None:
+        if self.registryFile is not None:
             root = xml.etree.ElementTree.parse(self.registryFile)
         else:
             root = self.registry.reg
@@ -1218,7 +1218,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
         # Find all of the extensions that use the system types
         self.sysTypes = set()
         for node in self.registry.reg.find('types').findall('type'):
-            if node.get('category') == None and node.get('requires') in self.includes and node.get('requires') != 'vk_platform' or \
+            if node.get('category') is None and node.get('requires') in self.includes and node.get('requires') != 'vk_platform' or \
                 (node.find('name') is not None and node.find('name').text in DEFINE_TYPES): #Handle system types that are '#define'd in spec
                 for extension in self.extTypes:
                     for structName in self.extTypes[extension].vktypes:
@@ -1259,14 +1259,14 @@ class ApiDumpOutputGenerator(OutputGenerator):
         loops = []
         unassignedControls = []
         depth = 0
-        while nextFor != None or nextFor != None or nextEnd != None:
+        while nextFor is not None or nextFor is not None or nextEnd is not None:
             # If this is a @foreach
-            if nextFor != None and ((nextIf == None or nextFor.start() < nextIf.start()) and nextFor.start() < nextEnd.start()):
+            if nextFor is not None and ((nextIf is None or nextFor.start() < nextIf.start()) and nextFor.start() < nextEnd.start()):
                 depth += 1
                 forType = re.search('(?<=\\s)[a-z]+', self.format[nextFor.start():nextFor.end()])
                 text = self.format[forType.start()+nextFor.start():forType.end()+nextFor.start()]
                 whereMatch = re.search('(?<=where\\().*(?=\\))', self.format[nextFor.start():nextFor.end()])
-                condition = None if whereMatch == None else self.format[whereMatch.start()+nextFor.start():whereMatch.end()+nextFor.start()]
+                condition = None if whereMatch is None else self.format[whereMatch.start()+nextFor.start():whereMatch.end()+nextFor.start()]
                 unassignedControls.append((nextFor.start(), nextFor.end(), text, condition))
 
                 try:
@@ -1275,10 +1275,10 @@ class ApiDumpOutputGenerator(OutputGenerator):
                     nextFor = None
 
             # If this is an @if
-            elif nextIf != None and nextIf.start() < nextEnd.start():
+            elif nextIf is not None and nextIf.start() < nextEnd.start():
                 depth += 1
                 condMatch = re.search('(?<=if\\().*(?=\\))', self.format[nextIf.start():nextIf.end()])
-                condition = None if condMatch == None else self.format[condMatch.start()+nextIf.start():condMatch.end()+nextIf.start()]
+                condition = None if condMatch is None else self.format[condMatch.start()+nextIf.start():condMatch.end()+nextIf.start()]
                 unassignedControls.append((nextIf.start(), nextIf.end(), 'if', condition))
 
                 try:
@@ -1363,7 +1363,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
             self.structs.add(VulkanStruct(typeinfo.elem, self.constants))
         elif typeinfo.elem.get('category') == 'basetype':
             self.basetypes.add(VulkanBasetype(typeinfo.elem))
-        elif typeinfo.elem.get('category') == None and typeinfo.elem.get('requires') == 'vk_platform':
+        elif typeinfo.elem.get('category') is None and typeinfo.elem.get('requires') == 'vk_platform':
             self.externalTypes.add(VulkanExternalType(typeinfo.elem))
         elif typeinfo.elem.get('category') == 'handle':
             self.handles.add(VulkanHandle(typeinfo.elem))
@@ -1423,7 +1423,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
                 values.update(parent.values())
 
             # Check if the condition is met
-            if loop.condition != None:
+            if loop.condition is not None:
                 cond = eval(loop.condition.format(**values))
                 assert(cond == True or cond == False)
                 if not cond:
@@ -1438,7 +1438,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
                 ext = item.ext
             else:
                 ext = None
-            if ext != None and ext.guard != None:
+            if ext is not None and ext.guard is not None:
                 out += '#if defined({})\n'.format(ext.guard)
 
             # Format the string
@@ -1450,7 +1450,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
             out += loop.fullString[lastIndex:loop.endPos[0]].format(**values)
 
             # Close the ifdef
-            if ext != None and ext.guard != None:
+            if ext is not None and ext.guard is not None:
                 out += '#endif // {}\n'.format(ext.guard)
 
         return out
@@ -1462,7 +1462,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
                 if isinstance(item, ty):
                     value = item
                     break
-        assert(value != None)
+        assert(value is not None)
         return value
 
 class Control:
@@ -1490,7 +1490,7 @@ class VulkanVariable:
         # Set basic properties
         self.name = rootNode.find('name').text      # Variable name
         self.typeID = rootNode.find('type').text    # Typename, dereferenced and converted to a useable C++ token
-        if aliases != None and self.typeID in aliases:
+        if aliases is not None and self.typeID in aliases:
             self.typeID = aliases[self.typeID]
         self.baseType = self.typeID                 # Type, dereferenced to the non-pointer type
         self.childType = None                       # Type, dereferenced to the non-pointer type (None if it isn't a pointer)
@@ -1500,7 +1500,7 @@ class VulkanVariable:
         self.text = ''
         for node in rootNode.itertext():
             comment = rootNode.find('comment')
-            if comment != None and comment.text == node:
+            if comment is not None and comment.text == node:
                 continue
             self.text += node
 
@@ -1508,7 +1508,7 @@ class VulkanVariable:
         self.type = typeMatch.string[typeMatch.start():typeMatch.end()]
         self.type = ' '.join(self.type.split())
         bracketMatch = re.search('(?<=\\[)[a-zA-Z0-9_]+(?=\\])', self.text)
-        if bracketMatch != None:
+        if bracketMatch is not None:
             matchText = bracketMatch.string[bracketMatch.start():bracketMatch.end()]
             self.childType = self.type
             self.type += '[' + matchText + ']'
@@ -1520,15 +1520,15 @@ class VulkanVariable:
         self.lengthMember = False
         lengthString = rootNode.get('len')
         lengths = []
-        if lengthString != None:
+        if lengthString is not None:
             lengths = re.split(',', lengthString)
             lengths = list(filter(('null-terminated').__ne__, lengths))
         assert(len(lengths) <= 1)
-        if self.arrayLength == None and len(lengths) > 0:
+        if self.arrayLength is None and len(lengths) > 0:
             self.childType = '*'.join(self.type.split('*')[0:-1])
             self.arrayLength = lengths[0]
             self.lengthMember = True
-        if self.arrayLength != None and self.arrayLength.startswith('latexmath'):
+        if self.arrayLength is not None and self.arrayLength.startswith('latexmath'):
             code = self.arrayLength[10:len(self.arrayLength)]
             code = re.sub('\\[', '', code)
             code = re.sub('\\]', '', code)
@@ -1539,7 +1539,7 @@ class VulkanVariable:
             self.arrayLength = code
 
         # Dereference if necessary and handle members of variables
-        if self.arrayLength != None:
+        if self.arrayLength is not None:
             self.arrayLength = re.sub('::', '->', self.arrayLength)
             sections = self.arrayLength.split('->')
             if sections[-1][0] == 'p' and sections[0][1].isupper():
@@ -1585,7 +1585,7 @@ class VulkanBitmask:
             childValue = child.get('value')
             childBitpos = child.get('bitpos')
             childComment = child.get('comment')
-            if childName == None or (childValue == None and childBitpos == None):
+            if childName is None or (childValue is None and childBitpos is None):
                 continue
 
             self.options.append(VulkanEnum.Option(childName, childValue, childBitpos, childComment))
@@ -1610,7 +1610,7 @@ class VulkanEnum:
             self.name = name
             self.comment = comment
 
-            if value == 0 or value == None:
+            if value == 0 or value is None:
                 value = 1 << int(bitpos)
             self.value = value
 
@@ -1632,7 +1632,7 @@ class VulkanEnum:
             childValue = child.get('value')
             childBitpos = child.get('bitpos')
             childComment = child.get('comment')
-            if childName == None or (childValue == None and childBitpos == None):
+            if childName is None or (childValue is None and childBitpos is None):
                 continue
             # Check for duplicates, TODO: Maybe solve up a level
             duplicate = False
@@ -1685,12 +1685,12 @@ class VulkanExtension:
                 bitpos = enum.get('bitpos')
                 offset = enum.get('offset')
 
-                if value == None and bitpos != None:
+                if value is None and bitpos is not None:
                     value = 1 << int(bitpos)
 
-                if offset != None:
+                if offset is not None:
                     offset = int(offset)
-                if base != None and offset != None:
+                if base is not None and offset is not None:
                     enumValue = 1000000000 + 1000*(self.number - 1) + offset
                     if enum.get('dir') == '-':
                         enumValue = -enumValue;

--- a/scripts/determine_vs_version.py
+++ b/scripts/determine_vs_version.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
     # If not found, return an invalid number but in the appropriate format so it will
     # fail if the program above tries to use it.
-    if foundExeName == None:
+    if foundExeName is None:
         print('00 0000')
         print('Executable ' + exeName + ' not found in PATH!')
     else:
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         for spaceString in spaceList:
 
             # If we've already found it, bail.
-            if version != None:
+            if version is not None:
                 break
         
             # Now split around line feeds
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             for curLine in lineList:
 
                 # If we've already found it, bail.
-                if version != None:
+                if version is not None:
                     break
             
                 # We only want to continue if there's a period in the list
@@ -109,7 +109,7 @@ if __name__ == '__main__':
                     break
         
         # Failsafe to return a number in the proper format, but one that will fail.
-        if version == None:
+        if version is None:
             version = 00
 
         # Determine the year associated with that version

--- a/scripts/layer_factory_generator.py
+++ b/scripts/layer_factory_generator.py
@@ -620,7 +620,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
             self.newline()
             # If type declarations are needed by other features based on this one, it may be necessary to suppress the ExtraProtect,
             # or move it below the 'for section...' loop.
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             for section in self.TYPE_SECTIONS:
                 contents = self.sections[section]
@@ -630,7 +630,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
             if (self.sections['command']):
                 write('\n'.join(self.sections['command']), end=u'', file=self.outFile)
                 self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#endif /*', self.featureExtraProtect, '*/', file=self.outFile)
         # Finish processing in superclass
         OutputGenerator.endFeature(self)
@@ -702,14 +702,14 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
         if self.header: # In the header declare all intercepts
             self.appendSection('command', '')
             self.appendSection('command', self.makeCDecls(cmdinfo.elem)[0])
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 self.intercepts += [ '#ifdef %s' % self.featureExtraProtect ]
                 self.layer_factory += '#ifdef %s\n' % self.featureExtraProtect
             # Update base class with virtual function declarations
             self.layer_factory += self.BaseClassCdecl(cmdinfo.elem, name)
             # Update function intercepts
             self.intercepts += [ '    {"%s", (void*)%s},' % (name,name[2:]) ]
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 self.intercepts += [ '#endif' ]
                 self.layer_factory += '#endif\n'
             return
@@ -738,10 +738,10 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
             self.intercepts += [ '    {"%s", (void*)%s},' % (name,name[2:]) ]
             return
         # Record that the function will be intercepted
-        if (self.featureExtraProtect != None):
+        if (self.featureExtraProtect is not None):
             self.intercepts += [ '#ifdef %s' % self.featureExtraProtect ]
         self.intercepts += [ '    {"%s", (void*)%s},' % (name,name[2:]) ]
-        if (self.featureExtraProtect != None):
+        if (self.featureExtraProtect is not None):
             self.intercepts += [ '#endif' ]
         OutputGenerator.genCmd(self, cmdinfo, name, alias)
         #
@@ -771,9 +771,9 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
 
         # Declare result variable, if any.
         resulttype = cmdinfo.elem.find('proto/type')
-        if (resulttype != None and resulttype.text == 'void'):
+        if (resulttype is not None and resulttype.text == 'void'):
           resulttype = None
-        if (resulttype != None):
+        if (resulttype is not None):
             assignresult = resulttype.text + ' result = '
         else:
             assignresult = ''
@@ -786,7 +786,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
         self.appendSection('command', '    }')
 
         # Return result variable, if any.
-        if (resulttype != None):
+        if (resulttype is not None):
             self.appendSection('command', '    return result;')
         self.appendSection('command', '}')
     #

--- a/scripts/tool_helper_file_generator.py
+++ b/scripts/tool_helper_file_generator.py
@@ -334,10 +334,10 @@ class ToolHelperFileOutputGenerator(OutputGenerator):
         outstring += 'size_t get_struct_size(const void* struct_ptr);\n'
         for item in self.structMembers:
             lower_case_name = item.name.lower()
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 outstring += '#ifdef %s\n' % item.ifdef_protect
             outstring += 'size_t vk_size_%s(const %s* struct_ptr);\n' % (item.name.lower(), item.name)
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 outstring += '#endif // %s\n' % item.ifdef_protect
         outstring += '#ifdef __cplusplus\n'
         outstring += '}\n'
@@ -412,7 +412,7 @@ class ToolHelperFileOutputGenerator(OutputGenerator):
         for item in self.structMembers:
             struct_size_funcs += '\n'
             lower_case_name = item.name.lower()
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 struct_size_funcs += '#ifdef %s\n' % item.ifdef_protect
                 struct_size += '#ifdef %s\n' % item.ifdef_protect
                 chain_size += '#ifdef %s\n' % item.ifdef_protect
@@ -460,7 +460,7 @@ class ToolHelperFileOutputGenerator(OutputGenerator):
             struct_size_funcs += '    }\n'
             struct_size_funcs += '    return struct_size;\n'
             struct_size_funcs += '}\n'
-            if item.ifdef_protect != None:
+            if item.ifdef_protect is not None:
                 struct_size_funcs += '#endif // %s\n' % item.ifdef_protect
                 struct_size += '#endif // %s\n' % item.ifdef_protect
                 chain_size += '#endif // %s\n' % item.ifdef_protect

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -157,7 +157,7 @@ def isSupportedCmd(cmd, cmd_extension_dict):
 def isInstanceCmd(cmd):
     cmdtarget = cmd.members[0].type
     handle = cmd.members[0].handle
-    return handle == None or cmdtarget == "VkInstance" or cmdtarget == 'VkPhysicalDevice'
+    return handle is None or cmdtarget == "VkInstance" or cmdtarget == 'VkPhysicalDevice'
 
 #
 # VkTraceFileOutputGeneratorOptions - subclass of GeneratorOptions.
@@ -726,7 +726,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
             # Handle return values, if any
             ret_value = True
             resulttype = cmdinfo.elem.find('proto/type')
-            if resulttype != None and resulttype.text == 'void' or cmdname in custom_body_dict:
+            if resulttype is not None and resulttype.text == 'void' or cmdname in custom_body_dict:
               ret_value = False
             create_func = True if True in [create_txt in cmdname for create_txt in ['Create', 'Allocate', 'Acquire', 'GetDeviceQueue']] else False
             create_view = True if True in [create_txt in cmdname for create_txt in ['CreateBufferView', 'CreateImageView']] else False
@@ -2930,7 +2930,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 elif 'FlushMappedMemoryRanges' in proto.name or 'InvalidateMappedMemoryRanges' in proto.name:
                     trace_pkt_hdr += '    void** ppData;\n'
                 resulttype = cmdinfo.elem.find('proto/type')
-                if resulttype != None and resulttype.text != 'void':
+                if resulttype is not None and resulttype.text != 'void':
                     trace_pkt_hdr += '    %s result;\n' % resulttype.text
                 trace_pkt_hdr += '} packet_%s;\n\n' % proto.name
                 trace_pkt_hdr += 'static packet_%s* interpret_body_as_%s(vktrace_trace_packet_header* pHeader) {\n' % (proto.name, proto.name)

--- a/scripts/vt_genvk.py
+++ b/scripts/vt_genvk.py
@@ -32,7 +32,7 @@ def endTimer(timeit, msg):
 
 # Turn a list of strings into a regexp string matching exactly those strings
 def makeREstring(list, default = None):
-    if len(list) > 0 or default == None:
+    if len(list) > 0 or default is None:
         return '^(' + '|'.join(list) + ')$'
     else:
         return default


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations