### PR TITLE
vktrace: Keep the order of instance and swapchain creation in trim

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -2814,7 +2814,11 @@ void write_all_referenced_object_calls() {
     vktrace_leave_critical_section(&trimStateTrackerLock);
 
     // Instances (& PhysicalDevices)
-    for (auto obj = stateTracker.createdInstances.begin(); obj != stateTracker.createdInstances.end(); obj++) {
+    for (auto iterator = stateTracker.seqInstances.begin(); iterator != stateTracker.seqInstances.end(); ++iterator) {
+        auto obj = stateTracker.createdInstances.find(*iterator);
+        if (obj == stateTracker.createdInstances.end()) {
+            continue;
+        }
         vktrace_write_trace_packet(obj->second.ObjectInfo.Instance.pCreatePacket, vktrace_trace_get_trace_file());
         vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Instance.pCreatePacket));
 
@@ -3058,7 +3062,11 @@ void write_all_referenced_object_calls() {
     // swapchain image.
 
     // SwapchainKHR
-    for (auto obj = stateTracker.createdSwapchainKHRs.begin(); obj != stateTracker.createdSwapchainKHRs.end(); obj++) {
+    for (auto iterator = stateTracker.seqSwapchainKHRs.begin(); iterator != stateTracker.seqSwapchainKHRs.end(); ++iterator) {
+        auto obj = stateTracker.createdSwapchainKHRs.find(*iterator);
+        if (obj == stateTracker.createdSwapchainKHRs.end()) {
+            continue;
+        }
         vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket, vktrace_trace_get_trace_file());
         vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket));
 

--- a/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_statetracker.h
@@ -465,6 +465,7 @@ class StateTracker {
     std::list<vktrace_trace_packet_header *> m_image_calls;
 
     std::unordered_map<VkInstance, ObjectInfo> createdInstances;
+    std::vector<VkInstance> seqInstances;
     std::unordered_map<VkPhysicalDevice, ObjectInfo> createdPhysicalDevices;
     std::unordered_map<VkDevice, ObjectInfo> createdDevices;
     std::unordered_map<VkSurfaceKHR, ObjectInfo> createdSurfaceKHRs;
@@ -479,6 +480,7 @@ class StateTracker {
     std::unordered_map<VkDeviceMemory, ObjectInfo> createdDeviceMemorys;
     std::unordered_map<VkFence, ObjectInfo> createdFences;
     std::unordered_map<VkSwapchainKHR, ObjectInfo> createdSwapchainKHRs;
+    std::vector<VkSwapchainKHR> seqSwapchainKHRs;
     std::unordered_map<VkImage, ObjectInfo> createdImages;
     std::unordered_map<VkImageView, ObjectInfo> createdImageViews;
     std::unordered_map<VkBuffer, ObjectInfo> createdBuffers;


### PR DESCRIPTION
This change records and keeps the creation order of instances and
swapchains in trim to make the trimmed trace file work when there are
multiple instances and swapchains.

It solves remap failures which are caused by the incorrect order of
instance creation or swapchain creation when replaying a trimmed trace
file.