### PR TITLE
vkreplay: Another try to preload trace file to replay

### DIFF
--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -109,6 +109,7 @@ The  `vkreplay` command-line  options are:
 | -lsf&nbsp;&lt;int&gt;<br>&#x2011;&#x2011;LoopStartFrame&nbsp;&lt;int&gt; | The start frame number of the loop range | 0 |
 | -lef&nbsp;&lt;int&gt;<br>&#x2011;&#x2011;LoopEndFrame&nbsp;&lt;int&gt; | The end frame number of the loop range | the last frame in the tracefile |
 | -c&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;CompatibilityMode&nbsp;&lt;bool&gt; | Enable compatibility mode - modify api calls as needed when replaying trace file created on different platform than replay platform. For example: Convert trace file memory indices to replay device memory indices. | true |
+| -pltf&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PreloadTraceFile&nbsp;&lt;bool&gt; | Preload tracefile to memory in a separate thread before replay. (NumLoops need to be 1) | false |
 | -s&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Screenshot&nbsp;&lt;string&gt; | Comma-separated list of frame numbers of which to take screen shots  | no screenshots |
 | -sf&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;ScreenshotFormat&nbsp;&lt;string&gt; | Color Space format of screenshot files. Formats are UNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB  | Format of swapchain image |
 | -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |

--- a/vktrace/vktrace_replay/vkreplay_main.h
+++ b/vktrace/vktrace_replay/vkreplay_main.h
@@ -33,6 +33,7 @@ typedef struct vkreplayer_settings {
     const char* screenshotColorFormat;
     const char* verbosity;
     const char* displayServer;
+    BOOL preloadTraceFile;
 } vkreplayer_settings;
 
 #include <vector>

--- a/vktrace/vktrace_replay/vkreplay_seq.cpp
+++ b/vktrace/vktrace_replay/vkreplay_seq.cpp
@@ -37,8 +37,11 @@ void Sequencer::preload_trace_file(uint64_t bufferedPacketCount) {
                     if (m_pRingBuffer->enqueue(pPacket)) {
                         break;
                     } else {
-                        // vktrace_LogDebug("Ring buffer is FULL!");
-                        usleep(10);
+#if defined(WIN32)
+                        Sleep(1);
+#else
+                        usleep(1000);
+#endif
                     }
                 }
             }
@@ -63,7 +66,11 @@ vktrace_trace_packet_header *Sequencer::get_next_packet() {
                 break;
             } else {
                 vktrace_LogWarning("Ring buffer is EMPTY! Performance impacted in preload!");
-                usleep(10);
+#if defined(WIN32)
+                Sleep(1);
+#else
+                usleep(1000);
+#endif
             }
         }
     }

