### PR TITLE
vkreplay: don't allow 32-bit trace replay on 64-bit replayer

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -128,6 +128,16 @@ uint64_t get_endianess() {
     return *((char*)&x) ? VKTRACE_LITTLE_ENDIAN : VKTRACE_BIG_ENDIAN;
 }
 
+// Function to return string describing given endianess
+uint64_t get_endianess_string(uint64_t endianess) {
+    if (endianess == VKTRACE_LITTLE_ENDIAN)
+        return "VKTRACE_LITTLE_ENDIAN";
+    else if (endianess == VKTRACE_BIG_ENDIAN)
+        return "VKTRACE_BIG_ENDIAN";
+    else
+        return ("Unknow");
+}
+
 uint64_t get_arch() {
     uint64_t rval = 0;
 #if defined(PLATFORM_LINUX)

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.h
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.h
@@ -40,6 +40,7 @@ void vktrace_initialize_trace_packet_utils();
 void vktrace_deinitialize_trace_packet_utils();
 
 uint64_t get_endianess();
+uint64_t get_endianess_string(uint64_t endianess);
 uint64_t get_arch();
 uint64_t get_os();
 

--- a/vktrace/vktrace_replay/vkreplay_main.cpp
+++ b/vktrace/vktrace_replay/vkreplay_main.cpp
@@ -555,6 +555,25 @@ int vkreplay_main(int argc, char** argv, vktrace_replay::ReplayDisplayImp* pDisp
         return -1;
     }
 
+    // Make sure we replay 64-bit traces with 64-bit replayer, and 32-bit traces with 32-bit replayer
+    if (sizeof(void*) != fileHeader.ptrsize) {
+        vktrace_LogError("%d-bit trace file is not supported by %d-bit vkreplay.", 8 * fileHeader.ptrsize, 8 * sizeof(void*));
+        fclose(tracefp);
+        vktrace_free(pTraceFile);
+        vktrace_free(traceFile);
+        return -1;
+    }
+
+    // Make sure replay system endianess matches endianess in trace file
+    if (get_endianess() != fileHeader.endianess) {
+        vktrace_LogError("System endianess (%s) does not appear match endianess of tracefile (%s).",
+                         get_endianess_string(get_endianess()), get_endianess_string(fileHeader.endianess));
+        fclose(tracefp);
+        vktrace_free(pTraceFile);
+        vktrace_free(traceFile);
+        return -1;
+    }
+
     // Allocate a new header that includes space for all gpuinfo structs
     if (!(pFileHeader = (vktrace_trace_file_header*)vktrace_malloc(sizeof(vktrace_trace_file_header) +
                                                                    (size_t)(fileHeader.n_gpuinfo * sizeof(struct_gpuinfo))))) {

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -285,13 +285,6 @@ int vkReplay::init(vktrace_replay::ReplayDisplay &disp) {
     m_replay_gpu = 0;
     m_replay_drv_vers = 0;
 
-    // 32bit/64bit trace file is not supported by 64bit/32bit vkreplay
-    if (m_replay_ptrsize != m_pFileHeader->ptrsize) {
-        vktrace_LogError("%d-bit trace file is not supported by %d-bit vkreplay.", m_pFileHeader->ptrsize * 8,
-                         m_replay_ptrsize * 8);
-        return -1;
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
Code was already in place to enforce this, but the recently
added code to pre-read portability packets crashes when
cross-playing, so the code to enforce it was not executed.
Moved the code to check for 32/64 to earlier in the replay.

Also added enforcing of not allowing replay if the Endianess of
the trace file and replay system do not match.

Change-Id: I018a806ac9cea68ba35c572e4a4177170cf4a73b