### PR TITLE
cmake: Add cmd to create layers/staging-json dir

### DIFF
--- a/layer_factory/CMakeLists.txt
+++ b/layer_factory/CMakeLists.txt
@@ -107,6 +107,7 @@ foreach(SUBDIR ${ST_SUBDIRS})
         else()
             add_custom_target(${TARGET_NAME}-json ALL
                     COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/../layers/staging-json
                     COMMAND ${CMAKE_COMMAND} -E copy ${JSON_DEST_PATH}/VkLayer_${SUBDIR}.json ${CMAKE_CURRENT_BINARY_DIR}/../layers/staging-json
                     COMMAND sed -i -e "/library_path.:/s=./libVkLayer=libVkLayer=" ${CMAKE_CURRENT_BINARY_DIR}/../layers/staging-json/VkLayer_${SUBDIR}.json
             )


### PR DESCRIPTION
build/layers/staging-json dir was not previously created, resulting
in build failure.  Not sure why sometimes it used to work.

Change-Id: I8712d1e29d4ca14e46cdfab6cc42389c9420ea68