### PR TITLE
api_dump: Add Environment variable support

### DIFF
--- a/layersvt/api_dump_layer.md
+++ b/layersvt/api_dump_layer.md
@@ -13,28 +13,143 @@ Copyright &copy; 2015-2019 LunarG, Inc.
 
 
 # VK\_LAYER\_LUNARG\_api\_dump
-The `VK_LAYER_LUNARG_api_dump` utility layer prints API calls, parameters, and values to the identified output stream.
+The `VK_LAYER_LUNARG_api_dump` utility layer prints API calls, parameters,
+and values to the identified output stream.
+It has several settings that can be adjusted by either environment variables
+or by using the vk_layer_settings.txt file.
 
-`VK_LAYER_LUNARG_api_dump` has three custom settings that can be set to `TRUE` or `FALSE` values:
+<br></br>
 
 
-| Setting       | Description                                                     |
-| ------------- |---------------------------------------------------------------- |
-| `lunarg_api_dump.detailed`   | if `TRUE` (the default), dump all function parameters and values; if `FALSE`, dump only function signatures        |
-| `lunarg_api_dump.file`       | dump to file; otherwise dump to `stdout`                          |
-| `lunarg_api_dump.no_addr`    | if `TRUE`, replace all addresses with static string "`address`" |
-| `lunarg_api_dump.flush`      | if `TRUE`, force I/O flush after every line                         |
+## Enabling the Layer
+
+### Desktop (Linux/Windows/iOS)
+
+You must add the location of the generated VK_LAYER_LUNARG_api.json file and corresponding
+VkLayer_api_dump library to your VK_LAYER_PATH in order for the Vulkan loader to be able
+to find the layer.
+
+Then, you must also enable the layer in one of two ways:
+
+ * Directly in your application using the layer's name during vkCreateInstance
+ * Indirectly by using the VK_INSTANCE_LAYERS environment variable.
+
+#### Setting the VK_LAYER_PATH
+
+**Windows**
+
+If your source was located in: C:\my_folder\vulkantools and your build folder was build64, then you would add it to the layer path in the following way:
+
+    set VK_LAYER_PATH=C:\my_folder\vulkantools\build64\layersvt\Debug;%VK_LAYER_PATH%
+
+**Linux**
+
+If your source was located in: /my_folder/vulkantools and your build folder was build, then you would add it to the layer path in the following way:
+
+    export VK_LAYER_PATH=/my_folder/vulkantools/build/layersvt;$VK_LAYER_PATH
+
+Forcing the layer with VK_INSTANCE_LAYERS
+
+To force the layer to be enabled for Vulkan applications, you can set the VK_INSTANCE_LAYERS environment variable in the following way:
+
+**Windows**
+
+    set VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_api_dump
+
+**Linux**
+
+    export VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_api_dump
+
+<br></br>
 
 ### Android
