### PR TITLE
vktrace: Fix trace/replay issues for some unity-based games

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -2671,6 +2671,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
         trace_vk_src += '#elif defined(PLATFORM_LINUX)\n'
         trace_vk_src += '    return;\n}\n'
         trace_vk_src += '#endif\n'
+        trace_vk_src += 'VkPhysicalDeviceMemoryProperties g_savedDevMemProps;\n'
         trace_vk_src += '\n'
 
         # Generate functions used to trace API calls and store the input and result data into a packet
@@ -2981,6 +2982,16 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                     trace_vk_src += '            vktrace_delete_trace_packet(&pHeader);\n'
                     trace_vk_src += '        }\n'
                 trace_vk_src += '    }\n'
+
+                # Save the device memory properties
+                if proto.name == "vkGetPhysicalDeviceMemoryProperties":
+                    trace_vk_src += "    g_savedDevMemProps = *pMemoryProperties;\n"
+
+                if proto.name == "vkGetPhysicalDeviceMemoryProperties2":
+                    trace_vk_src += "    g_savedDevMemProps = pMemoryProperties->memoryProperties;\n"
+
+                if proto.name == "vkGetPhysicalDeviceMemoryProperties2KHR":
+                    trace_vk_src += "    g_savedDevMemProps = pMemoryProperties->memoryProperties;\n"
 
                 # Clean up instance or device data if needed
                 if proto.name == "vkDestroyInstance":

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -460,14 +460,18 @@ VkResult vkFlushMappedMemoryRangesWithoutAPICall(VkDevice device, uint32_t memor
                 VkDeviceSize OPTPackageSizeTemp = 0;
                 if (pOPTMemoryTemp) {
                     PBYTE pOPTDataTemp = pOPTMemoryTemp->getChangedDataPackage(&OPTPackageSizeTemp);
-                    setFlagTovkFlushMappedMemoryRangesSpecial(pOPTDataTemp);
+                    if (pEntry->props & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) {
+                        setFlagTovkFlushMappedMemoryRangesSpecial(pOPTDataTemp);
+                    }
                     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->ppData[iter]), OPTPackageSizeTemp, pOPTDataTemp);
                     pOPTMemoryTemp->clearChangedDataPackage();
                     pOPTMemoryTemp->resetMemoryObjectAllChangedFlagAndPageGuard();
                 } else {
                     PBYTE pOPTDataTemp =
                         getPageGuardControlInstance().getChangedDataPackageOutOfMap(ppPackageData, iter, &OPTPackageSizeTemp);
-                    setFlagTovkFlushMappedMemoryRangesSpecial(pOPTDataTemp);
+                    if (pEntry->props & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) {
+                        setFlagTovkFlushMappedMemoryRangesSpecial(pOPTDataTemp);
+                    }
                     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->ppData[iter]), OPTPackageSizeTemp, pOPTDataTemp);
                     getPageGuardControlInstance().clearChangedDataPackageOutOfMap(ppPackageData, iter);
                 }

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -2450,6 +2450,7 @@ VkResult vkReplay::manually_replay_vkFlushMappedMemoryRanges(packet_vkFlushMappe
     VkMappedMemoryRange *localRanges = (VkMappedMemoryRange *)pPacket->pMemoryRanges;
 
     devicememoryObj *pLocalMems = VKTRACE_NEW_ARRAY(devicememoryObj, pPacket->memoryRangeCount);
+    std::set<VkDeviceMemory> flushed_mem;
     for (uint32_t i = 0; i < pPacket->memoryRangeCount; i++) {
         if (m_objMapper.m_devicememorys.find(pPacket->pMemoryRanges[i].memory) != m_objMapper.m_devicememorys.end()) {
             pLocalMems[i] = m_objMapper.m_devicememorys.find(pPacket->pMemoryRanges[i].memory)->second;
@@ -2466,6 +2467,9 @@ VkResult vkReplay::manually_replay_vkFlushMappedMemoryRanges(packet_vkFlushMappe
             VKTRACE_DELETE(pLocalMems);
             return VK_ERROR_VALIDATION_FAILED_EXT;
         }
+
+        if (flushed_mem.find(pPacket->pMemoryRanges[i].memory) != flushed_mem.end()) continue;
+        flushed_mem.insert(pPacket->pMemoryRanges[i].memory);
 
         if (!pLocalMems[i].pGpuMem->isPendingAlloc()) {
             if (pPacket->pMemoryRanges[i].size != 0) {


### PR DESCRIPTION
1. Sometimes the memory is flushed with several ranges in one call, but
the pageguard data only need be copied once time.
2. Only the coherent memory need not be flushed in the special flush
memory call.