### PR TITLE
Fix capture and trim problems for some titles.

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -201,9 +201,6 @@ vktrace_trace_packet_header* vktrace_create_trace_packet(uint8_t tracer_id, uint
     return pHeader;
 }
 
-// Delete packet after vktrace_create_trace_packet being called.
-void vktrace_delete_trace_packet(vktrace_trace_packet_header** ppHeader) { vktrace_delete_trace_packet_no_lock(ppHeader); }
-
 void* vktrace_trace_packet_get_new_buffer_address(vktrace_trace_packet_header* pHeader, uint64_t byteCount) {
     void* pBufferStart;
     assert(byteCount > 0);
@@ -442,7 +439,7 @@ vktrace_trace_packet_header* vktrace_read_trace_packet(FileLike* pFile) {
 }
 
 // Delete packet after vktrace_read_trace_packet being called.
-void vktrace_delete_trace_packet_no_lock(vktrace_trace_packet_header** ppHeader) {
+void vktrace_delete_trace_packet(vktrace_trace_packet_header** ppHeader) {
     if (ppHeader == NULL) return;
     if (*ppHeader == NULL) return;
 

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.h
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.h
@@ -76,7 +76,7 @@ static FILE* vktrace_open_trace_file(vktrace_process_info* pProcInfo) {
 vktrace_trace_packet_header* vktrace_create_trace_packet(uint8_t tracer_id, uint16_t packet_id, uint64_t packet_size,
                                                          uint64_t additional_buffers_size);
 
-// deletes a trace packet and sets pointer to NULL, this function should be used on a packet created to write to trace file
+// deletes a trace packet and sets pointer to NULL
 void vktrace_delete_trace_packet(vktrace_trace_packet_header** ppHeader);
 
 // gets the next address available to write a buffer into the packet
@@ -109,9 +109,6 @@ void vktrace_write_trace_packet(const vktrace_trace_packet_header* pHeader, File
 
 // Reads in the trace packet header, the body of the packet, and additional buffers
 vktrace_trace_packet_header* vktrace_read_trace_packet(FileLike* pFile);
-
-// deletes a trace packet and sets pointer to NULL, this function should be used on a packet read from trace file
-void vktrace_delete_trace_packet_no_lock(vktrace_trace_packet_header** ppHeader);
 
 // converts a pointer variable that is currently byte offset into a pointer to the actual offset location
 void* vktrace_trace_packet_interpret_buffer_pointer(vktrace_trace_packet_header* pHeader, intptr_t ptr_variable);

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -80,6 +80,13 @@ typedef struct _DeviceMemory {
     VkDeviceMemory memory;
 } DeviceMemory;
 
+// These mutexes are used to protect the following fence,buffer and
+// commandbuffer maps. Some title crash during capture due to multithreads
+// access the following maps simultaneously.
+static std::mutex g_Mutex_cmdBufferToBuffersMap;
+static std::mutex g_Mutex_fenceToCommandBuffersMap;
+static std::mutex g_Mutex_commandBufferToCommandBuffersMap;
+
 std::unordered_map<VkCommandBuffer, std::list<VkBuffer>> g_cmdBufferToBuffers;
 std::unordered_map<VkBuffer, DeviceMemory> g_bufferToDeviceMemory;
 std::unordered_map<VkFence, std::list<VkCommandBuffer>> g_fenceToCommandBuffers;
@@ -2195,6 +2202,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
     vktrace_set_packet_entrypoint_end_time(pHeader);
 #if defined(USE_PAGEGUARD_SPEEDUP) && !defined(PAGEGUARD_ADD_PAGEGUARD_ON_REAL_MAPPED_MEMORY)
     if (fence != VK_NULL_HANDLE) {
+        g_Mutex_fenceToCommandBuffersMap.lock();
         if (g_fenceToCommandBuffers.find(fence) != g_fenceToCommandBuffers.end()) {
             g_fenceToCommandBuffers[fence].clear();
         }
@@ -2204,6 +2212,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
                 g_fenceToCommandBuffers[fence].push_back(pSubmits[i].pCommandBuffers[j]);
             }
         }
+        g_Mutex_fenceToCommandBuffersMap.unlock();
     }
 #endif
     pPacket = interpret_body_as_vkQueueSubmit(pHeader);
@@ -4573,22 +4582,51 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkWaitForFences(VkDevice
     // Find a way to fully resolve the memory read not detectable issue in pageguard on Linux and Android.
     // Because current solution won't solve memory read problem when a linear image's memory is mapped to CPU memory and application
     // wants to read from that CPU memory. It only works for applications which always read from buffers instead of images.
-    for (uint32_t i = 0; i < fenceCount; ++i) {
-        if (g_fenceToCommandBuffers.find(pFences[i]) != g_fenceToCommandBuffers.end()) {
-            // Iterate command buffers related to a fence (from the mapping created in __HOOKED_vkQueueSubmit)
-            for (auto iterPrim = g_fenceToCommandBuffers[pFences[i]].begin(); iterPrim != g_fenceToCommandBuffers[pFences[i]].end();
-                 ++iterPrim) {
-                VkCommandBuffer primaryCmdBuffer = *iterPrim;
-                if (g_commandBufferToCommandBuffers.find(primaryCmdBuffer) != g_commandBufferToCommandBuffers.end()) {
-                    // Iterate secondary command buffers and their primary command buffer (from the mapping created in
-                    // __HOOKED_vkCmdExecuteCommands)
-                    for (auto iter = g_commandBufferToCommandBuffers[primaryCmdBuffer].begin();
-                         iter != g_commandBufferToCommandBuffers[primaryCmdBuffer].end(); ++iter) {
-                        VkCommandBuffer cmdBuffer = *iter;
-                        if (g_cmdBufferToBuffers.find(cmdBuffer) != g_cmdBufferToBuffers.end()) {
+    {
+        std::lock(g_Mutex_fenceToCommandBuffersMap, g_Mutex_commandBufferToCommandBuffersMap, g_Mutex_cmdBufferToBuffersMap);
+        std::lock_guard<std::mutex> lockFenceToCommandBuffersMap(g_Mutex_fenceToCommandBuffersMap, std::adopt_lock);
+        std::lock_guard<std::mutex> lockCommandBufferToCommandBuffersMap(g_Mutex_commandBufferToCommandBuffersMap, std::adopt_lock);
+        std::lock_guard<std::mutex> lockCmdBufferToBuffersMap(g_Mutex_cmdBufferToBuffersMap, std::adopt_lock);
+        for (uint32_t i = 0; i < fenceCount; ++i) {
+            if (g_fenceToCommandBuffers.find(pFences[i]) != g_fenceToCommandBuffers.end()) {
+                // Iterate command buffers related to a fence (from the mapping created in __HOOKED_vkQueueSubmit)
+                for (auto iterPrim = g_fenceToCommandBuffers[pFences[i]].begin();
+                     iterPrim != g_fenceToCommandBuffers[pFences[i]].end(); ++iterPrim) {
+                    VkCommandBuffer primaryCmdBuffer = *iterPrim;
+                    if (g_commandBufferToCommandBuffers.find(primaryCmdBuffer) != g_commandBufferToCommandBuffers.end()) {
+                        // Iterate secondary command buffers and their primary command buffer (from the mapping created in
+                        // __HOOKED_vkCmdExecuteCommands)
+                        for (auto iter = g_commandBufferToCommandBuffers[primaryCmdBuffer].begin();
+                             iter != g_commandBufferToCommandBuffers[primaryCmdBuffer].end(); ++iter) {
+                            VkCommandBuffer cmdBuffer = *iter;
+                            if (g_cmdBufferToBuffers.find(cmdBuffer) != g_cmdBufferToBuffers.end()) {
+                                // Iterate buffers (from the mapping created in __HOOKED_vkCmdCopyImageToBuffer)
+                                for (auto iterBuffer = g_cmdBufferToBuffers[cmdBuffer].begin();
+                                     iterBuffer != g_cmdBufferToBuffers[cmdBuffer].end(); ++iterBuffer) {
+                                    VkBuffer buffer = *iterBuffer;
+                                    if (g_bufferToDeviceMemory.find(buffer) != g_bufferToDeviceMemory.end()) {
+                                        // Sync real mapped memory (recorded in __HOOKED_vkBindBufferMemory) for the dest buffer
+                                        // (recorded in __HOOKED_vkCmdCopyImageToBuffer) back to the copy of that memory
+                                        VkDevice device = g_bufferToDeviceMemory[buffer].device;
+                                        VkDeviceMemory memory = g_bufferToDeviceMemory[buffer].memory;
+                                        getPageGuardControlInstance().SyncRealMappedMemoryToMemoryCopyHandle(device, memory);
+                                    }
+                                }
+                                // Assuming the command buffer which has vkCmdCopyImageToBuffer will not be re-used.
+                                if (g_cmdBufferToBuffers.find(cmdBuffer) != g_cmdBufferToBuffers.end()) {
+                                    g_cmdBufferToBuffers[cmdBuffer].clear();
+                                }
+                                g_cmdBufferToBuffers.erase(cmdBuffer);
+                            }
+                        }
+                        g_commandBufferToCommandBuffers[primaryCmdBuffer].clear();
+                        g_commandBufferToCommandBuffers.erase(primaryCmdBuffer);
+                    } else {
+                        // There's no secondary command buffer so no need to iterate.
+                        if (g_cmdBufferToBuffers.find(primaryCmdBuffer) != g_cmdBufferToBuffers.end()) {
                             // Iterate buffers (from the mapping created in __HOOKED_vkCmdCopyImageToBuffer)
-                            for (auto iterBuffer = g_cmdBufferToBuffers[cmdBuffer].begin();
-                                 iterBuffer != g_cmdBufferToBuffers[cmdBuffer].end(); ++iterBuffer) {
+                            for (auto iterBuffer = g_cmdBufferToBuffers[primaryCmdBuffer].begin();
+                                 iterBuffer != g_cmdBufferToBuffers[primaryCmdBuffer].end(); ++iterBuffer) {
                                 VkBuffer buffer = *iterBuffer;
                                 if (g_bufferToDeviceMemory.find(buffer) != g_bufferToDeviceMemory.end()) {
                                     // Sync real mapped memory (recorded in __HOOKED_vkBindBufferMemory) for the dest buffer
@@ -4599,39 +4637,16 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkWaitForFences(VkDevice
                                 }
                             }
                             // Assuming the command buffer which has vkCmdCopyImageToBuffer will not be re-used.
-                            if (g_cmdBufferToBuffers.find(cmdBuffer) != g_cmdBufferToBuffers.end()) {
-                                g_cmdBufferToBuffers[cmdBuffer].clear();
+                            if (g_cmdBufferToBuffers.find(primaryCmdBuffer) != g_cmdBufferToBuffers.end()) {
+                                g_cmdBufferToBuffers[primaryCmdBuffer].clear();
                             }
-                            g_cmdBufferToBuffers.erase(cmdBuffer);
+                            g_cmdBufferToBuffers.erase(primaryCmdBuffer);
                         }
-                    }
-                    g_commandBufferToCommandBuffers[primaryCmdBuffer].clear();
-                    g_commandBufferToCommandBuffers.erase(primaryCmdBuffer);
-                } else {
-                    // There's no secondary command buffer so no need to iterate.
-                    if (g_cmdBufferToBuffers.find(primaryCmdBuffer) != g_cmdBufferToBuffers.end()) {
-                        // Iterate buffers (from the mapping created in __HOOKED_vkCmdCopyImageToBuffer)
-                        for (auto iterBuffer = g_cmdBufferToBuffers[primaryCmdBuffer].begin();
-                             iterBuffer != g_cmdBufferToBuffers[primaryCmdBuffer].end(); ++iterBuffer) {
-                            VkBuffer buffer = *iterBuffer;
-                            if (g_bufferToDeviceMemory.find(buffer) != g_bufferToDeviceMemory.end()) {
-                                // Sync real mapped memory (recorded in __HOOKED_vkBindBufferMemory) for the dest buffer (recorded
-                                // in __HOOKED_vkCmdCopyImageToBuffer) back to the copy of that memory
-                                VkDevice device = g_bufferToDeviceMemory[buffer].device;
-                                VkDeviceMemory memory = g_bufferToDeviceMemory[buffer].memory;
-                                getPageGuardControlInstance().SyncRealMappedMemoryToMemoryCopyHandle(device, memory);
-                            }
-                        }
-                        // Assuming the command buffer which has vkCmdCopyImageToBuffer will not be re-used.
-                        if (g_cmdBufferToBuffers.find(primaryCmdBuffer) != g_cmdBufferToBuffers.end()) {
-                            g_cmdBufferToBuffers[primaryCmdBuffer].clear();
-                        }
-                        g_cmdBufferToBuffers.erase(primaryCmdBuffer);
                     }
                 }
+                g_fenceToCommandBuffers[pFences[i]].clear();
+                g_fenceToCommandBuffers.erase(pFences[i]);
             }
-            g_fenceToCommandBuffers[pFences[i]].clear();
-            g_fenceToCommandBuffers.erase(pFences[i]);
         }
     }
 #endif

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -3256,18 +3256,18 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(obj->second.ObjectInfo.Instance.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Instance.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Instance.pCreatePacket));
 
         if (obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesCountPacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesCountPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesCountPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesCountPacket));
         }
 
         if (obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesPacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Instance.pEnumeratePhysicalDevicesPacket));
         }
     }
 
@@ -3278,55 +3278,53 @@ void write_all_referenced_object_calls() {
             // process in vkAllocateMemory during playback.
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDevicePropertiesPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDevicePropertiesPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDevicePropertiesPacket));
         }
         if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceProperties2KHRPacket != nullptr) {
             // Generate GetPhysicalDeviceProperties2KHR Packet. It's needed by portability
             // process in vkAllocateMemory during playback.
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceProperties2KHRPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceProperties2KHRPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceProperties2KHRPacket));
         }
 
         if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceMemoryPropertiesPacket != nullptr) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceMemoryPropertiesPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceMemoryPropertiesPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceMemoryPropertiesPacket));
         }
 
         if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesCountPacket != nullptr) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesCountPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(
+            vktrace_delete_trace_packet(
                 &(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesCountPacket));
         }
 
         if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesPacket != nullptr) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(
-                &(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyPropertiesPacket));
         }
 
         if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyProperties2KHRCountPacket != nullptr) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyProperties2KHRCountPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(
+            vktrace_delete_trace_packet(
                 &(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyProperties2KHRCountPacket));
         }
 
         if (obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyProperties2KHRPacket != nullptr) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyProperties2KHRPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(
-                &(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyProperties2KHRPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PhysicalDevice.pGetPhysicalDeviceQueueFamilyProperties2KHRPacket));
         }
     }
 
     // SurfaceKHR and surface properties
     for (auto obj = stateTracker.createdSurfaceKHRs.begin(); obj != stateTracker.createdSurfaceKHRs.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.SurfaceKHR.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SurfaceKHR.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.SurfaceKHR.pCreatePacket));
 
         VkSurfaceKHR surface = obj->first;
 
