### PR TITLE
vkreplay: Preload portability table

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_main.h
+++ b/vktrace/vktrace_replay/vkreplay_main.h
@@ -36,7 +36,7 @@ typedef struct vkreplayer_settings {
 } vkreplayer_settings;
 
 #include <vector>
-extern std::vector<uint64_t> portabilityTable;
+extern std::vector<uintptr_t> portabilityTablePackets;
 extern FileLike* traceFile;
 
 #endif  // VKREPLAY__MAIN_H


### PR DESCRIPTION
This change preloads portability table before replaying to eliminate
the performance noise caused by file I/O (fseek/fread in
vkAllocateMemory when using portability table) when calculating FPS.