### PR TITLE
Add mutex lock for all manual and autogenerated hooked API when trim capture is enabled.

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -2574,6 +2574,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 ptr_packet_update_list = self.GetPacketPtrParamList(proto.members)
                 # End of function declaration portion, begin function body
                 trace_vk_src += ' {\n'
+                trace_vk_src += '    trim::TrimLockGuard<std::mutex> lock(g_mutex);\n'
                 if 'void' not in resulttype or '*' in resulttype:
                     trace_vk_src += '    %s result;\n' % resulttype
                     return_txt = 'result = '

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -2574,7 +2574,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 ptr_packet_update_list = self.GetPacketPtrParamList(proto.members)
                 # End of function declaration portion, begin function body
                 trace_vk_src += ' {\n'
-                trace_vk_src += '    trim::TrimLockGuard<std::mutex> lock(g_mutex);\n'
+                trace_vk_src += '    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);\n'
                 if 'void' not in resulttype or '*' in resulttype:
                     trace_vk_src += '    %s result;\n' % resulttype
                     return_txt = 'result = '

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -166,7 +166,6 @@ void* strip_create_extensions(const void* pNext) {
     return create_info;
 }
 
-
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkDeviceMemory* pMemory) {
@@ -220,7 +219,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevic
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset,
                                                                     VkDeviceSize size, VkFlags flags, void** ppData) {
-
     trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
@@ -4094,7 +4092,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateAndroidSurfaceKH
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplate(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 }
 
@@ -4779,7 +4776,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
     return result;
 }
 
-
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
     VkCommandBuffer commandBuffer,
     const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
@@ -5148,13 +5144,11 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPrope
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                                uint32_t* pPropertyCount,
                                                                                                VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties);
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                            VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties);
 }
 
@@ -5177,12 +5171,10 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetInstanceProcAddr(VkInstance instance,
                                                                                                     const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetInstanceProcAddr(instance, funcName);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetDeviceProcAddr(VkDevice device,
                                                                                                   const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetDeviceProcAddr(device, funcName);
 }

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -50,7 +50,8 @@
 
 #include "vk_struct_size_helper.h"
 
-std::mutex g_mutex;
+// This mutex is used to protect API calls sequence when trim starting process.
+std::mutex g_mutex_trim;
 
 VKTRACER_LEAVE _Unload(void) {
     // only do the hooking and networking if the tracer is NOT loaded by vktrace
@@ -169,7 +170,7 @@ void* strip_create_extensions(const void* pNext) {
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkDeviceMemory* pMemory) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateMemory* pPacket = NULL;
@@ -219,7 +220,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevic
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset,
                                                                     VkDeviceSize size, VkFlags flags, void** ppData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkMapMemory* pPacket = NULL;
@@ -301,7 +302,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
 }
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice device, VkDeviceMemory memory) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkUnmapMemory* pPacket;
     VKAllocInfo* entry;
@@ -368,7 +369,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice devic
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device, VkDeviceMemory memory,
                                                                  const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeMemory* pPacket = NULL;
 #if defined(USE_PAGEGUARD_SPEEDUP)
@@ -414,7 +415,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                        const VkMappedMemoryRange* pMemoryRanges) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     size_t rangesSize = 0;
@@ -517,7 +518,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemory
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                   const VkMappedMemoryRange* pMemoryRanges) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     uint64_t rangesSize = 0;
@@ -653,7 +654,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers(VkDevice device,
                                                                                  const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                                                  VkCommandBuffer* pCommandBuffers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateCommandBuffers* pPacket = NULL;
@@ -701,7 +702,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
                                                                              const VkCommandBufferBeginInfo* pBeginInfo) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBeginCommandBuffer* pPacket = NULL;
@@ -745,7 +746,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorPool(V
                                                                                const VkDescriptorPoolCreateInfo* pCreateInfo,
                                                                                const VkAllocationCallbacks* pAllocator,
                                                                                VkDescriptorPool* pDescriptorPool) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorPool* pPacket = NULL;