@@ -3390,13 +3388,13 @@ void write_all_referenced_object_calls() {
     // Devices
     for (auto obj = stateTracker.createdDevices.begin(); obj != stateTracker.createdDevices.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.Device.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Device.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Device.pCreatePacket));
     }
 
     // Queue
     for (auto obj = stateTracker.createdQueues.begin(); obj != stateTracker.createdQueues.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.Queue.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Queue.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Queue.pCreatePacket));
     }
 
     // CommandPool
@@ -3407,7 +3405,7 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(poolObj->second.ObjectInfo.CommandPool.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(poolObj->second.ObjectInfo.CommandPool.pCreatePacket));
+        vktrace_delete_trace_packet(&(poolObj->second.ObjectInfo.CommandPool.pCreatePacket));
 
         // Now allocate command buffers that were allocated on this pool
         for (int32_t level = VK_COMMAND_BUFFER_LEVEL_BEGIN_RANGE; level <= VK_COMMAND_BUFFER_LEVEL_END_RANGE; level++) {
@@ -3443,7 +3441,7 @@ void write_all_referenced_object_calls() {
     for (auto obj = stateTracker.createdDeviceMemorys.begin(); obj != stateTracker.createdDeviceMemorys.end(); obj++) {
         // AllocateMemory
         vktrace_write_trace_packet(obj->second.ObjectInfo.DeviceMemory.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.DeviceMemory.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.DeviceMemory.pCreatePacket));
     }
 
     // Image
@@ -3459,12 +3457,12 @@ void write_all_referenced_object_calls() {
             // replay
             if (obj->second.ObjectInfo.Image.pMapMemoryPacket != NULL) {
                 vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pMapMemoryPacket, vktrace_trace_get_trace_file());
-                vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Image.pMapMemoryPacket));
+                vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Image.pMapMemoryPacket));
             }
 
             if (obj->second.ObjectInfo.Image.pUnmapMemoryPacket != NULL) {
                 vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pUnmapMemoryPacket, vktrace_trace_get_trace_file());
