### PR TITLE
vkreplay: Some title hang during trim playback

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -665,7 +665,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
         # Special cases for functions that use do-while loops
         do_while_dict = {'GetFenceStatus': 'replayResult != pPacket->result  && pPacket->result == VK_SUCCESS',
                          'GetEventStatus': '(pPacket->result == VK_EVENT_SET || pPacket->result == VK_EVENT_RESET) && replayResult != pPacket->result',
-                         'GetQueryPoolResults': 'pPacket->result == VK_SUCCESS && replayResult != pPacket->result'}
+                         'GetQueryPoolResults': '(pPacket->result == VK_SUCCESS && replayResult != pPacket->result) && replayResult != VK_NOT_READY'}
 
         replay_gen_source  = '\n'
         replay_gen_source += '#include "vkreplay_vkreplay.h"\n'


### PR DESCRIPTION
which is caused by infinite loop condition of
vkGetQueryPoolResults, the non-error return code
include VK_NOT_READY, so this change add VK_NOT_READY
to the loop condition to prevent the hang.
Also, add parentheses around the conditions for clear
logic.

Change-Id: Id311ab97c051a29f4da501d48c72a36cb135b164