### PR TITLE
build: Fix python3 warning

### DIFF
--- a/scripts/vt_genvk.py
+++ b/scripts/vt_genvk.py
@@ -21,12 +21,13 @@ startTime = None
 
 def startTimer(timeit):
     global startTime
-    startTime = time.clock()
+    if timeit:
+        startTime = time.process_time()
 
 def endTimer(timeit, msg):
     global startTime
-    endTime = time.clock()
-    if (timeit):
+    if timeit:
+        endTime = time.process_time()
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None
 


### PR DESCRIPTION
Python 3.8 will deprecate time.clock. Replace it and also fix
the code to only calcualte times when needd.

Change-Id: I067d00fa40341dd7998d17d279e6130c5e8cb213