### PR TITLE
vktrace: trim not working due to duplicate mutex lock

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_trace.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trace.cpp
@@ -5038,7 +5038,6 @@ VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vktraceGetDeviceProcAdd
 
 /* GDPA with no trace packet creation */
 VKTRACER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL __HOOKED_vkGetDeviceProcAddr(VkDevice device, const char* funcName) {
-    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     if (!strcmp("vkGetDeviceProcAddr", funcName)) {
         if (gMessageStream != NULL) {
             return (PFN_vkVoidFunction)vktraceGetDeviceProcAddr;
@@ -5259,5 +5258,6 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktrace
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL VK_LAYER_LUNARG_vktraceGetDeviceProcAddr(VkDevice device,
                                                                                                   const char* funcName) {
+    trim::TraceLock<std::mutex> lock(g_mutex_trace);
     return __HOOKED_vkGetDeviceProcAddr(device, funcName);
 }


### PR DESCRIPTION
Game such as Strange Brigade cannot be trimmed because
the trim crashed in vktraceGetDeviceProcAddr function
call which has duplicate mutex tracelock when it calls
another function vkGetDeviceProcAddr. This change
removes the duplicate mutex lock and ensure only one
mutex lock enabled during trim.

VKTRACE-122

Change-Id: I4401b4f9575480f867d4a0a61f433d84dca800c9