### PR TITLE
Camden gh24 skip get call check

### DIFF
--- a/layer_factory/assistant_layer/interceptor_objects.h
+++ b/layer_factory/assistant_layer/interceptor_objects.h
@@ -26,3 +26,4 @@
 #include "exclusive_qfi.h"
 #include "api_version_warning.h"
 #include "result_check.h"
+#include "skip_get_call_warning.h"

--- a/layer_factory/assistant_layer/skip_get_call_warning.cpp
+++ b/layer_factory/assistant_layer/skip_get_call_warning.cpp
@@ -1,16 +1,119 @@
 #include "skip_get_call_warning.h"
 #include <sstream>
+#include <iostream>
 
+// TODO: REMOVE METHOD. THIS IS JUST FOR TESTING
 void SkipGetCallWarning::PreCallApiFunction(const char *api_name) { printf("Calling %s\n", api_name); }
 
 PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState() { return physical_device_state; }
-PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhyscialDeviceState(VkPhysicalDevice pd) {
+
+PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState(VkPhysicalDevice pd) {
     auto *phys_dev_map = &physical_device_map;
     auto physicalDevice = phys_dev_map->find(pd);
     if (physicalDevice == phys_dev_map->end()) {
         return nullptr;
     }
     return &physicalDevice->second;
+}
+
+// Populate physical_device_map with al the Physical Devices
+VkResult SkipGetCallWarning::PostCallEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                              VkPhysicalDevice* pPhysicalDevices, VkResult result) {
+    if ((pPhysicalDevices != NULL) && ((result == VK_SUCCESS || result == VK_INCOMPLETE))) {
+        for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
+            // TODO: Look at moving this to the [] accessor. Less readable but better complexity maybe.
+            PHYSICAL_DEVICE_STATE pd_state;
+            physical_device_map.insert(std::make_pair(pPhysicalDevices[i], pd_state));
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+void SkipGetCallWarning::PreCallGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures* pFeatures) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    physical_device_state->vkGetPhysicalDeviceFeaturesState = QUERY_DETAILS;
+}
+
+// need to set the physical_device_state when creating device to access the state for API Calls that do not have a physicalDevice
+// handle
+VkResult SkipGetCallWarning::PreCallCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+    auto pd_state = GetPhysicalDeviceState(physicalDevice);
+    physical_device_state = pd_state;
+
+    if (pd_state->vkGetPhysicalDeviceFeaturesState == UNCALLED) {
+        std::stringstream message;
+        message << "vkCreateDevice caled before getting physical device features from vkGetPhysicalDeviceFeatures().";
+        Warning(message.str());
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult SkipGetCallWarning::PreCallGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                                            VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = QUERY_DETAILS;
+
+    return VK_SUCCESS;
+}
+
+VkResult SkipGetCallWarning::PreCallGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                                            uint32_t* pPresentModeCount,
+                                                                            VkPresentModeKHR* pPresentModes) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    auto& call_state = physical_device_state->vkGetPhysicalDeviceSurfacePresentModesKHRState;
+
+    if (!pPresentModes) {
+        if (call_state == UNCALLED) call_state = QUERY_COUNT;
+    } else {
+        call_state = QUERY_DETAILS;
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult SkipGetCallWarning::PreCallGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                                       uint32_t* pSurfaceFormatCount,
+                                                                       VkSurfaceFormatKHR* pSurfaceFormats) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    auto& call_state = physical_device_state->vkGetPhysicalDeviceSurfaceFormatsKHRState;
+
+    if (!pSurfaceFormats) {
+        if (call_state == UNCALLED) call_state = QUERY_COUNT;
+    } else {
+        call_state = QUERY_DETAILS;
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult SkipGetCallWarning::PreCallCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) {
+    auto physical_device_state = GetPhysicalDeviceState();
+
+    if (physical_device_state->vkGetPhysicalDeviceSurfaceCapabilitiesKHRState == UNCALLED) {
+        std::stringstream message;
+        message
+            << "vkCreateSwapchainKHR called before getting surface capabilites from vkGetPhysicalDeviceSurfaceCapabilitiesKHR().";
+        Warning(message.str());
+    }
+
+    if (physical_device_state->vkGetPhysicalDeviceSurfacePresentModesKHRState != QUERY_DETAILS) {
+        std::stringstream message;
+        message << "vkCreateSwapchainKHR called before getting surface present mode(s) from "
+                   "vkGetPhysicalDeviceSurfacePresentModesKHR().";
+        Warning(message.str());
+    }
+
+    if (physical_device_state->vkGetPhysicalDeviceSurfaceFormatsKHRState != QUERY_DETAILS) {
+        std::stringstream message;
+        message << "vkCreateSwapchainKHR called before getting surface format(s) from vkGetPhysicalDeviceSurfaceFormatsKHR().";
+        Warning(message.str());
+    }
+
+    return VK_SUCCESS;
 }
 
 SkipGetCallWarning skip_get_call_warning;

