### PR TITLE
Capturing PMB by using external host memory extension

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -2636,6 +2636,11 @@ class VkTraceFileOutputGenerator(OutputGenerator):
         trace_vk_src += '#include "vktrace_trace_packet_utils.h"\n'
         trace_vk_src += '#include <stdio.h>\n'
         trace_vk_src += '#include <string.h>\n'
+        trace_vk_src += '#include "vktrace_pageguard_memorycopy.h"\n'
+        trace_vk_src += '#include "vktrace_lib_pagestatusarray.h"\n'
+        trace_vk_src += '#include "vktrace_lib_pageguardmappedmemory.h"\n'
+        trace_vk_src += '#include "vktrace_lib_pageguardcapture.h"\n'
+        trace_vk_src += '#include "vktrace_lib_pageguard.h"\n'
         trace_vk_src += '\n'
         trace_vk_src += '#ifdef WIN32\n'
         trace_vk_src += 'INIT_ONCE gInitOnce = INIT_ONCE_STATIC_INIT;\n'
@@ -2838,6 +2843,12 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 trace_vk_src += '    packet_%s* pPacket = NULL;\n' % proto.name
                 if proto.name == 'vkDestroyInstance' or proto.name == 'vkDestroyDevice':
                     trace_vk_src += '    dispatch_key key = get_dispatch_key(%s);\n' % proto.members[0].name
+                if proto.name == 'vkDestroyDevice':
+                    trace_vk_src += '#ifdef USE_PAGEGUARD_SPEEDUP\n'
+                    trace_vk_src += '    pageguardEnter();\n'
+                    trace_vk_src += '    getPageGuardControlInstance().vkDestroyDevice(%s, %s);\n' % (proto.members[0].name, proto.members[1].name)
+                    trace_vk_src += '    pageguardExit();\n'
+                    trace_vk_src += '#endif\n'
                 if proto.name == 'vkGetPhysicalDeviceSurfaceFormats2KHR':
                     trace_vk_src += '    size_t byteCount=0;\n'
                     trace_vk_src += '    uint32_t surfaceFormatCount = *pSurfaceFormatCount;\n'

--- a/vktrace/vktrace.md
+++ b/vktrace/vktrace.md
@@ -176,7 +176,7 @@ Several environment variables can be set to change the behavior of vktrace/vktra
 
  - VKTRACE_PMB_ENABLE
 
-    VKTRACE_PMB_ENABLE enables tracking of PMB if its value is 1.  Other values disable PMB tracking.  If this environment variable is not set, PMB tracking is enabled.  When creating a trace using client/server mode, set this variable to 0 when starting the client if you wish to disable PMB tracking.
+    VKTRACE_PMB_ENABLE enables tracking of PMB if its value is 1 or 2.  Other values disable PMB tracking.  Currently 2 is only used to enable using external host memory extension and memory write watch to capture PMB on Windows platform.  If this environment variable is not set, PMB tracking is enabled, same as setting VKTRACE_PMB_ENABLE to 1.  When creating a trace using client/server mode, set this variable to 0 when starting the client if you wish to disable PMB tracking.
 
  - VKTRACE_PAGEGUARD_ENABLE_READ_PMB
 

--- a/vktrace/vktrace_common/vktrace_common.h
+++ b/vktrace/vktrace_common/vktrace_common.h
@@ -67,7 +67,7 @@
 #define U_ASSERT_ONLY
 #endif
 
-static const uint32_t  INVALID_BINDING_INDEX = UINT32_MAX;
+static const uint32_t INVALID_BINDING_INDEX = UINT32_MAX;
 // Windows needs 64 bit versions of fseek and ftell
 #if defined(WIN32)
 #define Ftell _ftelli64
@@ -82,10 +82,13 @@ static const uint32_t  INVALID_BINDING_INDEX = UINT32_MAX;
 
 // Enviroment variables used by vktrace/replay
 
