### PR TITLE
vkreplay: default to x11 backend if XDG_SESSION_TYPE is unset

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -585,7 +585,7 @@ int vkreplay_main(int argc, char** argv, vktrace_replay::ReplayDisplayImp* pDisp
     // Choose default display server if unset
     if (replaySettings.displayServer == NULL) {
         auto session = getenv("XDG_SESSION_TYPE");
-        if (strcmp(session, "x11") == 0) {
+        if (session == NULL || strcmp(session, "x11") == 0) {
             replaySettings.displayServer = "xcb";
         } else if (strcmp(session, "wayland") == 0) {
             replaySettings.displayServer = "wayland";


### PR DESCRIPTION
If no display backend is specified via the "-ds" option when running
vkreplay and the XDG_SESSION_TYPE environment variable is not set
it will trigger a segmentation fault during initialization with no
other output. This would be the case, for example, if the user is not
running a full desktop environment or is connected over SSH.

With this change, it will instead default to using the x11 backend.