### PR TITLE
vktrace: fix error of generating invalid data pointer in trace packet

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguard.cpp
@@ -459,7 +459,9 @@ VkResult vkFlushMappedMemoryRangesWithoutAPICall(VkDevice device, uint32_t memor
 
     // insert into packet the data that was written by CPU between the vkMapMemory call and here
     // create a temporary local ppData array and add it to the packet (to reserve the space for the array)
-    void** ppTmpData = (void**)malloc(memoryRangeCount * sizeof(void*));
+    void** ppTmpData = reinterpret_cast<void**>(vktrace_malloc(memoryRangeCount * sizeof(void*)));
+    memset(ppTmpData, 0, (size_t)memoryRangeCount * sizeof(void*));
+
     vktrace_add_buffer_to_trace_packet(pHeader, (void**)&(pPacket->ppData), sizeof(void*) * memoryRangeCount, ppTmpData);
     free(ppTmpData);
 

--- a/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.cpp
@@ -2428,8 +2428,9 @@ void vkReplay::manually_replay_vkUnmapMemory(packet_vkUnmapMemory *pPacket) {
 BOOL isvkFlushMappedMemoryRangesSpecial(PBYTE pOPTPackageData) {
     BOOL bRet = FALSE;
     PageGuardChangedBlockInfo *pChangedInfoArray = (PageGuardChangedBlockInfo *)pOPTPackageData;
-    if (((uint64_t)pChangedInfoArray[0].reserve0) &
-        PAGEGUARD_SPECIAL_FORMAT_PACKET_FOR_VKFLUSHMAPPEDMEMORYRANGES)  // TODO need think about 32bit
+    if ((pOPTPackageData == nullptr) ||
+        ((static_cast<uint64_t>(pChangedInfoArray[0].reserve0)) &
+         PAGEGUARD_SPECIAL_FORMAT_PACKET_FOR_VKFLUSHMAPPEDMEMORYRANGES))  // TODO need think about 32bit
     {
         bRet = TRUE;
     }


### PR DESCRIPTION
The change add missing init process for an allocated memory, it cause wrong
data pointer generated in trace packet and playback crash. The change fix
the problem.

VKTRACE-135
Change-Id: I258d4d5d5eff10798c4e97ba28f890511f7f44f5