@@ -807,7 +808,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
     VkPhysicalDevice physicalDevice,
     VkPhysicalDeviceProperties* pProperties)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties, sizeof(VkPhysicalDeviceProperties));
@@ -851,7 +852,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice,
                                                                                       VkPhysicalDeviceProperties2KHR* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties2KHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties2KHR, get_struct_chain_size((void*)pProperties));
@@ -885,7 +886,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDevice(VkPhysicalDevice physicalDevice,
                                                                        const VkDeviceCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateDevice* pPacket = NULL;
@@ -993,7 +994,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateFramebuffer(VkDe
                                                                             const VkFramebufferCreateInfo* pCreateInfo,
                                                                             const VkAllocationCallbacks* pAllocator,
                                                                             VkFramebuffer* pFramebuffer) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateFramebuffer* pPacket = NULL;
@@ -1132,7 +1133,7 @@ static void send_vk_api_version_packet() {
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkInstance* pInstance) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateInstance* pPacket = NULL;
@@ -1252,7 +1253,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const V
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyInstance(VkInstance instance,
                                                                       const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     if (g_trimEnabled && g_trimIsInTrim) {
         trim::stop();
     }
@@ -1292,7 +1293,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateRenderPass(VkDev
                                                                            const VkRenderPassCreateInfo* pCreateInfo,
                                                                            const VkAllocationCallbacks* pAllocator,
                                                                            VkRenderPass* pRenderPass) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateRenderPass* pPacket = NULL;
@@ -1388,7 +1389,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
                                                                                              const char* pLayerName,
                                                                                              uint32_t* pPropertyCount,
                                                                                              VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceExtensionProperties* pPacket = NULL;
@@ -1439,7 +1440,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                          uint32_t* pPropertyCount,
                                                                                          VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceLayerProperties* pPacket = NULL;
@@ -1477,7 +1478,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerPr
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties* pQueueFamilyProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties* pPacket = NULL;
     uint64_t startTime;
@@ -1526,7 +1527,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties2KHR* pPacket = NULL;
     uint64_t startTime;
@@ -1579,7 +1580,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumeratePhysicalDevices(VkInstance instance,
                                                                                    uint32_t* pPhysicalDeviceCount,
                                                                                    VkPhysicalDevice* pPhysicalDevices) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumeratePhysicalDevices* pPacket = NULL;
@@ -1643,7 +1644,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
                                                                               uint32_t firstQuery, uint32_t queryCount,
                                                                               size_t dataSize, void* pData, VkDeviceSize stride,
                                                                               VkQueryResultFlags flags) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetQueryPoolResults* pPacket = NULL;
@@ -1686,7 +1687,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateDescriptorSets(VkDevice device,
                                                                                  const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                                                  VkDescriptorSet* pDescriptorSets) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateDescriptorSets* pPacket = NULL;
@@ -2011,7 +2012,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
                                                                            const VkWriteDescriptorSet* pDescriptorWrites,
                                                                            uint32_t descriptorCopyCount,
                                                                            const VkCopyDescriptorSet* pDescriptorCopies) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSets* pPacket = NULL;
     // begin custom code
@@ -2199,7 +2200,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue queue, uint32_t submitCount,
                                                                       const VkSubmitInfo* pSubmits, VkFence fence) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     if ((g_trimEnabled) && (pSubmits != NULL)) {
         vktrace_enter_critical_section(&trim::trimTransitionMapLock);
     }
@@ -2351,7 +2352,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueBindSparse(VkQueue queue, uint32_t bindInfoCount,
                                                                           const VkBindSparseInfo* pBindInfo, VkFence fence) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkQueueBindSparse* pPacket = NULL;
