### PR TITLE
screenshot: Use device to access correct dispatch table

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -306,7 +306,11 @@ static void populate_frame_list(const char *vk_screenshot_frames) {
     } else {
         int parsingStatus = initScreenShotFrameRange(vk_screenshot_frames, &screenShotFrameRange);
         if (parsingStatus != 0) {
+#ifdef ANDROID
+            __android_log_print(ANDROID_LOG_ERROR, "screenshot", "range error\n");
+#else
             fprintf(stderr, "Screenshot range error\n");
+#endif
         }
     }
 
@@ -1199,7 +1203,11 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
         }
     }
     if (device == NULL) {
-        printf("Screenshot layer QueuePresentKHR: device not found for queue %p\n", queue);
+#ifdef ANDROID
+        __android_log_print(ANDROID_LOG_INFO, "screenshot", "device not found for queue %p in vkQueuePresentKHR\n", queue);
+#else
+        fprintf(stderr, "Screenshot: device not found for queue %p in vkQueuePresentKHR\n", queue);
+#endif
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 


### PR DESCRIPTION
Fixes problem with gfxrecon replay of a Dawn Of War 3 trace.

The dispatch table being used was being keyed off of the queue
handle passed in to vkQueuePresentKHR. It would work because
the queue handle was the same as the device handle for a previously
destroyed device.

Changed code to figure the device associated with the passed in
queue handle and to then use that device's displatch table.

Change-Id: Id5be18f67c48a785623c266ed884af742c378aeb