### PR TITLE
fix blurriness on MacOS in vkconfig

### DIFF
--- a/vkconfig/macOS/Info.plist
+++ b/vkconfig/macOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Set "NSPrincipalClass" key as string "NSApplication", as detailed
in https://doc.qt.io/qt-5/highdpi.html

Tested on 2018 MacBook Pro 13 with MoltenVK on hidpi builtin LCD and 1080p TV 