@@ -2483,7 +2484,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdWaitEvents(
     VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdWaitEvents* pPacket = NULL;
     size_t customSize;
@@ -2561,7 +2562,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPipelineBarrier* pPacket = NULL;
     size_t customSize;
@@ -2651,7 +2652,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                                        VkShaderStageFlags stageFlags, uint32_t offset,
                                                                        uint32_t size, const void* pValues) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushConstants* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdPushConstants, size);
@@ -2681,7 +2682,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommand
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                                                          const VkCommandBuffer* pCommandBuffers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdExecuteCommands* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdExecuteCommands, commandBufferCount * sizeof(VkCommandBuffer));
@@ -2722,7 +2723,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkComma
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache,
                                                                                size_t* pDataSize, void* pData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkGetPipelineCacheData* pPacket = NULL;
@@ -2794,7 +2795,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipeline
                                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                                                   const VkAllocationCallbacks* pAllocator,
                                                                                   VkPipeline* pPipelines) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateGraphicsPipelines* pPacket = NULL;
@@ -2891,7 +2892,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateComputePipelines
                                                                                  const VkComputePipelineCreateInfo* pCreateInfos,
                                                                                  const VkAllocationCallbacks* pAllocator,
                                                                                  VkPipeline* pPipelines) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateComputePipelines* pPacket = NULL;
@@ -2970,7 +2971,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
                                                                               const VkPipelineCacheCreateInfo* pCreateInfo,
                                                                               const VkAllocationCallbacks* pAllocator,
                                                                               VkPipelineCache* pPipelineCache) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreatePipelineCache* pPacket = NULL;
@@ -3015,7 +3016,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkCommandBuffer commandBuffer,
                                                                          const VkRenderPassBeginInfo* pRenderPassBegin,
                                                                          VkSubpassContents contents) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdBeginRenderPass* pPacket = NULL;
     size_t clearValueSize = sizeof(VkClearValue) * pRenderPassBegin->clearValueCount;
@@ -3072,7 +3073,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkComma
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool,
                                                                              uint32_t descriptorSetCount,
                                                                              const VkDescriptorSet* pDescriptorSets) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeDescriptorSets* pPacket = NULL;
@@ -3116,7 +3117,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkD
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
                                                                       const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateImage* pPacket = NULL;
@@ -3231,7 +3232,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateBuffer* pPacket = NULL;
@@ -3287,7 +3288,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice 
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice device, VkBuffer buffer,
                                                                     const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyBuffer, sizeof(VkAllocationCallbacks));
@@ -3319,7 +3320,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice dev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
                                                                            VkDeviceSize memoryOffset) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBindBufferMemory* pPacket = NULL;
@@ -3361,7 +3362,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceSurfaceCapabilitiesKHR* pPacket = NULL;
@@ -3391,7 +3392,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                              VkSurfaceKHR surface,
                                                                                              uint32_t* pSurfaceFormatCount,
                                                                                              VkSurfaceFormatKHR* pSurfaceFormats) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3433,7 +3434,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                                   VkSurfaceKHR surface,
                                                                                                   uint32_t* pPresentModeCount,
                                                                                                   VkPresentModeKHR* pPresentModes) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3476,7 +3477,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
                                                                              const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                                              const VkAllocationCallbacks* pAllocator,
                                                                              VkSwapchainKHR* pSwapchain) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateSwapchainKHR* pPacket = NULL;
@@ -3520,7 +3521,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                                                 uint32_t* pSwapchainImageCount,
                                                                                 VkImage* pSwapchainImages) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3580,7 +3581,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkQueuePresentKHR* pPacket = NULL;
@@ -3696,7 +3697,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
                                                                                 const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                                                 const VkAllocationCallbacks* pAllocator,
                                                                                 VkSurfaceKHR* pSurface) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateWin32SurfaceKHR* pPacket = NULL;
@@ -3737,7 +3738,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
 
 VKTRACER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL
 __HOOKED_vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkBool32 result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceWin32PresentationSupportKHR* pPacket = NULL;
