### PR TITLE
vktrace: fix black screen and random crash issues on game title under test

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -94,6 +94,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_common/vktrace_settings.c
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_common/vktrace_tracelog.c
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_common/vktrace_pageguard_memorycopy.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_helpers.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_vk_exts.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pagestatusarray.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp

--- a/vktrace/vktrace_layer/CMakeLists.txt
+++ b/vktrace/vktrace_layer/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 set(SRC_LIST
     ${SRC_LIST}
     vktrace_lib.c
+    vktrace_lib_helpers.cpp
     vktrace_lib_pagestatusarray.cpp
     vktrace_lib_pageguardmappedmemory.cpp
     vktrace_lib_pageguardcapture.cpp

--- a/vktrace/vktrace_layer/vktrace_lib_helpers.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_helpers.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vktrace_lib_helpers.h"
+
+// templates to convert API handles to uint64_t type and vice versa
+
+template <>
+uint64_t ToHandleId<uint64_t>(const uint64_t &handle) {
+    return handle;
+}
+
+template <>
+uint64_t FromHandleId<uint64_t>(uint64_t handle_id) {
+    return handle_id;
+}

--- a/vktrace/vktrace_layer/vktrace_lib_helpers.h
+++ b/vktrace/vktrace_layer/vktrace_lib_helpers.h
@@ -30,6 +30,23 @@
 #include "vk_layer_dispatch_table.h"
 #include "vk_struct_size_helper.h"
 
+// utilities to convert API handles to uint64_t type and vice versa
+template <typename T>
+uint64_t ToHandleId(const T &handle) {
+    return reinterpret_cast<uint64_t>(handle);
+}
+
+template <>
+uint64_t ToHandleId<uint64_t>(const uint64_t &handle);
+
+template <typename T>
+T FromHandleId(uint64_t handle_id) {
+    return reinterpret_cast<T>(handle_id);
+}
+
+template <>
+uint64_t FromHandleId<uint64_t>(uint64_t handle_id);
+
 // Support for shadowing CPU mapped memory
 // TODO better handling of multiple range rather than fixed array
 typedef struct _VKAllocInfo {

--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -804,10 +804,8 @@ VkLayerDeviceCreateInfo* get_chain_info(const VkDeviceCreateInfo* pCreateInfo, V
     return chain_info;
 }
 
-VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceProperties(
-    VkPhysicalDevice physicalDevice,
-    VkPhysicalDeviceProperties* pProperties)
-{
+VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
+                                                                                  VkPhysicalDeviceProperties* pProperties) {
     trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkGetPhysicalDeviceProperties* pPacket = NULL;
@@ -3525,8 +3523,10 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkGetSwapchainImagesKHR(
         }
 
         if (g_trimIsInTrim) {
-            for (uint32_t i = 0; i < *pSwapchainImageCount; i++) {
-                trim::mark_Image_reference(pSwapchainImages[i]);
+            if ((pSwapchainImageCount != nullptr) && (pSwapchainImages != nullptr)) {
+                for (uint32_t i = 0; i < *pSwapchainImageCount; i++) {
+                    trim::mark_Image_reference(pSwapchainImages[i]);
+                }
             }
             trim::write_packet(pHeader);
         } else {
@@ -4046,14 +4046,7 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateAndroidSurfaceKH
 }
 #endif
 
-VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplate(
-    VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
-    VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
-    return __HOOKED_vkCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
-}
-
-static std::unordered_map<VkDescriptorUpdateTemplateKHR, VkDescriptorUpdateTemplateCreateInfoKHR*>
-    descriptorUpdateTemplateCreateInfo;
+static std::unordered_map<VkDescriptorUpdateTemplate, VkDescriptorUpdateTemplateCreateInfo*> descriptorUpdateTemplateCreateInfo;
 static vktrace_sem_id descriptorUpdateTemplateCreateInfo_sem_id;
 static bool descriptorUpdateTemplateCreateInfo_success = vktrace_sem_create(&descriptorUpdateTemplateCreateInfo_sem_id, 1);
 
@@ -4066,6 +4059,113 @@ void lockDescriptorUpdateTemplateCreateInfo() {
 
 void unlockDescriptorUpdateTemplateCreateInfo() { vktrace_sem_post(descriptorUpdateTemplateCreateInfo_sem_id); }
 
+void FinalizeTrimCreateDescriptorUpdateTemplate(vktrace_trace_packet_header* pHeader, VkDevice device,
+                                                const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator,
+                                                VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
+    vktrace_finalize_trace_packet(pHeader);
+    trim::ObjectInfo& info = trim::add_DescriptorUpdateTemplate_object(*pDescriptorUpdateTemplate);
+    info.belongsToDevice = device;
+    info.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket = trim::copy_packet(pHeader);
+    info.ObjectInfo.DescriptorUpdateTemplate.flags = pCreateInfo->flags;
+    info.ObjectInfo.DescriptorUpdateTemplate.descriptorUpdateEntryCount = pCreateInfo->descriptorUpdateEntryCount;
+    if ((pCreateInfo->descriptorUpdateEntryCount != 0) && (pCreateInfo->pDescriptorUpdateEntries != nullptr)) {
+        info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries =
+            VKTRACE_NEW_ARRAY(VkDescriptorUpdateTemplateEntry, pCreateInfo->descriptorUpdateEntryCount);
+        assert(info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries != nullptr);
+        memcpy(reinterpret_cast<void*>(
+                   const_cast<VkDescriptorUpdateTemplateEntry*>(info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries)),
+               reinterpret_cast<const void*>(const_cast<VkDescriptorUpdateTemplateEntry*>(pCreateInfo->pDescriptorUpdateEntries)),
+               pCreateInfo->descriptorUpdateEntryCount * sizeof(VkDescriptorUpdateTemplateEntry));
+    }
+    info.ObjectInfo.DescriptorUpdateTemplate.templateType = pCreateInfo->templateType;
+    info.ObjectInfo.DescriptorUpdateTemplate.descriptorSetLayout = pCreateInfo->descriptorSetLayout;
+    info.ObjectInfo.DescriptorUpdateTemplate.pipelineBindPoint = pCreateInfo->pipelineBindPoint;
+    info.ObjectInfo.DescriptorUpdateTemplate.pipelineLayout = pCreateInfo->pipelineLayout;
+    info.ObjectInfo.DescriptorUpdateTemplate.set = pCreateInfo->set;
+
+    if (pAllocator != NULL) {
+        info.ObjectInfo.DescriptorUpdateTemplate.pAllocator = pAllocator;
+        trim::add_Allocator(pAllocator);
+    }
+
+    if (g_trimIsInTrim) {
+        trim::write_packet(pHeader);
+    } else {
+        vktrace_delete_trace_packet(&pHeader);
+    }
+}
+
+VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplate(
+    VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+    VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
+    VkResult result;
+    vktrace_trace_packet_header* pHeader;
+    packet_vkCreateDescriptorUpdateTemplate* pPacket = NULL;
+
+    CREATE_TRACE_PACKET(
+        vkCreateDescriptorUpdateTemplate,
+        get_struct_chain_size(reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateCreateInfo*>(pCreateInfo))) +
+            sizeof(VkAllocationCallbacks) + sizeof(VkDescriptorUpdateTemplate) +
+            sizeof(VkDescriptorUpdateTemplateEntry) * pCreateInfo->descriptorUpdateEntryCount);
+    result = mdd(device)->devTable.CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
+    vktrace_set_packet_entrypoint_end_time(pHeader);
+
+    lockDescriptorUpdateTemplateCreateInfo();
+    descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate] =
+        reinterpret_cast<VkDescriptorUpdateTemplateCreateInfo*>(malloc(sizeof(VkDescriptorUpdateTemplateCreateInfo)));
+    memcpy(descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate], pCreateInfo,
+           sizeof(VkDescriptorUpdateTemplateCreateInfo));
+    descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate]->pDescriptorUpdateEntries =
+        reinterpret_cast<VkDescriptorUpdateTemplateEntry*>(
+            malloc(sizeof(VkDescriptorUpdateTemplateEntry) * pCreateInfo->descriptorUpdateEntryCount));
+    memcpy(reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateEntry*>(
+               descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate]->pDescriptorUpdateEntries)),
+           pCreateInfo->pDescriptorUpdateEntries,
+           sizeof(VkDescriptorUpdateTemplateEntry) * pCreateInfo->descriptorUpdateEntryCount);
+    unlockDescriptorUpdateTemplateCreateInfo();
+
+    pPacket = interpret_body_as_vkCreateDescriptorUpdateTemplate(pHeader);
+    pPacket->device = device;
+
+    vktrace_add_buffer_to_trace_packet(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateCreateInfo**>(&(pPacket->pCreateInfo))),
+        sizeof(VkDescriptorUpdateTemplateCreateInfo), pCreateInfo);
+
+    if (nullptr != pCreateInfo) {
+        vktrace_add_pnext_structs_to_trace_packet(
+            pHeader, reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateCreateInfo*>(pPacket->pCreateInfo)), pCreateInfo);
+    }
+
+    vktrace_add_buffer_to_trace_packet(
+        pHeader,
+        reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateEntry**>(&(pPacket->pCreateInfo->pDescriptorUpdateEntries))),
+        sizeof(VkDescriptorUpdateTemplateEntry) * pCreateInfo->descriptorUpdateEntryCount, pCreateInfo->pDescriptorUpdateEntries);
+    vktrace_add_buffer_to_trace_packet(pHeader,
+                                       reinterpret_cast<void**>(const_cast<VkAllocationCallbacks**>(&(pPacket->pAllocator))),
+                                       sizeof(VkAllocationCallbacks), NULL);
+    vktrace_add_buffer_to_trace_packet(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplate**>(&(pPacket->pDescriptorUpdateTemplate))),
+        sizeof(VkDescriptorUpdateTemplate), pDescriptorUpdateTemplate);
+    pPacket->result = result;
+    vktrace_finalize_buffer_address(
+        pHeader,
+        reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateEntry**>(&(pPacket->pCreateInfo->pDescriptorUpdateEntries))));
+    vktrace_finalize_buffer_address(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateCreateInfo**>(&(pPacket->pCreateInfo))));
+    vktrace_finalize_buffer_address(pHeader, reinterpret_cast<void**>(const_cast<VkAllocationCallbacks**>(&(pPacket->pAllocator))));
+    vktrace_finalize_buffer_address(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplate**>(&(pPacket->pDescriptorUpdateTemplate))));
+    if (!g_trimEnabled) {
+        FINISH_TRACE_PACKET();
+    } else {
+        FinalizeTrimCreateDescriptorUpdateTemplate(pHeader, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
+    }
+
+    return result;
+}
+
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdateTemplateKHR(
     VkDevice device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
     VkDescriptorUpdateTemplateKHR* pDescriptorUpdateTemplate) {
@@ -4074,22 +4174,24 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
     vktrace_trace_packet_header* pHeader;
     packet_vkCreateDescriptorUpdateTemplateKHR* pPacket = NULL;
 
-    CREATE_TRACE_PACKET(vkCreateDescriptorUpdateTemplate,
-                        get_struct_chain_size((void*)pCreateInfo) + sizeof(VkAllocationCallbacks) +
-                            sizeof(VkDescriptorUpdateTemplateKHR) +
-                            sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount);
+    CREATE_TRACE_PACKET(
+        vkCreateDescriptorUpdateTemplateKHR,
+        get_struct_chain_size(reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateCreateInfoKHR*>(pCreateInfo))) +
+            sizeof(VkAllocationCallbacks) + sizeof(VkDescriptorUpdateTemplateKHR) +
+            sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount);
     result = mdd(device)->devTable.CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     vktrace_set_packet_entrypoint_end_time(pHeader);
 
     lockDescriptorUpdateTemplateCreateInfo();
     descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate] =
