### PR TITLE
vktrace: Add mutex lock for all manual and autogenerated hooked API

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -2819,6 +2819,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 ptr_packet_update_list = self.GetPacketPtrParamList(proto.members)
                 # End of function declaration portion, begin function body
                 trace_vk_src += ' {\n'
+                trace_vk_src += '    trim::TrimLockGuard<std::mutex> lock(g_mutex);\n'
                 if 'void' not in resulttype or '*' in resulttype:
                     trace_vk_src += '    %s result;\n' % resulttype
                     return_txt = 'result = '

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -2819,7 +2819,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 ptr_packet_update_list = self.GetPacketPtrParamList(proto.members)
                 # End of function declaration portion, begin function body
                 trace_vk_src += ' {\n'
-                trace_vk_src += '    trim::TrimLockGuard<std::mutex> lock(g_mutex);\n'
+                trace_vk_src += '    trim::TraceLock<std::mutex> lock(g_mutex_trace);\n'
                 if 'void' not in resulttype or '*' in resulttype:
                     trace_vk_src += '    %s result;\n' % resulttype
                     return_txt = 'result = '

--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -17,7 +17,7 @@ Options for the `vktrace` command are:
 | -P&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PMB&nbsp;&lt;bool&gt; | Trace  persistently mapped buffers | true |
 | -tr&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TraceTrigger&nbsp;&lt;string&gt; | Start/stop trim by hotkey or frame range. String arg is one of:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hotkey-[F1-F12\|TAB\|CONTROL]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;frames-&lt;startframe&gt;-&lt;endframe&gt;| on |
 | -tpp&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TrimPostProcessing&nbsp;&lt;bool&gt; | Enable trim post-processing to make trimmed trace file smaller, see description of VKTRACE_TRIM_POST_PROCESS below | false |
-| -tl&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TraceLock&nbsp;&lt;bool&gt; | Enable locking of API calls during trace if TraceLock is set to TRUE, default is FALSEin which it is enabled only when trimming is enabled, see description of VKTRACE_ENABLE_TRACE_LOCK below | false |
+| -tl&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TraceLock&nbsp;&lt;bool&gt; | Enable locking of API calls during trace. Default is TRUE if trimming is enabled, FALSE otherwise. See description of VKTRACE_ENABLE_TRACE_LOCK below | See description |
 | -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
 | -tbs&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TrimBatchSize&nbsp;&lt;string&gt; | Set the maximum trim commands batch size per command buffer, see description of VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE below  |  device memory allocation limit divided by 100 |
 

--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -17,7 +17,7 @@ Options for the `vktrace` command are:
 | -P&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PMB&nbsp;&lt;bool&gt; | Trace  persistently mapped buffers | true |
 | -tr&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TraceTrigger&nbsp;&lt;string&gt; | Start/stop trim by hotkey or frame range. String arg is one of:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hotkey-[F1-F12\|TAB\|CONTROL]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;frames-&lt;startframe&gt;-&lt;endframe&gt;| on |
 | -tpp&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TrimPostProcessing&nbsp;&lt;bool&gt; | Enable trim post-processing to make trimmed trace file smaller, see description of VKTRACE_TRIM_POST_PROCESS below | false |
-| -lg&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;Lockguard&nbsp;&lt;bool&gt; | Always enable lock guard for all API calls if Lockguard is TRUE, default is FALSE in which it enabled only for trim, see description of VKTRACE_ENABLE_LOCKGUARD below | false |
+| -lg&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;Lockguard&nbsp;&lt;bool&gt; | Always enable lock guard for all API calls if Lockguard is TRUE, default is FALSE in which it enabled only for trim, see description of VKTRACE_ENABLE_TRACE_LOCK below | false |
 | -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
 | -tbs&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TrimBatchSize&nbsp;&lt;string&gt; | Set the maximum trim commands batch size per command buffer, see description of VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE below  |  device memory allocation limit divided by 100 |
 
@@ -203,9 +203,8 @@ Several environment variables can be set to change the behavior of vktrace/vktra
 
     VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE sets the maximum number of commands batched during trim resources upload (images and buffers recreation). The range is 1 - device memory allocation limit. This enviroment variable is used to reduce the number of  command buffers allocated  by batching the commands execution according to the size set. 
 
- - VKTRACE_ENABLE_LOCKGUARD
-
-    VKTRACE_ENABLE_LOCKGUARD enables lock guard all the time for all API calls if its value is 1. Otherwise, lock guard only enabled for trim only. Lock guard is needed to fix APi race condition and remap errors when trim enabled. This environment variable is used to enable lock guard for all the time. 
+ - VKTRACE_ENABLE_TRACE_LOCK
+    VKTRACE_ENABLE_TRACE_LOCK enables locking of API calls during trace if set to a non-null value. Not setting this variable will sometimes result in race conditions and remap errors during replay. Setting this variable will avoid those errors, with a slight performance loss during tracing. Locking of API calls is always enabled when trimming is enabled.
 
 ## Android
 

--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -17,6 +17,7 @@ Options for the `vktrace` command are:
 | -P&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PMB&nbsp;&lt;bool&gt; | Trace  persistently mapped buffers | true |
 | -tr&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TraceTrigger&nbsp;&lt;string&gt; | Start/stop trim by hotkey or frame range. String arg is one of:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hotkey-[F1-F12\|TAB\|CONTROL]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;frames-&lt;startframe&gt;-&lt;endframe&gt;| on |
 | -tpp&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TrimPostProcessing&nbsp;&lt;bool&gt; | Enable trim post-processing to make trimmed trace file smaller, see description of VKTRACE_TRIM_POST_PROCESS below | false |
+| -lg&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;Lockguard&nbsp;&lt;bool&gt; | Always enable lock guard for all API calls if Lockguard is TRUE, default is FALSE in which it enabled only for trim, see description of VKTRACE_ENABLE_LOCKGUARD below | false |
 | -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
 | -tbs&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TrimBatchSize&nbsp;&lt;string&gt; | Set the maximum trim commands batch size per command buffer, see description of VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE below  |  device memory allocation limit divided by 100 |
 
@@ -201,6 +202,10 @@ Several environment variables can be set to change the behavior of vktrace/vktra
  - VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE
 
     VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE sets the maximum number of commands batched during trim resources upload (images and buffers recreation). The range is 1 - device memory allocation limit. This enviroment variable is used to reduce the number of  command buffers allocated  by batching the commands execution according to the size set. 