-                vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Image.pUnmapMemoryPacket));
+                vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Image.pUnmapMemoryPacket));
             }
         }
     }
@@ -3472,7 +3470,7 @@ void write_all_referenced_object_calls() {
 #if TRIM_USE_ORDERED_IMAGE_CREATION
     for (auto iter = stateTracker.m_image_calls.begin(); iter != stateTracker.m_image_calls.end(); ++iter) {
         vktrace_write_trace_packet(*iter, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(*iter));
+        vktrace_delete_trace_packet(&(*iter));
     }
 #endif  // TRIM_USE_ORDERED_IMAGE_CREATION
 
@@ -3512,14 +3510,14 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.SwapchainKHR.pCreatePacket));
 
         vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImageCountPacket,
                                    vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImageCountPacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImageCountPacket));
 
         vktrace_write_trace_packet(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImagesPacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImagesPacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.SwapchainKHR.pGetSwapchainImagesPacket));
     }
 
     for (auto obj = stateTracker.createdImages.begin(); obj != stateTracker.createdImages.end(); obj++) {
@@ -3530,21 +3528,21 @@ void write_all_referenced_object_calls() {
         // CreateImage
         if (obj->second.ObjectInfo.Image.pCreatePacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pCreatePacket, vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Image.pCreatePacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Image.pCreatePacket));
         }
 
         // GetImageMemoryRequirements
         if (obj->second.ObjectInfo.Image.pGetImageMemoryRequirementsPacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pGetImageMemoryRequirementsPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Image.pGetImageMemoryRequirementsPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Image.pGetImageMemoryRequirementsPacket));
         }
 #endif  //! TRIM_USE_ORDERED_IMAGE_CREATION
 
         // BindImageMemory
         if (obj->second.ObjectInfo.Image.pBindImageMemoryPacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pBindImageMemoryPacket, vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Image.pBindImageMemoryPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Image.pBindImageMemoryPacket));
         }
     }
 