-To enable, make the following changes to vk_layer_settings.txt
-```
--lunarg_api_dump.file = FALSE
-+lunarg_api_dump.file = TRUE
 
--lunarg_api_dump.log_filename = stdout
-+lunarg_api_dump.log_filename = /sdcard/Android/vk_apidump.txt
-```
-Then:
-```
-adb push vk_layer_settings.txt /sdcard/Android
-```
+#### Permissions
+
+You may need to grant permissions to your application to write to system storage, even if it normally does not.
+This depends on whether or not you modify API Dump to output to a file or just leave it to output to text.
+
+If you're building with Android Studio, you do this by:
+
+ * Click on "Run" in the menu
+ * Choose "Edit Configurations..."
+ * In the dialog box, look for the "Install Flags:" text box
+ * Enter -g
+ * Click "Apply"
+
+If this does not work, you may still require enabling permissions for your application from the settings menu.
+
+Failure to do so will result in your application crashing during vkCreateInstance since the layer will attempt,
+but fail, to create the capture file.
+
+#### Globally Enabling the Layer
+
+Use ADB to enable the layer for your project by:
+
+    adb shell "setprop debug.vulkan.layers 'VK_LAYER_LUNARG_api_dump'"
+
+When done, disable the layer using:
+
+    adb shell "setprop debug.vulkan.layers ''"
+
+<br></br>
+
+
+## API Dump Options
+
+Setting  | Environment Variable | Settings File Value | Default | Description
+-------- | -------------------- | ------------------- | ------- | -----------
+Enable File Output | None: Implicitly defined when filename defined | `lunarg_api_dump.file` | Not Set | Force output of API Dump layer to be written to a file instead of `stdout`.
+Output File Name | `VK_APIDUMP_LOG_FILENAME` | `lunarg_api_dump.log_filename` | stdout | The name (and path) of the output file to save the generated content to.
+Detailed Output | `VK_APIDUMP_DETAILED` | `lunarg_api_dump.detailed` | true | Generate more detailed output of the commands including parameters and values.  If `false` only output function signature.
+No Addresses/Handles | `VK_APIDUMP_NO_ADDR` | `lunarg_api_dump.no_addr` | false | Generate output without addresses or handles (which can vary run to run. Instead use the placeholder value "address".
+Flush After Every Command | `VK_APIDUMP_FLUSH` | `lunarg_api_dump.flush` | true | Flush after every API command's output
+Flush After Every Command | `VK_APIDUMP_OUTPUT_FORMAT` | `lunarg_api_dump.output_format` | `text` | Output the API Dump information as either a plain text file (`text`) or as an HTML-formated file (`html`).
+
+### Settings Priority
+
+If you have a setting defined in both the Settings File as well as an Environment
+Variable, the Environment Variable value will **always** override the Settings File
+value.
+This is intended to let you dynamically change settings without having to adjust
+the Settings File.
+
+<br></br>
+
+
+### Applying Environment Settings on Android
+
+On Android, you must use properties to set the environment variables.
+The format of the properties to set takes the following form:
+
+    debug.vulkan.layer_opts. + (lower-case environment variable with 'vk_' stripped)
+
+The easiest way to set a property is from the ADB shell:
+
+    adb shell "setprop <property_name> '<property_value>'"
+
+**For example:**
+
+To set the API Dump output log filename, which on desktop uses `VK_APIDUMP_LOG_FILENAME`
+set the following property:
+
+    debug.vulkan.layer_opts.apidump_log_filename
+
+Which you can set in the following way:
+
+    adb shell "setprop debug.vulkan.layer_opts.apidump_log_filename '/sdcard/Android/vk_apidump.txt'"
+
+<br></br>
+
+### Settings File Specific Settings
+
+At this time, certain settings are only available to be set in the `vk_layer_settings.txt` file.  These are:
+
+Setting  | Settings File Value | Default | Description
+-------- | ------------------- | ------- | -----------
+Indent Size | `lunarg_api_dump.indent_size` | 4 | Set the indent size for writing out parameters and values for each command.  Only valid for `text` format and `stdout` writing.
+Name Size | `lunarg_api_dump.name_size` | 32 | Set the max length to assume for written names.  This is intended to allow cleaner indenting by reserving space for names shorter than this length.  A value of 0 means no additional spacing applied.  Only valid when "Use Spaces" is enabled.
+Show Shader | `lunarg_api_dump.show_shader` | false | Output the contents of any shader file loaded.
+Show Types | `lunarg_api_dump.show_types` | true | Output the types for each setting.
+Type Size | `lunarg_api_dump.type_size` | 0 | Set the max length to assume for written types.  This is intended to allow cleaner indenting by reserving space for types shorter than this length.  A value of 0 means no additional spacing applied.  Only valid when "Use Spaces" is enabled.
+Use Spaces| `lunarg_api_dump.use_spaces` | true | Attempt to use additional white space to produce a cleaner/easier-to-read output.


### PR DESCRIPTION
Sometimes, it's easier to modify settings using
environment variables instead of using the settings
file.  So, add support for some of the primary
API Dump layer settings using environment variables.
Those settings environment variables are:

 * APIDUMP_LOG_FILENAME  - Set the output filename.  If set, also
                           automatically retargets the output to this
                           file.
 * APIDUMP_OUTPUT_FORMAT - Set the output format to either "html" or
                           "text".
 * APIDUMP_DETAILED      - Boolean to enable the detailed output
 * APIDUMP_FLUSH         - Boolean to disable flushing after every write
 * APIDUMP_NO_ADDR       - Boolean to disable address outputs in the
                           API Dump output file.

Change-Id: I110609c48fb615d0eeae623c7de3176c65bd935d