-// VKTRACE_PMB_ENABLE env var enables tracking of PMB if the value is 1.
+// VKTRACE_PMB_ENABLE env var enables tracking of PMB if the value is 1 or 2.
+// Currently 2 is only used to enable using external host memory extension
+// and memory write watch to capture PMB on Windows platform.
 // Other values disable PMB tracking. If this env var is undefined, PMB
 // tracking is enabled. The env var is set by the vktrace program to
 // communicate the --PMB arg value to the trace layer.
+//
 #define VKTRACE_PMB_ENABLE_ENV "VKTRACE_PMB_ENABLE"
 
 // _VKTRACE_PMB_TARGET_RANGE_SIZE env var specifies the minimum size of

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -71,6 +71,12 @@ PVOID OPTHandler = nullptr;        // use to remove page guard handler
 uint32_t OPTHandlerRefAmount = 0;  // for persistent map and multi-threading environment, map and unmap maybe overlap, we need to
                                    // make sure remove handler after all persistent map has been unmapped.
 
+// return if user using VK_EXT_external_memory_host to disable shadow memory
+bool UseMappedExternalHostMemoryExtension() {
+    // TODO: read ENV variable to decide return value.
+    return false;
+}
+
 // return if enable pageguard;
 // if enable page guard, then check if need to update target range size, page guard only work for those persistent mapped memory
 // which >= target range size.

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -73,8 +73,21 @@ uint32_t OPTHandlerRefAmount = 0;  // for persistent map and multi-threading env
 
 // return if user using VK_EXT_external_memory_host to disable shadow memory
 bool UseMappedExternalHostMemoryExtension() {
-    // TODO: read ENV variable to decide return value.
-    return false;
+    static bool use_host_memory_extension = false;
+    static bool first_time_running = true;
+    if (first_time_running) {
+        first_time_running = false;
+        const char* env_use_host_memory_extension = vktrace_get_global_var(VKTRACE_PMB_ENABLE_ENV);
+        if (env_use_host_memory_extension) {
+            int envvalue;
+            if (sscanf(env_use_host_memory_extension, "%d", &envvalue) == 1) {
+                if (envvalue == 2) {
+                    use_host_memory_extension = true;
+                }
+            }
+        }
+    }
+    return use_host_memory_extension;
 }
 
 // return if enable pageguard;

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -373,7 +373,7 @@ LONG WINAPI PageGuardExceptionHandler(PEXCEPTION_POINTERS ExceptionInfo) {
                     }
 
 #else
-                    pMappedMem->setMappedBlockChanged(index, true);
+                    pMappedMem->setMappedBlockChanged(index, true, BLOCK_FLAG_ARRAY_CHANGED);
 #endif
                 }
                 resultCode = EXCEPTION_CONTINUE_EXECUTION;