@@ -3591,12 +3589,12 @@ void write_all_referenced_object_calls() {
                     // replay
                     if (obj->second.ObjectInfo.Image.pMapMemoryPacket != NULL) {
                         vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pMapMemoryPacket, vktrace_trace_get_trace_file());
-                        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Image.pMapMemoryPacket));
+                        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Image.pMapMemoryPacket));
                     }
 
                     if (obj->second.ObjectInfo.Image.pUnmapMemoryPacket != NULL) {
                         vktrace_write_trace_packet(obj->second.ObjectInfo.Image.pUnmapMemoryPacket, vktrace_trace_get_trace_file());
-                        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Image.pUnmapMemoryPacket));
+                        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Image.pUnmapMemoryPacket));
                     }
                 }
 
@@ -3851,7 +3849,7 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(obj->second.ObjectInfo.ImageView.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.ImageView.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.ImageView.pCreatePacket));
     }
 
     // Buffer
@@ -3869,7 +3867,7 @@ void write_all_referenced_object_calls() {
         assert(obj->second.ObjectInfo.Buffer.pCreatePacket != NULL);
         if (obj->second.ObjectInfo.Buffer.pCreatePacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.Buffer.pCreatePacket, vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Buffer.pCreatePacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Buffer.pCreatePacket));
         }
 
         if ((obj->second.ObjectInfo.Buffer.pBindBufferMemoryPacket != nullptr) && (obj->second.ObjectInfo.Buffer.size != 0)) {
@@ -3880,7 +3878,7 @@ void write_all_referenced_object_calls() {
             // BindBufferMemory
             if (obj->second.ObjectInfo.Buffer.pBindBufferMemoryPacket != NULL) {
                 vktrace_write_trace_packet(obj->second.ObjectInfo.Buffer.pBindBufferMemoryPacket, vktrace_trace_get_trace_file());
-                vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Buffer.pBindBufferMemoryPacket));
+                vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Buffer.pBindBufferMemoryPacket));
             }
 
             if (obj->second.ObjectInfo.Buffer.needsStagingBuffer) {
@@ -3896,13 +3894,13 @@ void write_all_referenced_object_calls() {
                     // replay
                     if (obj->second.ObjectInfo.Buffer.pMapMemoryPacket != NULL) {
                         vktrace_write_trace_packet(obj->second.ObjectInfo.Buffer.pMapMemoryPacket, vktrace_trace_get_trace_file());
-                        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Buffer.pMapMemoryPacket));
+                        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Buffer.pMapMemoryPacket));
                     }
 
                     if (obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket != NULL) {
                         vktrace_write_trace_packet(obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket,
                                                    vktrace_trace_get_trace_file());
-                        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket));
+                        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket));
                     }
                 }
 
