### PR TITLE
scripts: Script modifications for 106 hdr

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -738,6 +738,12 @@ inline std::ostream &dump_text_void(const void *object, const ApiDumpSettings &s
 
 inline std::ostream &dump_text_int(int object, const ApiDumpSettings &settings, int indents) { return settings.stream() << object; }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+inline std::ostream &dump_text_HMONITOR(HMONITOR object, const ApiDumpSettings &settings, int indents) {
+    return settings.stream() << object;
+}
+#endif // VK_USE_PLATFORM_WIN32_KHR
+
 //==================================== Html Backend Helpers ======================================//
 
 inline std::ostream &dump_html_nametype(std::ostream &stream, bool showType, const char *name, const char *type) {
@@ -890,3 +896,11 @@ inline std::ostream &dump_html_int(int object, const ApiDumpSettings &settings, 
     settings.stream() << object;
     return settings.stream() << "</div>";
 }
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+inline std::ostream &dump_html_HMONITOR(HMONITOR object, const ApiDumpSettings &settings, int indents) {
+    settings.stream() << "<div class='val'>";
+    settings.stream() << object;
+    return settings.stream() << "</div>";
+}
+#endif // VK_USE_PLATFORM_WIN32_KHR

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -397,8 +397,13 @@ TEXT_CODEGEN = """
 
 #include "api_dump.h"
 
-@foreach struct
+@foreach struct where('{sctName}' != 'VkSurfaceFullScreenExclusiveWin32InfoEXT')
 std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars});
+@end struct
+@foreach struct where('{sctName}' == 'VkSurfaceFullScreenExclusiveWin32InfoEXT')
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+std::ostream& dump_text_VkSurfaceFullScreenExclusiveWin32InfoEXT(const VkSurfaceFullScreenExclusiveWin32InfoEXT& object, const ApiDumpSettings& settings, int indents);
+#endif // VK_USE_PLATFORM_WIN32_KHR
 @end struct
 @foreach union
 std::ostream& dump_text_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
@@ -522,7 +527,7 @@ inline std::ostream& dump_text_{pfnName}({pfnName} object, const ApiDumpSettings
 
 //========================== Struct Implementations =========================//
 
-@foreach struct where('{sctName}' != 'VkShaderModuleCreateInfo')
+@foreach struct where('{sctName}' not in ['VkShaderModuleCreateInfo', 'VkSurfaceFullScreenExclusiveWin32InfoEXT'])
 std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars})
 {{
     if(settings.showAddress())
@@ -596,6 +601,22 @@ std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings
     @end member
     return settings.stream();
 }}
+@end struct
+
+@foreach struct where('{sctName}' == 'VkSurfaceFullScreenExclusiveWin32InfoEXT')
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+std::ostream& dump_text_VkSurfaceFullScreenExclusiveWin32InfoEXT(const VkSurfaceFullScreenExclusiveWin32InfoEXT& object, const ApiDumpSettings& settings, int indents)
+{{
+    if(settings.showAddress())
+        settings.stream() << &object << ":\\n";
+    else
+        settings.stream() << "address:\\n";
+    dump_text_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_text_VkStructureType);
+    dump_text_value<const void*>(object.pNext, settings, "const void*", "pNext", indents + 1, dump_text_void);
+    dump_text_value<const HMONITOR>(object.hmonitor, settings, "HMONITOR", "hmonitor", indents + 1, dump_text_HMONITOR);
+    return settings.stream();
+}}
+#endif // VK_USE_PLATFORM_WIN32_KHR
 @end struct
 
 //========================== Union Implementations ==========================//
@@ -714,8 +735,13 @@ HTML_CODEGEN = """
 
 #include "api_dump.h"
 
-@foreach struct
+@foreach struct where('{sctName}' != 'VkSurfaceFullScreenExclusiveWin32InfoEXT')
 std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars});
+@end struct
+@foreach struct where('{sctName}' == 'VkSurfaceFullScreenExclusiveWin32InfoEXT')
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+std::ostream& dump_html_VkSurfaceFullScreenExclusiveWin32InfoEXT(const VkSurfaceFullScreenExclusiveWin32InfoEXT& object, const ApiDumpSettings& settings, int indents);
+#endif // VK_USE_PLATFORM_WIN32_KHR
 @end struct
 @foreach union
 std::ostream& dump_html_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