-        (VkDescriptorUpdateTemplateCreateInfoKHR*)malloc(sizeof(VkDescriptorUpdateTemplateCreateInfoKHR));
+        reinterpret_cast<VkDescriptorUpdateTemplateCreateInfoKHR*>(malloc(sizeof(VkDescriptorUpdateTemplateCreateInfoKHR)));
     memcpy(descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate], pCreateInfo,
            sizeof(VkDescriptorUpdateTemplateCreateInfoKHR));
     descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate]->pDescriptorUpdateEntries =
-        (VkDescriptorUpdateTemplateEntryKHR*)malloc(sizeof(VkDescriptorUpdateTemplateEntryKHR) *
-                                                    pCreateInfo->descriptorUpdateEntryCount);
-    memcpy((void*)descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate]->pDescriptorUpdateEntries,
+        reinterpret_cast<VkDescriptorUpdateTemplateEntryKHR*>(
+            malloc(sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount));
+    memcpy(reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateEntry*>(
+               descriptorUpdateTemplateCreateInfo[*pDescriptorUpdateTemplate]->pDescriptorUpdateEntries)),
            pCreateInfo->pDescriptorUpdateEntries,
            sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount);
     unlockDescriptorUpdateTemplateCreateInfo();
@@ -4097,55 +4199,38 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateDescriptorUpdate
     pPacket = interpret_body_as_vkCreateDescriptorUpdateTemplateKHR(pHeader);
     pPacket->device = device;
 
