### PR TITLE
cmake: Use CMake 3.10.2 for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,15 +17,16 @@ os:
 environment:
   PYTHON_PATH: "C:/Python35"
   PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
+  CMAKE_URL: "http://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
 
 branches:
   only:
     - master
 
-# Install desired CMake version 3.10.2 before any other building
 install:
-  - choco upgrade cmake --version 3.10.2
-  - set path=C:\Program Files\CMake\bin;%path%
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\cmake > nul
+  - set path=C:\cmake\bin;%path%
   - cmake --version
 
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,12 @@ branches:
   only:
     - master
 
+# Install desired CMake version 3.10.2 before any other building
+install:
+  - choco upgrade cmake --version 3.10.2
+  - set path=C:\Program Files\CMake\bin;%path%
+  - cmake --version
+
 before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo.
@@ -46,7 +52,6 @@ before_build:
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build
   - cd build
-  - cmake --version
   - cmake -G %GENERATOR% -C../helper.cmake ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,18 @@ cache: ccache
 
 before_install:
   - set -e
+  # Install and use the desired CMake version
+  - CMAKE_VERSION=3.10.2
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      echo CMAKE_URL=${CMAKE_URL}
+      mkdir cmake-${CMAKE_VERSION} && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-${CMAKE_VERSION}
+      export PATH=${PWD}/cmake-${CMAKE_VERSION}/bin:${PATH}
+    else
+      brew install cmake || brew upgrade cmake
+    fi
+    cmake --version
   # Install the appropriate Linux packages.
   - |
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
@@ -79,7 +91,6 @@ script:
       python scripts/update_deps.py --config=Debug --arch=x64 $UPDATE_DEPS_EXTRA_OPTIONS
       mkdir dbuild
       pushd dbuild
-      cmake --version
       cmake -DCMAKE_BUILD_TYPE=Debug \
           -C../helper.cmake \
           ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,6 @@ script:
 notifications:
   email:
     recipients:
-      - karl@lunarg.com
       - david@lunarg.com
       - cnorthrop@google.com
     on_success: change


### PR DESCRIPTION
These changes ensure that the Travis and AppVeyor
builds use a known version of CMake.