### PR TITLE
vkreplay: update vktrace_file_generator.py for new ext

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -3330,8 +3330,7 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                             or (p.name in ['pFeatures'] and 'nvx' in p.type.lower())
                             or (p.name in ['pFeatures', 'pProperties','pFormatProperties','pImageFormatInfo','pImageFormatProperties','pQueueFamilyProperties',
                                            'pMemoryProperties','pFormatInfo','pSurfaceFormats','pMemoryRequirements','pInfo',
-                                           'pSparseMemoryRequirements','pSurfaceCapabilities'] and '2khr' in p.type.lower())
-                            or (p.name in ['pSurfaceCapabilities'] and '2ext' in p.type.lower())):
+                                           'pSparseMemoryRequirements','pSurfaceCapabilities'] and '2' in p.type.lower())):
                             trace_pkt_hdr += '    if (pPacket->%s != NULL) {\n' % p.name
                             trace_pkt_hdr += '        vkreplay_process_pnext_structs(pHeader, (void *)pPacket->%s);\n' % p.name
                             trace_pkt_hdr += '    }\n'


### PR DESCRIPTION
Dota2 failed with invalid
VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT
structure during playback. Update the generator script
to include check for '2' pointer type when generating
the packet interpretation code for replay. This update fixed the
invalid pNext issue in vkGetPhysicalDeviceMemoryProperties2KHR call.

VKTRACE-119

Change-Id: Idc95ef679610fc386b6ed9fe3075b30aef010250