+
+ - VKTRACE_ENABLE_LOCKGUARD
+
+    VKTRACE_ENABLE_LOCKGUARD enables lock guard all the time for all API calls if its value is 1. Otherwise, lock guard only enabled for trim only. Lock guard is needed to fix APi race condition and remap errors when trim enabled. This environment variable is used to enable lock guard for all the time. 
 
 ## Android
 

--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -17,7 +17,7 @@ Options for the `vktrace` command are:
 | -P&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;PMB&nbsp;&lt;bool&gt; | Trace  persistently mapped buffers | true |
 | -tr&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TraceTrigger&nbsp;&lt;string&gt; | Start/stop trim by hotkey or frame range. String arg is one of:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hotkey-[F1-F12\|TAB\|CONTROL]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;frames-&lt;startframe&gt;-&lt;endframe&gt;| on |
 | -tpp&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TrimPostProcessing&nbsp;&lt;bool&gt; | Enable trim post-processing to make trimmed trace file smaller, see description of VKTRACE_TRIM_POST_PROCESS below | false |
-| -lg&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;Lockguard&nbsp;&lt;bool&gt; | Always enable lock guard for all API calls if Lockguard is TRUE, default is FALSE in which it enabled only for trim, see description of VKTRACE_ENABLE_TRACE_LOCK below | false |
+| -tl&nbsp;&lt;bool&gt;<br>&#x2011;&#x2011;TraceLock&nbsp;&lt;bool&gt; | Enable locking of API calls during trace if TraceLock is set to TRUE, default is FALSEin which it is enabled only when trimming is enabled, see description of VKTRACE_ENABLE_TRACE_LOCK below | false |
 | -v&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;Verbosity&nbsp;&lt;string&gt; | Verbosity mode - "quiet", "errors", "warnings", or "full" | errors |
 | -tbs&nbsp;&lt;string&gt;<br>&#x2011;&#x2011;TrimBatchSize&nbsp;&lt;string&gt; | Set the maximum trim commands batch size per command buffer, see description of VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE below  |  device memory allocation limit divided by 100 |
 
@@ -204,6 +204,7 @@ Several environment variables can be set to change the behavior of vktrace/vktra
     VKTRACE_TRIM_MAX_COMMAND_BATCH_SIZE sets the maximum number of commands batched during trim resources upload (images and buffers recreation). The range is 1 - device memory allocation limit. This enviroment variable is used to reduce the number of  command buffers allocated  by batching the commands execution according to the size set. 
 
  - VKTRACE_ENABLE_TRACE_LOCK
+ 
     VKTRACE_ENABLE_TRACE_LOCK enables locking of API calls during trace if set to a non-null value. Not setting this variable will sometimes result in race conditions and remap errors during replay. Setting this variable will avoid those errors, with a slight performance loss during tracing. Locking of API calls is always enabled when trimming is enabled.
 
 ## Android

--- a/vktrace/vktrace_common/vktrace_common.h
+++ b/vktrace/vktrace_common/vktrace_common.h
@@ -165,6 +165,15 @@ static const uint32_t  INVALID_BINDING_INDEX = UINT32_MAX;
 // (e.g. when generating trace file with only 1 or small range of frames.)
 #define VKTRACE_TRIM_POST_PROCESS_ENV "VKTRACE_TRIM_POST_PROCESS"
 
+// VKTRACE_ENABLE_TRACE_LOCK env var is set by the vktrace program to
+// pass the option argument to the trace layer to enables locking
+// of API calls during trace if set to a non-null value.
+// Not setting this variable will sometimes result in race conditions
+// and remap errors during replay. Setting this variable will avoid those errors,
+// with a slight performance loss during tracing.
+// By default, locking of API calls is always enabled when trimming is enabled.
+#define VKTRACE_ENABLE_TRACE_LOCK_ENV "VKTRACE_ENABLE_TRACE_LOCK"
+
 // _VKTRACE_VERBOSITY env var is set by the vktrace program to
 // communicate verbosity level to the trace layer. It is set to
 // one of "quiet", "errors", "warnings", "full", or "debug".

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -166,7 +166,6 @@ void* strip_create_extensions(const void* pNext) {
     return create_info;
 }
 
-
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkDeviceMemory* pMemory) {
@@ -220,7 +219,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevic
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset,
                                                                     VkDeviceSize size, VkFlags flags, void** ppData) {
-
     trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
@@ -4050,7 +4048,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateAndroidSurfaceKH
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplate(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 }
 
@@ -4745,7 +4742,6 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
     return result;
 }
 
-
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
     VkCommandBuffer commandBuffer,
     const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
@@ -5114,13 +5110,11 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPrope
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                                uint32_t* pPropertyCount,
                                                                                                VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties);
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                            VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties);
 }
 
@@ -5143,12 +5137,10 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetInstanceProcAddr(VkInstance instance,
                                                                                                     const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetInstanceProcAddr(instance, funcName);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetDeviceProcAddr(VkDevice device,
                                                                                                   const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetDeviceProcAddr(device, funcName);
 }

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -50,6 +50,8 @@
 
 #include "vk_struct_size_helper.h"
 
+std::mutex g_mutex;
+
 VKTRACER_LEAVE _Unload(void) {
     // only do the hooking and networking if the tracer is NOT loaded by vktrace
     if (vktrace_is_loaded_into_vktrace() == FALSE) {
@@ -164,9 +166,11 @@ void* strip_create_extensions(const void* pNext) {
     return create_info;
 }
 
+
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkDeviceMemory* pMemory) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateMemory* pPacket = NULL;
@@ -216,6 +220,8 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevic
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset,
                                                                     VkDeviceSize size, VkFlags flags, void** ppData) {
+
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkMapMemory* pPacket = NULL;
@@ -297,6 +303,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
 }
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice device, VkDeviceMemory memory) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkUnmapMemory* pPacket;
     VKAllocInfo* entry;
@@ -363,6 +370,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice devic
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device, VkDeviceMemory memory,
                                                                  const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeMemory* pPacket = NULL;
 #if defined(USE_PAGEGUARD_SPEEDUP)
@@ -408,6 +416,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                        const VkMappedMemoryRange* pMemoryRanges) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     size_t rangesSize = 0;
@@ -510,6 +519,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemory
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                   const VkMappedMemoryRange* pMemoryRanges) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     uint64_t rangesSize = 0;
@@ -645,6 +655,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers(VkDevice device,
                                                                                  const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                                                  VkCommandBuffer* pCommandBuffers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateCommandBuffers* pPacket = NULL;
@@ -692,6 +703,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
                                                                              const VkCommandBufferBeginInfo* pBeginInfo) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBeginCommandBuffer* pPacket = NULL;
