### PR TITLE
vkreplay: Always use playable device features

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -681,9 +681,10 @@ VkResult vkReplay::manually_replay_vkCreateDevice(packet_vkCreateDevice *pPacket
     uint32_t savedExtensionCount = pCreateInfo->enabledExtensionCount;
     vector<const char *> extensionNames;
 
-    // Get replayable extensions in compatibility mode
+    // Get replayable extensions and features in compatibility mode
     uint32_t extensionCount = 0;
     VkExtensionProperties *extensions = NULL;
+    VkPhysicalDeviceFeatures features;
     if (g_pReplaySettings->compatibilityMode) {
         if (VK_SUCCESS != m_vkFuncs.EnumerateDeviceExtensionProperties(remappedPhysicalDevice, NULL, &extensionCount, NULL)) {
             vktrace_LogError("vkEnumerateDeviceExtensionProperties failed to get extension count!");
@@ -695,6 +696,11 @@ VkResult vkReplay::manually_replay_vkCreateDevice(packet_vkCreateDevice *pPacket
                 vktrace_free(extensions);
                 extensionCount = 0;
             }
+        }
+        if (pCreateInfo->pEnabledFeatures) {
+            m_vkFuncs.GetPhysicalDeviceFeatures(remappedPhysicalDevice, &features);
+            // Use replayable features instead of traced features
+            pCreateInfo->pEnabledFeatures = &features;
         }
     }
 


### PR DESCRIPTION
This change makes vkreplay always use playable device features in
compatibility mode.