### PR TITLE
vkreplay: Fix vkGetDisplayPlaneSupportedDisplaysKHR

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -4473,9 +4473,6 @@ VkResult vkReplay::manually_replay_vkGetDisplayPlaneSupportedDisplaysKHR(packet_
                                                                  pPacket->pDisplayCount, pDisplays);
 
     if (pPacket->pDisplays != NULL) {
-        if (memcmp(pDisplays, pPacket->pDisplays, sizeof(VkDisplayKHR) * (*pPacket->pDisplayCount)) != 0) {
-            vktrace_LogError("Display Plane supported displays differ. Displays may not match as expected.");
-        }
         for (uint32_t i = 0; i < *pPacket->pDisplayCount; ++i) {
             m_objMapper.add_to_displaykhrs_map(pPacket->pDisplays[i], pDisplays[i]);
         }


### PR DESCRIPTION
This change adds the missing VKTRACE_DELETE to the memory allocated
using VKTRACE_NEW_ARRAY.

It also adds the returned VkDisplayKHR to VkDisplayKHR map.