### PR TITLE
vktrace: Fix an issue of PMB host memory capture

### DIFF
--- a/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardcapture.cpp
@@ -78,7 +78,12 @@ void PageGuardCapture::vkMapMemoryPageGuardHandle(VkDevice device, VkDeviceMemor
         if (size >= ref_target_range_size())
 #endif
         {
-            OPTmappedmem.vkMapMemoryPageGuardHandle(device, memory, offset, size, flags, ppData);
+            void* pExternalHostMemory = nullptr;
+            auto iteratorExtPointer = MapMemoryExtHostPointer.find(memory);
+            if (iteratorExtPointer != MapMemoryExtHostPointer.end()) {
+                pExternalHostMemory = iteratorExtPointer->second;
+            }
+            OPTmappedmem.vkMapMemoryPageGuardHandle(device, memory, offset, size, flags, ppData, pExternalHostMemory);
             MapMemory[memory] = OPTmappedmem;
         }
     }

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.cpp
@@ -370,7 +370,7 @@ bool PageGuardMappedMemory::vkMapMemoryPageGuardHandle(VkDevice device, VkDevice
         *ppData = pMappedData;
     } else {
         pMappedData = reinterpret_cast<PBYTE>(*ppData);
-        StartingAddressOffset = (pMappedData-pExternalHostMemory)% PageGuardSize;
+        StartingAddressOffset = (pMappedData - reinterpret_cast<PBYTE>(pExternalHostMemory)) % PageGuardSize;
     }
 
     MappedSize = size;

--- a/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
+++ b/vktrace/vktrace_layer/vktrace_lib_pageguardmappedmemory.h
@@ -51,6 +51,8 @@ typedef class PageGuardMappedMemory {
     PageStatusArray *pPageStatus;
     bool BlockConflictError;  /// record if any block has been read by host and also write by host
     VkDeviceSize PageSizeLeft;
+    VkDeviceSize StartingAddressOffset;  /// the offset relative to the beginning of a system page where the starting address of the
+                                         /// mapped memory (returned to target title) located.
     uint64_t PageGuardAmount;
 
    public:
@@ -110,7 +112,7 @@ typedef class PageGuardMappedMemory {
                            VkMemoryPropertyFlags *pMemoryPropertyFlags);
 
     bool vkMapMemoryPageGuardHandle(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, VkFlags flags,
-                                    void **ppData);
+                                    void **ppData, void *pExternalHostMemory = nullptr);
 
     void vkUnmapMemoryPageGuardHandle(VkDevice device, VkDeviceMemory memory, void **MappedData);
 


### PR DESCRIPTION
Mapped shadow memory start from a system page starting address is a basic
assumption in PMB capture code, but for PMB host memory capture, it's not
true any more, it cause the changed page status doesn't match the changed
page index and cause wrong write/read in trace file packet and sometimes
crash in capture. The change fix the problem.

VKTRACE-135

Change-Id: I3353632160f064efd06c498f615562e3ef1b22a3