### PR TITLE
vktrace: make page guard be cleared during exception handler

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
-* Copyright (C) 2015-2017 LunarG, Inc.
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2016-2019 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2015-2017 LunarG, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "vktrace_common.h"
 #include "vktrace_pageguard_memorycopy.h"
@@ -319,7 +319,13 @@ LONG WINAPI PageGuardExceptionHandler(PEXCEPTION_POINTERS ExceptionInfo) {
 
         LPPageGuardMappedMemory pMappedMem =
             getPageGuardControlInstance().findMappedMemoryObject(addr, &OffsetOfAddr, &pBlock, &BlockSize);
-        if (pMappedMem) {
+        if (pMappedMem != nullptr) {
+            // Make sure pageguard is cleared because in multi-thread environment there's possibility
+            // that pageguard be re-armed during pageguard be triggered this time to current location.
+            // If pageguard be rearmed, the following sync between real mapped memory to shadow
+            // mapped memory will cause deadlock.
+            DWORD oldProt = 0;
+            VirtualProtect(pBlock, static_cast<SIZE_T>(BlockSize), PAGE_READWRITE, &oldProt);
             int64_t index = pMappedMem->getIndexOfChangedBlockByAddr(addr);
             if (index >= 0) {
                 if (!getEnableReadPMBFlag() || bWrite) {


### PR DESCRIPTION

Add process to make sure pageguard is cleared because in multi-thread
environment there's possibility that pageguard be re-armed during
pageguard be triggered this time to current location. If pageguard be
rearmed, the following sync between real mapped memory and shadow mapped
memory will cause deadlock.

VKTRACE-97

Change-Id: If886592ee1200d4f5d1bb2b9cda4f38fa4fd4631