@@ -735,6 +747,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorPool(V
                                                                                const VkDescriptorPoolCreateInfo* pCreateInfo,
                                                                                const VkAllocationCallbacks* pAllocator,
                                                                                VkDescriptorPool* pDescriptorPool) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorPool* pPacket = NULL;
@@ -796,6 +809,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
     VkPhysicalDevice physicalDevice,
     VkPhysicalDeviceProperties* pProperties)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties, sizeof(VkPhysicalDeviceProperties));
@@ -839,6 +853,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice,
                                                                                       VkPhysicalDeviceProperties2KHR* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties2KHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties2KHR, get_struct_chain_size((void*)pProperties));
@@ -872,6 +887,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDevice(VkPhysicalDevice physicalDevice,
                                                                        const VkDeviceCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateDevice* pPacket = NULL;
@@ -979,6 +995,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateFramebuffer(VkDe
                                                                             const VkFramebufferCreateInfo* pCreateInfo,
                                                                             const VkAllocationCallbacks* pAllocator,
                                                                             VkFramebuffer* pFramebuffer) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateFramebuffer* pPacket = NULL;
@@ -1117,6 +1134,7 @@ static void send_vk_api_version_packet() {
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkInstance* pInstance) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateInstance* pPacket = NULL;
@@ -1236,6 +1254,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const V
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyInstance(VkInstance instance,
                                                                       const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (g_trimEnabled && g_trimIsInTrim) {
         trim::stop();
     }
@@ -1275,6 +1294,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateRenderPass(VkDev
                                                                            const VkRenderPassCreateInfo* pCreateInfo,
                                                                            const VkAllocationCallbacks* pAllocator,
                                                                            VkRenderPass* pRenderPass) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateRenderPass* pPacket = NULL;
@@ -1370,6 +1390,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
                                                                                              const char* pLayerName,
                                                                                              uint32_t* pPropertyCount,
                                                                                              VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceExtensionProperties* pPacket = NULL;
@@ -1420,6 +1441,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                          uint32_t* pPropertyCount,
                                                                                          VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceLayerProperties* pPacket = NULL;
@@ -1457,6 +1479,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerPr
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties* pQueueFamilyProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties* pPacket = NULL;
     uint64_t startTime;
@@ -1505,6 +1528,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties2KHR* pPacket = NULL;
     uint64_t startTime;
@@ -1557,6 +1581,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumeratePhysicalDevices(VkInstance instance,
                                                                                    uint32_t* pPhysicalDeviceCount,
                                                                                    VkPhysicalDevice* pPhysicalDevices) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumeratePhysicalDevices* pPacket = NULL;
@@ -1620,6 +1645,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
                                                                               uint32_t firstQuery, uint32_t queryCount,
                                                                               size_t dataSize, void* pData, VkDeviceSize stride,
                                                                               VkQueryResultFlags flags) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetQueryPoolResults* pPacket = NULL;
@@ -1662,6 +1688,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateDescriptorSets(VkDevice device,
                                                                                  const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                                                  VkDescriptorSet* pDescriptorSets) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateDescriptorSets* pPacket = NULL;
@@ -2001,6 +2028,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
                                                                            const VkWriteDescriptorSet* pDescriptorWrites,
                                                                            uint32_t descriptorCopyCount,
                                                                            const VkCopyDescriptorSet* pDescriptorCopies) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSets* pPacket = NULL;
     // begin custom code
@@ -2129,6 +2157,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue queue, uint32_t submitCount,
                                                                       const VkSubmitInfo* pSubmits, VkFence fence) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if ((g_trimEnabled) && (pSubmits != NULL)) {
         vktrace_enter_critical_section(&trim::trimTransitionMapLock);
     }
@@ -2280,6 +2309,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueBindSparse(VkQueue queue, uint32_t bindInfoCount,
                                                                           const VkBindSparseInfo* pBindInfo, VkFence fence) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkQueueBindSparse* pPacket = NULL;
@@ -2411,6 +2441,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdWaitEvents(
     VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdWaitEvents* pPacket = NULL;
     size_t customSize;
@@ -2488,6 +2519,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPipelineBarrier* pPacket = NULL;
     size_t customSize;
@@ -2577,6 +2609,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                                        VkShaderStageFlags stageFlags, uint32_t offset,
                                                                        uint32_t size, const void* pValues) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushConstants* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdPushConstants, size);
@@ -2606,6 +2639,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommand
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                                                          const VkCommandBuffer* pCommandBuffers) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdExecuteCommands* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdExecuteCommands, commandBufferCount * sizeof(VkCommandBuffer));
@@ -2646,6 +2680,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkComma
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache,
                                                                                size_t* pDataSize, void* pData) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkGetPipelineCacheData* pPacket = NULL;
@@ -2717,6 +2752,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipeline
                                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                                                   const VkAllocationCallbacks* pAllocator,
                                                                                   VkPipeline* pPipelines) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateGraphicsPipelines* pPacket = NULL;
@@ -2813,6 +2849,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateComputePipelines
                                                                                  const VkComputePipelineCreateInfo* pCreateInfos,
                                                                                  const VkAllocationCallbacks* pAllocator,
                                                                                  VkPipeline* pPipelines) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateComputePipelines* pPacket = NULL;
@@ -2891,6 +2928,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
                                                                               const VkPipelineCacheCreateInfo* pCreateInfo,
                                                                               const VkAllocationCallbacks* pAllocator,
                                                                               VkPipelineCache* pPipelineCache) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreatePipelineCache* pPacket = NULL;
@@ -2935,6 +2973,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkCommandBuffer commandBuffer,
                                                                          const VkRenderPassBeginInfo* pRenderPassBegin,
                                                                          VkSubpassContents contents) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdBeginRenderPass* pPacket = NULL;
     size_t clearValueSize = sizeof(VkClearValue) * pRenderPassBegin->clearValueCount;
@@ -2991,6 +3030,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkComma
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool,
                                                                              uint32_t descriptorSetCount,
                                                                              const VkDescriptorSet* pDescriptorSets) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeDescriptorSets* pPacket = NULL;
@@ -3034,6 +3074,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkD
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
                                                                       const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateImage* pPacket = NULL;