--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.h
@@ -1,19 +1,19 @@
 /*
-* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
-* Copyright (C) 2015-2017 LunarG, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2016-2019 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2015-2017 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 //  Optimization by using page-guard for speed up capture and capture persistent mapped memory
 //
@@ -89,6 +89,10 @@
     } while (0)
 
 VkDeviceSize& ref_target_range_size();
+
+// return if user using VK_EXT_external_memory_host to disable shadow memory
+bool UseMappedExternalHostMemoryExtension();
+
 bool getPageGuardEnableFlag();
 bool getEnableReadPMBFlag();
 bool getEnablePageGuardLazyCopyFlag();

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2016-2019 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <stdbool.h>
@@ -52,11 +52,39 @@ typedef class PageGuardCapture {
     std::unordered_map<VkDeviceMemory, PBYTE> MapMemoryPtr;
     std::unordered_map<VkDeviceMemory, VkDeviceSize> MapMemorySize;
     std::unordered_map<VkDeviceMemory, VkDeviceSize> MapMemoryOffset;
+    std::unordered_map<VkDeviceMemory, VkMemoryAllocateInfo> MapMemoryAllocateInfo;
+    std::unordered_map<VkDevice, VkPhysicalDevice> MapDevice;
 
    public:
     PageGuardCapture();
 
     std::unordered_map<VkDeviceMemory, PageGuardMappedMemory>& getMapMemory();
+
+    /// Get memory object to its createinfo map reference
+    std::unordered_map<VkDeviceMemory, VkMemoryAllocateInfo>& getMapMemoryAllocateInfo();
+
+    /// Get device to its physical device map reference
+    std::unordered_map<VkDevice, VkPhysicalDevice>& getMapDevice();
+
+    /// The method is used to track device creation to record what physical
+    /// device is based to create the device. It's called when target app
+    /// create device.
+    void vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                        const VkAllocationCallbacks* pAllocator, VkDevice* pDevice);
+
+    /// The method is used to maintain the device to its physical device map,
+    /// it's called when target app destroy device.
+    void vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator);
+
+    /// The method is used to track memory allocation to record what
+    /// VkMemoryAllocateInfo is based to allocate the memory. It's called when
+    /// target app allocate memory.
+    void vkAllocateMemoryPageGuardHandle(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                         const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory);
+
+    /// The method is used to maintain the memory to its createinfo map,
+    /// it's called when target app free memory.
+    void vkFreeMemoryPageGuardHandle(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator);
 
     void vkMapMemoryPageGuardHandle(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, VkFlags flags,
                                     void** ppData);

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h
@@ -54,7 +54,7 @@ typedef class PageGuardCapture {
     std::unordered_map<VkDeviceMemory, VkDeviceSize> MapMemoryOffset;
     std::unordered_map<VkDeviceMemory, VkMemoryAllocateInfo> MapMemoryAllocateInfo;
     std::unordered_map<VkDevice, VkPhysicalDevice> MapDevice;
-    std::unordered_map<VkDeviceMemory, void *> MapMemoryExtHostPointer;
+    std::unordered_map<VkDeviceMemory, void*> MapMemoryExtHostPointer;
 
    public:
     PageGuardCapture();
@@ -63,7 +63,7 @@ typedef class PageGuardCapture {
 
     /// Get memory object to its createinfo map reference
     std::unordered_map<VkDeviceMemory, VkMemoryAllocateInfo>& getMapMemoryAllocateInfo();
-    std::unordered_map<VkDeviceMemory, void *>& getMapMemoryExtHostPointer();
+    std::unordered_map<VkDeviceMemory, void*>& getMapMemoryExtHostPointer();
 
     /// Get device to its physical device map reference
     std::unordered_map<VkDevice, VkPhysicalDevice>& getMapDevice();
@@ -82,7 +82,8 @@ typedef class PageGuardCapture {
     /// VkMemoryAllocateInfo is based to allocate the memory. It's called when
     /// target app allocate memory.
     void vkAllocateMemoryPageGuardHandle(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
-                                         const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory, void *pExternalHostPointer);
+                                         const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
+                                         void* pExternalHostPointer);
 
     /// The method is used to maintain the memory to its createinfo map,
     /// it's called when target app free memory.

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.h
@@ -54,6 +54,7 @@ typedef class PageGuardCapture {
     std::unordered_map<VkDeviceMemory, VkDeviceSize> MapMemoryOffset;
     std::unordered_map<VkDeviceMemory, VkMemoryAllocateInfo> MapMemoryAllocateInfo;
     std::unordered_map<VkDevice, VkPhysicalDevice> MapDevice;
+    std::unordered_map<VkDeviceMemory, void *> MapMemoryExtHostPointer;
 
    public:
     PageGuardCapture();
@@ -62,6 +63,7 @@ typedef class PageGuardCapture {
 
     /// Get memory object to its createinfo map reference
     std::unordered_map<VkDeviceMemory, VkMemoryAllocateInfo>& getMapMemoryAllocateInfo();
+    std::unordered_map<VkDeviceMemory, void *>& getMapMemoryExtHostPointer();
 
     /// Get device to its physical device map reference
     std::unordered_map<VkDevice, VkPhysicalDevice>& getMapDevice();
@@ -80,7 +82,7 @@ typedef class PageGuardCapture {
     /// VkMemoryAllocateInfo is based to allocate the memory. It's called when
     /// target app allocate memory.
     void vkAllocateMemoryPageGuardHandle(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
-                                         const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory);
+                                         const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory, void *pExternalHostPointer);
 
     /// The method is used to maintain the memory to its createinfo map,
     /// it's called when target app free memory.
@@ -142,4 +144,5 @@ typedef class PageGuardCapture {
                             uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
                             const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
                             const VkImageMemoryBarrier* pImageMemoryBarriers);
+    VkMemoryPropertyFlags getMemoryPropertyFlags(VkDevice device, uint32_t memoryTypeIndex);
 } PageGuardCapture;

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2016-2019 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <stdbool.h>
@@ -54,7 +54,6 @@ typedef class PageGuardMappedMemory {
     uint64_t PageGuardAmount;
 
    public:
-
     PageGuardMappedMemory();
     ~PageGuardMappedMemory();
 
@@ -97,6 +96,15 @@ typedef class PageGuardMappedMemory {
     void resetMemoryObjectAllReadFlagAndPageGuard();
 
     bool setAllPageGuardAndFlag(bool bSetPageGuard, bool bSetBlockChanged);
+
+    /// Get VkMemoryPropertyFlags for a logical device and specific memoryTypeIndex
+    VkMemoryPropertyFlags getMemoryPropertyFlags(std::unordered_map<VkDevice, VkPhysicalDevice> &mapDevice, VkDevice device,
+                                                 uint32_t memoryTypeIndex);
+
+    /// Get VkMemoryPropertyFlags for this memory object.
+    bool getMemoryProperty(std::unordered_map<VkDeviceMemory, VkMemoryAllocateInfo> &mapMemoryCreateInfo,
+                           std::unordered_map<VkDevice, VkPhysicalDevice> &mapDevice, VkDeviceSize *pMemoryWholeSize,
+                           VkMemoryPropertyFlags *pMemoryPropertyFlags);
 
     bool vkMapMemoryPageGuardHandle(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, VkFlags flags,
                                     void **ppData);

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
@@ -90,6 +90,9 @@ typedef class PageGuardMappedMemory {
     uint64_t getMappedBlockOffset(uint64_t index);
 
     bool isNoMappedBlockChanged();
+#if defined(WIN32)
+    uint64_t getWriteWatchForPage(DWORD dwFlags, void *pgAddr);
+#endif
 
     void resetMemoryObjectAllChangedFlagAndPageGuard();
 

--- a/vktrace/vktrace_layer/vktrace_lib_pagestatusarray.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pagestatusarray.cpp
@@ -1,17 +1,17 @@
 /*
-* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2016-2019 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 // OPT: Optimization by using page-guard for speed up capture
 //     The speed is extremely slow when use vktrace to capture DOOM4. It took over half a day and 900G of trace for a capture from
@@ -147,3 +147,4 @@ void PageStatusArray::clearAll() {
     memset(capturedReadArray, 0, (size_t)ByteCount);
     memset(firstTimeLoadArray, 0, (size_t)ByteCount);
 }
+void PageStatusArray::clearActiveChangesArray() { memset(activeChangesArray, 0, (size_t)ByteCount); }

--- a/vktrace/vktrace_layer/vktrace_lib_pagestatusarray.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pagestatusarray.h
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2016-2019 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <stdbool.h>
@@ -53,6 +53,7 @@ typedef class PageStatusArray {
     void backupChangedArray();
     void backupReadArray();
     void clearAll();
+    void clearActiveChangesArray();
 
    private:
     const static uint64_t PAGE_FLAG_AMOUNT_PER_BYTE;


### PR DESCRIPTION
The method uses Vulkan host memory extension and memory write watch to capture PMB data on Windows platform. Usage:  set VKTRACE_PMB_ENABLE=2 to enable  PMB capture with write watch detection on target application's PMB allocated with host memory extension.