### PR TITLE
scripts: Modify scripts for 102 header update

### DIFF
--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2017 The Khronos Group Inc.
-# Copyright (c) 2015-2017 Valve Corporation
-# Copyright (c) 2015-2017 LunarG, Inc.
+# Copyright (c) 2015-2017, 2019 The Khronos Group Inc.
+# Copyright (c) 2015-2017, 2019 Valve Corporation
+# Copyright (c) 2015-2017, 2019 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ from collections import namedtuple
 # Copyright text prefixing all headers (list of strings).
 prefixStrings = [
     '/*',
-    '** Copyright (c) 2015-2017 The Khronos Group Inc.',
-    '** Copyright (c) 2015-2017 Valve Corporation',
-    '** Copyright (c) 2015-2017 LunarG, Inc.',
-    '** Copyright (c) 2015-2017 Google Inc.',
+    '** Copyright (c) 2015-2017, 2019 The Khronos Group Inc.',
+    '** Copyright (c) 2015-2017, 2019 Valve Corporation',
+    '** Copyright (c) 2015-2017, 2019 LunarG, Inc.',
+    '** Copyright (c) 2015-2017, 2019 Google Inc.',
     '**',
     '** Licensed under the Apache License, Version 2.0 (the "License");',
     '** you may not use this file except in compliance with the License.',
@@ -52,7 +52,7 @@ platform_dict = {
     'fuchsia' : 'VK_USE_PLATFORM_FUCHSIA',
     'ios' : 'VK_USE_PLATFORM_IOS_MVK',
     'macos' : 'VK_USE_PLATFORM_MACOS_MVK',
-    'mir' : 'VK_USE_PLATFORM_MIR_KHR',
+    'metal' : 'VK_USE_PLATFORM_METAL_EXT',
     'vi' : 'VK_USE_PLATFORM_VI_NN',
     'wayland' : 'VK_USE_PLATFORM_WAYLAND_KHR',
     'win32' : 'VK_USE_PLATFORM_WIN32_KHR',

--- a/scripts/layer_factory_generator.py
+++ b/scripts/layer_factory_generator.py
@@ -677,6 +677,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
         # If any new return types are required, they'll need to be added to this dict.
         return_map = {
             'PFN_vkVoidFunction': ' { return nullptr; };',
+            'uint32_t': ' { return VK_NULL_HANDLE; };',
             'VkBool32': ' { return VK_TRUE; };',
             'VkDeviceAddress': '{ return 0; };',
             'VkResult': ' { return VK_SUCCESS; };',


### PR DESCRIPTION
The addition of the `VK_EXT_metal_surface` extension required the
addition of "metal" to the platform dictionary. This extension also
introduced the `vkGetImageViewHandleNVX` function which has a return
type of `uint32_t`. This return type was not previously defined in
`layer_factory_generator.py`'s return map.

Modified:
- `scripts/common_codegen.py`
- `scripts/layer_factory_generator.py`