@@ -845,7 +871,7 @@ inline std::ostream& dump_html_{pfnName}({pfnName} object, const ApiDumpSettings
 
 //========================== Struct Implementations =========================//
 
-@foreach struct where('{sctName}' != 'VkShaderModuleCreateInfo')
+@foreach struct where('{sctName}' not in ['VkShaderModuleCreateInfo', 'VkSurfaceFullScreenExclusiveWin32InfoEXT'])
 std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars})
 {{
     settings.stream() << "<div class=\'val\'>";
@@ -924,6 +950,24 @@ std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings
     @end member
     return settings.stream();
 }}
+@end struct
+
+@foreach struct where('{sctName}' == 'VkSurfaceFullScreenExclusiveWin32InfoEXT')
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+std::ostream& dump_html_VkSurfaceFullScreenExclusiveWin32InfoEXT(const VkSurfaceFullScreenExclusiveWin32InfoEXT& object, const ApiDumpSettings& settings, int indents)
+{{
+    settings.stream() << "<div class='val'>";
+    if(settings.showAddress())
+        settings.stream() << &object << "\\n";
+    else
+        settings.stream() << "address\\n";
+    settings.stream() << "</div></summary>";
+    dump_html_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_html_VkStructureType);
+    dump_html_value<const void*>(object.pNext, settings, "const void*", "pNext", indents + 1, dump_html_void);
+    dump_html_value<const HMONITOR>(object.hmonitor, settings, "HMONITOR", "hmonitor", indents + 1, dump_html_HMONITOR);
+    return settings.stream();
+}}
+#endif // VK_USE_PLATFORM_WIN32_KHR
 @end struct
 
 //========================== Union Implementations ==========================//
@@ -1134,8 +1178,8 @@ VALIDITY_CHECKS = {
 }
 
 class ApiDumpGeneratorOptions(GeneratorOptions):
-
     def __init__(self,
+                 conventions = None,
                  input = None,
                  filename = None,
                  directory = '.',
@@ -1162,7 +1206,7 @@ class ApiDumpGeneratorOptions(GeneratorOptions):
                  alignFuncParam = 0,
                  expandEnumerants = True,
                  ):
-        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
             versions, emitversions, defaultExtensions,
             addExtensions, removeExtensions, emitExtensions, sortProcedure)
         self.input           = input

--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -50,6 +50,7 @@ prefixStrings = [
 platform_dict = {
     'android' : 'VK_USE_PLATFORM_ANDROID_KHR',
     'fuchsia' : 'VK_USE_PLATFORM_FUCHSIA',
+    'ggp': 'VK_USE_PLATFORM_GGP',
     'ios' : 'VK_USE_PLATFORM_IOS_MVK',
     'macos' : 'VK_USE_PLATFORM_MACOS_MVK',
     'metal' : 'VK_USE_PLATFORM_METAL_EXT',

--- a/scripts/layer_factory_generator.py
+++ b/scripts/layer_factory_generator.py
@@ -62,6 +62,7 @@ from common_codegen import *
 #     separate line, align parameter names at the specified column
 class LayerFactoryGeneratorOptions(GeneratorOptions):
     def __init__(self,
+                 conventions = None,
                  filename = None,
                  directory = '.',
                  apiname = None,
@@ -85,7 +86,7 @@ class LayerFactoryGeneratorOptions(GeneratorOptions):
                  alignFuncParam = 0,
                  helper_file_type = '',
                  expandEnumerants = True):
-        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
                                   versions, emitversions, defaultExtensions,
                                   addExtensions, removeExtensions, emitExtensions, sortProcedure)
         self.prefixText      = prefixText

--- a/scripts/tool_helper_file_generator.py
+++ b/scripts/tool_helper_file_generator.py
@@ -30,6 +30,7 @@ from common_codegen import *
 # ToolHelperFileOutputGeneratorOptions - subclass of GeneratorOptions.
 class ToolHelperFileOutputGeneratorOptions(GeneratorOptions):
     def __init__(self,
+                 conventions = None,
                  filename = None,
                  directory = '.',
                  apiname = None,
@@ -53,7 +54,7 @@ class ToolHelperFileOutputGeneratorOptions(GeneratorOptions):
                  alignFuncParam = 0,
                  library_name = '',
                  helper_file_type = ''):
-        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
                                   versions, emitversions, defaultExtensions,
                                   addExtensions, removeExtensions, emitExtensions, sortProcedure)
         self.prefixText       = prefixText

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -163,6 +163,7 @@ def isInstanceCmd(cmd):
 # VkTraceFileOutputGeneratorOptions - subclass of GeneratorOptions.
 class VkTraceFileOutputGeneratorOptions(GeneratorOptions):
     def __init__(self,
+                 conventions = None,
                  filename = None,
                  directory = '.',
                  apiname = None,
@@ -185,7 +186,7 @@ class VkTraceFileOutputGeneratorOptions(GeneratorOptions):
                  expandEnumerants = True,
                  library_name = '',
                  vktrace_file_type = ''):
