### PR TITLE
Minor grammar and consistency improvements

### DIFF
--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -11,7 +11,7 @@ Is your Vulkan application stress-tested to ensure it behaves correctly across t
 If either answer is "no," LunarG offers a free tool that could extend your test coverage and increase your peace of mind.
 
 ### Introducing the LunarG Device Simulation Layer
-The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device. It can be applied without modifying any application binaries, and in a fully-automated fashion. The Device Simulation layer (aka DevSim) is a Vulkan layer that can override the values returned by your application’s queries of the GPU. DevSim uses a JSON text configuration file to make your application see a different driver/GPU than is actually in your system. This capability is useful to verify that your application both a) properly queries the limits from Vulkan, and b) obeys those limits.
+The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device. It can be applied without modifying any application binaries, and in a fully automated fashion. The Device Simulation layer (aka DevSim) is a Vulkan layer that can override the values returned by your application’s queries of the GPU. DevSim uses a JSON text configuration file to make your application see a different driver/GPU than is actually in your system. This capability is useful to verify that your application both a) properly queries the limits from Vulkan, and b) obeys those limits.
 
 The DevSim layer library is available pre-built in the LunarG Vulkan SDK, and continues to evolve. DevSim works for all Vulkan platforms (Linux, Windows, and Android), and is open-source software hosted on GitHub.
 
@@ -174,7 +174,7 @@ A JSON index of the available device records can be queried with https://vulkan.
 That index includes URLs to download the specific device records in DevSim-compatible format, for example https://vulkan.gpuinfo.org/api/v2/devsim/getreport.php?id=1456
 
 As mentioned above, attempting to use a configuration file that does not fit within the capabilities of the underlying device may produce undefined results.
-Downloaded device records should be reviewed to determine that its capabilities can be simulated by the underlying device.
+Downloaded device records should be reviewed to determine that their capabilities can be simulated by the underlying device.
 
 ### Device configuration data from the local system
 Vulkan Info can write its output in a format compatible the DevSim JSON schema,

--- a/via/README.md
+++ b/via/README.md
@@ -151,7 +151,7 @@ example, if the user runs `via --output_path /home/me/Documents`, then the outpu
 LunarG's VIA could detect no problems with your setup.  In fact it was able to create an instance and device up through Vulkan version X.Y.
 
 ##### Possible Reason:
-Your system is likely setup properly.  If you have trouble running Vulkan from another location, it could be that your environment variables aren't setup properly.
+Your system is likely set up properly.  If you have trouble running Vulkan from another location, it could be that your environment variables aren't set up properly.
 
 ##### Next Step:
 Re-run VIA from the location your Vulkan application/game is supposed to run.
@@ -163,7 +163,7 @@ Re-run VIA from the location your Vulkan application/game is supposed to run.
 LunarG's VIA could detect no problems with your setup other than a missing SDK.  It was able to run some limited tests and create both a Vulkan instance and device.
 
 ##### Possible Reason:
-Your system is likely setup properly, but is either missing an installed Vulkan SDK or you didn't setup your VK_SDK_PATH environment variable to point at an installed SDK.  If you have trouble running Vulkan from another location, it could be that your environment variables aren't setup properly.
+Your system is likely set up properly, but is either missing an installed Vulkan SDK or you didn't set up your VK_SDK_PATH environment variable to point at an installed SDK.  If you have trouble running Vulkan from another location, it could be that your environment variables aren't set up properly.
 
 ##### Next Step:
 Install the LunarG Vulkan SDK and define the VK_SDK_PATH to point to the location of the installed SDK.