@@ -3997,12 +3995,12 @@ void write_all_referenced_object_calls() {
                 // replay
                 if (obj->second.ObjectInfo.Buffer.pMapMemoryPacket != NULL) {
                     vktrace_write_trace_packet(obj->second.ObjectInfo.Buffer.pMapMemoryPacket, vktrace_trace_get_trace_file());
-                    vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Buffer.pMapMemoryPacket));
+                    vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Buffer.pMapMemoryPacket));
                 }
 
                 if (obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket != NULL) {
                     vktrace_write_trace_packet(obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket, vktrace_trace_get_trace_file());
-                    vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket));
+                    vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Buffer.pUnmapMemoryPacket));
                 }
             }
         }
@@ -4014,7 +4012,7 @@ void write_all_referenced_object_calls() {
         if (obj->second.ObjectInfo.DeviceMemory.pPersistentlyMapMemoryPacket != NULL) {
             vktrace_write_trace_packet(obj->second.ObjectInfo.DeviceMemory.pPersistentlyMapMemoryPacket,
                                        vktrace_trace_get_trace_file());
-            vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.DeviceMemory.pPersistentlyMapMemoryPacket));
+            vktrace_delete_trace_packet(&(obj->second.ObjectInfo.DeviceMemory.pPersistentlyMapMemoryPacket));
         }
     }
 
