### PR TITLE
vkreplay: Handle muliple swapchains in trace file

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -3368,6 +3368,9 @@ VkResult vkReplay::manually_replay_vkCreateSwapchainKHR(packet_vkCreateSwapchain
 
     (*pSC) = save_oldSwapchain;
     *pSurf = save_surface;
+
+    m_objMapper.m_pImageIndex.clear();
+
     return replayResult;
 }
 


### PR DESCRIPTION
This change resets pImageIndex in vkCreateSwapchainKHR to make replay work
when there are multiple vkCreateSwapchainKHR API calls being replayed.