--- a/layer_factory/assistant_layer/skip_get_call_warning.cpp
+++ b/layer_factory/assistant_layer/skip_get_call_warning.cpp
@@ -1,0 +1,16 @@
+#include "skip_get_call_warning.h"
+#include <sstream>
+
+void SkipGetCallWarning::PreCallApiFunction(const char *api_name) { printf("Calling %s\n", api_name); }
+
+PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState() { return physical_device_state; }
+PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhyscialDeviceState(VkPhysicalDevice pd) {
+    auto *phys_dev_map = &physical_device_map;
+    auto physicalDevice = phys_dev_map->find(pd);
+    if (physicalDevice == phys_dev_map->end()) {
+        return nullptr;
+    }
+    return &physicalDevice->second;
+}
+
+SkipGetCallWarning skip_get_call_warning;

--- a/layer_factory/assistant_layer/skip_get_call_warning.cpp
+++ b/layer_factory/assistant_layer/skip_get_call_warning.cpp
@@ -2,9 +2,6 @@
 #include <sstream>
 #include <iostream>
 
-// TODO: REMOVE METHOD. THIS IS JUST FOR TESTING
-void SkipGetCallWarning::PreCallApiFunction(const char *api_name) { printf("Calling %s\n", api_name); }
-
 PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState() { return physical_device_state; }
 
 PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState(VkPhysicalDevice pd) {
@@ -16,12 +13,21 @@ PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState(VkPhysicalDevi
     return &physicalDevice->second;
 }
 
+// helper function that sets the state of any get call that has a count check as well
+template <typename T, typename S>
+void SetStateWithCount(T& call_state, S pStruct) {
+    if (!pStruct) {
+        if (call_state == UNCALLED) call_state = QUERY_COUNT;
+    } else {
+        call_state = QUERY_DETAILS;
+    }
+}
+
 // Populate physical_device_map with al the Physical Devices
 VkResult SkipGetCallWarning::PostCallEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                               VkPhysicalDevice* pPhysicalDevices, VkResult result) {
     if ((pPhysicalDevices != NULL) && ((result == VK_SUCCESS || result == VK_INCOMPLETE))) {
         for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {
-            // TODO: Look at moving this to the [] accessor. Less readable but better complexity maybe.
             PHYSICAL_DEVICE_STATE pd_state;
             physical_device_map.insert(std::make_pair(pPhysicalDevices[i], pd_state));
         }
@@ -42,9 +48,9 @@ VkResult SkipGetCallWarning::PreCallCreateDevice(VkPhysicalDevice physicalDevice
     auto pd_state = GetPhysicalDeviceState(physicalDevice);
     physical_device_state = pd_state;
 
-    if (pd_state->vkGetPhysicalDeviceFeaturesState == UNCALLED) {
+    if ((pd_state->vkGetPhysicalDeviceFeaturesState == UNCALLED) && (pCreateInfo->pEnabledFeatures != NULL)) {
         std::stringstream message;
-        message << "vkCreateDevice caled before getting physical device features from vkGetPhysicalDeviceFeatures().";
+        message << "vkCreateDevice called before getting physical device features from vkGetPhysicalDeviceFeatures().";
         Warning(message.str());
     }
 
@@ -65,11 +71,7 @@ VkResult SkipGetCallWarning::PreCallGetPhysicalDeviceSurfacePresentModesKHR(VkPh
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     auto& call_state = physical_device_state->vkGetPhysicalDeviceSurfacePresentModesKHRState;
 
-    if (!pPresentModes) {
-        if (call_state == UNCALLED) call_state = QUERY_COUNT;
-    } else {
-        call_state = QUERY_DETAILS;
-    }
+    SetStateWithCount(call_state, pPresentModes);
 
     return VK_SUCCESS;
 }
@@ -80,15 +82,12 @@ VkResult SkipGetCallWarning::PreCallGetPhysicalDeviceSurfaceFormatsKHR(VkPhysica
     auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
     auto& call_state = physical_device_state->vkGetPhysicalDeviceSurfaceFormatsKHRState;
 
-    if (!pSurfaceFormats) {
-        if (call_state == UNCALLED) call_state = QUERY_COUNT;
-    } else {
-        call_state = QUERY_DETAILS;
-    }
+    SetStateWithCount(call_state, pSurfaceFormats);
 
     return VK_SUCCESS;
 }
 
+// check that makes sure all necessary get calls are made before creating the swapchain
 VkResult SkipGetCallWarning::PreCallCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) {
     auto physical_device_state = GetPhysicalDeviceState();
@@ -110,6 +109,91 @@ VkResult SkipGetCallWarning::PreCallCreateSwapchainKHR(VkDevice device, const Vk
     if (physical_device_state->vkGetPhysicalDeviceSurfaceFormatsKHRState != QUERY_DETAILS) {
         std::stringstream message;
         message << "vkCreateSwapchainKHR called before getting surface format(s) from vkGetPhysicalDeviceSurfaceFormatsKHR().";
+        Warning(message.str());
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult SkipGetCallWarning::PreCallGetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice,
+                                                                               uint32_t* pPropertyCount,
+                                                                               VkDisplayPlanePropertiesKHR* pProperties) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    auto& call_state = physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState;
+
+    SetStateWithCount(call_state, pProperties);
+
+    return VK_SUCCESS;
+}
+
+VkResult SkipGetCallWarning::PreCallGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
+                                                                        uint32_t* pDisplayCount, VkDisplayKHR* pDisplays) {
+    auto physical_device_state = GetPhysicalDeviceState();
+
+    if (physical_device_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHRState != QUERY_DETAILS) {
+        std::stringstream message;
+        message << "vkGetDisplayPlaneSupportedDiesplaysKHR called before getting diplay plane properties from "
+                   "vkGetPhysicalDeviceDisplayPlanePropertiesKHR().";
+        Warning(message.str());
+    }
+
+    return VK_SUCCESS;
+}
+
+void SkipGetCallWarning::PreCallGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice,
+                                                                  VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
+    auto physical_device_state = GetPhysicalDeviceState(physicalDevice);
+    physical_device_state->vkGetPhysicalDeviceMemoryPropertiesState = QUERY_DETAILS;
+}
+
+VkResult SkipGetCallWarning::PreCallAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory) {
+    auto physical_device_state = GetPhysicalDeviceState();
+
+    if (physical_device_state->vkGetPhysicalDeviceMemoryPropertiesState == UNCALLED) {
+        std::stringstream message;
+        message << "vkAllocateMemory called before retrieving memoryHeaps[pAllocateInfo->memoryTypeIndex].size and memoryTypeCount "
+                   "from vkGetPhysicalDeviceMemoryProperties().";
+        Warning(message.str());
+    }
+
+    return VK_SUCCESS;
+}
+
+void SkipGetCallWarning::PreCallGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer,
+                                                            VkMemoryRequirements* pMemoryRequirements) {
+    auto physical_device_state = GetPhysicalDeviceState();
+    physical_device_state->vkGetBufferMemoryRequirementsState = QUERY_DETAILS;
+}
+
+void SkipGetCallWarning::PreCallGetImageMemoryRequirements(VkDevice device, VkImage image,
+                                                           VkMemoryRequirements* pMemoryRequirements) {
+    auto physical_device_state = GetPhysicalDeviceState();
+    physical_device_state->vkGetImageMemoryRequirementsState = QUERY_DETAILS;
+}
+
+VkResult SkipGetCallWarning::PreCallBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
+                                                     VkDeviceSize memoryOffset) {
+    auto physical_device_state = GetPhysicalDeviceState();
+
+    if (physical_device_state->vkGetBufferMemoryRequirementsState == UNCALLED) {
+        std::stringstream message;
+        message << "vkBindBufferMemory called before retrieving memoryTypeBits, alignment, and size in the VkMemoryRequirements "
+                   "structure returned from vkGetBufferMemoryRequirements().";
+        Warning(message.str());
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult SkipGetCallWarning::PreCallBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory,
+                                                    VkDeviceSize memoryOffset) {
+    auto physical_device_state = GetPhysicalDeviceState();
+
+    if (physical_device_state->vkGetImageMemoryRequirementsState == UNCALLED) {
+        std::stringstream message;
+        message << "vkBindImageMemory called before retrieving memoryTypeBits, alignment, and size in the VkMemoryRequirements "
+                   "structure returned fro vkGetImagememoryRequirements().";
         Warning(message.str());
     }
 

--- a/layer_factory/assistant_layer/skip_get_call_warning.cpp
+++ b/layer_factory/assistant_layer/skip_get_call_warning.cpp
@@ -2,10 +2,10 @@
 #include <sstream>
 #include <iostream>
 
-PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState() { return physical_device_state; }
+PHYSICAL_DEVICE_STATE* SkipGetCallWarning::GetPhysicalDeviceState() { return physical_device_state; }
 
-PHYSICAL_DEVICE_STATE *SkipGetCallWarning::GetPhysicalDeviceState(VkPhysicalDevice pd) {
-    auto *phys_dev_map = &physical_device_map;
+PHYSICAL_DEVICE_STATE* SkipGetCallWarning::GetPhysicalDeviceState(VkPhysicalDevice pd) {
+    auto* phys_dev_map = &physical_device_map;
     auto physicalDevice = phys_dev_map->find(pd);
     if (physicalDevice == phys_dev_map->end()) {
         return nullptr;
@@ -23,7 +23,7 @@ void SetStateWithCount(T& call_state, S pStruct) {
     }
 }
 
-// Populate physical_device_map with al the Physical Devices
+// Populate physical_device_map with all the Physical Devices
 VkResult SkipGetCallWarning::PostCallEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                               VkPhysicalDevice* pPhysicalDevices, VkResult result) {
     if ((pPhysicalDevices != NULL) && ((result == VK_SUCCESS || result == VK_INCOMPLETE))) {

--- a/layer_factory/assistant_layer/skip_get_call_warning.h
+++ b/layer_factory/assistant_layer/skip_get_call_warning.h
@@ -17,9 +17,9 @@ struct PHYSICAL_DEVICE_STATE {
     // Track the call state and array sizes for various query functions
     CALL_STATE vkGetPhysicalDeviceQueueFamilyPropertiesState = UNCALLED;
     // not used
-    CALL_STATE vkGetPhysicalDeviceLayerPropertiesState = UNCALLED;
-    CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState = UNCALLED;
-    CALL_STATE vkGetPhysicalDeviceFeaturesState = UNCALLED;
+    CALL_STATE vkGetPhysicalDeviceLayerPropertiesState = UNCALLED;      // depracated
+    CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState = UNCALLED;  // not sure
+    CALL_STATE vkGetPhysicalDeviceFeaturesState = UNCALLED;             // needs to be called before vkCreateDevice
     // end not used
     CALL_STATE vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfacePresentModesKHRState = UNCALLED;
@@ -35,7 +35,23 @@ class SkipGetCallWarning : public layer_factory {
     void PreCallApiFunction(const char *api_name);
 
     PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState();
-    PHYSICAL_DEVICE_STATE *GetPhyscialDeviceState(VkPhysicalDevice pd);
+    PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState(VkPhysicalDevice pd);
+
+    VkResult PostCallEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                              VkPhysicalDevice* pPhysicalDevices, VkResult result);
+
+    void PreCallGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures* pFeatures);
+    VkResult PreCallCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                 const VkAllocationCallbacks* pAllocator, VkDevice* pDevice);
+
+    VkResult PreCallGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                            VkSurfaceCapabilitiesKHR* pSurfaceCapabilities);
+    VkResult PreCallGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                            uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
+    VkResult PreCallGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                       uint32_t* pSurfaceFormatCount, VkSurfaceFormatKHR* pSurfaceFormats);
+    VkResult PreCallCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain);
 
    private:
     PHYSICAL_DEVICE_STATE *physical_device_state;

--- a/layer_factory/assistant_layer/skip_get_call_warning.h
+++ b/layer_factory/assistant_layer/skip_get_call_warning.h
@@ -31,8 +31,8 @@ class SkipGetCallWarning : public layer_factory {
     SkipGetCallWarning(){};
 
     // getters for the physical device state
-    PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState();
-    PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState(VkPhysicalDevice pd);
+    PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState();
+    PHYSICAL_DEVICE_STATE* GetPhysicalDeviceState(VkPhysicalDevice pd);
 
     VkResult PostCallEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                               VkPhysicalDevice* pPhysicalDevices, VkResult result);
@@ -67,6 +67,6 @@ class SkipGetCallWarning : public layer_factory {
     VkResult PreCallBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
    private:
-    PHYSICAL_DEVICE_STATE *physical_device_state;
+    PHYSICAL_DEVICE_STATE* physical_device_state;
     std::unordered_map<VkPhysicalDevice, PHYSICAL_DEVICE_STATE> physical_device_map;
 };

--- a/layer_factory/assistant_layer/skip_get_call_warning.h
+++ b/layer_factory/assistant_layer/skip_get_call_warning.h
@@ -14,17 +14,15 @@ enum CALL_STATE {
 
 // pulled from KhronosGroup/Validation-Layers
 struct PHYSICAL_DEVICE_STATE {
-    // Track the call state and array sizes for various query functions
-    CALL_STATE vkGetPhysicalDeviceQueueFamilyPropertiesState = UNCALLED;
-    // not used
-    CALL_STATE vkGetPhysicalDeviceLayerPropertiesState = UNCALLED;      // depracated
-    CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState = UNCALLED;  // not sure
-    CALL_STATE vkGetPhysicalDeviceFeaturesState = UNCALLED;             // needs to be called before vkCreateDevice
-    // end not used
+    CALL_STATE vkGetPhysicalDeviceFeaturesState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfacePresentModesKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceSurfaceFormatsKHRState = UNCALLED;
     CALL_STATE vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = UNCALLED;
+
+    CALL_STATE vkGetPhysicalDeviceMemoryPropertiesState = UNCALLED;
+    CALL_STATE vkGetBufferMemoryRequirementsState = UNCALLED;
+    CALL_STATE vkGetImageMemoryRequirementsState = UNCALLED;
 };
 
 class SkipGetCallWarning : public layer_factory {
@@ -32,8 +30,7 @@ class SkipGetCallWarning : public layer_factory {
     // Constructor for state_tracker
     SkipGetCallWarning(){};
 
-    void PreCallApiFunction(const char *api_name);
-
+    // getters for the physical device state
     PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState();
     PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState(VkPhysicalDevice pd);
 
@@ -52,6 +49,22 @@ class SkipGetCallWarning : public layer_factory {
                                                        uint32_t* pSurfaceFormatCount, VkSurfaceFormatKHR* pSurfaceFormats);
     VkResult PreCallCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain);
+
+    VkResult PreCallGetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                               VkDisplayPlanePropertiesKHR* pProperties);
+    VkResult PreCallGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
+                                                        uint32_t* pDisplayCount, VkDisplayKHR* pDisplays);
+
+    void PreCallGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice,
+                                                  VkPhysicalDeviceMemoryProperties* pMemoryProperties);
+    VkResult PreCallAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory);
+
+    void PreCallGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements);
+    void PreCallGetImageMemoryRequirements(VkDevice device, VkImage image, VkMemoryRequirements* pMemoryRequirements);
+
+    VkResult PreCallBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
+    VkResult PreCallBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
    private:
     PHYSICAL_DEVICE_STATE *physical_device_state;

