### PR TITLE
build: Update cmake_minimum_required(VERSION 3.12.4)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -19,11 +19,11 @@ These additional packages are needed for building the components in this repo.
 
 Ubuntu 16.04 LTS and 18.04 have been tested with this repo.
 
-Continuous integration tools use [CMake 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) for Linux
+CMake [version 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) or greater is required.
 
 ```
 # Dependencies from included submodule components
-sudo apt-get install git cmake build-essential bison libx11-xcb-dev libxkbcommon-dev libwayland-dev libxrandr-dev libxcb-randr0-dev
+sudo apt-get install git build-essential bison libx11-xcb-dev libxkbcommon-dev libwayland-dev libxrandr-dev libxcb-randr0-dev
 # Additional dependencies for this repo:
 sudo apt-get install wget autotools-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-ewmh-dev
 # If performing 32-bit builds, you will also need:
@@ -42,13 +42,13 @@ sudo apt-get install qt5-default qtwebengine5-dev
 
 Fedora Core 28 and 29 were tested with this repo.
 
-Continuous integration tools use [CMake 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) for Linux
+CMake [version 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) or greater is required.
 
 Additional package dependencies include:
 
 ```
 # Dependencies from included submodule components
-sudo dnf install git cmake @development-tools glm-devel \
+sudo dnf install git @development-tools glm-devel \
                  libpng-devel wayland-devel libpciaccess-devel \
                  libX11-devel libXpresent libxcb xcb-util libxcb-devel libXrandr-devel \
                  xcb-util-keysyms-devel xcb-util-wm-devel
@@ -271,8 +271,7 @@ make -j8
 Windows 7+ with additional required software packages:
 
 - Microsoft Visual Studio 2015 Professional or 2017 Professional.  Note: it is possible that lesser/older versions may work, but not guaranteed.
-- CMake: Continuous integration tools use [CMake 3.12.2](https://github.com/Kitware/CMake/releases/tag/v3.12.2) for Windows
-  - In order to build the VkTrace tools, you need at least version 3.0.
+- CMake [version 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) or greater is required.
   - Tell the installer to "Add CMake to the system PATH" environment variable.
 - Python 3 (from https://www.python.org/downloads).  Notes:
   - Select to install the optional sub-package to add Python to the system PATH environment variable.
@@ -355,9 +354,9 @@ export PATH=$HOME/Library/Android/sdk/ndk-bundle:$PATH
 ### Additional OSX System Requirements
 Tested on OSX version 10.11.4
 
-Continuous integration tools use [CMake 3.11.3](https://github.com/Kitware/CMake/releases/tag/v3.11.3) for MacOS
+- CMake [version 3.12.4](https://github.com/Kitware/CMake/releases/tag/v3.12.4) or greater is required.
 
- Setup Homebrew and components
+Setup Homebrew and components
 - Follow instructions on [brew.sh](http://brew.sh) to get homebrew installed.
 ```
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -368,7 +367,7 @@ export PATH=/usr/local/bin:$PATH
 ```
 - Add packages with the following (may need refinement)
 ```
-brew install cmake python python3 git
+brew install python python3 git
 ```
 
 ### Build steps for Android

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")
 

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.12.4)
 
 # Validation layers could be built with code from
 #    github repo   OR

--- a/layer_factory/CMakeLists.txt
+++ b/layer_factory/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX -DWIN32_LEAN_AND_MEAN)
     set(DisplayServer Win32)

--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 
 file(GLOB IMAGES
    "${PROJECT_SOURCE_DIR}/layersvt/images/*"

--- a/via/CMakeLists-SDK.txt
+++ b/via/CMakeLists-SDK.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.4)
 
 # Define GNU standard installation directories.
 include(GNUInstallDirs)

--- a/vkconfig/CMakeLists.txt
+++ b/vkconfig/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.12.4)
 project(vkconfig)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/vktrace/CMakeLists.txt
+++ b/vktrace/CMakeLists.txt
@@ -1,5 +1,3 @@
-PROJECT(vktrace_project)
-
 #
 # cmake -DCMAKE_BUILD_TYPE=Debug ..
 #
@@ -8,7 +6,8 @@ PROJECT(vktrace_project)
 #   http://clang.llvm.org/docs/LanguageExtensions.html
 #
 #
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12.4)
+PROJECT(vktrace_project)
 
 set(BUILD_X64 "" CACHE STRING "whether to perform 64-bit build: ON or OFF overrides default detection")
 
@@ -536,13 +535,6 @@ else()
 endif()
 
 option(BUILD_VKTRACEVIEWER "Build VkTraceViewer" ON)
-
-if (BUILD_VKTRACEVIEWER)
-    # We need CMake version 3.0+ in order to "find_package(Qt5)":
-    cmake_minimum_required(VERSION 3.0)
-else ()
-    cmake_minimum_required(VERSION 2.8.11)
-endif()
 
 set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/vktrace/vktrace_common/CMakeLists.txt
+++ b/vktrace/vktrace_common/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.12.4)
 project(vktrace_common)
-cmake_minimum_required(VERSION 2.8)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)

--- a/vktrace/vktrace_dump/CMakeLists.txt
+++ b/vktrace/vktrace_dump/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12.4)
 project(vktracedump)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)

--- a/vktrace/vktrace_layer/CMakeLists.txt
+++ b/vktrace/vktrace_layer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12.4)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
    if (BUILD_WSI_XCB_SUPPORT)

--- a/vktrace/vktrace_replay/CMakeLists.txt
+++ b/vktrace/vktrace_replay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12.4)
 project(vkreplay)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)

--- a/vktrace/vktrace_trace/CMakeLists.txt
+++ b/vktrace/vktrace_trace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12.4)
 project(vktrace)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)

--- a/vktrace/vktrace_viewer/CMakeLists.txt
+++ b/vktrace/vktrace_viewer/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.12.4)
 project(vktraceviewer)
-cmake_minimum_required(VERSION 3.0)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/../)


### PR DESCRIPTION
Update both CMakeLists.txt files and documents to the new required CMake version.
This PR will not be merged to master until the CI systems are updated.

Also, cmake_minimum_required() must occur before the project() command,
see https://cmake.org/cmake/help/latest/command/project.html