@@ -4026,32 +4024,32 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(obj->second.ObjectInfo.BufferView.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.BufferView.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.BufferView.pCreatePacket));
     }
 
     // Sampler
     for (auto obj = stateTracker.createdSamplers.begin(); obj != stateTracker.createdSamplers.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.Sampler.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Sampler.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Sampler.pCreatePacket));
     }
 
     // DescriptorSetLayout
     for (auto obj = stateTracker.createdDescriptorSetLayouts.begin(); obj != stateTracker.createdDescriptorSetLayouts.end();
          obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.DescriptorSetLayout.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.DescriptorSetLayout.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.DescriptorSetLayout.pCreatePacket));
     }
 
     // PipelineLayout
     for (auto obj = stateTracker.createdPipelineLayouts.begin(); obj != stateTracker.createdPipelineLayouts.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.PipelineLayout.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.PipelineLayout.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PipelineLayout.pCreatePacket));
     }
 
     // RenderPass
     for (auto obj = stateTracker.createdRenderPasss.begin(); obj != stateTracker.createdRenderPasss.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.RenderPass.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.RenderPass.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.RenderPass.pCreatePacket));
     }
 
     // ShaderModule
@@ -4077,7 +4075,7 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(obj->second.ObjectInfo.PipelineCache.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.PipelineCache.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.PipelineCache.pCreatePacket));
     }
 
     // Pipeline
@@ -4178,7 +4176,7 @@ void write_all_referenced_object_calls() {
         }
         // write the createDescriptorPool packet
         vktrace_write_trace_packet(poolObj->second.ObjectInfo.DescriptorPool.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(poolObj->second.ObjectInfo.DescriptorPool.pCreatePacket));
+        vktrace_delete_trace_packet(&(poolObj->second.ObjectInfo.DescriptorPool.pCreatePacket));
 
         if (poolObj->second.ObjectInfo.DescriptorPool.numSets > 0) {
             // now allocate all DescriptorSets that are part of this pool
@@ -4272,13 +4270,13 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(obj->second.ObjectInfo.Framebuffer.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Framebuffer.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Framebuffer.pCreatePacket));
     }
 
     // Semaphore
     for (auto obj = stateTracker.createdSemaphores.begin(); obj != stateTracker.createdSemaphores.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.Semaphore.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Semaphore.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Semaphore.pCreatePacket));
     }
 
     // Fence
@@ -4300,7 +4298,7 @@ void write_all_referenced_object_calls() {
     // Event
     for (auto obj = stateTracker.createdEvents.begin(); obj != stateTracker.createdEvents.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.Event.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.Event.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.Event.pCreatePacket));
     }
 
     // QueryPool
