### PR TITLE
android: interactive pauses, save logs

### DIFF
--- a/build-android/vktracereplay.sh
+++ b/build-android/vktracereplay.sh
@@ -283,6 +283,9 @@ fi
 # We want to halt on errors here
 set -e
 
+# Start up for logging
+adb $serialFlag logcat -c
+
 # Wake up the device
 adb $serialFlag shell input keyevent "KEYCODE_MENU"
 adb $serialFlag shell input keyevent "KEYCODE_HOME"
@@ -348,6 +351,7 @@ do
         adb $serialFlag shell am force-stop $package
         adb $serialFlag shell setprop debug.vulkan.layer.1 '""'
         adb $serialFlag shell setprop debug.vulkan.layer.2 '""'
+        adb $serialFlag logcat -d > $serial.$package.$frame.logcat.txt
         exit 1
     fi
 
@@ -386,7 +390,9 @@ sleep 5 # small pause to allow permission to take
 
 # Wake up the device
 adb $serialFlag shell input keyevent "KEYCODE_MENU"
+sleep 1
 adb $serialFlag shell input keyevent "KEYCODE_HOME"
+sleep 1
 
 adb $serialFlag shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.vkreplay/android.app.NativeActivity --es args "-v\ full\ -t\ /sdcard/$package.vktrace"
 
@@ -409,6 +415,7 @@ do
         # Cleanup
         adb $serialFlag shell am force-stop com.example.vkreplay
         adb $serialFlag shell setprop debug.vulkan.layer.1 '""'
+        adb $serialFlag logcat -d > $serial.$package.$frame.logcat.txt
         exit 1
     fi
     sleep 5
@@ -424,6 +431,7 @@ adb $serialFlag shell mv /sdcard/Android/$frame.ppm /sdcard/Android/$package.$fr
 # clean up
 adb $serialFlag shell am force-stop com.example.vkreplay
 adb $serialFlag shell setprop debug.vulkan.layer.1 '""'
+adb $serialFlag logcat -d > $serial.$package.$frame.logcat.txt
 
 # don't halt in the exit code below
 set +e


### PR DESCRIPTION
Android tests are showing unreliable behavior when replaying
many vktrace traces; it seems the device doesn't always recognize
when an action has started.

I've added a couple of pauses as an experiment to try to get
the test to behave more like it were being driven by a human.
This seems to make at least some of the traces more reliable.

In addition, Android log files from the execution are now
saved for later examination in case of failure (or to ensure
that the device behaved as expected).