-        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
                                   versions, emitversions, defaultExtensions,
                                   addExtensions, removeExtensions, emitExtensions, sortProcedure)
         self.prefixText       = prefixText

--- a/scripts/vt_genvk.py
+++ b/scripts/vt_genvk.py
@@ -118,10 +118,14 @@ def makeGenOpts(args):
     # Defaults for generating re-inclusion protection wrappers (or not)
     protectFeature = protect
 
+    # An API style convention object
+    conventions = VulkanConventions()
+
     # Options for Vulkan Layer Factory header
     genOpts['layer_factory.h'] = [
           LayerFactoryOutputGenerator,
           LayerFactoryGeneratorOptions(
+            conventions       = conventions,
             filename          = 'layer_factory.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -145,6 +149,7 @@ def makeGenOpts(args):
     genOpts['layer_factory.cpp'] = [
           LayerFactoryOutputGenerator,
           LayerFactoryGeneratorOptions(
+            conventions       = conventions,
             filename          = 'layer_factory.cpp',
             directory         = directory,
             apiname           = 'vulkan',
@@ -168,6 +173,7 @@ def makeGenOpts(args):
     genOpts['api_dump.cpp'] = [
         ApiDumpOutputGenerator,
         ApiDumpGeneratorOptions(
+            conventions       = conventions,
             input             = COMMON_CODEGEN,
             filename          = 'api_dump.cpp',
             apiname           = 'vulkan',
@@ -195,6 +201,7 @@ def makeGenOpts(args):
     genOpts['api_dump_text.h'] = [
         ApiDumpOutputGenerator,
         ApiDumpGeneratorOptions(
+            conventions       = conventions,
             input             = TEXT_CODEGEN,
             filename          = 'api_dump_text.h',
             apiname           = 'vulkan',
@@ -222,6 +229,7 @@ def makeGenOpts(args):
     genOpts['api_dump_html.h'] = [
         ApiDumpOutputGenerator,
         ApiDumpGeneratorOptions(
+            conventions       = conventions,
             input             = HTML_CODEGEN,
             filename          = 'api_dump_html.h',
             apiname           = 'vulkan',
@@ -249,6 +257,7 @@ def makeGenOpts(args):
     genOpts['vkreplay_vk_objmapper.h'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vkreplay_vk_objmapper.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -272,6 +281,7 @@ def makeGenOpts(args):
     genOpts['vkreplay_vk_func_ptrs.h'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vkreplay_vk_func_ptrs.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -295,6 +305,7 @@ def makeGenOpts(args):
     genOpts['vkreplay_vk_replay_gen.cpp'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vkreplay_vk_replay_gen.cpp',
             directory         = directory,
             apiname           = 'vulkan',
@@ -318,6 +329,7 @@ def makeGenOpts(args):
     genOpts['vktracedump_vk_dump_gen.cpp'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vktracedump_vk_dump_gen.cpp',
             directory         = directory,
             apiname           = 'vulkan',
@@ -344,6 +356,7 @@ def makeGenOpts(args):
     genOpts['vktrace_vk_packet_id.h'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vktrace_vk_packet_id.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -367,6 +380,7 @@ def makeGenOpts(args):
     genOpts['vktrace_vk_vk.h'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vktrace_vk_vk.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -390,6 +404,7 @@ def makeGenOpts(args):
     genOpts['vktrace_vk_vk.cpp'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vktrace_vk_vk.cpp',
             directory         = directory,
             apiname           = 'vulkan',
@@ -414,6 +429,7 @@ def makeGenOpts(args):
     genOpts['vktrace_vk_vk_packets.h'] = [
           VkTraceFileOutputGenerator,
           VkTraceFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vktrace_vk_vk_packets.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -439,6 +455,7 @@ def makeGenOpts(args):
     genOpts['vk_struct_size_helper.h'] = [
           ToolHelperFileOutputGenerator,
           ToolHelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_struct_size_helper.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -462,6 +479,7 @@ def makeGenOpts(args):
     genOpts['vk_struct_size_helper.c'] = [
           ToolHelperFileOutputGenerator,
           ToolHelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_struct_size_helper.c',
             directory         = directory,
             apiname           = 'vulkan',
@@ -593,6 +611,7 @@ if __name__ == '__main__':
     from api_dump_generator import ApiDumpGeneratorOptions, ApiDumpOutputGenerator, COMMON_CODEGEN, TEXT_CODEGEN, HTML_CODEGEN
     from vktrace_file_generator import VkTraceFileOutputGenerator, VkTraceFileOutputGeneratorOptions
     from layer_factory_generator import LayerFactoryGeneratorOptions, LayerFactoryOutputGenerator
+    from vkconventions import VulkanConventions
 
     # This splits arguments which are space-separated lists
     args.feature = [name for arg in args.feature for name in arg.split()]

--- a/vktrace/vktrace_common/vktrace_multiplatform.h
+++ b/vktrace/vktrace_common/vktrace_multiplatform.h
@@ -226,6 +226,15 @@ typedef VkResult(VKAPI_PTR* PFN_vkGetFenceWin32HandleKHR)(VkDevice device, const
                                                           HANDLE* pHandle);
 typedef VkResult(VKAPI_PTR* PFN_vkGetMemoryWin32HandleNV)(VkDevice device, VkDeviceMemory memory,
                                                           VkExternalMemoryHandleTypeFlagsNV handleType, HANDLE* pHandle);
+typedef VkResult(VKAPI_PTR* PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT)(VkPhysicalDevice physicalDevice,
+                                                                            const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                            uint32_t* pPresentModeCount,
+                                                                            VkPresentModeKHR* pPresentModes);
+typedef VkResult(VKAPI_PTR* PFN_vkAcquireFullScreenExclusiveModeEXT)(VkDevice device, VkSwapchainKHR swapchain);
+typedef VkResult(VKAPI_PTR* PFN_vkReleaseFullScreenExclusiveModeEXT)(VkDevice device, VkSwapchainKHR swapchain);
+typedef VkResult(VKAPI_PTR* PFN_vkGetDeviceGroupSurfacePresentModes2EXT)(VkDevice device,
+                                                                         const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                         VkDeviceGroupPresentModeFlagsKHR* pModes);
 
 #endif
 


### PR DESCRIPTION
Changes:
- Integrate upstream script changes: We have to plumb-through the new
conventions object to continue using the makeCParamDecl utility function
- Add GGP to available platforms
- Workarounds for missing platform guards

Note: Vulkan-ValidationLayers 106 known-good update requires the
script changes in this commit to build successfully

Modified:
- `layersvt/api_dump.h`
- `scripts/api_dump_generator.py`
- `scripts/common_codegen.py`
- `scripts/layer_factory_generator.py`
- `scripts/tool_helper_file_generator.py`
- `scripts/vktrace_file_generator.py`
- `scripts/vt_genvk.py`
- `vktrace/vktrace_common/vktrace_multiplatform.h`

Change-Id: Ib653c9fc3e804a02897917596914490ab843dc5b