### PR TITLE
add reporting of cmake version to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ script:
       python scripts/update_deps.py --config=Debug --arch=x64 $UPDATE_DEPS_EXTRA_OPTIONS
       mkdir dbuild
       pushd dbuild
+      cmake --version
       cmake -DCMAKE_BUILD_TYPE=Debug \
           -C../helper.cmake \
           ..


### PR DESCRIPTION
This makes it easier to track cmake versions should Travis change suddenly