--- a/layer_factory/assistant_layer/skip_get_call_warning.h
+++ b/layer_factory/assistant_layer/skip_get_call_warning.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <unordered_map>
+#include "vulkan/vulkan.h"
+#include "vk_layer_logging.h"
+#include "layer_factory.h"
+
+// pulled from KhronosGroup/Validation-Layers
+enum CALL_STATE {
+    UNCALLED,       // Function has not been called
+    QUERY_COUNT,    // Function called once to query a count
+    QUERY_DETAILS,  // Function called w/ a count to query details
+};
+
+// pulled from KhronosGroup/Validation-Layers
+struct PHYSICAL_DEVICE_STATE {
+    // Track the call state and array sizes for various query functions
+    CALL_STATE vkGetPhysicalDeviceQueueFamilyPropertiesState = UNCALLED;
+    // not used
+    CALL_STATE vkGetPhysicalDeviceLayerPropertiesState = UNCALLED;
+    CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState = UNCALLED;
+    CALL_STATE vkGetPhysicalDeviceFeaturesState = UNCALLED;
+    // end not used
+    CALL_STATE vkGetPhysicalDeviceSurfaceCapabilitiesKHRState = UNCALLED;
+    CALL_STATE vkGetPhysicalDeviceSurfacePresentModesKHRState = UNCALLED;
+    CALL_STATE vkGetPhysicalDeviceSurfaceFormatsKHRState = UNCALLED;
+    CALL_STATE vkGetPhysicalDeviceDisplayPlanePropertiesKHRState = UNCALLED;
+};
+
+class SkipGetCallWarning : public layer_factory {
+   public:
+    // Constructor for state_tracker
+    SkipGetCallWarning(){};
+
+    void PreCallApiFunction(const char *api_name);
+
+    PHYSICAL_DEVICE_STATE *GetPhysicalDeviceState();
+    PHYSICAL_DEVICE_STATE *GetPhyscialDeviceState(VkPhysicalDevice pd);
+
+   private:
+    PHYSICAL_DEVICE_STATE *physical_device_state;
+    std::unordered_map<VkPhysicalDevice, PHYSICAL_DEVICE_STATE> physical_device_map;
+};


### PR DESCRIPTION
resolves issue within tracking issue KhronosGroup/Vulkan-ValidationLayers#24 that states "Warn for skipping Get calls -- GetBufferMemoryRequirements, GetImageMemoryRequirements, etc."

Note: I may have missed a few "get call" warnings so feel free to suggest anything missing. At the very least, the architecture is setup to easily add more warnings in the future.