### PR TITLE
via: Rename physical memory section

### DIFF
--- a/via/via_system_linux.cpp
+++ b/via/via_system_linux.cpp
@@ -244,7 +244,7 @@ ViaSystem::ViaResults ViaSystemLinux::PrintSystemHardwareInfo() {
 
     PrintBeginTableRow();
     PrintTableElement("Memory");
-    PrintTableElement("Physical");
+    PrintTableElement("Physical Available");
     PrintTableElement(generic_string);
     PrintEndTableRow();
 

--- a/via/via_system_windows.cpp
+++ b/via/via_system_windows.cpp
@@ -770,42 +770,26 @@ ViaSystem::ViaResults ViaSystemWindows::PrintSystemHardwareInfo() {
     }
 
     if (TRUE == GlobalMemoryStatusEx(&mem_stat)) {
+        PrintBeginTableRow();
+        PrintTableElement("Memory");
+        PrintTableElement("Physical Available");
         if ((mem_stat.ullTotalPhys >> 40) > 0x0ULL) {
             snprintf(generic_string, 1023, "%u TB", static_cast<uint32_t>(mem_stat.ullTotalPhys >> 40));
-            PrintBeginTableRow();
-            PrintTableElement("Memory");
-            PrintTableElement("Physical");
             PrintTableElement(generic_string);
-            PrintEndTableRow();
         } else if ((mem_stat.ullTotalPhys >> 30) > 0x0ULL) {
             snprintf(generic_string, 1023, "%u GB", static_cast<uint32_t>(mem_stat.ullTotalPhys >> 30));
-            PrintBeginTableRow();
-            PrintTableElement("Memory");
-            PrintTableElement("Physical");
             PrintTableElement(generic_string);
-            PrintEndTableRow();
         } else if ((mem_stat.ullTotalPhys >> 20) > 0x0ULL) {
             snprintf(generic_string, 1023, "%u MB", static_cast<uint32_t>(mem_stat.ullTotalPhys >> 20));
-            PrintBeginTableRow();
-            PrintTableElement("Memory");
-            PrintTableElement("Physical");
             PrintTableElement(generic_string);
-            PrintEndTableRow();
         } else if ((mem_stat.ullTotalPhys >> 10) > 0x0ULL) {
             snprintf(generic_string, 1023, "%u KB", static_cast<uint32_t>(mem_stat.ullTotalPhys >> 10));
-            PrintBeginTableRow();
-            PrintTableElement("Memory");
-            PrintTableElement("Physical");
             PrintTableElement(generic_string);
-            PrintEndTableRow();
         } else {
             snprintf(generic_string, 1023, "%u bytes", static_cast<uint32_t>(mem_stat.ullTotalPhys));
-            PrintBeginTableRow();
-            PrintTableElement("Memory");
-            PrintTableElement("Physical");
             PrintTableElement(generic_string);
-            PrintEndTableRow();
         }
+        PrintEndTableRow();
     }
 
     if (TRUE == GetDiskFreeSpaceA(NULL, &sect_per_cluster, &bytes_per_sect, &num_free_cluster, &total_num_cluster)) {


### PR DESCRIPTION
Because the functions from the OS don't always return all memory
available, just return it as "available" memory.

Change-Id: Ica74db88b85e39a87f46623346f12f4c4763ee81