@@ -3148,6 +3189,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateBuffer* pPacket = NULL;
@@ -3203,6 +3245,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice 
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice device, VkBuffer buffer,
                                                                     const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyBuffer, sizeof(VkAllocationCallbacks));
@@ -3234,6 +3277,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice dev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
                                                                            VkDeviceSize memoryOffset) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBindBufferMemory* pPacket = NULL;
@@ -3275,6 +3319,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceSurfaceCapabilitiesKHR* pPacket = NULL;
@@ -3304,6 +3349,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                              VkSurfaceKHR surface,
                                                                                              uint32_t* pSurfaceFormatCount,
                                                                                              VkSurfaceFormatKHR* pSurfaceFormats) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3345,6 +3391,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                                   VkSurfaceKHR surface,
                                                                                                   uint32_t* pPresentModeCount,
                                                                                                   VkPresentModeKHR* pPresentModes) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3387,6 +3434,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
                                                                              const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                                              const VkAllocationCallbacks* pAllocator,
                                                                              VkSwapchainKHR* pSwapchain) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateSwapchainKHR* pPacket = NULL;
@@ -3430,6 +3478,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                                                 uint32_t* pSwapchainImageCount,
                                                                                 VkImage* pSwapchainImages) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3489,6 +3538,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkQueuePresentKHR* pPacket = NULL;
@@ -3604,6 +3654,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
                                                                                 const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                                                 const VkAllocationCallbacks* pAllocator,
                                                                                 VkSurfaceKHR* pSurface) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateWin32SurfaceKHR* pPacket = NULL;
@@ -3644,6 +3695,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
 
 VKTRACER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL
 __HOOKED_vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkBool32 result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceWin32PresentationSupportKHR* pPacket = NULL;
@@ -3998,6 +4050,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateAndroidSurfaceKH
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplate(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 }
 
@@ -4018,6 +4071,7 @@ void unlockDescriptorUpdateTemplateCreateInfo() { vktrace_sem_post(descriptorUpd
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplateKHR(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorUpdateTemplateKHR* pPacket = NULL;
@@ -4101,6 +4155,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplate(
     VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplate* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplate, sizeof(VkAllocationCallbacks));
@@ -4136,6 +4191,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplateKHR(
     VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplateKHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplateKHR, sizeof(VkAllocationCallbacks));
@@ -4221,6 +4277,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplateKHR(
     VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4337,6 +4394,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
                                                                               VkPipelineLayout layout, uint32_t set,
                                                                               uint32_t descriptorWriteCount,
                                                                               const VkWriteDescriptorSet* pDescriptorWrites) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetKHR* pPacket = NULL;
     size_t arrayByteCount = 0;
@@ -4445,6 +4503,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetWithTemplateKHR(
     VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, VkPipelineLayout layout, uint32_t set,
     const void* pData) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4479,6 +4538,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
                                                                            VkImageLayout srcImageLayout, VkBuffer dstBuffer,
                                                                            uint32_t regionCount,
                                                                            const VkBufferImageCopy* pRegions) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdCopyImageToBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdCopyImageToBuffer, regionCount * sizeof(VkBufferImageCopy));
@@ -4513,6 +4573,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkWaitForFences(VkDevice device, uint32_t fenceCount,
                                                                         const VkFence* pFences, VkBool32 waitAll,
                                                                         uint64_t timeout) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkWaitForFences* pPacket = NULL;
@@ -4632,6 +4693,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
      const VkAllocationCallbacks*                pAllocator,
      VkObjectTableNVX*                           pObjectTable)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateObjectTableNVX* pPacket = NULL;
@@ -4688,6 +4750,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
     VkCommandBuffer commandBuffer,
     const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdProcessCommandsNVX* pPacket;
     size_t datasize = 0;
