### PR TITLE
tests: reduce expected count of vk_format_feature

### DIFF
--- a/tests/apidump_test.sh
+++ b/tests/apidump_test.sh
@@ -71,7 +71,7 @@ then
     pipelineCacheUUID_count=$(grep pipelineCacheUUID apidump_file.tmp | wc -l)
     vk_format_feature_count=$(grep VK_FORMAT_FEATURE apidump_file.tmp | wc -l)
     echo COUNTS: $GPDFP_count $pipelineCacheUUID_count $vk_format_feature_count  # Debug
-    if (( $GPDFP_count > 50 && $pipelineCacheUUID_count > 10 && $vk_format_feature_count > 1000 ))
+    if (( $GPDFP_count > 50 && $pipelineCacheUUID_count > 10 && $vk_format_feature_count > 500 ))
     then
         printf "$GREEN[  PASSED  ]$NC $0\n"
     else


### PR DESCRIPTION
Modifid apidump test.sh so that it expects a smaller number
of lines containing VK_FEATURE_COUNT when doing an apidump
of vulkaninfo. vulkaninfo was recently modified to only
query supported formats, causing this test to fail
because much fewer lines containing VK_FEATURE_COUNT
were output by vulkaninfo/apidump.

Change-Id: Ib34a9331632cdb952cfecf9616785393e4d2f36a