### PR TITLE
vkreplay: fix type returned by get_endianess_string

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -129,13 +129,13 @@ uint64_t get_endianess() {
 }
 
 // Function to return string describing given endianess
-uint64_t get_endianess_string(uint64_t endianess) {
+const char* get_endianess_string(uint64_t endianess) {
     if (endianess == VKTRACE_LITTLE_ENDIAN)
         return "VKTRACE_LITTLE_ENDIAN";
     else if (endianess == VKTRACE_BIG_ENDIAN)
         return "VKTRACE_BIG_ENDIAN";
     else
-        return ("Unknow");
+        return ("Unknown");
 }
 
 uint64_t get_arch() {

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.h
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.h
@@ -40,7 +40,7 @@ void vktrace_initialize_trace_packet_utils();
 void vktrace_deinitialize_trace_packet_utils();
 
 uint64_t get_endianess();
-uint64_t get_endianess_string(uint64_t endianess);
+const char* get_endianess_string(uint64_t endianess);
 uint64_t get_arch();
 uint64_t get_os();
 


### PR DESCRIPTION
get_endianess_string was declared as returning an uint64_t, but
it returns a pointer to a const char. Changed function definition
declaration to indicate it returns a const char *.

Also fixed the value returned when endianess is unknown - it was
misspelled.

Change-Id: Id27dc2da68660542073c36718c3b34c767b816e1