### PR TITLE
vktrace: add front end to vktrace_interpret_pnext_pointers

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -880,32 +880,32 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                     replay_gen_source += '                break;\n'
                     replay_gen_source += '            }\n'
                 elif 'SparseMemoryRequirements2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pInfo);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pInfo);\n'
                     replay_gen_source += '            for (uint32_t i=0; i<*pPacket->pSparseMemoryRequirementCount; i++)\n'
-                    replay_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)(&pPacket->pSparseMemoryRequirements[i]));\n'
+                    replay_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)(&pPacket->pSparseMemoryRequirements[i]));\n'
                 elif 'CreateSamplerYcbcrConversion' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pCreateInfo);\n'
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pYcbcrConversion);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pCreateInfo);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pYcbcrConversion);\n'
                 elif 'GetPhysicalDeviceFeatures2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pFeatures);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pFeatures);\n'
                 elif 'GetPhysicalDeviceProperties2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pProperties);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pProperties);\n'
                 elif 'GetPhysicalDeviceFormatProperties2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pFormatProperties);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pFormatProperties);\n'
                 elif 'GetPhysicalDeviceImageFormatProperties2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pImageFormatInfo);\n'
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pImageFormatProperties);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pImageFormatInfo);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pImageFormatProperties);\n'
                 elif 'GetPhysicalDeviceQueueFamilyProperties2' in cmdname:
                     replay_gen_source += '            for (uint32_t i=0; i<*pPacket->pQueueFamilyPropertyCount; i++)\n'
-                    replay_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)(&pPacket->pQueueFamilyProperties[i]));\n'
+                    replay_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)(&pPacket->pQueueFamilyProperties[i]));\n'
                 elif 'GetPhysicalDeviceMemoryProperties2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pMemoryProperties);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pMemoryProperties);\n'
                 elif 'GetDeviceQueue2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pQueueInfo);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pQueueInfo);\n'
                 elif 'GetPhysicalDeviceSparseImageFormatProperties2' in cmdname:
-                    replay_gen_source += '            vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pFormatInfo);\n'
+                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pFormatInfo);\n'
                     replay_gen_source += '            for (uint32_t i=0; i<*pPacket->pPropertyCount; i++)\n'
-                    replay_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)(&pPacket->pProperties[i]));\n'
+                    replay_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)(&pPacket->pProperties[i]));\n'
                 # Build the call to the "real_" entrypoint
                 rr_string = '            '
                 if ret_value:
@@ -2465,7 +2465,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                     dump_gen_source += '            VkBindSparseInfo *pLocalBIs = VKTRACE_NEW_ARRAY(VkBindSparseInfo, pPacket->bindInfoCount);\n'
                     dump_gen_source += '            memcpy((void *)pLocalBIs, (void *)(pPacket->pBindInfo), sizeof(VkBindSparseInfo) * pPacket->bindInfoCount);\n'
                     dump_gen_source += '            for (uint32_t i = 0; i < pPacket->bindInfoCount; i++) {\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pLocalBIs[i]);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)&pLocalBIs[i]);\n'
                     dump_gen_source += '                if (pLocalBIs[i].pBufferBinds) {\n'
                     dump_gen_source += '                    sBMBinf = VKTRACE_NEW_ARRAY(VkSparseBufferMemoryBindInfo, pLocalBIs[i].bufferBindCount);\n'
                     dump_gen_source += '                    pLocalBIs[i].pBufferBinds =\n'
@@ -2514,7 +2514,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                     dump_gen_source += '            VkComputePipelineCreateInfo *pLocalCIs = VKTRACE_NEW_ARRAY(VkComputePipelineCreateInfo, pPacket->createInfoCount);\n'
                     dump_gen_source += '            memcpy((void *)pLocalCIs, (void *)(pPacket->pCreateInfos), sizeof(VkComputePipelineCreateInfo) * pPacket->createInfoCount);\n'
                     dump_gen_source += '            for (uint32_t i = 0; i < pPacket->createInfoCount; i++) {\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pLocalCIs[i]);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)&pLocalCIs[i]);\n'
                     dump_gen_source += '                if (pLocalCIs[i].stage.pName) {\n'
                     dump_gen_source += '                    pLocalCIs[i].stage.pName =\n'
                     dump_gen_source += '                        (const char *)(vktrace_trace_packet_interpret_buffer_pointer(pPacket->header, (intptr_t)pLocalCIs[i].stage.pName));\n'
