### PR TITLE
tests: disable devsim test that depends on vulkaninfo output

### DIFF
--- a/tests/devsim_layer_test.sh
+++ b/tests/devsim_layer_test.sh
@@ -104,8 +104,9 @@ JSON_SECTIONS='{VkPhysicalDeviceProperties,VkPhysicalDeviceFeatures,VkPhysicalDe
 jq -S $JSON_SECTIONS $FILENAME_02_TEMP1 > $FILENAME_02_TEMP2
 [ $? -eq 0 ] || fail_msg "test2 jq extraction"
 
-jq --slurp  --exit-status '.[0] == .[1]' devsim_test2_gold.json $FILENAME_02_TEMP2 > /dev/null
-[ $? -eq 0 ] || fail_msg "test2 jq comparison"
+# Temporarily disabled
+#jq --slurp  --exit-status '.[0] == .[1]' devsim_test2_gold.json $FILENAME_02_TEMP2 > /dev/null
+#[ $? -eq 0 ] || fail_msg "test2 jq comparison"
 
 #############################################################################
 


### PR DESCRIPTION
Doing this temporarily, until either golden image can be updated or
vulkaninfo is added to VulkanTools/tests so as to avoid changes to
Vulkan-Tools/vulkaninfo affecting VulkanTools tests.

Change-Id: Ic46e7909e729afc071d4730b3dfa704a7f756eae