### PR TITLE
vkreplay: Add processing of pNext structs to vkCreateSampler

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -653,7 +653,8 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                  'BindBufferMemory2KHR',
                                  'BindImageMemory2KHR',
                                  'GetDisplayPlaneSupportedDisplaysKHR',
-                                 'EnumerateDeviceExtensionProperties'
+                                 'EnumerateDeviceExtensionProperties',
+                                 'CreateSampler'
                                  ]
         # Map APIs to functions if body is fully custom
         custom_body_dict = {'CreateInstance': self.GenReplayCreateInstance,

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -2929,20 +2929,20 @@ VkResult vkReplay::manually_replay_vkCreateSampler(packet_vkCreateSampler *pPack
     // We only remap from m_objMapper.remap_samplerycbcrconversions because
     // m_objMapper.add_to_samplerycbcrconversionkhrs_map is not used.
     if (pPacket->pCreateInfo && pPacket->pCreateInfo->pNext) {
-         VkSamplerYcbcrConversionInfo *sci = (VkSamplerYcbcrConversionInfo *)pPacket->pCreateInfo->pNext;
-         while (sci) {
-             if (sci->sType == VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO) {
-                 sci->conversion = m_objMapper.remap_samplerycbcrconversions(sci->conversion);
-                 sci = (VkSamplerYcbcrConversionInfo *)sci->pNext;
-             }
-         }
-     }
+        VkSamplerYcbcrConversionInfo *sci = (VkSamplerYcbcrConversionInfo *)pPacket->pCreateInfo->pNext;
+        while (sci) {
+            if (sci->sType == VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO) {
+                sci->conversion = m_objMapper.remap_samplerycbcrconversions(sci->conversion);
+                sci = (VkSamplerYcbcrConversionInfo *)sci->pNext;
+            }
+        }
+    }
 
-     replayResult = m_vkDeviceFuncs.CreateSampler(remappeddevice, pPacket->pCreateInfo, pPacket->pAllocator, &local_pSampler);
-     if (replayResult == VK_SUCCESS) {
-         m_objMapper.add_to_samplers_map(*(pPacket->pSampler), local_pSampler);
-     }
-     return replayResult;
+    replayResult = m_vkDeviceFuncs.CreateSampler(remappeddevice, pPacket->pCreateInfo, pPacket->pAllocator, &local_pSampler);
+    if (replayResult == VK_SUCCESS) {
+        m_objMapper.add_to_samplers_map(*(pPacket->pSampler), local_pSampler);
+    }
+    return replayResult;
 }
 
 VkResult vkReplay::manually_replay_vkCreateSwapchainKHR(packet_vkCreateSwapchainKHR *pPacket) {

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -288,6 +288,7 @@ class vkReplay {
     VkResult manually_replay_vkBindImageMemory(packet_vkBindImageMemory* pPacket);
     void manually_replay_vkGetImageMemoryRequirements2(packet_vkGetImageMemoryRequirements2* pPacket);
     void manually_replay_vkGetBufferMemoryRequirements2(packet_vkGetBufferMemoryRequirements2* pPacket);
+    VkResult manually_replay_vkCreateSampler(packet_vkCreateSampler* pPacket);
 
     void process_screenshot_list(const char* list) {
         std::string spec(list), word;


### PR DESCRIPTION
When replaying a vkCreateSampler api call, traverse the pNext list
in pCreateInfo, looking for VkSamplerYcbcrConversionInfo structs
and remapping the pYcbcrConversion handles.

Change-Id: I9c8a3c505119d140ca568b9a52a793174d7ec536