### PR TITLE
Fixed comparison of threadID against wrong initial value. UINT32 -> UINT64

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -438,7 +438,7 @@ class ApiDumpInstance {
     void setThreadID(uint64_t trace_thread_id) { thread_id = trace_thread_id; }
 
     uint64_t threadID() {
-        if (thread_id != UINT32_MAX) {
+        if (thread_id != UINT64_MAX) {
             return thread_id;
         }
         loader_platform_thread_id id = loader_platform_get_thread_id();


### PR DESCRIPTION
Causes the output threadID to be UINT64_MAX in some cases.

Change-Id: I9ab7397c7f1423c9ff8826ad7ee4543b075cb160