### PR TITLE
Remove redundant memory allocation vkreplay

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -789,7 +789,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                     else:
                         replay_gen_source += '            %s local_%s;\n' % (params[-1].type.strip('*').replace('const ', ''), params[-1].name)
                 elif cmdname == 'ResetFences':
-                    replay_gen_source += '            VkFence* fences = VKTRACE_NEW_ARRAY(VkFence, pPacket->fenceCount);\n'
+                    replay_gen_source += '            VkFence* fences = (VkFence *)pPacket->pFences;\n'
                     replay_gen_source += '            for (uint32_t i = 0; i < pPacket->fenceCount; i++) {\n'
                     replay_gen_source += '                fences[i] = m_objMapper.remap_fences(pPacket->%s[i]);\n' % (params[-1].name)
                     replay_gen_source += '                if (fences[i] == VK_NULL_HANDLE) {\n'
@@ -965,8 +965,6 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                     replay_gen_source += '            if (memcmp(&memProperties, pPacket->pMemoryProperties, sizeof(VkPhysicalDeviceMemoryProperties)) != 0) {\n'
                     replay_gen_source += '                vktrace_LogError("Physical Device Memory properties differ. Memory heaps may not match as expected.");\n'
                     replay_gen_source += '            }\n'
-                elif cmdname == 'ResetFences':
-                    replay_gen_source += '            VKTRACE_DELETE(fences);\n'
                 elif create_func: # Save handle mapping if create successful
                     if ret_value:
                         replay_gen_source += '            if (replayResult == VK_SUCCESS) {\n'

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -3174,7 +3174,7 @@ VkResult vkReplay::manually_replay_vkQueuePresentKHR(packet_vkQueuePresentKHR *p
         pResults = VKTRACE_NEW_ARRAY(VkResult, pPacket->pPresentInfo->swapchainCount);
     }
 
-    if (pRemappedSwapchains == NULL || pRemappedWaitSems == NULL || pResults == NULL) {
+    if (pResults == NULL) {
         replayResult = VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 


### PR DESCRIPTION
This PR fixes vkQuake replay failure issue mentioned in #661 based on #652 

This change removes redundant memory allocate/copy/free calls from
following functions in vkreplay to reduce vkreplay's CPU load. (CPU
time per frame is reduced from 40ms to 30ms when replaying a benchmark)
manually_replay_vkUpdateDescriptorSets()
manually_replay_vkCmdBindVertexBuffers()
manually_replay_vkCmdBindDescriptorSets()
manually_replay_vkQueueSubmit()
manually_replay_vkQueueBindSparse()
manually_replay_vkAllocateDescriptorSets()
manually_replay_vkCreateGraphicsPipelines()
manually_replay_vkCmdWaitEvents()
manually_replay_vkCmdPipelineBarrier()
manually_replay_vkCreateFramebuffer()
manually_replay_vkWaitForFences()
manually_replay_vkFlushMappedMemoryRanges()
manually_replay_vkInvalidateMappedMemoryRanges()
manually_replay_vkQueuePresentKHR()
manually_replay_vkCmdPushDescriptorSetKHR()
manually_replay_vkCreatePipelineLayout()
vkResetFences in vkReplay::replay()