@@ -4112,7 +4113,7 @@ void unlockDescriptorUpdateTemplateCreateInfo() { vktrace_sem_post(descriptorUpd
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplateKHR(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorUpdateTemplateKHR* pPacket = NULL;
@@ -4196,7 +4197,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplate(
     VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplate* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplate, sizeof(VkAllocationCallbacks));
@@ -4232,7 +4233,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplateKHR(
     VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplateKHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplateKHR, sizeof(VkAllocationCallbacks));
@@ -4313,7 +4314,7 @@ static size_t getDescriptorSetDataSize(VkDescriptorUpdateTemplateKHR descriptorU
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplate(
     VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSetWithTemplate* pPacket = NULL;
     size_t dataSize;
@@ -4346,7 +4347,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplateKHR(
     VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4382,7 +4383,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
                                                                               VkPipelineLayout layout, uint32_t set,
                                                                               uint32_t descriptorWriteCount,
                                                                               const VkWriteDescriptorSet* pDescriptorWrites) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetKHR* pPacket = NULL;
     size_t arrayByteCount = 0;
@@ -4534,7 +4535,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetWithTemplateKHR(
     VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, VkPipelineLayout layout, uint32_t set,
     const void* pData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4569,7 +4570,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
                                                                            VkImageLayout srcImageLayout, VkBuffer dstBuffer,
                                                                            uint32_t regionCount,
                                                                            const VkBufferImageCopy* pRegions) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdCopyImageToBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdCopyImageToBuffer, regionCount * sizeof(VkBufferImageCopy));
@@ -4604,7 +4605,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkWaitForFences(VkDevice device, uint32_t fenceCount,
                                                                         const VkFence* pFences, VkBool32 waitAll,
                                                                         uint64_t timeout) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkWaitForFences* pPacket = NULL;
@@ -4724,7 +4725,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
      const VkAllocationCallbacks*                pAllocator,
      VkObjectTableNVX*                           pObjectTable)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateObjectTableNVX* pPacket = NULL;
@@ -4780,7 +4781,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
     VkCommandBuffer commandBuffer,
     const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdProcessCommandsNVX* pPacket;
     size_t datasize = 0;
@@ -4826,7 +4827,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateIndirectCommands
     const VkAllocationCallbacks* pAllocator,
     VkIndirectCommandsLayoutNVX* pIndirectCommandsLayout)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateIndirectCommandsLayoutNVX* pPacket = NULL;
@@ -4923,7 +4924,7 @@ pSurfaceDescription);
  * but not for loader initiated calls to GDPA. Thus need two versions of GDPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAddr(VkDevice device, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     PFN_vkVoidFunction addr;
 
     vktrace_trace_packet_header* pHeader;
@@ -4952,7 +4953,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAdd
 
 /* GDPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDeviceProcAddr(VkDevice device, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     if (!strcmp("vkGetDeviceProcAddr", funcName)) {
         if (gMessageStream != NULL) {
             return (PFN_vkVoidFunction)vktraceGetDeviceProcAddr;
@@ -4990,7 +4991,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDevicePro
  * but not for loader initiated calls to GIPA. Thus need two versions of GIPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcAddr(VkInstance instance, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     PFN_vkVoidFunction addr;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetInstanceProcAddr* pPacket = NULL;
@@ -5020,7 +5021,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcA
 
 /* GIPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     PFN_vkVoidFunction addr;
     layer_instance_data* instData;
 
@@ -5127,14 +5128,12 @@ VkResult EnumerateProperties(uint32_t src_count, const T* src_props, uint32_t* d
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                   VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                       uint32_t* pPropertyCount,
                                                                                       VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 
@@ -5144,25 +5143,26 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPrope
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                                uint32_t* pPropertyCount,
                                                                                                VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     return vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties);
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                            VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     return vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                 uint32_t* pPropertyCount,
                                                                                 VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TrimLockGuard<std::mutex> lock(g_mutex_trim);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(const char* pLayerName,
                                                                                     uint32_t* pPropertyCount,
                                                                                     VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -50,6 +50,8 @@
 
 #include "vk_struct_size_helper.h"
 
+std::mutex g_mutex;
+
 VKTRACER_LEAVE _Unload(void) {
     // only do the hooking and networking if the tracer is NOT loaded by vktrace
     if (vktrace_is_loaded_into_vktrace() == FALSE) {
@@ -164,9 +166,11 @@ void* strip_create_extensions(const void* pNext) {
     return create_info;
 }
 
+
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkDeviceMemory* pMemory) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateMemory* pPacket = NULL;
@@ -216,6 +220,8 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevic
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset,
                                                                     VkDeviceSize size, VkFlags flags, void** ppData) {
+
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkMapMemory* pPacket = NULL;
@@ -297,6 +303,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
 }
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice device, VkDeviceMemory memory) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkUnmapMemory* pPacket;
     VKAllocInfo* entry;
@@ -363,6 +370,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice devic
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device, VkDeviceMemory memory,
                                                                  const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeMemory* pPacket = NULL;
 #if defined(USE_PAGEGUARD_SPEEDUP)
@@ -408,6 +416,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                        const VkMappedMemoryRange* pMemoryRanges) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     size_t rangesSize = 0;
@@ -510,6 +519,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemory
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                   const VkMappedMemoryRange* pMemoryRanges) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     uint64_t rangesSize = 0;
@@ -645,6 +655,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers(VkDevice device,
                                                                                  const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                                                  VkCommandBuffer* pCommandBuffers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateCommandBuffers* pPacket = NULL;
@@ -692,6 +703,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
                                                                              const VkCommandBufferBeginInfo* pBeginInfo) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBeginCommandBuffer* pPacket = NULL;
@@ -735,6 +747,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorPool(V
                                                                                const VkDescriptorPoolCreateInfo* pCreateInfo,
                                                                                const VkAllocationCallbacks* pAllocator,
                                                                                VkDescriptorPool* pDescriptorPool) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorPool* pPacket = NULL;
@@ -796,6 +809,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
     VkPhysicalDevice physicalDevice,
     VkPhysicalDeviceProperties* pProperties)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties, sizeof(VkPhysicalDeviceProperties));
@@ -839,6 +853,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice,
                                                                                       VkPhysicalDeviceProperties2KHR* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties2KHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties2KHR, get_struct_chain_size((void*)pProperties));
@@ -872,6 +887,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDevice(VkPhysicalDevice physicalDevice,
                                                                        const VkDeviceCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateDevice* pPacket = NULL;
@@ -979,6 +995,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateFramebuffer(VkDe
                                                                             const VkFramebufferCreateInfo* pCreateInfo,
                                                                             const VkAllocationCallbacks* pAllocator,
                                                                             VkFramebuffer* pFramebuffer) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateFramebuffer* pPacket = NULL;
@@ -1117,6 +1134,7 @@ static void send_vk_api_version_packet() {
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkInstance* pInstance) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateInstance* pPacket = NULL;
@@ -1236,6 +1254,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const V
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyInstance(VkInstance instance,
                                                                       const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (g_trimEnabled && g_trimIsInTrim) {
         trim::stop();
     }
@@ -1275,6 +1294,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateRenderPass(VkDev
                                                                            const VkRenderPassCreateInfo* pCreateInfo,
                                                                            const VkAllocationCallbacks* pAllocator,
                                                                            VkRenderPass* pRenderPass) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateRenderPass* pPacket = NULL;
@@ -1370,6 +1390,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
                                                                                              const char* pLayerName,
                                                                                              uint32_t* pPropertyCount,
                                                                                              VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceExtensionProperties* pPacket = NULL;
@@ -1420,6 +1441,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                          uint32_t* pPropertyCount,
                                                                                          VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceLayerProperties* pPacket = NULL;
@@ -1457,6 +1479,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerPr
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties* pQueueFamilyProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties* pPacket = NULL;
     uint64_t startTime;
@@ -1505,6 +1528,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties2KHR* pPacket = NULL;
     uint64_t startTime;
@@ -1557,6 +1581,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumeratePhysicalDevices(VkInstance instance,
                                                                                    uint32_t* pPhysicalDeviceCount,
                                                                                    VkPhysicalDevice* pPhysicalDevices) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumeratePhysicalDevices* pPacket = NULL;
@@ -1620,6 +1645,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
                                                                               uint32_t firstQuery, uint32_t queryCount,
                                                                               size_t dataSize, void* pData, VkDeviceSize stride,
                                                                               VkQueryResultFlags flags) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetQueryPoolResults* pPacket = NULL;
@@ -1662,6 +1688,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateDescriptorSets(VkDevice device,
                                                                                  const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                                                  VkDescriptorSet* pDescriptorSets) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateDescriptorSets* pPacket = NULL;
@@ -1986,6 +2013,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
                                                                            const VkWriteDescriptorSet* pDescriptorWrites,
                                                                            uint32_t descriptorCopyCount,
                                                                            const VkCopyDescriptorSet* pDescriptorCopies) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSets* pPacket = NULL;
     // begin custom code
@@ -2173,6 +2201,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue queue, uint32_t submitCount,
                                                                       const VkSubmitInfo* pSubmits, VkFence fence) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if ((g_trimEnabled) && (pSubmits != NULL)) {
         vktrace_enter_critical_section(&trim::trimTransitionMapLock);
     }
@@ -2324,6 +2353,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueBindSparse(VkQueue queue, uint32_t bindInfoCount,
                                                                           const VkBindSparseInfo* pBindInfo, VkFence fence) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkQueueBindSparse* pPacket = NULL;
@@ -2455,6 +2485,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdWaitEvents(
     VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdWaitEvents* pPacket = NULL;
     size_t customSize;
@@ -2532,6 +2563,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPipelineBarrier* pPacket = NULL;
     size_t customSize;
@@ -2621,6 +2653,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                                        VkShaderStageFlags stageFlags, uint32_t offset,
                                                                        uint32_t size, const void* pValues) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushConstants* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdPushConstants, size);
@@ -2650,6 +2683,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommand
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                                                          const VkCommandBuffer* pCommandBuffers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdExecuteCommands* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdExecuteCommands, commandBufferCount * sizeof(VkCommandBuffer));
@@ -2690,6 +2724,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkComma
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache,
                                                                                size_t* pDataSize, void* pData) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkGetPipelineCacheData* pPacket = NULL;
@@ -2761,6 +2796,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipeline
                                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                                                   const VkAllocationCallbacks* pAllocator,
                                                                                   VkPipeline* pPipelines) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateGraphicsPipelines* pPacket = NULL;
@@ -2857,6 +2893,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateComputePipelines
                                                                                  const VkComputePipelineCreateInfo* pCreateInfos,
                                                                                  const VkAllocationCallbacks* pAllocator,
                                                                                  VkPipeline* pPipelines) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateComputePipelines* pPacket = NULL;
@@ -2935,6 +2972,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
                                                                               const VkPipelineCacheCreateInfo* pCreateInfo,
                                                                               const VkAllocationCallbacks* pAllocator,
                                                                               VkPipelineCache* pPipelineCache) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreatePipelineCache* pPacket = NULL;
@@ -2979,6 +3017,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkCommandBuffer commandBuffer,
                                                                          const VkRenderPassBeginInfo* pRenderPassBegin,
                                                                          VkSubpassContents contents) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdBeginRenderPass* pPacket = NULL;
     size_t clearValueSize = sizeof(VkClearValue) * pRenderPassBegin->clearValueCount;
@@ -3035,6 +3074,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkComma
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool,
                                                                              uint32_t descriptorSetCount,
                                                                              const VkDescriptorSet* pDescriptorSets) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeDescriptorSets* pPacket = NULL;
@@ -3078,6 +3118,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkD
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
                                                                       const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateImage* pPacket = NULL;
@@ -3192,6 +3233,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateBuffer* pPacket = NULL;
@@ -3247,6 +3289,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice 
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice device, VkBuffer buffer,
                                                                     const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyBuffer, sizeof(VkAllocationCallbacks));
@@ -3278,6 +3321,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice dev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
                                                                            VkDeviceSize memoryOffset) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBindBufferMemory* pPacket = NULL;
@@ -3319,6 +3363,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceSurfaceCapabilitiesKHR* pPacket = NULL;
@@ -3348,6 +3393,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                              VkSurfaceKHR surface,
                                                                                              uint32_t* pSurfaceFormatCount,
                                                                                              VkSurfaceFormatKHR* pSurfaceFormats) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3389,6 +3435,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                                   VkSurfaceKHR surface,
                                                                                                   uint32_t* pPresentModeCount,
                                                                                                   VkPresentModeKHR* pPresentModes) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3431,6 +3478,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
                                                                              const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                                              const VkAllocationCallbacks* pAllocator,
                                                                              VkSwapchainKHR* pSwapchain) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateSwapchainKHR* pPacket = NULL;
@@ -3474,6 +3522,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                                                 uint32_t* pSwapchainImageCount,
                                                                                 VkImage* pSwapchainImages) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3533,6 +3582,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkQueuePresentKHR* pPacket = NULL;
@@ -3648,6 +3698,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
                                                                                 const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                                                 const VkAllocationCallbacks* pAllocator,
                                                                                 VkSurfaceKHR* pSurface) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateWin32SurfaceKHR* pPacket = NULL;
@@ -3688,6 +3739,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
 
 VKTRACER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL
 __HOOKED_vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkBool32 result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceWin32PresentationSupportKHR* pPacket = NULL;
@@ -4042,6 +4094,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateAndroidSurfaceKH
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplate(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 }
 
@@ -4062,6 +4115,7 @@ void unlockDescriptorUpdateTemplateCreateInfo() { vktrace_sem_post(descriptorUpd
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplateKHR(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorUpdateTemplateKHR* pPacket = NULL;
@@ -4145,6 +4199,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplate(
     VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplate* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplate, sizeof(VkAllocationCallbacks));
@@ -4180,6 +4235,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplateKHR(
     VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplateKHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplateKHR, sizeof(VkAllocationCallbacks));
@@ -4260,6 +4316,7 @@ static size_t getDescriptorSetDataSize(VkDescriptorUpdateTemplateKHR descriptorU
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplate(
     VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSetWithTemplate* pPacket = NULL;
     size_t dataSize;
@@ -4292,6 +4349,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplateKHR(
     VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4327,6 +4385,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
                                                                               VkPipelineLayout layout, uint32_t set,
                                                                               uint32_t descriptorWriteCount,
                                                                               const VkWriteDescriptorSet* pDescriptorWrites) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetKHR* pPacket = NULL;
     size_t arrayByteCount = 0;
@@ -4478,6 +4537,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetWithTemplateKHR(
     VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, VkPipelineLayout layout, uint32_t set,
     const void* pData) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4512,6 +4572,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
                                                                            VkImageLayout srcImageLayout, VkBuffer dstBuffer,
                                                                            uint32_t regionCount,
                                                                            const VkBufferImageCopy* pRegions) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdCopyImageToBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdCopyImageToBuffer, regionCount * sizeof(VkBufferImageCopy));
@@ -4546,6 +4607,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkWaitForFences(VkDevice device, uint32_t fenceCount,
                                                                         const VkFence* pFences, VkBool32 waitAll,
                                                                         uint64_t timeout) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkWaitForFences* pPacket = NULL;
@@ -4665,6 +4727,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
      const VkAllocationCallbacks*                pAllocator,
      VkObjectTableNVX*                           pObjectTable)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateObjectTableNVX* pPacket = NULL;
@@ -4721,6 +4784,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
     VkCommandBuffer commandBuffer,
     const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdProcessCommandsNVX* pPacket;
     size_t datasize = 0;
@@ -4766,6 +4830,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateIndirectCommands
     const VkAllocationCallbacks* pAllocator,
     VkIndirectCommandsLayoutNVX* pIndirectCommandsLayout)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateIndirectCommandsLayoutNVX* pPacket = NULL;
@@ -4862,6 +4927,7 @@ pSurfaceDescription);
  * but not for loader initiated calls to GDPA. Thus need two versions of GDPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAddr(VkDevice device, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     PFN_vkVoidFunction addr;
 
     vktrace_trace_packet_header* pHeader;
@@ -4890,6 +4956,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAdd
 
 /* GDPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDeviceProcAddr(VkDevice device, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (!strcmp("vkGetDeviceProcAddr", funcName)) {
         if (gMessageStream != NULL) {
             return (PFN_vkVoidFunction)vktraceGetDeviceProcAddr;
@@ -4927,6 +4994,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDevicePro
  * but not for loader initiated calls to GIPA. Thus need two versions of GIPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcAddr(VkInstance instance, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     PFN_vkVoidFunction addr;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetInstanceProcAddr* pPacket = NULL;
@@ -4956,6 +5024,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcA
 
 /* GIPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     PFN_vkVoidFunction addr;
     layer_instance_data* instData;
 
@@ -5062,12 +5131,14 @@ VkResult EnumerateProperties(uint32_t src_count, const T* src_props, uint32_t* d
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                   VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                       uint32_t* pPropertyCount,
                                                                                       VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 
@@ -5077,23 +5148,27 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPrope
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                                uint32_t* pPropertyCount,
                                                                                                VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties);
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                            VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                 uint32_t* pPropertyCount,
                                                                                 VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(const char* pLayerName,
                                                                                     uint32_t* pPropertyCount,
                                                                                     VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 
@@ -5102,10 +5177,12 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetInstanceProcAddr(VkInstance instance,
                                                                                                     const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetInstanceProcAddr(instance, funcName);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetDeviceProcAddr(VkDevice device,
                                                                                                   const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetDeviceProcAddr(device, funcName);
 }

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -49,7 +49,9 @@ extern uint64_t g_trimStartFrame;
 extern uint64_t g_trimEndFrame;
 extern bool g_trimAlreadyFinished;
 
-extern std::mutex g_mutex;
+// This mutex is used to protect API calls sequence
+// when trim starting process.
+extern std::mutex g_mutex_trim;
 
 namespace trim {
 

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -49,7 +49,39 @@ extern uint64_t g_trimStartFrame;
 extern uint64_t g_trimEndFrame;
 extern bool g_trimAlreadyFinished;
 
+extern std::mutex g_mutex;
+
 namespace trim {
+
+template <typename _Mutex>
+class TrimLockGuard {  // specialization for a single mutex
+   private:
+    _Mutex &_MyMutex;
+    bool m_islocked;
+
+   public:
+    typedef _Mutex mutex_type;
+
+    explicit TrimLockGuard(_Mutex &_Mtx) : _MyMutex(_Mtx) {  // construct and lock only when trim enabled
+        if (g_trimEnabled) {
+            _MyMutex.lock();
+            m_islocked = true;
+        } else {
+            m_islocked = false;
+        }
+    }
+
+    ~TrimLockGuard() {  // unlock
+        if (m_islocked) {
+            _MyMutex.unlock();
+            m_islocked = false;
+        }
+    }
+
+    TrimLockGuard(const TrimLockGuard &) = delete;
+    TrimLockGuard &operator=(const TrimLockGuard &) = delete;
+};
+
 void initialize();
 void deinitialize();
 


### PR DESCRIPTION
Add mutex lock for all manual and autogenerated hooked API when trim capture is enabled.
declare extern mutex variable in vktrace_lib_trim header file.