-    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkDescriptorUpdateTemplateCreateInfoKHR),
-                                       pCreateInfo);
-    if (pCreateInfo) vktrace_add_pnext_structs_to_trace_packet(pHeader, (void*)pPacket->pCreateInfo, pCreateInfo);
-    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pDescriptorUpdateEntries),
-                                       sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount,
-                                       pCreateInfo->pDescriptorUpdateEntries);
-    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pAllocator), sizeof(VkAllocationCallbacks), NULL);
-    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pDescriptorUpdateTemplate),
-                                       sizeof(VkDescriptorUpdateTemplateKHR), pDescriptorUpdateTemplate);
+    vktrace_add_buffer_to_trace_packet(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateCreateInfo**>(&(pPacket->pCreateInfo))),
+        sizeof(VkDescriptorUpdateTemplateCreateInfoKHR), pCreateInfo);
+    if (nullptr != pCreateInfo) {
+        vktrace_add_pnext_structs_to_trace_packet(
+            pHeader, reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateCreateInfo*>(pPacket->pCreateInfo)), pCreateInfo);
+    }
+
+    vktrace_add_buffer_to_trace_packet(
+        pHeader,
+        reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateEntry**>(&(pPacket->pCreateInfo->pDescriptorUpdateEntries))),
+        sizeof(VkDescriptorUpdateTemplateEntryKHR) * pCreateInfo->descriptorUpdateEntryCount,
+        pCreateInfo->pDescriptorUpdateEntries);
+    vktrace_add_buffer_to_trace_packet(pHeader,
+                                       reinterpret_cast<void**>(const_cast<VkAllocationCallbacks**>(&(pPacket->pAllocator))),
+                                       sizeof(VkAllocationCallbacks), NULL);
+    vktrace_add_buffer_to_trace_packet(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplate**>(&(pPacket->pDescriptorUpdateTemplate))),
+        sizeof(VkDescriptorUpdateTemplateKHR), pDescriptorUpdateTemplate);
     pPacket->result = result;
