### PR TITLE
vkreplay: fix playback crash due to extra pNext process call

### DIFF
--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -887,10 +887,6 @@ class VkTraceFileOutputGenerator(OutputGenerator):
                 elif 'CreateSamplerYcbcrConversion' in cmdname:
                     replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pCreateInfo);\n'
                     replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pYcbcrConversion);\n'
-                elif 'GetPhysicalDeviceFeatures2' in cmdname:
-                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pFeatures);\n'
-                elif 'GetPhysicalDeviceProperties2' in cmdname:
-                    replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pProperties);\n'
                 elif 'GetPhysicalDeviceFormatProperties2' in cmdname:
                     replay_gen_source += '            vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pFormatProperties);\n'
                 elif 'GetPhysicalDeviceImageFormatProperties2' in cmdname:

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -3050,7 +3050,6 @@ void vkReplay::manually_replay_vkGetImageMemoryRequirements2KHR(packet_vkGetImag
         ((VkImageMemoryRequirementsInfo2KHR *)pPacket->pInfo)->image = remappedimage;
     }
     vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pInfo);
-    vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pMemoryRequirements);
     m_vkDeviceFuncs.GetImageMemoryRequirements2KHR(remappeddevice, pPacket->pInfo, pPacket->pMemoryRequirements);
 
     replayGetImageMemoryRequirements[remappedimage] = pPacket->pMemoryRequirements->memoryRequirements;
@@ -3108,7 +3107,6 @@ void vkReplay::manually_replay_vkGetBufferMemoryRequirements2KHR(packet_vkGetBuf
     *((VkBuffer *)(&pPacket->pInfo->buffer)) = remappedBuffer;
 
     vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pInfo);
-    vkreplay_process_pnext_structs(pPacket->header, (void *)pPacket->pMemoryRequirements);
     m_vkDeviceFuncs.GetBufferMemoryRequirements2KHR(remappedDevice, pPacket->pInfo, pPacket->pMemoryRequirements);
     replayGetBufferMemoryRequirements[pPacket->pInfo->buffer] = pPacket->pMemoryRequirements->memoryRequirements;
     return;


### PR DESCRIPTION
Remove extra pNext process call as the process pNext already handled in the vktrace_vk_vk_packets.h due to previous fix to the header file generation script.