### PR TITLE
api_dump: Fixed core enums not dumping extension elements

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1703,8 +1703,25 @@ class VulkanEnum:
             childValue = child.get('value')
             childBitpos = child.get('bitpos')
             childComment = child.get('comment')
-            if childName is None or (childValue is None and childBitpos is None):
+            childExtends = child.get('extends')
+            childOffset = child.get('offset')
+            childExtNum = child.get('extnumber')
+
+            if childName is None:
                 continue
+            if (childValue is None and childBitpos is None and childOffset is None):
+                continue
+
+            if childExtends is not None and childExtNum is not None and childOffset is not None:
+                enumNegative = False
+                extNum = int(childExtNum)
+                extOffset = int(childOffset)
+                extBase      = 1000000000
+                extBlockSize = 1000
+                childValue = extBase + (extNum - 1) * extBlockSize + extOffset
+                if ('dir' in child.keys()):
+                    childValue = -childValue
+               
             # Check for duplicates, TODO: Maybe solve up a level
             duplicate = False
             for o in self.options:


### PR DESCRIPTION
Core spec enums didn't print elements that were added by an extension.

Change-Id: I4b2cb4f7eb0cc3f3805386cd23de38898967deaf