### PR TITLE
vkreplay: Add device local memory type in getMemoryTypeIdx

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -1814,6 +1814,15 @@ bool vkReplay::getMemoryTypeIdx(VkDevice traceDevice, VkDevice replayDevice, uin
         }
     }
 
+    // At last, search for mem type with DEVICE_LOCAL set
+    // from set of bits in memoryRequirements->memoryTypeBits
+    for (i = 0; i < replayMemoryProperties[replayPhysicalDevice].memoryTypeCount; i++) {
+        if (((1 << i) & memRequirements->memoryTypeBits) &&
+            (VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT & replayMemoryProperties[replayPhysicalDevice].memoryTypes[i].propertyFlags)) {
+            *pReplayIdx = i;
+            return true;
+        }
+    }
 
 fail:
     // Didn't find a match


### PR DESCRIPTION
This change adds search for device local memory type in getMemoryTypeIdx().

The search for device local memory type is needed because it is possible to have VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT bit set in a memory type according to the description for vkGetPhysicalDeviceMemoryProperties in Vulkan Spec 1.1.73:
> There must be at least one memory type with both the VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT and
> VK_MEMORY_PROPERTY_HOST_COHERENT_BIT bits set in its propertyFlags. There must be at least one
> memory type with the VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT bit set in its propertyFlags.