@@ -4733,6 +4796,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateIndirectCommands
     const VkAllocationCallbacks* pAllocator,
     VkIndirectCommandsLayoutNVX* pIndirectCommandsLayout)
 {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateIndirectCommandsLayoutNVX* pPacket = NULL;
@@ -4829,6 +4893,7 @@ pSurfaceDescription);
  * but not for loader initiated calls to GDPA. Thus need two versions of GDPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAddr(VkDevice device, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     PFN_vkVoidFunction addr;
 
     vktrace_trace_packet_header* pHeader;
@@ -4857,6 +4922,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAdd
 
 /* GDPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDeviceProcAddr(VkDevice device, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (!strcmp("vkGetDeviceProcAddr", funcName)) {
         if (gMessageStream != NULL) {
             return (PFN_vkVoidFunction)vktraceGetDeviceProcAddr;
@@ -4894,6 +4960,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDevicePro
  * but not for loader initiated calls to GIPA. Thus need two versions of GIPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcAddr(VkInstance instance, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     PFN_vkVoidFunction addr;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetInstanceProcAddr* pPacket = NULL;
@@ -4923,6 +4990,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcA
 
 /* GIPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     PFN_vkVoidFunction addr;
     layer_instance_data* instData;
 
@@ -5029,12 +5097,14 @@ VkResult EnumerateProperties(uint32_t src_count, const T* src_props, uint32_t* d
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                   VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                       uint32_t* pPropertyCount,
                                                                                       VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 
@@ -5044,23 +5114,27 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPrope
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                                uint32_t* pPropertyCount,
                                                                                                VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties);
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                            VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return vkEnumerateInstanceLayerProperties(pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                 uint32_t* pPropertyCount,
                                                                                 VkLayerProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(const char* pLayerName,
                                                                                     uint32_t* pPropertyCount,
                                                                                     VkExtensionProperties* pProperties) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 
@@ -5069,10 +5143,12 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetInstanceProcAddr(VkInstance instance,
                                                                                                     const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetInstanceProcAddr(instance, funcName);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetDeviceProcAddr(VkDevice device,
                                                                                                   const char* funcName) {
+    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return __HOOKED_vkGetDeviceProcAddr(device, funcName);
 }

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -50,7 +50,8 @@
 
 #include "vk_struct_size_helper.h"
 
-std::mutex g_mutex;
+// This mutex is used to protect API calls sequence when trim starting process.
+std::mutex g_mutex_trace;
 
 VKTRACER_LEAVE _Unload(void) {
     // only do the hooking and networking if the tracer is NOT loaded by vktrace
@@ -169,7 +170,7 @@ void* strip_create_extensions(const void* pNext) {
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkDeviceMemory* pMemory) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateMemory* pPacket = NULL;
@@ -219,7 +220,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateMemory(VkDevic
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset,
                                                                     VkDeviceSize size, VkFlags flags, void** ppData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkMapMemory* pPacket = NULL;
@@ -301,7 +302,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkMapMemory(VkDevice dev
 }
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice device, VkDeviceMemory memory) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkUnmapMemory* pPacket;
     VKAllocInfo* entry;
@@ -368,7 +369,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUnmapMemory(VkDevice devic
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device, VkDeviceMemory memory,
                                                                  const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeMemory* pPacket = NULL;
 #if defined(USE_PAGEGUARD_SPEEDUP)
@@ -414,7 +415,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkFreeMemory(VkDevice device
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                        const VkMappedMemoryRange* pMemoryRanges) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     size_t rangesSize = 0;
@@ -517,7 +518,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkInvalidateMappedMemory
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                                   const VkMappedMemoryRange* pMemoryRanges) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     uint64_t rangesSize = 0;
@@ -653,7 +654,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFlushMappedMemoryRange
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers(VkDevice device,
                                                                                  const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                                                  VkCommandBuffer* pCommandBuffers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateCommandBuffers* pPacket = NULL;
@@ -701,7 +702,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateCommandBuffers
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
                                                                              const VkCommandBufferBeginInfo* pBeginInfo) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBeginCommandBuffer* pPacket = NULL;
@@ -745,7 +746,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorPool(V
                                                                                const VkDescriptorPoolCreateInfo* pCreateInfo,
                                                                                const VkAllocationCallbacks* pAllocator,
                                                                                VkDescriptorPool* pDescriptorPool) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorPool* pPacket = NULL;
@@ -807,7 +808,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
     VkPhysicalDevice physicalDevice,
     VkPhysicalDeviceProperties* pProperties)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties, sizeof(VkPhysicalDeviceProperties));
@@ -851,7 +852,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice physicalDevice,
                                                                                       VkPhysicalDeviceProperties2KHR* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties2KHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkGetPhysicalDeviceProperties2KHR, get_struct_chain_size((void*)pProperties));
@@ -885,7 +886,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDevicePropertie
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDevice(VkPhysicalDevice physicalDevice,
                                                                        const VkDeviceCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateDevice* pPacket = NULL;
@@ -993,7 +994,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateFramebuffer(VkDe
                                                                             const VkFramebufferCreateInfo* pCreateInfo,
                                                                             const VkAllocationCallbacks* pAllocator,
                                                                             VkFramebuffer* pFramebuffer) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateFramebuffer* pPacket = NULL;
@@ -1132,7 +1133,7 @@ static void send_vk_api_version_packet() {
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                                                                          const VkAllocationCallbacks* pAllocator,
                                                                          VkInstance* pInstance) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateInstance* pPacket = NULL;
@@ -1252,7 +1253,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateInstance(const V
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyInstance(VkInstance instance,
                                                                       const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     if (g_trimEnabled && g_trimIsInTrim) {
         trim::stop();
     }
@@ -1292,7 +1293,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateRenderPass(VkDev
                                                                            const VkRenderPassCreateInfo* pCreateInfo,
                                                                            const VkAllocationCallbacks* pAllocator,
                                                                            VkRenderPass* pRenderPass) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateRenderPass* pPacket = NULL;
@@ -1388,7 +1389,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
                                                                                              const char* pLayerName,
                                                                                              uint32_t* pPropertyCount,
                                                                                              VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceExtensionProperties* pPacket = NULL;
@@ -1439,7 +1440,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceExtensi
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                          uint32_t* pPropertyCount,
                                                                                          VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumerateDeviceLayerProperties* pPacket = NULL;
@@ -1477,7 +1478,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateDeviceLayerPr
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties* pQueueFamilyProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties* pPacket = NULL;
     uint64_t startTime;
@@ -1526,7 +1527,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceQueueFamilyProperties2KHR* pPacket = NULL;
     uint64_t startTime;
@@ -1579,7 +1580,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceQueueFami
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumeratePhysicalDevices(VkInstance instance,
                                                                                    uint32_t* pPhysicalDeviceCount,
                                                                                    VkPhysicalDevice* pPhysicalDevices) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkEnumeratePhysicalDevices* pPacket = NULL;
@@ -1643,7 +1644,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
                                                                               uint32_t firstQuery, uint32_t queryCount,
                                                                               size_t dataSize, void* pData, VkDeviceSize stride,
                                                                               VkQueryResultFlags flags) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetQueryPoolResults* pPacket = NULL;
@@ -1686,7 +1687,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetQueryPoolResults(Vk
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkAllocateDescriptorSets(VkDevice device,
                                                                                  const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                                                  VkDescriptorSet* pDescriptorSets) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkAllocateDescriptorSets* pPacket = NULL;
@@ -2026,7 +2027,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
                                                                            const VkWriteDescriptorSet* pDescriptorWrites,
                                                                            uint32_t descriptorCopyCount,
                                                                            const VkCopyDescriptorSet* pDescriptorCopies) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSets* pPacket = NULL;
     // begin custom code
@@ -2155,7 +2156,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSets(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue queue, uint32_t submitCount,
                                                                       const VkSubmitInfo* pSubmits, VkFence fence) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     if ((g_trimEnabled) && (pSubmits != NULL)) {
         vktrace_enter_critical_section(&trim::trimTransitionMapLock);
     }
@@ -2307,7 +2308,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueSubmit(VkQueue qu
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueueBindSparse(VkQueue queue, uint32_t bindInfoCount,
                                                                           const VkBindSparseInfo* pBindInfo, VkFence fence) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkQueueBindSparse* pPacket = NULL;
@@ -2439,7 +2440,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdWaitEvents(
     VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdWaitEvents* pPacket = NULL;
     size_t customSize;
@@ -2517,7 +2518,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPipelineBarrier* pPacket = NULL;
     size_t customSize;
@@ -2607,7 +2608,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPipelineBarrier(
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                                        VkShaderStageFlags stageFlags, uint32_t offset,
                                                                        uint32_t size, const void* pValues) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushConstants* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdPushConstants, size);
@@ -2637,7 +2638,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushConstants(VkCommand
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                                                          const VkCommandBuffer* pCommandBuffers) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdExecuteCommands* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdExecuteCommands, commandBufferCount * sizeof(VkCommandBuffer));
@@ -2678,7 +2679,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdExecuteCommands(VkComma
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache,
                                                                                size_t* pDataSize, void* pData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkGetPipelineCacheData* pPacket = NULL;
@@ -2750,7 +2751,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateGraphicsPipeline
                                                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                                                   const VkAllocationCallbacks* pAllocator,
                                                                                   VkPipeline* pPipelines) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateGraphicsPipelines* pPacket = NULL;
@@ -2847,7 +2848,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateComputePipelines
                                                                                  const VkComputePipelineCreateInfo* pCreateInfos,
                                                                                  const VkAllocationCallbacks* pAllocator,
                                                                                  VkPipeline* pPipelines) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateComputePipelines* pPacket = NULL;
@@ -2926,7 +2927,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
                                                                               const VkPipelineCacheCreateInfo* pCreateInfo,
                                                                               const VkAllocationCallbacks* pAllocator,
                                                                               VkPipelineCache* pPipelineCache) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreatePipelineCache* pPacket = NULL;
@@ -2971,7 +2972,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreatePipelineCache(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkCommandBuffer commandBuffer,
                                                                          const VkRenderPassBeginInfo* pRenderPassBegin,
                                                                          VkSubpassContents contents) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdBeginRenderPass* pPacket = NULL;
     size_t clearValueSize = sizeof(VkClearValue) * pRenderPassBegin->clearValueCount;
@@ -3028,7 +3029,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdBeginRenderPass(VkComma
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool,
                                                                              uint32_t descriptorSetCount,
                                                                              const VkDescriptorSet* pDescriptorSets) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkFreeDescriptorSets* pPacket = NULL;
@@ -3072,7 +3073,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkFreeDescriptorSets(VkD
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
                                                                       const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     VkResult result;
     packet_vkCreateImage* pPacket = NULL;
@@ -3187,7 +3188,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateImage(VkDevice d
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateBuffer* pPacket = NULL;
@@ -3243,7 +3244,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateBuffer(VkDevice 
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice device, VkBuffer buffer,
                                                                     const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyBuffer, sizeof(VkAllocationCallbacks));
@@ -3275,7 +3276,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyBuffer(VkDevice dev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
                                                                            VkDeviceSize memoryOffset) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkBindBufferMemory* pPacket = NULL;
@@ -3317,7 +3318,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkBindBufferMemory(VkDev
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceSurfaceCapabilitiesKHR* pPacket = NULL;
@@ -3347,7 +3348,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                              VkSurfaceKHR surface,
                                                                                              uint32_t* pSurfaceFormatCount,
                                                                                              VkSurfaceFormatKHR* pSurfaceFormats) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3389,7 +3390,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetPhysicalDeviceSurfa
                                                                                                   VkSurfaceKHR surface,
                                                                                                   uint32_t* pPresentModeCount,
                                                                                                   VkPresentModeKHR* pPresentModes) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3432,7 +3433,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
                                                                              const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                                              const VkAllocationCallbacks* pAllocator,
                                                                              VkSwapchainKHR* pSwapchain) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateSwapchainKHR* pPacket = NULL;
@@ -3476,7 +3477,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateSwapchainKHR(VkD
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                                                 uint32_t* pSwapchainImageCount,
                                                                                 VkImage* pSwapchainImages) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     size_t _dataSize;
@@ -3536,7 +3537,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkQueuePresentKHR* pPacket = NULL;
@@ -3652,7 +3653,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
                                                                                 const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                                                 const VkAllocationCallbacks* pAllocator,
                                                                                 VkSurfaceKHR* pSurface) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateWin32SurfaceKHR* pPacket = NULL;
@@ -3693,7 +3694,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateWin32SurfaceKHR(
 
 VKTRACER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL
 __HOOKED_vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkBool32 result;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceWin32PresentationSupportKHR* pPacket = NULL;
@@ -4068,7 +4069,7 @@ void unlockDescriptorUpdateTemplateCreateInfo() { vktrace_sem_post(descriptorUpd
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplateKHR(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorUpdateTemplateKHR* pPacket = NULL;
@@ -4152,7 +4153,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplate(
     VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplate* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplate, sizeof(VkAllocationCallbacks));
@@ -4188,7 +4189,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTemplateKHR(
     VkDevice device, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkDestroyDescriptorUpdateTemplateKHR* pPacket = NULL;
     CREATE_TRACE_PACKET(vkDestroyDescriptorUpdateTemplateKHR, sizeof(VkAllocationCallbacks));
@@ -4274,7 +4275,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTem
 
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplateKHR(
     VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4391,7 +4392,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
                                                                               VkPipelineLayout layout, uint32_t set,
                                                                               uint32_t descriptorWriteCount,
                                                                               const VkWriteDescriptorSet* pDescriptorWrites) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetKHR* pPacket = NULL;
     size_t arrayByteCount = 0;
@@ -4500,7 +4501,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetKHR(Vk
 VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdPushDescriptorSetWithTemplateKHR(
     VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, VkPipelineLayout layout, uint32_t set,
     const void* pData) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdPushDescriptorSetWithTemplateKHR* pPacket = NULL;
     size_t dataSize;
@@ -4535,7 +4536,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
                                                                            VkImageLayout srcImageLayout, VkBuffer dstBuffer,
                                                                            uint32_t regionCount,
                                                                            const VkBufferImageCopy* pRegions) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdCopyImageToBuffer* pPacket = NULL;
     CREATE_TRACE_PACKET(vkCmdCopyImageToBuffer, regionCount * sizeof(VkBufferImageCopy));
@@ -4570,7 +4571,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdCopyImageToBuffer(VkCom
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkWaitForFences(VkDevice device, uint32_t fenceCount,
                                                                         const VkFence* pFences, VkBool32 waitAll,
                                                                         uint64_t timeout) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkWaitForFences* pPacket = NULL;
@@ -4690,7 +4691,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
      const VkAllocationCallbacks*                pAllocator,
      VkObjectTableNVX*                           pObjectTable)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateObjectTableNVX* pPacket = NULL;
@@ -4746,7 +4747,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
     VkCommandBuffer commandBuffer,
     const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdProcessCommandsNVX* pPacket;
     size_t datasize = 0;
@@ -4792,7 +4793,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateIndirectCommands
     const VkAllocationCallbacks* pAllocator,
     VkIndirectCommandsLayoutNVX* pIndirectCommandsLayout)
 {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateIndirectCommandsLayoutNVX* pPacket = NULL;
@@ -4889,7 +4890,7 @@ pSurfaceDescription);
  * but not for loader initiated calls to GDPA. Thus need two versions of GDPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAddr(VkDevice device, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     PFN_vkVoidFunction addr;
 
     vktrace_trace_packet_header* pHeader;
@@ -4918,7 +4919,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAdd
 
 /* GDPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDeviceProcAddr(VkDevice device, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     if (!strcmp("vkGetDeviceProcAddr", funcName)) {
         if (gMessageStream != NULL) {
             return (PFN_vkVoidFunction)vktraceGetDeviceProcAddr;
@@ -4956,7 +4957,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDevicePro
  * but not for loader initiated calls to GIPA. Thus need two versions of GIPA.
  */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcAddr(VkInstance instance, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     PFN_vkVoidFunction addr;
     vktrace_trace_packet_header* pHeader;
     packet_vkGetInstanceProcAddr* pPacket = NULL;
@@ -4986,7 +4987,7 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetInstanceProcA
 
 /* GIPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     PFN_vkVoidFunction addr;
     layer_instance_data* instData;
 
@@ -5121,14 +5122,13 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkEnumerateInstanceLayer
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
                                                                                 uint32_t* pPropertyCount,
                                                                                 VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(const char* pLayerName,
                                                                                     uint32_t* pPropertyCount,
                                                                                     VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -5094,14 +5094,12 @@ VkResult EnumerateProperties(uint32_t src_count, const T* src_props, uint32_t* d
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
                                                                                   VkLayerProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     return EnumerateProperties(1, &layerProps, pPropertyCount, pProperties);
 }
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName,
                                                                                       uint32_t* pPropertyCount,
                                                                                       VkExtensionProperties* pProperties) {
-    trim::TrimLockGuard<std::mutex> lock(g_mutex);
     if (pLayerName && !strcmp(pLayerName, layerProps.layerName))
         return EnumerateProperties(0, (VkExtensionProperties*)nullptr, pPropertyCount, pProperties);
 

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -36,6 +36,8 @@ uint64_t g_trimMaxBatchCmdCount = UINT64_MAX;
 bool g_trimAlreadyFinished = false;
 bool g_trimPostProcess = false;
 
+bool g_TraceLockEnabled = false;
+
 std::mutex g_trimImageHandling_Mutex;
 
 static std::mutex g_Mutex_CommandBufferPipelineMap;
@@ -487,7 +489,7 @@ char *getTraceTriggerOptionString(enum enum_trim_trigger triggerType) {
 }
 
 //=========================================================================
-void getTrimPreProcessOption() {
+void getTrimPreProcessAndTraceLockOptions() {
     static bool firstTimeRun = true;
     if (firstTimeRun) {
         firstTimeRun = false;
@@ -502,6 +504,18 @@ void getTrimPreProcessOption() {
                 } else {
                     // Other values
                     g_trimPostProcess = false;
+                }
+            }
+        }
+
+        const char *lock_guard_alway_enabled_env = vktrace_get_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV);
+        if (lock_guard_alway_enabled_env) {
+            int lock_guard_value;
+            if (sscanf(lock_guard_alway_enabled_env, "%d", &lock_guard_value) == 1) {
+                if (1 == lock_guard_value) {
+                    g_TraceLockEnabled = true;
+                } else {
+                    g_TraceLockEnabled = false;
                 }
             }
         }
@@ -546,7 +560,7 @@ void getTrimMaxBatchCmdCountOption() {
 
 //=========================================================================
 void initialize() {
-    getTrimPreProcessOption();
+    getTrimPreProcessAndTraceLockOptions();
     const char *trimFrames = getTraceTriggerOptionString(enum_trim_trigger::frameCounter);
     if (trimFrames != nullptr) {
         uint32_t numFrames = 0;

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -50,7 +50,39 @@ extern uint64_t g_trimStartFrame;
 extern uint64_t g_trimEndFrame;
 extern bool g_trimAlreadyFinished;
 
+extern std::mutex g_mutex;
+
 namespace trim {
+
+template <typename _Mutex>
+class TrimLockGuard {  // specialization for a single mutex
+   private:
+    _Mutex &_MyMutex;
+    bool m_islocked;
+
+   public:
+    typedef _Mutex mutex_type;
+
+    explicit TrimLockGuard(_Mutex &_Mtx) : _MyMutex(_Mtx) {  // construct and lock only when trim enabled
+        if (g_trimEnabled) {
+            _MyMutex.lock();
+            m_islocked = true;
+        } else {
+            m_islocked = false;
+        }
+    }
+
+    ~TrimLockGuard() {  // unlock
+        if (m_islocked) {
+            _MyMutex.unlock();
+            m_islocked = false;
+        }
+    }
+
+    TrimLockGuard(const TrimLockGuard &) = delete;
+    TrimLockGuard &operator=(const TrimLockGuard &) = delete;
+};
+
 void initialize();
 void deinitialize();
 

--- a/vktrace/vktrace_layer/vktrace_lib_trim.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.h
@@ -63,8 +63,10 @@ class TrimLockGuard {  // specialization for a single mutex
    public:
     typedef _Mutex mutex_type;
 
-    explicit TrimLockGuard(_Mutex &_Mtx) : _MyMutex(_Mtx) {  // construct and lock only when trim enabled
-        if (g_trimEnabled) {
+    explicit TrimLockGuard(_Mutex &_Mtx) : _MyMutex(_Mtx) {
+        // construct and lock only when trim enabled (default behaviour)
+        // or when env var VKTRACE_ENABLE_TRACE_LOCK is set to "1"
+        if (g_trimEnabled || g_LockGuardAlwaysEnabled) {
             _MyMutex.lock();
             m_islocked = true;
         } else {

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -143,8 +143,8 @@ vktrace_SettingInfo g_settings_info[] = {
     {"tl",
      "TraceLock",
      VKTRACE_SETTING_BOOL,
-     {&g_settings.enable_lock_guard_all},
-     {&g_default_settings.enable_lock_guard_all},
+     {&g_settings.enable_trace_lock},
+     {&g_default_settings.enable_trace_lock},
      TRUE,
      "Enable locking of API calls during trace if TraceLock is set to TRUE,\n\
                                        default is FALSE in which it is enabled only when trimming is enabled."},
@@ -361,8 +361,8 @@ int main(int argc, char* argv[]) {
     // if it is set to "1" (true), locking for API calls is enabled.
     // by default it is set to "0" (false), in which locking is enabled only when trimming is enabled.
     // Note that the command line option will override the env variable.
-    char* lg_enable_env = vktrace_get_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV);
-    if (lg_enable_env && (strcmp(lg_enable_env, "1") == 0)) g_default_settings.enable_lock_guard_all = true;
+    char* tl_enable_env = vktrace_get_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV);
+    if (tl_enable_env && (strcmp(tl_enable_env, "1") == 0)) g_default_settings.enable_trace_lock = true;
 
     if (vktrace_SettingGroup_init(&g_settingGroup, NULL, argc, argv, &g_settings.arguments) != 0) {
         // invalid cmd-line parameters
@@ -445,7 +445,7 @@ int main(int argc, char* argv[]) {
 
     vktrace_set_global_var(VKTRACE_PMB_ENABLE_ENV, g_settings.enable_pmb ? "1" : "0");
     vktrace_set_global_var(VKTRACE_TRIM_POST_PROCESS_ENV, g_settings.enable_trim_post_processing ? "1" : "0");
-    vktrace_set_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV, g_settings.enable_lock_guard_all ? "1" : "0");
+    vktrace_set_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV, g_settings.enable_trace_lock ? "1" : "0");
 
     if (g_settings.traceTrigger) {
         // Export list to screenshot layer

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -350,6 +350,13 @@ int main(int argc, char* argv[]) {
     if (tppEnableEnv && strcmp(tppEnableEnv, "1")) g_default_settings.enable_trim_post_processing = false;
     if (tppEnableEnv && !strcmp(tppEnableEnv, "1")) g_default_settings.enable_trim_post_processing = true;
 
+    // get the value of VKTRACE_ENABLE_TRACE_LOCK_ENV env variable.
+    // if it is set to "1" (true), lock guard always enabled for API calls.
+    // by default it is set to "0" (false), in which lock guard only enabled during trim for API calls.
+    // Note that the command line option will override the env variable.
+    char* lg_enable_env = vktrace_get_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV);
+    if (lg_enable_env && (strcmp(lg_enable_env, "1") == 0)) g_default_settings.enable_lock_guard_all = true;
+
     if (vktrace_SettingGroup_init(&g_settingGroup, NULL, argc, argv, &g_settings.arguments) != 0) {
         // invalid cmd-line parameters
         vktrace_SettingGroup_delete(&g_settingGroup);
@@ -431,6 +438,7 @@ int main(int argc, char* argv[]) {
 
     vktrace_set_global_var(VKTRACE_PMB_ENABLE_ENV, g_settings.enable_pmb ? "1" : "0");
     vktrace_set_global_var(VKTRACE_TRIM_POST_PROCESS_ENV, g_settings.enable_trim_post_processing ? "1" : "0");
+    vktrace_set_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV, g_settings.enable_lock_guard_all ? "1" : "0");
 
     if (g_settings.traceTrigger) {
         // Export list to screenshot layer

--- a/vktrace/vktrace_trace/vktrace.cpp
+++ b/vktrace/vktrace_trace/vktrace.cpp
@@ -133,7 +133,6 @@ vktrace_SettingInfo g_settings_info[] = {
     //{ "z", "pauze", VKTRACE_SETTING_BOOL, &g_settings.pause,
     //&g_default_settings.pause, TRUE, "Wait for a key at startup (so a debugger
     // can be attached)" },
-
     {"tbs",
      "TrimBatchSize",
      VKTRACE_SETTING_STRING,
@@ -141,6 +140,14 @@ vktrace_SettingInfo g_settings_info[] = {
      {&g_default_settings.trimCmdBatchSizeStr},
      TRUE,
      "Set the maximum trim commands batch size, default is device allocation limit count divide by 100."},
+    {"tl",
+     "TraceLock",
+     VKTRACE_SETTING_BOOL,
+     {&g_settings.enable_lock_guard_all},
+     {&g_default_settings.enable_lock_guard_all},
+     TRUE,
+     "Enable locking of API calls during trace if TraceLock is set to TRUE,\n\
+                                       default is FALSE in which it is enabled only when trimming is enabled."},
 };
 
 vktrace_SettingGroup g_settingGroup = {"vktrace", sizeof(g_settings_info) / sizeof(g_settings_info[0]), &g_settings_info[0]};
@@ -351,8 +358,8 @@ int main(int argc, char* argv[]) {
     if (tppEnableEnv && !strcmp(tppEnableEnv, "1")) g_default_settings.enable_trim_post_processing = true;
 
     // get the value of VKTRACE_ENABLE_TRACE_LOCK_ENV env variable.
-    // if it is set to "1" (true), lock guard always enabled for API calls.
-    // by default it is set to "0" (false), in which lock guard only enabled during trim for API calls.
+    // if it is set to "1" (true), locking for API calls is enabled.
+    // by default it is set to "0" (false), in which locking is enabled only when trimming is enabled.
     // Note that the command line option will override the env variable.
     char* lg_enable_env = vktrace_get_global_var(VKTRACE_ENABLE_TRACE_LOCK_ENV);
     if (lg_enable_env && (strcmp(lg_enable_env, "1") == 0)) g_default_settings.enable_lock_guard_all = true;

--- a/vktrace/vktrace_trace/vktrace.h
+++ b/vktrace/vktrace_trace/vktrace.h
@@ -45,7 +45,7 @@ typedef struct vktrace_settings {
     const char* verbosity;
     const char* traceTrigger;
     BOOL enable_trim_post_processing;
-    BOOL enable_lock_guard_all;
+    BOOL enable_trace_lock;
     const char* trimCmdBatchSizeStr;
 } vktrace_settings;
 

--- a/vktrace/vktrace_trace/vktrace.h
+++ b/vktrace/vktrace_trace/vktrace.h
@@ -45,6 +45,7 @@ typedef struct vktrace_settings {
     const char* verbosity;
     const char* traceTrigger;
     BOOL enable_trim_post_processing;
+    BOOL enable_lock_guard_all;
     const char* trimCmdBatchSizeStr;
 } vktrace_settings;
 


### PR DESCRIPTION

This changes add locking of API calls during trace. 'tl' , 'TraceLock' option is added to always turn on/off the locking of API calls. This avoids race conditions and remaps error during trim playback, with slight performance loss. By default, locking is enabled when trim enabled.
It is respond to pull request [#675](https://github.com/LunarG/VulkanTools/pull/675)