### PR TITLE
vkreplay: Release vulkan objects before quit replay

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -976,6 +976,14 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                         replay_gen_source += '            if (replayResult == VK_SUCCESS) {\n'
                     clean_type = params[-1].type.strip('*').replace('const ', '')
                     replay_gen_source += '                m_objMapper.add_to_%ss_map(*(pPacket->%s), local_%s);\n' % (clean_type.lower()[2:], params[-1].name, params[-1].name)
+                    if not isInstanceCmd(api) \
+                       and cmdname != 'GetDeviceQueue' \
+                       and cmdname != 'GetDeviceQueue2' \
+                       and cmdname != 'CreateSamplerYcbcrConversion' \
+                       and cmdname != 'CreateSharedSwapchainsKHR' \
+                       and cmdname != 'CreateSamplerYcbcrConversionKHR' \
+                       and cmdname != 'CreateValidationCacheEXT': \
+                        replay_gen_source += '                replay%sToDevice[local_%s] = remappeddevice;\n' % (cmdname[6:], params[-1].name)
                     if 'AllocateMemory' == cmdname:
                         replay_gen_source += '                m_objMapper.add_entry_to_mapData(local_%s, pPacket->pAllocateInfo->allocationSize);\n' % (params[-1].name)
                     if ret_value:

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -205,7 +205,8 @@ vkReplay::~vkReplay() {
                     replaySwapchainImageToDevice[subobj->second.replayImage] != obj->second) {
                     m_vkDeviceFuncs.DestroyImage(obj->second, subobj->second.replayImage, NULL);
                     if (g_pReplaySettings->compatibilityMode && m_pFileHeader->portability_table_valid && !platformMatch() &&
-                        replayOptimalImageToDeviceMemory.find(subobj->second.replayImage) != replayOptimalImageToDeviceMemory.end()) {
+                        replayOptimalImageToDeviceMemory.find(subobj->second.replayImage) !=
+                            replayOptimalImageToDeviceMemory.end()) {
                         m_vkDeviceFuncs.FreeMemory(obj->second, replayOptimalImageToDeviceMemory[subobj->second.replayImage], NULL);
                         replayOptimalImageToDeviceMemory.erase(subobj->second.replayImage);
                     }

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -330,6 +330,27 @@ class vkReplay {
     std::unordered_map<VkImage, VkDevice> traceImageToDevice;
     std::unordered_map<VkImage, VkDevice> replayImageToDevice;
 
+    // Map Vulkan objects to VkDevice, so we can search for the VkDevice used to create an object
+    std::unordered_map<VkQueryPool, VkDevice> replayQueryPoolToDevice;
+    std::unordered_map<VkEvent, VkDevice> replayEventToDevice;
+    std::unordered_map<VkFence, VkDevice> replayFenceToDevice;
+    std::unordered_map<VkSemaphore, VkDevice> replaySemaphoreToDevice;
+    std::unordered_map<VkFramebuffer, VkDevice> replayFramebufferToDevice;
+    std::unordered_map<VkDescriptorPool, VkDevice> replayDescriptorPoolToDevice;
+    std::unordered_map<VkPipeline, VkDevice> replayPipelineToDevice;
+    std::unordered_map<VkPipelineCache, VkDevice> replayPipelineCacheToDevice;
+    std::unordered_map<VkShaderModule, VkDevice> replayShaderModuleToDevice;
+    std::unordered_map<VkRenderPass, VkDevice> replayRenderPassToDevice;
+    std::unordered_map<VkPipelineLayout, VkDevice> replayPipelineLayoutToDevice;
+    std::unordered_map<VkDescriptorSetLayout, VkDevice> replayDescriptorSetLayoutToDevice;
+    std::unordered_map<VkSampler, VkDevice> replaySamplerToDevice;
+    std::unordered_map<VkBufferView, VkDevice> replayBufferViewToDevice;
+    std::unordered_map<VkImageView, VkDevice> replayImageViewToDevice;
+    std::unordered_map<VkDeviceMemory, VkDevice> replayDeviceMemoryToDevice;
+    std::unordered_map<VkSwapchainKHR, VkDevice> replaySwapchainKHRToDevice;
+    std::unordered_map<VkCommandPool, VkDevice> replayCommandPoolToDevice;
+    std::unordered_map<VkImage, VkDevice> replaySwapchainImageToDevice;
+
     // Map VkSwapchainKHR to vector of VkImage, so we can unmap swapchain images at vkDestroySwapchainKHR
     std::unordered_map<VkSwapchainKHR, std::vector<VkImage>> traceSwapchainToImages;
 


### PR DESCRIPTION
This change releases (not freed) allocated memories and (not destroyed)
vulkan objects before quit replay.

This will help to make valgrind happy when using vkreplay on a debug version GPU driver.