-    vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pCreateInfo->pDescriptorUpdateEntries));
-    vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pCreateInfo));
-    vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pAllocator));
-    vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pDescriptorUpdateTemplate));
+    vktrace_finalize_buffer_address(
+        pHeader,
+        reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateEntry**>(&(pPacket->pCreateInfo->pDescriptorUpdateEntries))));
+    vktrace_finalize_buffer_address(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplateCreateInfo**>(&(pPacket->pCreateInfo))));
+    vktrace_finalize_buffer_address(pHeader, reinterpret_cast<void**>(const_cast<VkAllocationCallbacks**>(&(pPacket->pAllocator))));
+    vktrace_finalize_buffer_address(
+        pHeader, reinterpret_cast<void**>(const_cast<VkDescriptorUpdateTemplate**>(&(pPacket->pDescriptorUpdateTemplate))));
     if (!g_trimEnabled) {
         FINISH_TRACE_PACKET();
     } else {
-        vktrace_finalize_trace_packet(pHeader);
-        trim::ObjectInfo& info = trim::add_DescriptorUpdateTemplate_object(*pDescriptorUpdateTemplate);
-        info.belongsToDevice = device;
-        info.ObjectInfo.DescriptorUpdateTemplate.pCreatePacket = trim::copy_packet(pHeader);
-        info.ObjectInfo.DescriptorUpdateTemplate.flags = pCreateInfo->flags;
-        info.ObjectInfo.DescriptorUpdateTemplate.descriptorUpdateEntryCount = pCreateInfo->descriptorUpdateEntryCount;
-        if ((pCreateInfo->descriptorUpdateEntryCount != 0) && (pCreateInfo->pDescriptorUpdateEntries != nullptr)) {
-            info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries =
-                VKTRACE_NEW_ARRAY(VkDescriptorUpdateTemplateEntry, pCreateInfo->descriptorUpdateEntryCount);
-            assert(info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries != nullptr);
-            memcpy(
-                reinterpret_cast<void*>(const_cast<VkDescriptorUpdateTemplateEntry*>(
-                    info.ObjectInfo.DescriptorUpdateTemplate.pDescriptorUpdateEntries)),
-                reinterpret_cast<const void*>(const_cast<VkDescriptorUpdateTemplateEntry*>(pCreateInfo->pDescriptorUpdateEntries)),
-                pCreateInfo->descriptorUpdateEntryCount * sizeof(VkDescriptorUpdateTemplateEntry));
-        }
-        info.ObjectInfo.DescriptorUpdateTemplate.templateType = pCreateInfo->templateType;
-        info.ObjectInfo.DescriptorUpdateTemplate.descriptorSetLayout = pCreateInfo->descriptorSetLayout;
-        info.ObjectInfo.DescriptorUpdateTemplate.pipelineBindPoint = pCreateInfo->pipelineBindPoint;
-        info.ObjectInfo.DescriptorUpdateTemplate.pipelineLayout = pCreateInfo->pipelineLayout;
-        info.ObjectInfo.DescriptorUpdateTemplate.set = pCreateInfo->set;
-
-        if (pAllocator != NULL) {
-            info.ObjectInfo.DescriptorUpdateTemplate.pAllocator = pAllocator;
-            trim::add_Allocator(pAllocator);
-        }
-
-        if (g_trimIsInTrim) {
-            trim::write_packet(pHeader);
-        } else {
-            vktrace_delete_trace_packet(&pHeader);
-        }
+        FinalizeTrimCreateDescriptorUpdateTemplate(pHeader, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     }
 
     return result;
@@ -4223,7 +4308,7 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkDestroyDescriptorUpdateTem
     unlockDescriptorUpdateTemplateCreateInfo();
 }
 