@@ -4311,7 +4309,7 @@ void write_all_referenced_object_calls() {
             continue;
         }
         vktrace_write_trace_packet(obj->second.ObjectInfo.QueryPool.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.QueryPool.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.QueryPool.pCreatePacket));
 
         VkCommandBuffer commandBuffer = obj->second.ObjectInfo.QueryPool.commandBuffer;
 
@@ -4405,7 +4403,7 @@ void write_all_referenced_object_calls() {
             for (std::list<vktrace_trace_packet_header *>::iterator packet = packets.begin(); packet != packets.end(); ++packet) {
                 vktrace_trace_packet_header *pHeader = *packet;
                 vktrace_write_trace_packet(pHeader, vktrace_trace_get_trace_file());
-                vktrace_delete_trace_packet_no_lock(&pHeader);
+                vktrace_delete_trace_packet(&pHeader);
             }
             packets.clear();
         }
@@ -4422,7 +4420,7 @@ void write_all_referenced_object_calls() {
             for (std::list<vktrace_trace_packet_header *>::iterator packet = packets.begin(); packet != packets.end(); ++packet) {
                 vktrace_trace_packet_header *pHeader = *packet;
                 vktrace_write_trace_packet(pHeader, vktrace_trace_get_trace_file());
-                vktrace_delete_trace_packet_no_lock(&pHeader);
+                vktrace_delete_trace_packet(&pHeader);
             }
             packets.clear();
         }
@@ -4496,7 +4494,7 @@ void write_all_referenced_object_calls() {
     for (auto obj = stateTracker.createdDescriptorUpdateTemplates.begin();
          obj != stateTracker.createdDescriptorUpdateTemplates.end(); obj++) {
         vktrace_write_trace_packet(obj->second.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(obj->second.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket));
+        vktrace_delete_trace_packet(&(obj->second.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket));
     }
 
     // Recreate in-trim objects
@@ -4504,7 +4502,7 @@ void write_all_referenced_object_calls() {
     for (auto iter = s_trimGlobalStateTracker.m_inTrim_calls.begin(); iter != s_trimGlobalStateTracker.m_inTrim_calls.end();
          ++iter) {
         vktrace_write_trace_packet(*iter, vktrace_trace_get_trace_file());
-        vktrace_delete_trace_packet_no_lock(&(*iter));
+        vktrace_delete_trace_packet(&(*iter));
     }
     vktrace_leave_critical_section(&trimStateTrackerLock);
 

--- a/vktrace/vktrace_replay/vkreplay_seq.cpp
+++ b/vktrace/vktrace_replay/vkreplay_seq.cpp
@@ -27,7 +27,7 @@ extern "C" {
 namespace vktrace_replay {
 
 vktrace_trace_packet_header *Sequencer::get_next_packet() {
-    vktrace_delete_trace_packet_no_lock(&m_lastPacket);
+    vktrace_delete_trace_packet(&m_lastPacket);
     if (!m_pFile) return (NULL);
     m_lastPacket = vktrace_read_trace_packet(m_pFile);
     return (m_lastPacket);

--- a/vktrace/vktrace_trace/vktrace_process.cpp
+++ b/vktrace/vktrace_trace/vktrace_process.cpp
@@ -275,7 +275,7 @@ VKTRACE_THREAD_ROUTINE_RETURN_TYPE Process_RunRecordTraceThread(LPVOID _threadIn
 
             if (pHeader->packet_id == VKTRACE_TPI_MARKER_TERMINATE_PROCESS) {
                 pInfo->pProcessInfo->serverRequestsTermination = true;
-                vktrace_delete_trace_packet_no_lock(&pHeader);
+                vktrace_delete_trace_packet(&pHeader);
                 vktrace_LogVerbose("Thread_CaptureTrace is exiting.");
                 break;
             }
@@ -309,7 +309,7 @@ VKTRACE_THREAD_ROUTINE_RETURN_TYPE Process_RunRecordTraceThread(LPVOID _threadIn
         }
 
         // clean up
-        vktrace_delete_trace_packet_no_lock(&pHeader);
+        vktrace_delete_trace_packet(&pHeader);
     }
 
 #if defined(WIN32)


### PR DESCRIPTION
It Include the following changes: fixes for some titles capture and trim problem including remove s_trace_lock, delete vktrace_delete_trace_packet_no_lock and rename all references of the function to vktrace_delete_trace_packet, add lock to protect fence,buffer and command buffer maps.