@@ -2540,17 +2540,17 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                     dump_gen_source += '            VkGraphicsPipelineCreateInfo *pLocalCIs = VKTRACE_NEW_ARRAY(VkGraphicsPipelineCreateInfo, pPacket->createInfoCount);\n'
                     dump_gen_source += '            for (uint32_t i = 0; i < pPacket->createInfoCount; i++) {\n'
                     dump_gen_source += '                memcpy((void *)&(pLocalCIs[i]), (void *)&(pPacket->pCreateInfos[i]), sizeof(VkGraphicsPipelineCreateInfo));\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pLocalCIs[i]);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pStages);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pVertexInputState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pInputAssemblyState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pTessellationState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pViewportState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pRasterizationState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pMultisampleState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pDepthStencilState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pColorBlendState);\n'
-                    dump_gen_source += '                vktrace_interpret_pnext_pointers(pPacket->header, (void *)pLocalCIs[i].pDynamicState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)&pLocalCIs[i]);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pStages);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pVertexInputState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pInputAssemblyState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pTessellationState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pViewportState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pRasterizationState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pMultisampleState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pDepthStencilState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pColorBlendState);\n'
+                    dump_gen_source += '                vkreplay_process_pnext_structs(pPacket->header, (void *)pLocalCIs[i].pDynamicState);\n'
                     dump_gen_source += '                ((VkPipelineViewportStateCreateInfo *)pLocalCIs[i].pViewportState)->pViewports =\n'
                     dump_gen_source += '                    (VkViewport *)vktrace_trace_packet_interpret_buffer_pointer(\n'
                     dump_gen_source += '                        pPacket->header, (intptr_t)pPacket->pCreateInfos[i].pViewportState->pViewports);\n'
@@ -3042,6 +3042,10 @@ class VkTraceFileOutputGenerator(OutputGenerator):
         trace_pkt_hdr += '#include "vulkan/vulkan.h"\n'
         trace_pkt_hdr += '#include "vktrace_trace_packet_utils.h"\n'
         trace_pkt_hdr += '\n'
+        trace_pkt_hdr += 'static void vkreplay_process_pnext_structs(vktrace_trace_packet_header *pHeader, void *struct_ptr)\n'
+        trace_pkt_hdr += '{\n'
+        trace_pkt_hdr += '    vkreplay_interpret_pnext_pointers(pHeader, struct_ptr);\n'
+        trace_pkt_hdr += '}\n\n'
 
         # Custom txt for given function and parameter.  First check if param is NULL, then insert txt if not
         # First some common code used by both CmdWaitEvents & CmdPipelineBarrier
