### PR TITLE
Fix undefined PRIxLEAST64 on CentOS6 in vk_layer_logging.h

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -21,7 +21,6 @@
  * Author: Tony Barbour <tony@lunarg.com>
  */
 
-#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
by not including inttypes.h in screenshot.cpp

I discovered this while trying to build the Vulkan SDK 1.1.106.0 on CentOS6. The following error was emitted:

In file included from .../include/vk_layer_utils.h:32:0,
                 from .../VulkanTools/layersvt/vk_layer_table.h:25,
                 from .../VulkanTools/layersvt/screenshot.cpp:42:
                 .../include/vk_layer_logging.h: In member function ‘std::string _debug_report_data::FormatHandle(uint64_t) const’:
                 .../include/vk_layer_logging.h:191:38: error: expected ‘)’ before ‘PRIxLEAST64’
         sprintf(uint64_string, "0x%" PRIxLEAST64, h);
                                      ^~~~~~~~~~~
make[2]: *** [layersvt/CMakeFiles/VkLayer_screenshot.dir/screenshot.cpp.o] Error 1

There are 2 ways to fix this:
1. define macro __STDC_FORMAT_MACROS before including inttypes.h
2. just include cinttypes

What happen here is that screenshot.cpp includes the C header inttypes.h directly without defining __STDC_FORMAT_MACROS first. Later screenshot.cpp indirectly includes vk_layer_logging.h. vk_layer_logging.h includes cinttypes properly but it has no effect as inttypes.h is already included.


There are therefore 2 solutions here:
1. Include cinttypes instead of inttypes.h in screenshot.cpp
2. Not even include inttypes.h or cinttypes are they are indirectly included by vk_layer_logging.h.

I picked solution 2.

Side note 1: I did the minimal change to fix the build issue but really screenshot.cpp should not include C header files (stdio.h, stdlib.h, string.h, assert.h) , it should include C++ wrap files instead (cstdio, cstdlib, cstring, cassert).

Side note 2: it turns out that none of the headers prior to fstream (stdio.h, stdlib.h, string.h, assert.h, unordered_map, iostream, algorithm, list, map, set, vector) are required to build screenshot.cpp successfully. They should be removed but I leave this task to the primary maintainers of this project as I may have a too narrow view of the project to make this kind of decision.
