### PR TITLE
via: Fix runtime output on Linux

### DIFF
--- a/via/via_system_linux.cpp
+++ b/via/via_system_linux.cpp
@@ -974,13 +974,16 @@ ViaSystem::ViaResults ViaSystemLinux::PrintSystemLoaderInfo() {
                         std::string find_so = vulkan_so_prefix;
                         ViaResults temp_res = PrintRuntimesInFolder(trimmed, find_so, false);
                         if (!found) {
+                            // If nothing's been found so far, save the current error message
                             result = temp_res;
-                        } else {
-                            // We found one runtime, clear any failures
-                            if (result == VIA_VULKAN_CANT_FIND_RUNTIME) {
-                                result = VIA_SUCCESSFUL;
+                            // If the result was successful, then we did end up finding at least
+                            // one.
+                            if (result == VIA_SUCCESSFUL) {
                                 found = true;
                             }
+                            // We found at least one runtime already, clear any failures
+                        } else if (found && result == VIA_VULKAN_CANT_FIND_RUNTIME) {
+                            result = VIA_SUCCESSFUL;
                         }
                     }
                     break;


### PR DESCRIPTION
We failed to set the 'found' variable resulting in an incorrect
statement that no runtimes were found even though we had just
printed a statement indicating we found a runtime.

Change-Id: Id75d39df6c7a40ce44929f14a46f4961a6b17ea6