### PR TITLE
vktrace: CreateImage and DestroyImage should use same allocator.

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -138,7 +138,7 @@ VkDeviceSize calculateImageSubResourceSize(VkDevice device, VkImageCreateInfo im
         mdd(device)->devTable.GetImageMemoryRequirements(device, image, &memoryRequirements);
         imageSubResourceSize = memoryRequirements.size;
     }
-    mdd(device)->devTable.DestroyImage(device, image, pAllocator);
+    mdd(device)->devTable.DestroyImage(device, image, NULL);
     return imageSubResourceSize;
 }
 


### PR DESCRIPTION
This minor fix avoids some game title crash during trim.

Change-Id: I92903eb94a67b2c2fbe4906bb3e7603cb166db02