### PR TITLE
Fixed missing guards when -DBUILD_WSI_WAYLAND_SUPPORT=OFF

### DIFF
--- a/vktrace/vktrace_replay/CMakeLists.txt
+++ b/vktrace/vktrace_replay/CMakeLists.txt
@@ -28,22 +28,24 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         vktrace_common
     )
 
-    set(WAYLAND_DISPLAY_LIB vkdisplay_wayland)
+    if(BUILD_WSI_WAYLAND_SUPPORT)
+        set(WAYLAND_DISPLAY_LIB vkdisplay_wayland)
 
-    set(WAYLAND_SRC_LIST
-        vkreplay_vkdisplay_wayland.cpp
-    )
+        set(WAYLAND_SRC_LIST
+            vkreplay_vkdisplay_wayland.cpp
+        )
 
-    set (WAYLAND_HDR_LIST
-        vkreplay_vkdisplay.h
-    )
+        set (WAYLAND_HDR_LIST
+            vkreplay_vkdisplay.h
+        )
 
-    add_library(${WAYLAND_DISPLAY_LIB} SHARED ${WAYLAND_SRC_LIST} ${WAYLAND_HDR_LIST})
+        add_library(${WAYLAND_DISPLAY_LIB} SHARED ${WAYLAND_SRC_LIST} ${WAYLAND_HDR_LIST})
 
-    target_link_libraries(${WAYLAND_DISPLAY_LIB}
-        ${WAYLAND_CLIENT_LIBRARIES}
-        vktrace_common
-    )
+        target_link_libraries(${WAYLAND_DISPLAY_LIB}
+            ${WAYLAND_CLIENT_LIBRARIES}
+            vktrace_common
+        )
+    endif()
 
     # Make sure the exe directory is searched when loading libraries with dlopen
     SET(CMAKE_EXE_LINKER_FLAGS
@@ -103,5 +105,7 @@ build_options_finalize()
 if(UNIX)
     install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(TARGETS ${XCB_DISPLAY_LIB} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(TARGETS ${WAYLAND_DISPLAY_LIB} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    if(BUILD_WSI_WAYLAND_SUPPORT)
+        install(TARGETS ${WAYLAND_DISPLAY_LIB} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif()
 endif()

--- a/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkdisplay.cpp
@@ -46,6 +46,7 @@ int GetDisplayImplementation(const char *displayServer, vktrace_replay::ReplayDi
         auto CreateVkDisplayXcb = reinterpret_cast<vkDisplayXcb *(*)()>(dlsym(xcb_handle, "CreateVkDisplayXcb"));
         *ppDisp = CreateVkDisplayXcb();
     } else if (strcasecmp(displayServer, "wayland") == 0) {
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
         // Attempt to load libvkdisplay_wayland and constructor
         auto wayland_handle = dlopen("libvkdisplay_wayland.so", RTLD_NOW);
         if (dlerror()) {
@@ -54,6 +55,10 @@ int GetDisplayImplementation(const char *displayServer, vktrace_replay::ReplayDi
         }
         auto CreateVkDisplayWayland = reinterpret_cast<vkDisplayWayland *(*)()>(dlsym(wayland_handle, "CreateVkDisplayWayland"));
         *ppDisp = CreateVkDisplayWayland();
+#else
+        vktrace_LogError("vktrace not built with wayland support.");
+        return -1;
+#endif
     } else {
         vktrace_LogError("Invalid display server. Valid options are: xcb, wayland");
         return -1;


### PR DESCRIPTION
Most of the changes are in the `CMakeFiles.txt` file. One change is in `vkreplay_vkdisplay.cpp` where the behavior is the following: if the user passes "wayland" as the "ds" argument, the following error message is emitted: "vktrace not built with wayland support".

I have not changed the help text in `vkreplay_main.cpp` nor the logic for picking the
default server if it is not set by the user. Therefore if wayland is detected at runtime but VulkanTools was built with `-DBUILD_WSI_WAYLAND_SUPPORT=OFF`, there will be the following error message "vkreplay error: vktrace not built with wayland support."

I tested it with:
`vktrace -o /tmp/mytracefile -p vkcubepp`
followed by:
`vkreplay -o /tmp/mytracefile -ds wayland`
`vkreplay error: vktrace not built with wayland support.`

`vkreplay -o /tmp/mytracefile -ds xcb` (or default) is working fine
