### PR TITLE
vkreplay: Skip replaying failed api calls in trace

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -736,6 +736,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
             replay_gen_source += '            packet_vk%s* pPacket = (packet_vk%s*)(packet->pBody);\n' % (cmdname, cmdname)
             if resulttype is not None and resulttype.text != 'void' and resulttype.text != 'PFN_vkVoidFunction':
                 replay_gen_source += '            if (pPacket->result &&\n'
+                replay_gen_source += '                g_pReplaySettings->compatibilityMode && m_pFileHeader->portability_table_valid && !platformMatch() &&\n'
                 replay_gen_source += '                pPacket->result != VK_SUCCESS && pPacket->result != VK_NOT_READY && pPacket->result != VK_TIMEOUT && pPacket->result != VK_EVENT_SET &&\n'
                 replay_gen_source += '                pPacket->result != VK_EVENT_RESET && pPacket->result != VK_INCOMPLETE && pPacket->result != VK_SUBOPTIMAL_KHR) {\n'
                 replay_gen_source += '                vktrace_LogVerbose("Skip %s which has failed result in trace file!", vktrace_vk_packet_id_name((VKTRACE_TRACE_PACKET_ID_VK)packet->packet_id));\n'

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -734,6 +734,13 @@ class VkTraceFileOutputGenerator(OutputGenerator):
             params = cmd_member_dict[vk_cmdname]
             replay_gen_source += '        case VKTRACE_TPI_VK_vk%s: { \n' % cmdname
             replay_gen_source += '            packet_vk%s* pPacket = (packet_vk%s*)(packet->pBody);\n' % (cmdname, cmdname)
+            if resulttype is not None and resulttype.text != 'void' and resulttype.text != 'PFN_vkVoidFunction':
+                replay_gen_source += '            if (pPacket->result &&\n'
+                replay_gen_source += '                pPacket->result != VK_SUCCESS && pPacket->result != VK_NOT_READY && pPacket->result != VK_TIMEOUT && pPacket->result != VK_EVENT_SET &&\n'
+                replay_gen_source += '                pPacket->result != VK_EVENT_RESET && pPacket->result != VK_INCOMPLETE && pPacket->result != VK_SUBOPTIMAL_KHR) {\n'
+                replay_gen_source += '                vktrace_LogVerbose("Skip %s which has failed result in trace file!", vktrace_vk_packet_id_name((VKTRACE_TRACE_PACKET_ID_VK)packet->packet_id));\n'
+                replay_gen_source += '                break;\n'
+                replay_gen_source += '            }\n'
 
             if cmdname in manually_replay_funcs:
                 if ret_value == True:

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -174,6 +174,8 @@ class vkReplay {
         return (m_platformMatch == 1);
     }
 
+    bool callFailedDuringTrace(VkResult result, uint16_t packet_id);
+
     struct ValidationMsg {
         VkFlags msgFlags;
         VkDebugReportObjectTypeEXT objType;


### PR DESCRIPTION
This change makes vkreplay to skip replaying the API calls with failed
results recorded in trace file.  The expected to fail API calls in
trace file will not be replayed in case those API calls may success on
replay platform.