### PR TITLE
Fixed undefined symbols PRIu64/PRIu32 and reference to clock_gettime

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -40,7 +40,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <string.h>
 
 #include <functional>

--- a/vktrace/vktrace_common/CMakeLists.txt
+++ b/vktrace/vktrace_common/CMakeLists.txt
@@ -55,6 +55,10 @@ target_link_Libraries(${PROJECT_NAME}
     dl
     pthread
 )
+    find_library(LIBRT rt)
+    if(LIBRT)
+        target_link_libraries(${PROJECT_NAME} ${LIBRT})
+    endif()
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
 build_options_finalize()


### PR DESCRIPTION
On CentOS6.8 with a local build of g++ 6.4.0 (the default g++ version on CentOS6.8 is 4.4.7), the build fails with undefined symbol PRIu64 and PRIu32 at compile time and undefined reference to 'clock_gettime' at link time.

Fixed undefined symbols PRIu64/PRIu32 by including `<cinttypes>` instead of
`<inttypes.h>`. (a less elegant solution would be to add `#define __STDC_FORMAT_MACROS` prior to include `<inttypes.h>`). `layersvt/device_simulation.cpp` is a C++ file and as such should include C header files that way anyway (note that this file includes other C header files the wrong way: `<stdarg.h>`, `<stdio.h>`, `<stdlib.h>` and `<string.h>` instead of `<cstdarg>`, `<cstdio>`, `<cstdlib>` and `<cstring>` respectively. I have not fixed these inclusions in the current patch as I want to keep it minimal to address the actual build issue)

Fixed undefined reference to clock_gettime by linking rt library
This fix is similar to https://github.com/KhronosGroup/SPIRV-Tools/pull/2409
