### PR TITLE
update layer settings if enabled layers are set

### DIFF
--- a/vkconfig/active_layers_widget.cpp
+++ b/vkconfig/active_layers_widget.cpp
@@ -263,6 +263,7 @@ void ActiveLayersWidget::setEnabledLayers(const QList<QString> &layers)
             }
         }
     }
+    emit enabledLayersUpdated(enabled_layers, unset_layers);
 }
 
 void ActiveLayersWidget::setExpiration(int seconds, DurationUnit unit)


### PR DESCRIPTION
Fix the case where previously-enabled layers aren't shown as enabled in Layer Settings after re-running vkconfig

Add emission of signal `enableLayersUpdated` in `ActiveLayersWidget::setEnabledLayers()`.

`ActiveLayersWidget::setEnabledLayers()` is called at initialization to set the previously-saved enabled and disabled layer lists and should update the layer settings widget by calling `LayerSettingsWidget::updateAvailableLayers()`.