### PR TITLE
android: improve trace testing

### DIFF
--- a/build-android/vktracereplay.sh
+++ b/build-android/vktracereplay.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-#set -vex
+# Verbosity helps when triaging failures
+set -x
 
 script_start_time=$(date +%s)
 
@@ -328,8 +329,8 @@ adb $serialFlag reverse localabstract:vktrace tcp:34201
 $vktrace_exe -v full -o $package.vktrace &
 adb $serialFlag shell am start $package/$activity
 
-# don't halt on error for this loop
-set +e
+# don't halt on the errors in this loop.  don't need verbosity either.
+set +ex
 
 # wait until trace screenshot arrives, or a timeout
 vktrace_seconds=300                                    # Duration in seconds.
@@ -359,20 +360,20 @@ kill -9 $!
 # pause for a moment to let our trace file finish writing
 sleep 1
 
-# halt on errors here
-set -e
+# halt on errors here, and bring verbosity back
+set -ex
 
 # set up for vkreplay
 adb $serialFlag shell am force-stop $package
 if [ -f $package.vktrace ]; then
-    adb $serialFlag push $package.vktrace /sdcard/$package.vktrace
+    adb $serialFlag push $package.vktrace /sdcard/$package.vktrace > /dev/null
 fi
 if [ -f $package\0.vktrace ]; then
-    adb $serialFlag push $package\0.vktrace /sdcard/$package.vktrace
+    adb $serialFlag push $package\0.vktrace /sdcard/$package.vktrace > /dev/null
 fi
 
 # grab the screenshot
-adb $serialFlag pull /sdcard/Android/$frame.ppm $package.$frame.vktrace.ppm
+adb $serialFlag pull /sdcard/Android/$frame.ppm $serial.$package.$frame.vktrace.ppm > /dev/null
 adb $serialFlag shell mv /sdcard/Android/$frame.ppm /sdcard/Android/$package.$frame.vktrace.ppm
 
 # replay and screenshot
@@ -389,8 +390,8 @@ adb $serialFlag shell input keyevent "KEYCODE_HOME"
 
 adb $serialFlag shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.vkreplay/android.app.NativeActivity --es args "-v\ full\ -t\ /sdcard/$package.vktrace"
 
-# don't halt on the errors in this loop
-set +e
+# don't halt on the errors in this loop.  don't need verbosity either.
+set +ex
 
 # wait until vkreplay screenshot arrives, or a timeout
 vkreplay_seconds=300                                     # Duration in seconds.
@@ -402,6 +403,7 @@ do
 
     if [ $(date +%s) -gt $vkreplay_end_time ]
     then
+        set -x
         echo "vkreplay timeout reached: $vkreplay_seconds seconds"
         echo "No vkreplay screenshot, closing down"
         # Cleanup
@@ -412,11 +414,11 @@ do
     sleep 5
 done
 
-# halt on any errors here
-set -e
+# halt on any errors here, and be verbose again.
+set -ex
 
 # grab the screenshot
-adb $serialFlag pull /sdcard/Android/$frame.ppm $package.$frame.vkreplay.ppm
+adb $serialFlag pull /sdcard/Android/$frame.ppm $serial.$package.$frame.vkreplay.ppm > /dev/null
 adb $serialFlag shell mv /sdcard/Android/$frame.ppm /sdcard/Android/$package.$frame.vkreplay.ppm
 
 # clean up
@@ -438,15 +440,32 @@ else
     NC=''
 fi
 
-cmp -s $package.$frame.vktrace.ppm $package.$frame.vkreplay.ppm
+cmp -s $serial.$package.$frame.vktrace.ppm $serial.$package.$frame.vkreplay.ppm
 
 if [ $? -eq 0 ] ; then
-    printf "$GREEN[  PASSED  ]$NC {$apk-$package}\n"
+    printf "$GREEN[  PASSED  ]$NC {$apk-$package} identical images\n"
 else
-    printf "$RED[  FAILED  ]$NC screenshot file compare failed\n"
-    printf "$RED[  FAILED  ]$NC {$apk-$package}\n"
-    printf "TEST FAILED\n"
-    exit 1
+    # An ImageMagick comparison might work where an exact match failed.
+    # If ImageMagick is installed on the system, the output will look like:
+    #    133.176 (0.00203213)
+    # We want the value in parentheses.  Generally, a threshold of 0.01 means the
+    # images are close enough to be casually indistinguishable.
+    compare=$(which compare)
+    if [ -n "$compare" ]; then
+        metric=$($compare -metric RMSE $serial.$package.$frame.vktrace.ppm $serial.$package.$frame.vkreplay.ppm null: 2>&1 | sed -n '/^.*(\([0-9.]*\)).*$/s//\1/p')
+        # bash can't do floating-point comparison, but awk can.  Awk evaluates
+        # boolean expressions to 1 if true or 0 if false, so we need to reverse the
+        # sense of the comparison to get an exit value of 0 if good and 1 if bad.
+        if echo $metric | awk '{exit(!($1 < 0.01));}' ; then
+            printf "$GREEN[  PASSED  ]$NC {$apk-$package} similar images (RMSE=$metric)\n"
+        else
+            printf "$RED[  FAILED  ]$NC {$apk-$package} screenshot compare failed (RMSE=$metric)\n"
+            exit 1
+        fi
+    else
+        printf "$RED[  FAILED  ]$NC {$apk-$package} screenshot compare failed\n"
+        exit 1
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
We found by accident that Android devices were often failing
trace testing, but the failure indication was not getting
back to the main script, so success was always reported on
Android.  This was only on 32-bit Android builds, because
extensive trace testing is only done on 32-bit builds (because
we have no 64-bit traces).

The tests were failing in one of several ways:
- Some traces simply did not replay on some devices, and produced
  no image at all.
- Sometimes (sporadically) a screenshot image failed comparison
  testing (because the image was imperceptibly different, but was
  only being checked for being identical).

These changes have been made to both improve the testing and
to make it easier to triage failures:

- the script properly exits with a failure return code if the
  test has failed
- important parts of the script is executed with "set -x" for
  verbosity and visibility of what the script is trying to do;
  this output is swallowed by the caller if script execution
  passes (so there's no impact on normal test logs), but the
  increased verbosity is very helpful for triaging failures.
- "adb" operations which copy files to or from Android devices tend
  to be very noisy (hundreds of progress messages); these have their
  output silenced.
- images are compared using ImageMagick RMSE instead of file equality,
  if ImageMagick is available on the system.  If ImageMagic is not
  available, the behavior is as it is now.
- captured images are saved in different files for different devices.
  This allows triage to examine all the produced images.  Before,
  each device overwrote the images from earlier devices.
- The image capture directory is preserved after execution, so that
  it can be examined.  Before, it was deleted after execution.
  This isn't an issue for CI because CI deletes the whole tree before
  beginning anyway.