### PR TITLE
vktrace: add new structure type for vkCreateDescriptorSetLayout pNext handling and fix trim exception.

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -1488,8 +1488,9 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                                                                      '    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pPoolSizes), pCreateInfo->poolSizeCount * sizeof(VkDescriptorPoolSize), pCreateInfo->pPoolSizes)',
                                                      'finalize_txt': 'vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pCreateInfo->pPoolSizes));\n'
                                                                      '    vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pCreateInfo))'},
-                           'VkDescriptorSetLayoutCreateInfo': {'add_txt': 'add_create_ds_layout_to_trace_packet(pHeader, &pPacket->pCreateInfo, pCreateInfo)',
-                                                          'finalize_txt': '// pCreateInfo finalized in add_create_ds_layout_to_trace_packet'},
+                           'VkDescriptorSetLayoutCreateInfo': {'add_txt': 'vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkDescriptorSetLayoutCreateInfo), pCreateInfo)',
+                                                          'finalize_txt': 'add_create_ds_layout_to_trace_packet(pHeader, &pPacket->pCreateInfo, pCreateInfo);\n'
+                                                                          '    // pCreateInfo finalized in add_create_ds_layout_to_trace_packet'},
                            'VkSwapchainCreateInfoKHR': {'add_txt':      'vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo), sizeof(VkSwapchainCreateInfoKHR), pCreateInfo);\n'
                                                                         '    vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->pCreateInfo->pQueueFamilyIndices), pPacket->pCreateInfo->queueFamilyIndexCount * sizeof(uint32_t), pCreateInfo->pQueueFamilyIndices)',
                                                         'finalize_txt': 'vktrace_finalize_buffer_address(pHeader, (void**)&(pPacket->pCreateInfo->pQueueFamilyIndices));\n'

--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -393,6 +393,10 @@ void vktrace_add_pnext_structs_to_trace_packet(vktrace_trace_packet_header* pHea
                 case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
                     AddPointerWithCountToTracebuffer(VkPresentTimesInfoGOOGLE, VkPresentTimeGOOGLE, pTimes, swapchainCount);
                     break;
+                case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT:
+                    AddPointerWithCountToTracebuffer(VkDescriptorSetLayoutBindingFlagsCreateInfoEXT, VkDescriptorBindingFlagsEXT,
+                                                     pBindingFlags, bindingCount);
+
                 default:
                     // The cases in this switch statement are only those pnext struct types that have
                     // pointers inside them that need to be added. The pnext list may contain
@@ -788,6 +792,9 @@ void vkreplay_interpret_pnext_pointers(vktrace_trace_packet_header* pHeader, voi
 #endif
             case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
                 InterpretPointerInPNext(VkPresentTimesInfoGOOGLE, VkPresentTimeGOOGLE, pTimes);
+                break;
+            case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT:
+                InterpretPointerInPNext(VkDescriptorSetLayoutBindingFlagsCreateInfoEXT, VkDescriptorBindingFlagsEXT, pBindingFlags);
                 break;
             default:
                 // The cases in this switch statement are only those pnext struct types that have

--- a/vktrace/vktrace_layer/vktrace_lib_helpers.h
+++ b/vktrace/vktrace_layer/vktrace_lib_helpers.h
@@ -277,7 +277,6 @@ static void add_create_ds_layout_to_trace_packet(vktrace_trace_packet_header *pH
                                                  const VkDescriptorSetLayoutCreateInfo **ppOut,
                                                  const VkDescriptorSetLayoutCreateInfo *pIn) {
     uint32_t i;
-    vktrace_add_buffer_to_trace_packet(pHeader, (void **)(ppOut), sizeof(VkDescriptorSetLayoutCreateInfo), pIn);
     vktrace_add_buffer_to_trace_packet(pHeader, (void **)&((*ppOut)->pBindings),
                                        sizeof(VkDescriptorSetLayoutBinding) * pIn->bindingCount, pIn->pBindings);
     for (i = 0; i < pIn->bindingCount; i++) {

--- a/vktrace/vktrace_layer/vktrace_lib_trim.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_trim.cpp
@@ -183,7 +183,14 @@ void deleteImageSubResourceSizes(VkImage image) {
 VkDeviceSize getImageSize(VkImage image) {
     std::vector<VkDeviceSize> subResourceSizes;
     getImageSubResourceSizes(image, &subResourceSizes);
-    return subResourceSizes[0];
+    // Note: the image to subsresource map is created for
+    // VK_IMAGE_TILING_OPTIMAL image difference fix, the vector
+    // might be empty for other image tiling
+    if (subResourceSizes.size() > 0) {
+        return subResourceSizes[0];
+    } else {
+        return 0;
+    }
 }
 
 VkDeviceSize getImageSubResourceOffset(VkImage image, uint32_t mipLevel) {


### PR DESCRIPTION
Add VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT for vkCreateDescriptorSetLayout pNext handling and add check for valid map size before accessing the map.