### PR TITLE
via: Rename executable/html to vkvia

### DIFF
--- a/via/CMakeLists-SDK.txt
+++ b/via/CMakeLists-SDK.txt
@@ -80,7 +80,7 @@ endif()
 
 if(WIN32)
 add_definitions(-DVIA_WINDOWS_TARGET)
-add_executable(via
+add_executable(vkvia
                   via.cpp
                   via_system.hpp
                   via_system.cpp
@@ -89,7 +89,7 @@ add_executable(via
                   ${JSONCPP_SOURCE_DIR}/jsoncpp.cpp)
 else()
 add_definitions(-DVIA_LINUX_TARGET)
-add_executable(via
+add_executable(vkvia
                   via.cpp
                   via_system.hpp
                   via_system.cpp
@@ -97,8 +97,8 @@ add_executable(via
                   via_system_linux.cpp
                   ${JSONCPP_SOURCE_DIR}/jsoncpp.cpp)
 endif()
-target_include_directories(via PUBLIC ${JSONCPP_INCLUDE_DIR})
-target_link_libraries(via ${LIBRARIES})
+target_include_directories(vkvia PUBLIC ${JSONCPP_INCLUDE_DIR})
+target_link_libraries(vkvia ${LIBRARIES})
 if(WIN32)
-    target_link_libraries(via version)
+    target_link_libraries(vkvia version)
 endif()

--- a/via/CMakeLists.txt
+++ b/via/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 endif()
 
 if(WIN32)
-add_executable(via
+add_executable(vkvia
                   via.cpp
                   via_system.hpp
                   via_system.cpp
@@ -60,7 +60,7 @@ add_executable(via
                   via_system_windows.cpp
                   ${JSONCPP_SOURCE_DIR}/jsoncpp.cpp)
 else()
-add_executable(via
+add_executable(vkvia
                   via.cpp
                   via_system.hpp
                   via_system.cpp
@@ -69,13 +69,13 @@ add_executable(via
                   ${JSONCPP_SOURCE_DIR}/jsoncpp.cpp)
 endif()
 
-target_include_directories(via PUBLIC ${JSONCPP_INCLUDE_DIR})
-target_link_libraries(via Vulkan::Vulkan)
+target_include_directories(vkvia PUBLIC ${JSONCPP_INCLUDE_DIR})
+target_link_libraries(vkvia Vulkan::Vulkan)
 if(WIN32)
-    target_link_libraries(via version shlwapi Cfgmgr32)
+    target_link_libraries(vkvia version shlwapi Cfgmgr32)
 else()
-    target_link_libraries(via dl)
+    target_link_libraries(vkvia dl)
 endif()
 if(UNIX)
-    install(TARGETS via DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS vkvia DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/via/README.md
+++ b/via/README.md
@@ -62,21 +62,21 @@ You will find the VIA binary in a different location depending on which OS you a
 
 When running, if VIA detects an installed Vulkan SDK, it will attempt to run the "Cube" demo in several ways to make sure the install truly appears valid.  The first run of "Cube" it attempts will run in the standard way, but only for a few frames.  After that completes, it will attempt to run "Cube" with validation enabled, again, for only a few frames.  Because of this, you may notice "Cube" popping up several times while running VIA.  When it has completed the tests, it will then record the results as normal to the HTML file.
 
-Please note that if you are trying to diagnose a troublesome application, the **best way** to run VIA to assist in diagnosis is to change to the location of the application, and run via in that folder locally (by typing in a relative or absolute path to the via executable).
+Please note that if you are trying to diagnose a troublesome application, the **best way** to run VIA to assist in diagnosis is to change to the location of the application, and run via in that folder locally (by typing in a relative or absolute path to the vkvia executable).
 
 #### In the Windows Vulkan SDK
-VIA is installed into your start menu as part of the Windows Vulkan SDK.  Simply open your start menu, search for the "Vulkan SDK" and click "via".  This will output the resulting via.html directly to your desktop.
+VIA is installed into your start menu as part of the Windows Vulkan SDK.  Simply open your start menu, search for the "Vulkan SDK" and click "vkvia".  This will output the resulting vkvia.html directly to your desktop.
 
 If you need to run via from the command-line, you will find it in your SDK folder (defined by the environment variable "VULKAN_SDK") under the "Bin" folder for 64-bit executables, and "Bin32" folder for 32-bit executables.  From there, simply run:
 ```
-via.exe
+vkvia.exe
 ```
 
 #### In the Linux Vulkan SDK
 Once built, VIA can be found in the x86_64/bin directory.  You can simply execute it from there using:
 
 ```
-via
+vkvia
 ```
 
 <BR />
@@ -89,7 +89,7 @@ Go into the folder where you generated the build items from the above building s
 
 Simply run:
 ```
-via
+vkvia
 ```
 
 
@@ -103,17 +103,17 @@ Steps to run the first time:
  3. Go into the "Debug" or "Release" folder (whichever you are desiring to work with) 
  4. Run 
 ```
-via.exe
+vkvia.exe
 ```
 
-After the first time, you just need to go into the folder and re-run "via.exe".
+After the first time, you just need to go into the folder and re-run "vkvia.exe".
 
 <BR />
 
 ### Resulting Output
 VIA outputs two things:
  - A command-line output indicating the overall status
- - An HTML file (called via.html) containing the details which will be output to one of two locations:
+ - An HTML file (called vkvia.html) containing the details which will be output to one of two locations:
   1. If the current directory is writable, the HTML will be placed in that location.
   2. Otherwise, it will be saved to your home folder, except for the Windows Start Menu short-cut which writes the file to your desktop.
 
@@ -138,7 +138,7 @@ Where each component stands for the numeric values for year (YYYY), month (MM), 
 #### --output_path
 The --output_path arument allows the user to specify a location for the output html file. For
 example, if the user runs `via --output_path /home/me/Documents`, then the output file will be
-`/home/me/Documents/via.html`.
+`/home/me/Documents/vkvia.html`.
 
 <BR />
 


### PR DESCRIPTION
Rename the VIA executable from "via" to "vkvia" since we're going
to be installing this globally on Linux systems.