### PR TITLE
scripts: Add multiple-require support to api_dump

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -738,12 +738,6 @@ inline std::ostream &dump_text_void(const void *object, const ApiDumpSettings &s
 
 inline std::ostream &dump_text_int(int object, const ApiDumpSettings &settings, int indents) { return settings.stream() << object; }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-inline std::ostream &dump_text_HMONITOR(HMONITOR object, const ApiDumpSettings &settings, int indents) {
-    return settings.stream() << object;
-}
-#endif // VK_USE_PLATFORM_WIN32_KHR
-
 //==================================== Html Backend Helpers ======================================//
 
 inline std::ostream &dump_html_nametype(std::ostream &stream, bool showType, const char *name, const char *type) {
@@ -896,11 +890,3 @@ inline std::ostream &dump_html_int(int object, const ApiDumpSettings &settings, 
     settings.stream() << object;
     return settings.stream() << "</div>";
 }
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-inline std::ostream &dump_html_HMONITOR(HMONITOR object, const ApiDumpSettings &settings, int indents) {
-    settings.stream() << "<div class='val'>";
-    settings.stream() << object;
-    return settings.stream() << "</div>";
-}
-#endif // VK_USE_PLATFORM_WIN32_KHR

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1741,15 +1741,14 @@ class VulkanExtension:
         self.constants = {}
         self.enumValues = {}
 
-        req = rootNode.find('require') # TODO: Figure out why this is None sometimes
-        if req:
-            for ty in rootNode.find('require').findall('type'):
+        for req in rootNode.findall('require'):
+            for ty in req.findall('type'):
                 self.vktypes.append(ty.get('name'))
 
-            for func in rootNode.find('require').findall('command'):
+            for func in req.findall('command'):
                 self.vkfuncs.append(func.get('name'))
 
-            for enum in rootNode.find('require').findall('enum'):
+            for enum in req.findall('enum'):
                 base = enum.get('extends')
                 name = enum.get('name')
                 value = enum.get('value')


### PR DESCRIPTION
Previously, `api_dump_generator.py` did not support commands with
multiple require blocks.

This change is required to update the Validation Layers known good for the 108 headers.