### PR TITLE
vktrace doc: remove vktracedump from vktrace.md

### DIFF
--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -158,28 +158,6 @@ The Vulkan validation layers may be enabled for trace replay.  Replaying a trace
 
 To activate specific layers on a trace replay, set the `VK_INSTANCE_LAYERS` environment variable to a colon-separated list of layer names before replaying the trace. Refer to the [Vulkan Validation and Debugging Layers](./layers.md) guide for additional information on layers and how to configure layer output options.
 
-## Dump API Calls from Vulkan Trace File
-
-The vktracedump command is used to dump Vulkan API calls from a Vulkan application trace.
-
-The  `vktracedump` command-line  options are:
-
-| Option                | Description | Default |
-| --------------------- | ----------- | ------- |
-| -o &lt;string&gt; | Name of trace file to open and dump | **required** |
-| -s &lt;string&gt; | Name of simple dump file to save the outputs of simple/brief API dump. <br> Use 'stdout' to send outputs to stdout. | **optional** |
-| -f &lt;string&gt; | Name of full dump file to save the outputs of full/detailed API dump. <br> Use 'stdout' to send outputs to stdout. | **optional** |
-| -ds | Dump the shader binary code in pCode to shader dump files shader&lowbar;&lt;index&gt;.hex (when &lt;fullDumpFile&gt; is a file) or to stdout (when &lt;fullDumpFile&gt; is stdout). <br> Only works with "-f &lt;fullDumpFile&gt;" option. <br> The file name shader&lowbar;&lt;index&gt;.hex can be found in pCode in the &lt;fullDumpFile&gt; to associate with vkCreateShaderModule. | disabled |
-| -dh | Save full/detailed API dump as HTML format. Only works with "-f &lt;fullDumpFile&gt;" option. | text format |
-| -na | Dump string "address" in place of hex addresses. Only works with "-f &lt;fullDumpFile&gt;" option.  | disabled |
-
-To dump API calls from the Vulkan Cube application trace captured in the example above:
-
-```
-$ cd examples/build
-$ vktracedump -o cubetrace.vktrace -s <simple_api_dump_file> -f <full_api_dump_file>
-```
-
 ## vktraceviewer
 
 The vktraceviewer tool allows interactive creation and viewing of Vulkan trace files. In the future, it will include support for interactively playing back trace files. This is alpha software.

--- a/vktrace/vktrace_dump/vktracedump.md
+++ b/vktrace/vktrace_dump/vktracedump.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable MD041 -->
+[![LunarG][1]][2]
+
+[1]: https://vulkan.lunarg.com/img/LunarGLogo.png "www.LunarG.com"
+[2]: https://www.LunarG.com/
+
+[![Creative Commons][3]][4]
+
+[3]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
+[4]: https://creativecommons.org/licenses/by-nd/4.0/
+
+Copyright &copy; 2015-2019 LunarG, Inc.
+
+## Dump API Calls from Vulkan Trace File
+
+The vktracedump command dumps Vulkan API calls from a Vulkan application trace as plain text or html.
+
+The  `vktracedump` command-line  options are:
+
+| Option                | Description | Default |
+| --------------------- | ----------- | ------- |
+| -o &lt;string&gt; | Name of trace file to open and dump | **required** |
+| -s &lt;string&gt; | Name of simple dump file to save the outputs of simple/brief API dump. <br> Use 'stdout' to send outputs to stdout. | **optional** |
+| -f &lt;string&gt; | Name of full dump file to save the outputs of full/detailed API dump. <br> Use 'stdout' to send outputs to stdout. | **optional** |
+| -ds | Dump the shader binary code in pCode to shader dump files shader&lowbar;&lt;index&gt;.hex (when &lt;fullDumpFile&gt; is a file) or to stdout (when &lt;fullDumpFile&gt; is stdout). <br> Only works with "-f &lt;fullDumpFile&gt;" option. <br> The file name shader&lowbar;&lt;index&gt;.hex can be found in pCode in the &lt;fullDumpFile&gt; to associate with vkCreateShaderModule. | disabled |
+| -dh | Save full/detailed API dump as HTML format. Only works with "-f &lt;fullDumpFile&gt;" option. | text format |
+| -na | Dump string "address" in place of hex addresses. Only works with "-f &lt;fullDumpFile&gt;" option.  | disabled |
+
+To dump API calls from a Vulkan vkcube trace:
+
+```
+$ vktracedump -o vkcube.vktrace -s vkcube-sdump.txt -f vkcube-fdump.txt
+```


### PR DESCRIPTION
Removed vktracedump documentation from vktrace.md because vktrace.md
is included in the Vulkan SDK, but vktracedump is not in the SDK.

Moved the vktracedump documentation to vktrace/vktrace_dump/vktracedump.md

Change-Id: I892bf2cf39ca3d278bfeff393f0d2880ded50921