### PR TITLE
add cmake version reporting to appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,7 @@ before_build:
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
+  - cmake --version
   - cmake -G %GENERATOR% -C../helper.cmake ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 


### PR DESCRIPTION
This will allow us to check our build logs to determine the exact
CMake version used with that build.