@@ -3135,7 +3139,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                              'CmdPushDescriptorSetKHR' : {'param': 'pDescriptorWrites', 'txt':
                                                                                [ 'uint32_t i;\n',
                                                                                  'for (i = 0; i < pPacket->descriptorWriteCount; i++) {\n',
-                                                                                 '    vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pPacket->pDescriptorWrites[i]);\n',
+                                                                                 '    vkreplay_process_pnext_structs(pPacket->header, (void *)&pPacket->pDescriptorWrites[i]);\n',
                                                                                  '    switch (pPacket->pDescriptorWrites[i].descriptorType) {\n',
                                                                                  '    case VK_DESCRIPTOR_TYPE_SAMPLER:\n',
                                                                                  '    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:\n',
@@ -3168,7 +3172,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                              'UpdateDescriptorSets' : {'param': 'pDescriptorWrites', 'txt':
                                                                                [ 'uint32_t i;\n',
                                                                                  'for (i = 0; i < pPacket->descriptorWriteCount; i++) {\n',
-                                                                                 '    vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pPacket->pDescriptorWrites[i]);\n',
+                                                                                 '    vkreplay_process_pnext_structs(pPacket->header, (void *)&pPacket->pDescriptorWrites[i]);\n',
                                                                                  '    switch (pPacket->pDescriptorWrites[i].descriptorType) {\n',
                                                                                  '    case VK_DESCRIPTOR_TYPE_SAMPLER:\n',
                                                                                  '    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:\n',
@@ -3198,7 +3202,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                                                                  '    }\n',
                                                                                  '}\n',
                                                                                  'for (i = 0; i < pPacket->descriptorCopyCount; i++) {\n',
-                                                                                 '    vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pPacket->pDescriptorCopies[i]);\n',
+                                                                                 '    vkreplay_process_pnext_structs(pPacket->header, (void *)&pPacket->pDescriptorCopies[i]);\n',
                                                                                  '}'
                                                                                ]},
                              'QueueSubmit' : {'param': 'pSubmits', 'txt':
@@ -3212,7 +3216,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                                                                  '   *ppSems = (VkSemaphore*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pPacket->pSubmits[i].pSignalSemaphores);\n',
                                                                                  '   VkPipelineStageFlags** ppStageMask = (VkPipelineStageFlags**)&pPacket->pSubmits[i].pWaitDstStageMask;\n',
                                                                                  '   *ppStageMask = (VkPipelineStageFlags*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pPacket->pSubmits[i].pWaitDstStageMask);\n',
-                                                                                 '   vktrace_interpret_pnext_pointers(pHeader, (void *)&pPacket->pSubmits[i]);\n'
+                                                                                 '   vkreplay_process_pnext_structs(pHeader, (void *)&pPacket->pSubmits[i]);\n'
                                                                                  '}'
                                                                                ]},
                              'CreateGraphicsPipelines' : {'param': 'pCreateInfos', 'txt': create_gfx_pipe},
@@ -3309,7 +3313,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                            'pSparseMemoryRequirements','pSurfaceCapabilities'] and '2khr' in p.type.lower())
                             or (p.name in ['pSurfaceCapabilities'] and '2ext' in p.type.lower())):
                             trace_pkt_hdr += '    if (pPacket->%s != NULL) {\n' % p.name
-                            trace_pkt_hdr += '        vktrace_interpret_pnext_pointers(pHeader, (void *)pPacket->%s);\n' % p.name
+                            trace_pkt_hdr += '        vkreplay_process_pnext_structs(pHeader, (void *)pPacket->%s);\n' % p.name
                             trace_pkt_hdr += '    }\n'
                 if 'UnmapMemory' in proto.name:
                     trace_pkt_hdr += '    pPacket->pData = (void*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)pPacket->pData);\n'

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -692,7 +692,7 @@ VkDeviceGroupDeviceCreateInfo* interpret_VkDeviceGroupDeviceCreateInfo(vktrace_t
             (_sPtrType*)vktrace_trace_packet_interpret_buffer_pointer(pHeader, (intptr_t)struct_ptr_cur->_sPtr); \
     } while (0)
 
-void vktrace_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void* struct_ptr) {
+void vkreplay_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void* struct_ptr) {
     uint32_t i;
     if (!struct_ptr) return;
 

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.h
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.h
@@ -132,7 +132,7 @@ void interpret_VkPipelineShaderStageCreateInfo(vktrace_trace_packet_header* pHea
 VkDeviceGroupDeviceCreateInfo* interpret_VkDeviceGroupDeviceCreateInfoKHX(vktrace_trace_packet_header* pHeader,
                                                                           intptr_t ptr_variable);
 // converts the Vulkan struct pnext chain that is currently byte offsets into pointers
-void vktrace_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void* struct_ptr);
+void vkreplay_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, void* struct_ptr);
 
 //=============================================================================
 // trace packet message

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -624,7 +624,7 @@ VkResult vkReplay::manually_replay_vkCreateDevice(packet_vkCreateDevice *pPacket
     const char strScreenShot[] = "VK_LAYER_LUNARG_screenshot";
 
     for (uint32_t i = 0; i < pPacket->pCreateInfo->queueCreateInfoCount; i++)
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pPacket->pCreateInfo->pQueueCreateInfos[i]);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)&pPacket->pCreateInfo->pQueueCreateInfos[i]);
 
     if (remappedPhysicalDevice == VK_NULL_HANDLE) {
         vktrace_LogError("Skipping vkCreateDevice() due to invalid remapped VkPhysicalDevice.");
@@ -1073,7 +1073,7 @@ VkResult vkReplay::manually_replay_vkQueueBindSparse(packet_vkQueueBindSparse *p
     VkSparseImageOpaqueMemoryBindInfo *sIMOBinf = NULL;
 
     for (uint32_t bindInfo_idx = 0; bindInfo_idx < pPacket->bindInfoCount; bindInfo_idx++) {
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&remappedBindSparseInfos[bindInfo_idx]);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)&remappedBindSparseInfos[bindInfo_idx]);
 
         if (remappedBindSparseInfos[bindInfo_idx].pBufferBinds) {
             remappedBindSparseInfos[bindInfo_idx].pBufferBinds =
@@ -1555,7 +1555,7 @@ VkResult vkReplay::manually_replay_vkCreateComputePipelines(packet_vkCreateCompu
 
     // Fix up stage sub-elements
     for (i = 0; i < pPacket->createInfoCount; i++) {
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pLocalCIs[i]);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)&pLocalCIs[i]);
 
         pLocalCIs[i].stage.module = m_objMapper.remap_shadermodules(pLocalCIs[i].stage.module);
 