-static size_t getDescriptorSetDataSize(VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate) {
+static size_t getDescriptorSetDataSize(VkDescriptorUpdateTemplate descriptorUpdateTemplate) {
     size_t dataSize = 0;
     lockDescriptorUpdateTemplateCreateInfo();
     for (uint32_t i = 0; i < descriptorUpdateTemplateCreateInfo[descriptorUpdateTemplate]->descriptorUpdateEntryCount; i++) {
@@ -4268,44 +4353,19 @@ static size_t getDescriptorSetDataSize(VkDescriptorUpdateTemplateKHR descriptorU
     return dataSize;
 }
 
-VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplate(
-    VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {
-    __HOOKED_vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
-}
+void FinalizeTrimUpdateDescriptorSetWithTemplate(vktrace_trace_packet_header* pHeader, VkDescriptorSet descriptorSet,
+                                                 VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {
+    vktrace_finalize_trace_packet(pHeader);
+    lockDescriptorUpdateTemplateCreateInfo();
 
-VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplateKHR(
-    VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) {
-    trim::TraceLock<std::mutex> lock(g_mutex_trace);
-    vktrace_trace_packet_header* pHeader;
-    packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket = NULL;
-    size_t dataSize;
-
-    // TODO: We're saving all the data, from pData to the end of the last item, including data before offset and skipped data.
-    // This could be optimized to save only the data chunks that are actually needed.
-    dataSize = getDescriptorSetDataSize(descriptorUpdateTemplate);
-
-    CREATE_TRACE_PACKET(vkUpdateDescriptorSetWithTemplateKHR, dataSize);
-    mdd(device)->devTable.UpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
-    vktrace_set_packet_entrypoint_end_time(pHeader);
-    pPacket = interpret_body_as_vkUpdateDescriptorSetWithTemplateKHR(pHeader);
-    pPacket->device = device;
-    pPacket->descriptorSet = descriptorSet;
-    pPacket->descriptorUpdateTemplate = descriptorUpdateTemplate;
-    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pData), dataSize, pData);
-    vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pData));
-    if (!g_trimEnabled) {
-        FINISH_TRACE_PACKET();
-    } else {
-        vktrace_finalize_trace_packet(pHeader);
-        lockDescriptorUpdateTemplateCreateInfo();
-
-        // Trim keep tracking all descriptorsets from beginning, include all
-        // descriptors in the descriptorset. If any function change any
-        // descriptor of it, the track info of that descriptorset should
-        // also be changed. The following source code update the descriptorset
-        // trackinfo to make sure the track info reflect current descriptorset
-        // state after the function update its descriptors.
-        //
+    // Trim keep tracking all descriptorsets from beginning, include all
+    // descriptors in the descriptorset. If any function change any
+    // descriptor of it, the track info of that descriptorset should
+    // also be changed. The following source code update the descriptorset
+    // trackinfo to make sure the track info reflect current descriptorset
+    // state after the function update its descriptors.
+    //
+    if (VK_NULL_HANDLE != descriptorUpdateTemplate) {
         for (uint32_t i = 0; i < descriptorUpdateTemplateCreateInfo[descriptorUpdateTemplate]->descriptorUpdateEntryCount; i++) {
             const VkDescriptorUpdateTemplateEntry* pDescriptorUpdateEntry =
                 &(descriptorUpdateTemplateCreateInfo[descriptorUpdateTemplate]->pDescriptorUpdateEntries[i]);
@@ -4343,11 +4403,17 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTem
             for (trim::DescriptorIterator descriptor_iterator(pInfo, bindingIndex, bindingDescriptorInfoArrayWriteIndex,
                                                               pDescriptorUpdateEntry->descriptorCount);
                  !descriptor_iterator.IsEnd(); descriptor_iterator++, j++) {
+                // update writeDescriptorCount accordingly with the number of binding
+                // the descriptorset has been updated by chekcing the binding index.
+                if (descriptor_iterator.GetCurrentBindingIndex() >= pInfo->ObjectInfo.DescriptorSet.writeDescriptorCount) {
+                    pInfo->ObjectInfo.DescriptorSet.writeDescriptorCount = descriptor_iterator.GetCurrentBindingIndex() + 1;
+                }
+
                 // First get the descriptor data pointer, Doc provide the
                 // following formula to calculate the pointer for every
                 // array element:
                 const char* pDescriptorRawData =
-                    (const char*)pData + pDescriptorUpdateEntry->offset + j * pDescriptorUpdateEntry->stride;
+                    reinterpret_cast<const char*>(pData) + pDescriptorUpdateEntry->offset + j * pDescriptorUpdateEntry->stride;
 
                 // The following code update the descriptorset track info
                 // with the descriptor data.
@@ -4377,13 +4443,68 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTem
                 }
             }
         }
-        unlockDescriptorUpdateTemplateCreateInfo();
-        if (g_trimIsInTrim) {
-            trim::mark_DescriptorSet_reference(descriptorSet);
-            trim::write_packet(pHeader);
-        } else {
-            vktrace_delete_trace_packet(&pHeader);
-        }
+    }
+
+    unlockDescriptorUpdateTemplateCreateInfo();
+    if (g_trimIsInTrim) {
+        trim::mark_DescriptorSet_reference(descriptorSet);
+        trim::write_packet(pHeader);
+    } else {
+        vktrace_delete_trace_packet(&pHeader);
+    }
+}
+
+VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplate(
+    VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
+    vktrace_trace_packet_header* pHeader;
+    packet_vkUpdateDescriptorSetWithTemplate* pPacket = NULL;
+    size_t dataSize;
+
+    // TODO: We're saving all the data, from pData to the end of the last item, including data before offset and skipped data.
+    // This could be optimized to save only the data chunks that are actually needed.
+    dataSize = getDescriptorSetDataSize(descriptorUpdateTemplate);
+
+    CREATE_TRACE_PACKET(vkUpdateDescriptorSetWithTemplate, dataSize);
+    mdd(device)->devTable.UpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
+    vktrace_set_packet_entrypoint_end_time(pHeader);
+    pPacket = interpret_body_as_vkUpdateDescriptorSetWithTemplate(pHeader);
+    pPacket->device = device;
+    pPacket->descriptorSet = descriptorSet;
+    pPacket->descriptorUpdateTemplate = descriptorUpdateTemplate;
+    vktrace_add_buffer_to_trace_packet(pHeader, const_cast<void**>(&(pPacket->pData)), dataSize, pData);
+    vktrace_finalize_buffer_address(pHeader, const_cast<void**>(&(pPacket->pData)));
+    if (!g_trimEnabled) {
+        FINISH_TRACE_PACKET();
+    } else {
+        FinalizeTrimUpdateDescriptorSetWithTemplate(pHeader, descriptorSet, descriptorUpdateTemplate, pData);
+    }
+}
+
+VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkUpdateDescriptorSetWithTemplateKHR(
+    VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData) {
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
+    vktrace_trace_packet_header* pHeader;
+    packet_vkUpdateDescriptorSetWithTemplateKHR* pPacket = NULL;
+    size_t dataSize;
+
+    // TODO: We're saving all the data, from pData to the end of the last item, including data before offset and skipped data.
+    // This could be optimized to save only the data chunks that are actually needed.
+    dataSize = getDescriptorSetDataSize(descriptorUpdateTemplate);
+
+    CREATE_TRACE_PACKET(vkUpdateDescriptorSetWithTemplateKHR, dataSize);
+    mdd(device)->devTable.UpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
+    vktrace_set_packet_entrypoint_end_time(pHeader);
+    pPacket = interpret_body_as_vkUpdateDescriptorSetWithTemplateKHR(pHeader);
+    pPacket->device = device;
+    pPacket->descriptorSet = descriptorSet;
+    pPacket->descriptorUpdateTemplate = descriptorUpdateTemplate;
+    vktrace_add_buffer_to_trace_packet(pHeader, const_cast<void**>(&(pPacket->pData)), dataSize, pData);
+    vktrace_finalize_buffer_address(pHeader, const_cast<void**>(&(pPacket->pData)));
+    if (!g_trimEnabled) {
+        FINISH_TRACE_PACKET();
+    } else {
+        FinalizeTrimUpdateDescriptorSetWithTemplate(pHeader, descriptorSet, descriptorUpdateTemplate, pData);
     }
 }
 
@@ -4685,12 +4806,10 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkWaitForFences(VkDevice
     return result;
 }
 
-VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
-     VkDevice                                    device,
-     const VkObjectTableCreateInfoNVX*           pCreateInfo,
-     const VkAllocationCallbacks*                pAllocator,
-     VkObjectTableNVX*                           pObjectTable)
-{
+VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(VkDevice device,
+                                                                               const VkObjectTableCreateInfoNVX* pCreateInfo,
+                                                                               const VkAllocationCallbacks* pAllocator,
+                                                                               VkObjectTableNVX* pObjectTable) {
     trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;
@@ -4743,10 +4862,8 @@ VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateObjectTableNVX(
     return result;
 }
 
-VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
-    VkCommandBuffer commandBuffer,
-    const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
-{
+VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL
+__HOOKED_vkCmdProcessCommandsNVX(VkCommandBuffer commandBuffer, const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo) {
     trim::TraceLock<std::mutex> lock(g_mutex_trace);
     vktrace_trace_packet_header* pHeader;
     packet_vkCmdProcessCommandsNVX* pPacket;
@@ -4788,11 +4905,8 @@ VKTRACER_EXPORT VKAPI_ATTR void VKAPI_CALL __HOOKED_vkCmdProcessCommandsNVX(
 }
 
 VKTRACER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL __HOOKED_vkCreateIndirectCommandsLayoutNVX(
-    VkDevice device,
-    const VkIndirectCommandsLayoutCreateInfoNVX* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkIndirectCommandsLayoutNVX* pIndirectCommandsLayout)
-{
+    VkDevice device, const VkIndirectCommandsLayoutCreateInfoNVX* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+    VkIndirectCommandsLayoutNVX* pIndirectCommandsLayout) {
     trim::TraceLock<std::mutex> lock(g_mutex_trace);
     VkResult result;
     vktrace_trace_packet_header* pHeader;

--- a/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_generate.cpp
@@ -658,6 +658,42 @@ vktrace_trace_packet_header *vkResetFences(bool makeCall, VkDevice device, uint3
 }
 
 //=====================================================================
+vktrace_trace_packet_header *vkResetEvent(bool makeCall, VkDevice device, VkEvent event) {
+    VkResult result = VK_SUCCESS;
+    vktrace_trace_packet_header *pHeader;
+    packet_vkResetEvent *pPacket = nullptr;
+    CREATE_TRACE_PACKET(vkResetEvent, 0);
+    if (makeCall) {
+        result = mdd(device)->devTable.ResetEvent(device, event);
+    }
+    vktrace_set_packet_entrypoint_end_time(pHeader);
+    pPacket = interpret_body_as_vkResetEvent(pHeader);
+    pPacket->device = device;
+    pPacket->event = event;
+    pPacket->result = result;
+    vktrace_finalize_trace_packet(pHeader);
+    return pHeader;
+}
+
+//=====================================================================
+vktrace_trace_packet_header *vkSetEvent(bool makeCall, VkDevice device, VkEvent event) {
+    VkResult result = VK_SUCCESS;
+    vktrace_trace_packet_header *pHeader;
+    packet_vkSetEvent *pPacket = nullptr;
+    CREATE_TRACE_PACKET(vkSetEvent, 0);
+    if (makeCall) {
+        result = mdd(device)->devTable.SetEvent(device, event);
+    }
+    vktrace_set_packet_entrypoint_end_time(pHeader);
+    pPacket = interpret_body_as_vkSetEvent(pHeader);
+    pPacket->device = device;
+    pPacket->event = event;
+    pPacket->result = result;
+    vktrace_finalize_trace_packet(pHeader);
+    return pHeader;
+}
+
+//=====================================================================
 vktrace_trace_packet_header *vkDestroyBuffer(bool makeCall, VkDevice device, VkBuffer buffer,
                                              const VkAllocationCallbacks *pAllocator) {
     vktrace_trace_packet_header *pHeader;

--- a/vktrace/vktrace_layer/vktrace_lib_trim_generate.h
+++ b/vktrace/vktrace_layer/vktrace_lib_trim_generate.h
@@ -96,6 +96,10 @@ vktrace_trace_packet_header *vkWaitForFences(bool makeCall, VkDevice device, uin
 
 vktrace_trace_packet_header *vkResetFences(bool makeCall, VkDevice device, uint32_t fenceCount, const VkFence *pFences);
 
+vktrace_trace_packet_header *vkResetEvent(bool makeCall, VkDevice device, VkEvent event);
+
+vktrace_trace_packet_header *vkSetEvent(bool makeCall, VkDevice device, VkEvent event);
+
 vktrace_trace_packet_header *vkDestroyBuffer(bool makeCall, VkDevice device, VkBuffer buffer,
                                              const VkAllocationCallbacks *pAllocator);
 

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -4159,7 +4159,40 @@ static std::unordered_map<VkDescriptorUpdateTemplateKHR, VkDescriptorUpdateTempl
     descriptorUpdateTemplateCreateInfo;
 
 VkResult vkReplay::manually_replay_vkCreateDescriptorUpdateTemplate(packet_vkCreateDescriptorUpdateTemplate *pPacket) {
-    return manually_replay_vkCreateDescriptorUpdateTemplateKHR((packet_vkCreateDescriptorUpdateTemplateKHR *)pPacket);
+    VkResult replayResult;
+    VkDescriptorUpdateTemplate local_pDescriptorUpdateTemplate;
+    VkDevice remappeddevice = m_objMapper.remap_devices(pPacket->device);
+    if (pPacket->device != VK_NULL_HANDLE && remappeddevice == VK_NULL_HANDLE) {
+        vktrace_LogError("Error detected in CreateDescriptorUpdateTemplate() due to invalid remapped VkDevice.");
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
+    *(reinterpret_cast<VkDescriptorUpdateTemplateCreateInfo **>(
+        const_cast<VkDescriptorUpdateTemplateEntry **>(&pPacket->pCreateInfo->pDescriptorUpdateEntries))) =
+        reinterpret_cast<VkDescriptorUpdateTemplateCreateInfo *>(vktrace_trace_packet_interpret_buffer_pointer(
+            pPacket->header, (intptr_t)pPacket->pCreateInfo->pDescriptorUpdateEntries));
+
+    *(const_cast<VkDescriptorSetLayout *>(&pPacket->pCreateInfo->descriptorSetLayout)) =
+        m_objMapper.remap_descriptorsetlayouts(pPacket->pCreateInfo->descriptorSetLayout);
+
+    replayResult = m_vkDeviceFuncs.CreateDescriptorUpdateTemplate(remappeddevice, pPacket->pCreateInfo, pPacket->pAllocator,
+                                                                  &local_pDescriptorUpdateTemplate);
+
+    if (replayResult == VK_SUCCESS) {
+        m_objMapper.add_to_descriptorupdatetemplates_map(*(pPacket->pDescriptorUpdateTemplate), local_pDescriptorUpdateTemplate);
+        descriptorUpdateTemplateCreateInfo[local_pDescriptorUpdateTemplate] =
+            reinterpret_cast<VkDescriptorUpdateTemplateCreateInfo *>(malloc(sizeof(VkDescriptorUpdateTemplateCreateInfo)));
+        memcpy(descriptorUpdateTemplateCreateInfo[local_pDescriptorUpdateTemplate], pPacket->pCreateInfo,
+               sizeof(VkDescriptorUpdateTemplateCreateInfo));
+        descriptorUpdateTemplateCreateInfo[local_pDescriptorUpdateTemplate]->pDescriptorUpdateEntries =
+            reinterpret_cast<VkDescriptorUpdateTemplateEntry *>(
+                malloc(sizeof(VkDescriptorUpdateTemplateEntry) * pPacket->pCreateInfo->descriptorUpdateEntryCount));
+        memcpy(const_cast<VkDescriptorUpdateTemplateEntry *>(
+                   descriptorUpdateTemplateCreateInfo[local_pDescriptorUpdateTemplate]->pDescriptorUpdateEntries),
+               pPacket->pCreateInfo->pDescriptorUpdateEntries,
+               sizeof(VkDescriptorUpdateTemplateEntry) * pPacket->pCreateInfo->descriptorUpdateEntryCount);
+    }
+    return replayResult;
 }
 
 VkResult vkReplay::manually_replay_vkCreateDescriptorUpdateTemplateKHR(packet_vkCreateDescriptorUpdateTemplateKHR *pPacket) {
@@ -4249,6 +4282,12 @@ void vkReplay::manually_replay_vkDestroyDescriptorUpdateTemplateKHR(packet_vkDes
 
 void vkReplay::remapHandlesInDescriptorSetWithTemplateData(VkDescriptorUpdateTemplateKHR remappedDescriptorUpdateTemplate,
                                                            char *pData) {
+    if (VK_NULL_HANDLE == remappedDescriptorUpdateTemplate) {
+        vktrace_LogError(
+            "Error detected in remapHandlesInDescriptorSetWithTemplateData() due to invalid remapped VkDescriptorUpdateTemplate.");
+        return;
+    }
+
     for (uint32_t i = 0; i < descriptorUpdateTemplateCreateInfo[remappedDescriptorUpdateTemplate]->descriptorUpdateEntryCount;
          i++) {
         for (uint32_t j = 0;
@@ -4315,13 +4354,13 @@ void vkReplay::manually_replay_vkUpdateDescriptorSetWithTemplate(packet_vkUpdate
     VkDescriptorUpdateTemplate remappedDescriptorUpdateTemplate =
         m_objMapper.remap_descriptorupdatetemplates(pPacket->descriptorUpdateTemplate);
     if (pPacket->descriptorUpdateTemplate != VK_NULL_HANDLE && remappedDescriptorUpdateTemplate == VK_NULL_HANDLE) {
-        vktrace_LogError(
-            "Error detected in UpdateDescriptorSetWithTemplate() due to invalid remapped VkDescriptorUpdateTemplateKHR.");
+        vktrace_LogError("Error detected in UpdateDescriptorSetWithTemplate() due to invalid remapped VkDescriptorUpdateTemplate.");
         return;
     }
 
     // Map handles inside of pData
-    remapHandlesInDescriptorSetWithTemplateData(remappedDescriptorUpdateTemplate, (char *)pPacket->pData);
+    remapHandlesInDescriptorSetWithTemplateData(remappedDescriptorUpdateTemplate,
+                                                const_cast<char *>(reinterpret_cast<const char *>(pPacket->pData)));
 
     m_vkDeviceFuncs.UpdateDescriptorSetWithTemplate(remappeddevice, remappedDescriptorSet, remappedDescriptorUpdateTemplate,
                                                     pPacket->pData);
@@ -4349,7 +4388,8 @@ void vkReplay::manually_replay_vkUpdateDescriptorSetWithTemplateKHR(packet_vkUpd
     }
 
     // Map handles inside of pData
-    remapHandlesInDescriptorSetWithTemplateData(remappedDescriptorUpdateTemplate, (char *)pPacket->pData);
+    remapHandlesInDescriptorSetWithTemplateData(remappedDescriptorUpdateTemplate,
+                                                const_cast<char *>(reinterpret_cast<const char *>(pPacket->pData)));
 
     m_vkDeviceFuncs.UpdateDescriptorSetWithTemplateKHR(remappeddevice, remappedDescriptorSet, remappedDescriptorUpdateTemplate,
                                                        pPacket->pData);


### PR DESCRIPTION
Adding trim event state recreation and update the vkGetSwapchainImagesKHR handling to fix the game random crash issues. Also, fix the black screen issues for the same game title during trace and playback by updating the descriptors update templates handling. 