@@ -357,7 +357,7 @@ it's possible the SDK did not install properly.
 See the [Vulkan SDK Issues](#vulkan-sdk-issues) section below.
 
 
-#### [WINDOWS] Dialog box pop's up indicating "vulkan-1.dll is missing from your computer."
+#### [WINDOWS] Dialog box pops up indicating "vulkan-1.dll is missing from your computer."
 
 ##### Problem:
 The Vulkan loader "vulkan-1.dll" couldn't be found on your system.  This file is typically installed with some Vulkan driver installs,

--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -16,7 +16,7 @@ Options for the `vktrace` command are:
 | -w&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;WorkingDir&nbsp;&lt;string&gt; | Alternate working directory | the application's directory |
 | -P&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PMB&nbsp;&lt;bool&gt; | Trace  persistently mapped buffers | true |
 | -tr&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TraceTrigger&nbsp;&lt;string&gt; | Start/stop trim by hotkey or frame range. String arg is one of:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hotkey-[F1-F12\|TAB\|CONTROL]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;frames-&lt;startframe&gt;-&lt;endframe&gt;| on |
-| -tpp&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TrimPostProcessing&nbsp;&lt;bool&gt; | Enable trim post processing to make trimmed trace file smaller, see description of VKTRACE_TRIM_POST_PROCESS below | false |
+| -tpp&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TrimPostProcessing&nbsp;&lt;bool&gt; | Enable trim post-processing to make trimmed trace file smaller, see description of VKTRACE_TRIM_POST_PROCESS below | false |
 | -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
 
 In local tracing mode, both the `vktrace` and application executables reside on the same system.
@@ -168,11 +168,11 @@ Several environment variables can be set to change the behavior of vktrace/vkrep
 
  - VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS
 
-    VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS, when set to a non-null value, enables post processing  when read PMB support is enabled.  When VKTRACE_PAGEGUARD_ENABLE_READ_PMB is set, PMB processing will sometimes miss writes following reads if writes occur on the same page as a read. Set this environment variable to enable post processing to fix missed pmb writes. It is supported only on Windows.
+    VKTRACE_PAGEGUARD_ENABLE_READ_POST_PROCESS, when set to a non-null value, enables post-processing  when read PMB support is enabled.  When VKTRACE_PAGEGUARD_ENABLE_READ_PMB is set, PMB processing will sometimes miss writes following reads if writes occur on the same page as a read. Set this environment variable to enable post-processing to fix missed PMB writes. It is supported only on Windows.
 
  - VKTRACE_TRIM_POST_PROCESS
 
-    VKTRACE_TRIM_POST_PROCESS enables post processing of trim if its value is 1.  Other values disable trim post processing.  Disable post processing means the trimmed trace file will record all the not destroyed objects no matter they are used/referenced in the trim frame range or not.  Enable post processing will drop most of the pre-trim objects which are not used/referenced in the trim frame range.  Set this environment variable to 1 to enable post processing of trim to generate a smaller trace file and eliminate most useless pre-trim objects and vulkan calls.  Do NOT enable trim post processing when there's a large trim frame range because both the referenced pre-trim data and in-trim data are kept in memory until writing to trace file in the trim end frame which may exceeds the system memory.
+    VKTRACE_TRIM_POST_PROCESS enables post-processing of trim if its value is 1.  Other values disable trim post-processing.  Disable post-processing means the trimmed trace file will record all the not destroyed objects whether they are used/referenced in the trim frame range or not.  Enable post-processing will drop most of the pre-trim objects which are not used/referenced in the trim frame range.  Set this environment variable to 1 to enable post-processing of trim to generate a smaller trace file and eliminate most useless pre-trim objects and Vulkan calls.  Do NOT enable trim post-processing when there's a large trim frame range because both the referenced pre-trim data and in-trim data are kept in memory until writing to trace file in the trim end frame which may exceeds the system memory.
 
 ## Android
 


### PR DESCRIPTION
device_simulation.md:
- fully-automated => fully automated
- records should be reviewed to determine that its capabilities => records should be reviewed to determine that their capabilities

README.md:
- setup => set up (when used as a verb)
- Dialog box pop's up => Dialog box pops up

vktrace.md:
- post processing => post-processing