@@ -1623,17 +1623,17 @@ VkResult vkReplay::manually_replay_vkCreateGraphicsPipelines(packet_vkCreateGrap
             }
         }
 
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)&pCIs[i]);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pStages);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pVertexInputState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pInputAssemblyState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pTessellationState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pViewportState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pRasterizationState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pMultisampleState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pDepthStencilState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pColorBlendState);
-        vktrace_interpret_pnext_pointers(pPacket->header, (void *)pCIs[i].pDynamicState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)&pCIs[i]);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pStages);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pVertexInputState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pInputAssemblyState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pTessellationState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pViewportState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pRasterizationState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pMultisampleState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pDepthStencilState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pColorBlendState);
+        vkreplay_process_pnext_structs(pPacket->header, (void *)pCIs[i].pDynamicState);
 
         pCIs[i].layout = m_objMapper.remap_pipelinelayouts(pPacket->pCreateInfos[i].layout);
         if (pCIs[i].layout == VK_NULL_HANDLE) {
@@ -2589,7 +2589,7 @@ void vkReplay::manually_replay_vkGetPhysicalDeviceProperties2KHR(packet_vkGetPhy
         vktrace_LogError("Error detected in GetPhysicalDeviceProperties2KHR() due to invalid remapped VkPhysicalDevice.");
         return;
     }
-    vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pProperties);
+    vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pProperties);
     // No need to remap pProperties
     m_vkFuncs.GetPhysicalDeviceProperties2KHR(remappedphysicalDevice, pPacket->pProperties);
     m_replay_gpu =
@@ -3031,8 +3031,8 @@ void vkReplay::manually_replay_vkGetImageMemoryRequirements2KHR(packet_vkGetImag
 
         ((VkImageMemoryRequirementsInfo2KHR *)pPacket->pInfo)->image = remappedimage;
     }
-    vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pInfo);
-    vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pMemoryRequirements);
+    vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pInfo);
+    vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pMemoryRequirements);
     m_vkDeviceFuncs.GetImageMemoryRequirements2KHR(remappeddevice, pPacket->pInfo, pPacket->pMemoryRequirements);
 
     replayGetImageMemoryRequirements[remappedimage] = pPacket->pMemoryRequirements->memoryRequirements;
@@ -3070,8 +3070,8 @@ void vkReplay::manually_replay_vkGetBufferMemoryRequirements2KHR(packet_vkGetBuf
     }
     *((VkBuffer *)(&pPacket->pInfo->buffer)) = remappedBuffer;
 
-    vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pInfo);
-    vktrace_interpret_pnext_pointers(pPacket->header, (void *)pPacket->pMemoryRequirements);
+    vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pInfo);
+    vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pMemoryRequirements);
     m_vkDeviceFuncs.GetBufferMemoryRequirements2KHR(remappedDevice, pPacket->pInfo, pPacket->pMemoryRequirements);
     replayGetBufferMemoryRequirements[pPacket->pInfo->buffer] = pPacket->pMemoryRequirements->memoryRequirements;
     return;


### PR DESCRIPTION
Added a front end function to vktrace_interpret_pnext_pointers.
Renamed vktrace_interpret_pnext_pointers to vkreplay_interpret_pnext_pointers.

This is in preparation for an upcoming commit to add more general remapping of
handles in pnext structures during replay.

Change-Id: Id461bbc73e6a8b410771a22d1179fff39f36c7c2