--- a/vktrace/vktrace_replay/vkreplay_seq.cpp
+++ b/vktrace/vktrace_replay/vkreplay_seq.cpp
@@ -26,10 +26,47 @@ extern "C" {
 
 namespace vktrace_replay {
 
+void Sequencer::preload_trace_file(uint64_t bufferedPacketCount) {
+    if (m_pFile) {
+        m_pRingBuffer = new RingBuffer<vktrace_trace_packet_header *>(bufferedPacketCount);
+        vktrace_trace_packet_header *pPacket = NULL;
+        do {
+            pPacket = vktrace_read_trace_packet(m_pFile);
+            if (pPacket != NULL) {
+                while (!m_fileLoadCompleted) {
+                    if (m_pRingBuffer->enqueue(pPacket)) {
+                        break;
+                    } else {
+                        // vktrace_LogDebug("Ring buffer is FULL!");
+                        usleep(10);
+                    }
+                }
+            }
+        } while (pPacket != NULL && !m_fileLoadCompleted);
+        m_fileLoadCompleted = true;
+    }
+}
+
 vktrace_trace_packet_header *Sequencer::get_next_packet() {
-    vktrace_delete_trace_packet_no_lock(&m_lastPacket);
     if (!m_pFile) return (NULL);
-    m_lastPacket = vktrace_read_trace_packet(m_pFile);
+    if (!m_pRingBuffer) {
+        vktrace_delete_trace_packet_no_lock(&m_lastPacket);
+        m_lastPacket = vktrace_read_trace_packet(m_pFile);
+    } else {
+        if (m_lastPacket) {
+            vktrace_delete_trace_packet_no_lock(&m_lastPacket);
+            m_pRingBuffer->dequeue_release();
+        }
+
+        while (1) {
+            if (m_pRingBuffer->dequeue_get(m_lastPacket) || m_fileLoadCompleted) {
+                break;
+            } else {
+                vktrace_LogWarning("Ring buffer is EMPTY! Performance impacted in preload!");
+                usleep(10);
+            }
+        }
+    }
     return (m_lastPacket);
 }
 

--- a/vktrace/vktrace_replay/vkreplay_seq.h
+++ b/vktrace/vktrace_replay/vkreplay_seq.h
@@ -23,12 +23,55 @@
 extern "C" {
 #include "vktrace_filelike.h"
 #include "vktrace_trace_packet_identifiers.h"
+#include "vktrace_trace_packet_utils.h"
 }
+#include <memory>
 
 /* Class to handle fetching and sequencing packets from a tracefile.
  * Contains no knowledge of type of tracer needed to process packet.
  * Requires low level file/stream reading/seeking support. */
 namespace vktrace_replay {
+
+template <class T>
+class RingBuffer {
+   public:
+    explicit RingBuffer(uint64_t size) : m_buffer(std::unique_ptr<T[]>(new T[size])), m_bufferSize(size) {}
+
+    bool enqueue(T item) {
+        if (full()) {
+            return false;
+        }
+        m_buffer[m_write] = item;
+        m_write = (m_write + 1) % m_bufferSize;
+        return true;
+    };
+
+    bool dequeue_get(T &item) {
+        if (empty()) {
+            return false;
+        }
+        // Read data.
+        // Advance the tail will be done in dequeue_release()
+        item = m_buffer[m_read];
+        return true;
+    };
+
+    void dequeue_release() {
+        if (empty()) {
+            return;
+        }
+        m_read = (m_read + 1) % m_bufferSize;
+    };
+
+    bool full() const { return (m_read == ((m_write + 1) % m_bufferSize)); };
+    bool empty() const { return (m_read == m_write); };
+
+   private:
+    std::unique_ptr<T[]> m_buffer;
+    const uint64_t m_bufferSize;
+    uint64_t m_write = 0;
+    uint64_t m_read = 0;
+};
 
 struct seqBookmark {
     uint64_t file_offset;
@@ -45,7 +88,7 @@ class AbstractSequencer {
 
 class Sequencer : public AbstractSequencer {
    public:
-    Sequencer(FileLike *pFile) : m_lastPacket(NULL), m_pFile(pFile) {}
+    Sequencer(FileLike *pFile) : m_lastPacket(NULL), m_pFile(pFile), m_pRingBuffer(NULL), m_fileLoadCompleted(false) {}
     ~Sequencer() { this->clean_up(); }
 
     void clean_up() {
@@ -53,17 +96,32 @@ class Sequencer : public AbstractSequencer {
             free(m_lastPacket);
             m_lastPacket = NULL;
         }
+        if (m_pRingBuffer) {
+            m_pRingBuffer->dequeue_release();
+            while (m_pRingBuffer->dequeue_get(m_lastPacket)) {
+                vktrace_delete_trace_packet_no_lock(&m_lastPacket);
+                m_pRingBuffer->dequeue_release();
+            }
+            delete (m_pRingBuffer);
+            m_pRingBuffer = NULL;
+            m_fileLoadCompleted = false;
+        }
     }
 
     vktrace_trace_packet_header *get_next_packet();
     void get_bookmark(seqBookmark &bookmark);
     void set_bookmark(const seqBookmark &bookmark);
     void record_bookmark();
+    void preload_trace_file(uint64_t buffered_packet_count);
+    bool ready_to_replay() { return (m_pRingBuffer && (m_pRingBuffer->full() || m_fileLoadCompleted)); };
+    void stop_preload() { m_fileLoadCompleted = true; };
 
    private:
     vktrace_trace_packet_header *m_lastPacket;
     seqBookmark m_bookmark;
     FileLike *m_pFile;
+    RingBuffer<vktrace_trace_packet_header *> *m_pRingBuffer;
+    bool m_fileLoadCompleted;
 };
 
 } /* namespace vktrace_replay */

--- a/vktrace/vktrace_replay/vkreplay_settings.cpp
+++ b/vktrace/vktrace_replay/vkreplay_settings.cpp
@@ -27,7 +27,7 @@
 // declared as extern in header
 vkreplayer_settings g_vkReplaySettings;
 
-static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, UINT_MAX, UINT_MAX, true, NULL, NULL, NULL, NULL};
+static vkreplayer_settings s_defaultVkReplaySettings = {NULL, 1, UINT_MAX, UINT_MAX, true, NULL, NULL, NULL, NULL, FALSE};
 
 vktrace_SettingInfo g_vk_settings_info[] = {
     {"o",
@@ -44,6 +44,13 @@ vktrace_SettingInfo g_vk_settings_info[] = {
      {&s_defaultVkReplaySettings.pTraceFilePath},
      TRUE,
      "(Deprecated, use -o or --Open instead) The trace file to replay."},
+    {"pltf",
+     "PreloadTraceFile",
+     VKTRACE_SETTING_BOOL,
+     {&g_vkReplaySettings.preloadTraceFile},
+     {&s_defaultVkReplaySettings.preloadTraceFile},
+     TRUE,
+     "Preload tracefile to memory before replay."},
     {"l",
      "NumLoops",
      VKTRACE_SETTING_UINT,


### PR DESCRIPTION
This is an experimental change to make the vkreplay run faster.

This change adds a new option "-pltf" to help user to pre-load trace
file to memory when running vkreplay. (with "-pltf true")

It helps to replay a trace file faster especially on a system with slow
file I/O.