### PR TITLE
vktrace: handle error when exec of program fails

### DIFF
--- a/vktrace/vktrace_common/vktrace_process.c
+++ b/vktrace/vktrace_common/vktrace_process.c
@@ -100,7 +100,11 @@ BOOL vktrace_process_spawn(vktrace_process_info* pInfo) {
         if (execv(fullExePath, args) < 0) {
             vktrace_LogError("Failed to spawn process.");
             perror(NULL);
-            exit(1);
+            // Exit by killing the whole process group.
+            // This kills both our process and our parent. We do this because
+            // we don't want to leave the parent hanging, waiting for data
+            // to arrive from the child.
+            kill(0, SIGINT);
         }
     }
 #endif


### PR DESCRIPTION
Kill all processes in the process group when the program
specified by the -p option cannot be executed. This prevents
the vktrace command from simply hanging when the program file
doesn't exist.

Change-Id: Iffc5cd7f864c5577b97e856d75dddc4a274077ba