### PR TITLE
Memory Freed While Still Bound Warning

### DIFF
--- a/layer_factory/assistant_layer/interceptor_objects.h
+++ b/layer_factory/assistant_layer/interceptor_objects.h
@@ -27,3 +27,4 @@
 #include "api_version_warning.h"
 #include "result_check.h"
 #include "skip_get_call_warning.h"
+#include "mem_bound_warning.h"

--- a/layer_factory/assistant_layer/mem_bound_warning.cpp
+++ b/layer_factory/assistant_layer/mem_bound_warning.cpp
@@ -1,0 +1,205 @@
+#include "mem_bound_warning.h"
+#include <iostream>
+
+VkResult MemBoundWarning::PostCallAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
+                                                 const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory,
+                                                 VkResult result) {
+    if (result == VK_SUCCESS) {
+        // create new memory entry into the map but give it no values
+        std::unordered_set<uint64_t> set;
+        memory_handle_map.insert(std::make_pair(*pMemory, set));
+    }
+
+    return VK_SUCCESS;
+}
+
+// helper function that update all the dictionaries for both image and buffer handles
+template <typename T>
+void MemBoundWarning::SetBindMemoryState(T handle, VkDeviceMemory memory) {
+    uint64_t handle_64 = HandleToUint64(handle);
+
+    if (memory != VK_NULL_HANDLE) {
+        // If the entry does not exist yet, then create it
+        if (handle_memory_map.count(handle_64) <= 0) {
+            std::unordered_set<VkDeviceMemory> set;
+            handle_memory_map.insert(std::make_pair(handle_64, set));
+        }
+
+        // insert the memory and handle into their respective maps
+        auto &memory_set = handle_memory_map.find(handle_64)->second;
+        memory_set.insert(memory);
+
+        auto &handle_set = memory_handle_map.find(memory)->second;
+        handle_set.insert(handle_64);
+    }
+}
+
+// 3 buffer memory state tracker entry points
+VkResult MemBoundWarning::PostCallBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
+                                                   VkDeviceSize memoryOffset, VkResult result) {
+    if (result == VK_SUCCESS) SetBindMemoryState<VkBuffer>(buffer, memory);
+
+    return VK_SUCCESS;
+}
+
+VkResult MemBoundWarning::PostCallBindBufferMemory2(VkDevice device, uint32_t bindInfoCount,
+                                                    const VkBindBufferMemoryInfo *pBindInfos, VkResult result) {
+    if (result == VK_SUCCESS) {
+        for (uint32_t i = 0; i < bindInfoCount; i++) {
+            SetBindMemoryState<VkBuffer>(pBindInfos[i].buffer, pBindInfos[i].memory);
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult MemBoundWarning::PostCallBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount,
+                                                       const VkBindBufferMemoryInfo *pBindInfos, VkResult result) {
+    if (result == VK_SUCCESS) {
+        for (uint32_t i = 0; i < bindInfoCount; i++) {
+            SetBindMemoryState<VkBuffer>(pBindInfos[i].buffer, pBindInfos[i].memory);
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+// 3 buffer memory state tracker entry points
+VkResult MemBoundWarning::PostCallBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
+                                                  VkResult result) {
+    if (result == VK_SUCCESS) SetBindMemoryState<VkImage>(image, memory);
+
+    return VK_SUCCESS;
+}
+
+VkResult MemBoundWarning::PostCallBindImageMemory2(VkDevice device, uint32_t bindInfoCount,
+                                                   const VkBindImageMemoryInfoKHR *pBindInfos, VkResult result) {
+    if (result == VK_SUCCESS) {
+        for (uint32_t i = 0; i < bindInfoCount; i++) {
+            SetBindMemoryState<VkImage>(pBindInfos[i].image, pBindInfos[i].memory);
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult MemBoundWarning::PostCallBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount,
+                                                      const VkBindImageMemoryInfo *pBindInfos, VkResult result) {
+    if (result == VK_SUCCESS) {
+        for (uint32_t i = 0; i < bindInfoCount; i++) {
+            SetBindMemoryState<VkImage>(pBindInfos[i].image, pBindInfos[i].memory);
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+// intercept for the sparse memory to track memory state
+VkResult MemBoundWarning::PostCallQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
+                                                  VkFence fence, VkResult result) {
+    for (uint32_t bindIdx = 0; bindIdx < bindInfoCount; bindIdx++) {
+        const VkBindSparseInfo &bindInfo = pBindInfo[bindIdx];
+
+        for (uint32_t j = 0; j < bindInfo.bufferBindCount; j++) {
+            for (uint32_t k = 0; k < bindInfo.pBufferBinds[j].bindCount; k++) {
+                auto sparse_binding = bindInfo.pBufferBinds[j].pBinds[k];
+                SetBindMemoryState<VkBuffer>(bindInfo.pBufferBinds[j].buffer, sparse_binding.memory);
+            }
+        }
+        for (uint32_t j = 0; j < bindInfo.imageOpaqueBindCount; j++) {
+            for (uint32_t k = 0; k < bindInfo.pImageOpaqueBinds[j].bindCount; k++) {
+                auto sparse_binding = bindInfo.pImageOpaqueBinds[j].pBinds[k];
+                SetBindMemoryState<VkImage>(bindInfo.pImageOpaqueBinds[j].image, sparse_binding.memory);
+            }
+        }
+        for (uint32_t j = 0; j < bindInfo.imageBindCount; j++) {
+            for (uint32_t k = 0; k < bindInfo.pImageBinds[j].bindCount; k++) {
+                auto sparse_binding = bindInfo.pImageBinds[j].pBinds[k];
+                SetBindMemoryState<VkImage>(bindInfo.pImageBinds[j].image, sparse_binding.memory);
+            }
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+// Get memory associated with the handle being destroyed then find handle set using this memory and erase it
+template <typename T>
+void MemBoundWarning::RemoveBindedMemory(T handle) {
+    uint64_t handle_64 = HandleToUint64(handle);
+    auto memory_set = handle_memory_map.find(handle_64)->second;
+    // remove all memory in the memory set. If it is not sparse memory, there will only be one item in set
+    for (VkDeviceMemory memory : memory_set) {
+        auto &handle_set = memory_handle_map.find(memory)->second;
+        handle_set.erase(handle_64);
+    }
+}
+
+VkResult MemBoundWarning::PostCallCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
+                                                     const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain,
+                                                     VkResult result) {
+    if (result == VK_SUCCESS) {
+        std::vector<VkImage> images;
+        swapchain_image_map.insert(std::make_pair(*pSwapchain, images));
+    }
+
+    return VK_SUCCESS;
+}
+
+VkResult MemBoundWarning::PostCallGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
+                                                        VkImage *pSwapchainImages, VkResult result) {
+    auto images = swapchain_image_map.find(swapchain)->second;
+
+    if (*pSwapchainImageCount > images.size()) images.resize(*pSwapchainImageCount);
+
+    if (pSwapchainImages) {
+        for (uint32_t i = 0; i < *pSwapchainImageCount; i++) {
+            if (images[i] != VK_NULL_HANDLE) continue;  // Already retrieved image
+            // TODO: Check if this should be a pointer
+            images[i] = pSwapchainImages[i];
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+void MemBoundWarning::PostCallDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
+                                                  const VkAllocationCallbacks *pAllocator) {
+    if (!swapchain) return;
+
+    auto images = swapchain_image_map.find(swapchain)->second;
+    if (images.size() > 0) {
+        for (auto swapchain_image : images) {
+            RemoveBindedMemory<VkImage>(swapchain_image);
+        }
+    }
+
+    swapchain_image_map.erase(swapchain);
+}
+
+void MemBoundWarning::PreCallDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {
+    RemoveBindedMemory<VkBuffer>(buffer);
+}
+
+void MemBoundWarning::PreCallDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
+    RemoveBindedMemory<VkImage>(image);
+}
+
+void MemBoundWarning::PreCallFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator) {
+    auto handle_set = memory_handle_map.find(memory)->second;
+
+    for (const auto &handle : handle_set) {
+        char handle_string[64];
+        char memory_string[64];
+        uint64_t handle_64 = HandleToUint64(handle);
+        uint64_t memory_64 = HandleToUint64(memory);
+        sprintf(handle_string, "0x%" PRIxLEAST64, handle_64);
+        sprintf(memory_string, "0x%" PRIxLEAST64, memory_64);
+
+        std::stringstream message;
+        message << "Vk Object " << handle_string << " still has a reference to Memory Object " << memory_string;
+        Information(message.str());
+    }
+}
+
+MemBoundWarning mem_bound_warning;

--- a/layer_factory/assistant_layer/mem_bound_warning.h
+++ b/layer_factory/assistant_layer/mem_bound_warning.h
@@ -28,179 +28,40 @@
 
 class MemBoundWarning : public layer_factory {
    public:
-    // Constructor for interceptor
+    //     // Constructor for interceptor
     MemBoundWarning(){};
 
     VkResult PostCallAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
-                                    const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory, VkResult result) {
-        if (result == VK_SUCCESS) {
-            // create new memory entry into the map but give it no values
-            std::unordered_set<uint64_t> set;
-            memory_handle_map.insert(std::make_pair(*pMemory, set));
-        }
-    }
+                                    const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory, VkResult result);
 
-    // helper functin that update all the dictionaries for both image and buffer handles
     template <typename T>
-    void SetBindMemoryState(T handle, VkDeviceMemory memory) {
-        uint64_t handle_64 = HandleToUint64(handle);
-
-        if (memory != VK_NULL_HANDLE) {
-            // If the entry does not exist yet, then create it
-            if (handle_memory_map.count(handle_64) < 0) {
-                std::unordered_set<VkDeviceMemory> set;
-                handle_memory_map.insert(std::make_pair(handle_64, set));
-            }
-
-            auto memory_set = handle_memory_map.find(handle_64)->second;
-            memory_set.insert(memory);
-
-            auto handle_set = memory_handle_map.find(memory)->second;
-            handle_set.insert(handle_64);
-        }
-    }
-
-    // 3 buffer memory state tracker entry points
+    void SetBindMemoryState(T handle, VkDeviceMemory memory);
     VkResult PostCallBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                      VkResult result) {
-        if (result == VK_SUCCESS) SetBindMemoryState<VkBuffer>(buffer, memory);
-    }
-
+                                      VkResult result);
     VkResult PostCallBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos,
-                                       VkResult result) {
-        if (result == VK_SUCCESS) {
-            for (uint32_t i = 0; i < bindInfoCount; i++) {
-                SetBindMemoryState<VkBuffer>(pBindInfos[i].buffer, pBindInfos[i].memory);
-            }
-        }
-    }
-
+                                       VkResult result);
     VkResult PostCallBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos,
-                                          VkResult result) {
-        if (result == VK_SUCCESS) {
-            for (uint32_t i = 0; i < bindInfoCount; i++) {
-                SetBindMemoryState<VkBuffer>(pBindInfos[i].buffer, pBindInfos[i].memory);
-            }
-        }
-    }
-
-    // 3 buffer memory state tracker entry points
+                                          VkResult result);
     VkResult PostCallBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                     VkResult result) {
-        if (result == VK_SUCCESS) SetBindMemoryState<VkImage>(image, memory);
-    }
-
+                                     VkResult result);
     VkResult PostCallBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR *pBindInfos,
-                                      VkResult result) {
-        if (result == VK_SUCCESS) {
-            for (uint32_t i = 0; i < bindInfoCount; i++) {
-                SetBindMemoryState<VkImage>(pBindInfos[i].image, pBindInfos[i].memory);
-            }
-        }
-    }
-
+                                      VkResult result);
     VkResult PostCallBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
-                                         VkResult result) {
-        if (result == VK_SUCCESS) {
-            for (uint32_t i = 0; i < bindInfoCount; i++) {
-                SetBindMemoryState<VkImage>(pBindInfos[i].image, pBindInfos[i].memory);
-            }
-        }
-    }
-
-    // intercept for the Sparse memory to track memory state
+                                         VkResult result);
     VkResult PostCallQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo, VkFence fence,
-                                     VkResult result) {
-        for (uint32_t bindIdx = 0; bindIdx < bindInfoCount; bindIdx++) {
-            const VkBindSparseInfo &bindInfo = pBindInfo[bindIdx];
+                                     VkResult result);
 
-            for (uint32_t j = 0; j < bindInfo.bufferBindCount; j++) {
-                for (uint32_t k = 0; k < bindInfo.pBufferBinds[j].bindCount; k++) {
-                    auto sparse_binding = bindInfo.pBufferBinds[j].pBinds[k];
-                    SetBindMemoryState<VkBuffer>(bindInfo.pBufferBinds[j].buffer, sparse_binding.memory);
-                }
-            }
-            for (uint32_t j = 0; j < bindInfo.imageOpaqueBindCount; j++) {
-                for (uint32_t k = 0; k < bindInfo.pImageOpaqueBinds[j].bindCount; k++) {
-                    auto sparse_binding = bindInfo.pImageOpaqueBinds[j].pBinds[k];
-                    SetBindMemoryState<VkImage>(bindInfo.pImageOpaqueBinds[j].image, sparse_binding.memory);
-                }
-            }
-            for (uint32_t j = 0; j < bindInfo.imageBindCount; j++) {
-                for (uint32_t k = 0; k < bindInfo.pImageBinds[j].bindCount; k++) {
-                    auto sparse_binding = bindInfo.pImageBinds[j].pBinds[k];
-                    SetBindMemoryState<VkImage>(bindInfo.pImageBinds[j].image, sparse_binding.memory);
-                }
-            }
-        }
-    }
-
-    // Get memory associated with the handle being destroyed then find handle set using this memory and erase it
     template <typename T>
-    void RemoveBindedMemory(T handle) {
-        uint64_t handle_64 = HandleToUint64(handle);
-        auto memory_set = handle_memory_map.find(handle_64)->second;
-        // remove all memory in the memory set. If it is not sparse memory, there will only be one item in set
-        for (VkDeviceMemory memory : memory_set) {
-            auto handle_set = memory_handle_map.find(memory)->second;
-            handle_set.erase(handle_64);
-        }
-    }
-
+    void RemoveBindedMemory(T handle);
+    VkResult PostCallCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
+                                        const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain, VkResult result);
     VkResult PostCallGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
-                                           VkImage *pSwapchainImages, VkResult result) {
-        auto images = swapchain_image_map.find(swapchain)->second;
+                                           VkImage *pSwapchainImages, VkResult result);
+    void PostCallDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator);
+    void PreCallDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator);
+    void PreCallDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator);
 
-        if (*pSwapchainImageCount > images.size()) images.resize(*pSwapchainImageCount);
-
-        if (pSwapchainImages) {
-            for (uint32_t i = 0; i < *pSwapchainImageCount; i++) {
-                if (images[i] != VK_NULL_HANDLE) continue;  // Already retrieved image
-                images[i] = pSwapchainImages[i];
-            }
-        }
-    }
-
-    void PostCallDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator,
-                                     VkResult result) {
-        if (!swapchain) return;
-
-        auto images = swapchain_image_map.find(swapchain)->second;
-        if (images.size() > 0) {
-            for (auto swapchain_image : images) {
-                RemoveBindedMemory<VkImage>(swapchain_image);
-            }
-        }
-
-        swapchain_image_map.erase(swapchain);
-    }
-
-    void PreCallDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {
-        RemoveBindedMemory<VkBuffer>(buffer);
-    }
-
-    void PreCallDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
-        RemoveBindedMemory<VkImage>(image);
-    }
-
-    // TODO: You know what TO DO :)
-    void PreCallFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator) {
-        auto handle_set = memory_handle_map.find(memory)->second;
-
-        for (const auto &handle : handle_set) {
-            uint64_t handle_64 = HandleToUint64(handle);
-            uint64_t memory_64 = HandleToUint64(memory);
-
-            char handle_string[64];
-            char memory_string[64];
-            sprintf(handle_string, "0x%" PRIxLEAST64, handle_64);
-            sprintf(memory_string, "0x%" PRIxLEAST64, memory_64);
-
-            std::stringstream message;
-            message << "Vk Object" << handle_string << "still has a reference to mem obj" << memory_string;
-            Information(message.str());
-        }
-    }
+    void PreCallFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator);
 
    private:
     // double linked maps from device memory to a set containing the uint64_t versions of the handle.
@@ -208,5 +69,3 @@ class MemBoundWarning : public layer_factory {
     std::unordered_map<uint64_t, std::unordered_set<VkDeviceMemory>> handle_memory_map;
     std::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_image_map;
 };
-
-MemBoundWarning mem_bound_warning;

--- a/layer_factory/assistant_layer/mem_bound_warning.h
+++ b/layer_factory/assistant_layer/mem_bound_warning.h
@@ -31,9 +31,6 @@ class MemBoundWarning : public layer_factory {
     //     // Constructor for interceptor
     MemBoundWarning(){};
 
-    VkResult PostCallAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
-                                    const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory, VkResult result);
-
     template <typename T>
     void SetBindMemoryState(T handle, VkDeviceMemory memory);
     VkResult PostCallBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
@@ -50,17 +47,14 @@ class MemBoundWarning : public layer_factory {
                                          VkResult result);
     VkResult PostCallQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo, VkFence fence,
                                      VkResult result);
+    VkResult PostCallGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
+                                           VkImage *pSwapchainImages, VkResult result);
 
     template <typename T>
     void RemoveBindedMemory(T handle);
-    VkResult PostCallCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
-                                        const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain, VkResult result);
-    VkResult PostCallGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
-                                           VkImage *pSwapchainImages, VkResult result);
     void PostCallDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator);
     void PreCallDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator);
     void PreCallDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator);
-
     void PreCallFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator);
 
    private:

--- a/layer_factory/assistant_layer/mem_bound_warning.h
+++ b/layer_factory/assistant_layer/mem_bound_warning.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2015-2018 Valve Corporation
+ * Copyright (c) 2015-2018 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Camden Stocker <camden@lunarg.com>
+ */
+
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include "vulkan/vulkan.h"
+#include "vk_layer_logging.h"
+#include "layer_factory.h"
+
+class MemBoundWarning : public layer_factory {
+   public:
+    // Constructor for interceptor
+    MemBoundWarning(){};
+
+    VkResult PostCallAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
+                                    const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory, VkResult result) {
+        if (result == VK_SUCCESS) {
+            // create new memory entry into the map but give it no values
+            std::unordered_set<uint64_t> set;
+            memory_handle_map.insert(std::make_pair(*pMemory, set));
+        }
+    }
+
+    // helper functin that update all the dictionaries for both image and buffer handles
+    template <typename T>
+    void SetBindMemoryState(T handle, VkDeviceMemory memory) {
+        uint64_t handle_64 = HandleToUint64(handle);
+
+        if (memory != VK_NULL_HANDLE) {
+            // If the entry does not exist yet, then create it
+            if (handle_memory_map.count(handle_64) < 0) {
+                std::unordered_set<VkDeviceMemory> set;
+                handle_memory_map.insert(std::make_pair(handle_64, set));
+            }
+
+            auto memory_set = handle_memory_map.find(handle_64)->second;
+            memory_set.insert(memory);
+
+            auto handle_set = memory_handle_map.find(memory)->second;
+            handle_set.insert(handle_64);
+        }
+    }
+
+    // 3 buffer memory state tracker entry points
+    VkResult PostCallBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
+                                      VkResult result) {
+        if (result == VK_SUCCESS) SetBindMemoryState<VkBuffer>(buffer, memory);
+    }
+
+    VkResult PostCallBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos,
+                                       VkResult result) {
+        if (result == VK_SUCCESS) {
+            for (uint32_t i = 0; i < bindInfoCount; i++) {
+                SetBindMemoryState<VkBuffer>(pBindInfos[i].buffer, pBindInfos[i].memory);
+            }
+        }
+    }
+
+    VkResult PostCallBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos,
+                                          VkResult result) {
+        if (result == VK_SUCCESS) {
+            for (uint32_t i = 0; i < bindInfoCount; i++) {
+                SetBindMemoryState<VkBuffer>(pBindInfos[i].buffer, pBindInfos[i].memory);
+            }
+        }
+    }
+
+    // 3 buffer memory state tracker entry points
+    VkResult PostCallBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
+                                     VkResult result) {
+        if (result == VK_SUCCESS) SetBindMemoryState<VkImage>(image, memory);
+    }
+
+    VkResult PostCallBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfoKHR *pBindInfos,
+                                      VkResult result) {
+        if (result == VK_SUCCESS) {
+            for (uint32_t i = 0; i < bindInfoCount; i++) {
+                SetBindMemoryState<VkImage>(pBindInfos[i].image, pBindInfos[i].memory);
+            }
+        }
+    }
+
+    VkResult PostCallBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
+                                         VkResult result) {
+        if (result == VK_SUCCESS) {
+            for (uint32_t i = 0; i < bindInfoCount; i++) {
+                SetBindMemoryState<VkImage>(pBindInfos[i].image, pBindInfos[i].memory);
+            }
+        }
+    }
+
+    // intercept for the Sparse memory to track memory state
+    VkResult PostCallQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo, VkFence fence,
+                                     VkResult result) {
+        for (uint32_t bindIdx = 0; bindIdx < bindInfoCount; bindIdx++) {
+            const VkBindSparseInfo &bindInfo = pBindInfo[bindIdx];
+
+            for (uint32_t j = 0; j < bindInfo.bufferBindCount; j++) {
+                for (uint32_t k = 0; k < bindInfo.pBufferBinds[j].bindCount; k++) {
+                    auto sparse_binding = bindInfo.pBufferBinds[j].pBinds[k];
+                    SetBindMemoryState<VkBuffer>(bindInfo.pBufferBinds[j].buffer, sparse_binding.memory);
+                }
+            }
+            for (uint32_t j = 0; j < bindInfo.imageOpaqueBindCount; j++) {
+                for (uint32_t k = 0; k < bindInfo.pImageOpaqueBinds[j].bindCount; k++) {
+                    auto sparse_binding = bindInfo.pImageOpaqueBinds[j].pBinds[k];
+                    SetBindMemoryState<VkImage>(bindInfo.pImageOpaqueBinds[j].image, sparse_binding.memory);
+                }
+            }
+            for (uint32_t j = 0; j < bindInfo.imageBindCount; j++) {
+                for (uint32_t k = 0; k < bindInfo.pImageBinds[j].bindCount; k++) {
+                    auto sparse_binding = bindInfo.pImageBinds[j].pBinds[k];
+                    SetBindMemoryState<VkImage>(bindInfo.pImageBinds[j].image, sparse_binding.memory);
+                }
+            }
+        }
+    }
+
+    // Get memory associated with the handle being destroyed then find handle set using this memory and erase it
+    template <typename T>
+    void RemoveBindedMemory(T handle) {
+        uint64_t handle_64 = HandleToUint64(handle);
+        auto memory_set = handle_memory_map.find(handle_64)->second;
+        // remove all memory in the memory set. If it is not sparse memory, there will only be one item in set
+        for (VkDeviceMemory memory : memory_set) {
+            auto handle_set = memory_handle_map.find(memory)->second;
+            handle_set.erase(handle_64);
+        }
+    }
+
+    VkResult PostCallGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
+                                           VkImage *pSwapchainImages, VkResult result) {
+        auto images = swapchain_image_map.find(swapchain)->second;
+
+        if (*pSwapchainImageCount > images.size()) images.resize(*pSwapchainImageCount);
+
+        if (pSwapchainImages) {
+            for (uint32_t i = 0; i < *pSwapchainImageCount; i++) {
+                if (images[i] != VK_NULL_HANDLE) continue;  // Already retrieved image
+                images[i] = pSwapchainImages[i];
+            }
+        }
+    }
+
+    void PostCallDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator,
+                                     VkResult result) {
+        if (!swapchain) return;
+
+        auto images = swapchain_image_map.find(swapchain)->second;
+        if (images.size() > 0) {
+            for (auto swapchain_image : images) {
+                RemoveBindedMemory<VkImage>(swapchain_image);
+            }
+        }
+
+        swapchain_image_map.erase(swapchain);
+    }
+
+    void PreCallDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {
+        RemoveBindedMemory<VkBuffer>(buffer);
+    }
+
+    void PreCallDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
+        RemoveBindedMemory<VkImage>(image);
+    }
+
+    // TODO: You know what TO DO :)
+    void PreCallFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator) {
+        auto handle_set = memory_handle_map.find(memory)->second;
+
+        for (const auto &handle : handle_set) {
+            uint64_t handle_64 = HandleToUint64(handle);
+            uint64_t memory_64 = HandleToUint64(memory);
+
+            char handle_string[64];
+            char memory_string[64];
+            sprintf(handle_string, "0x%" PRIxLEAST64, handle_64);
+            sprintf(memory_string, "0x%" PRIxLEAST64, memory_64);
+
+            std::stringstream message;
+            message << "Vk Object" << handle_string << "still has a reference to mem obj" << memory_string;
+            Information(message.str());
+        }
+    }
+
+   private:
+    // double linked maps from device memory to a set containing the uint64_t versions of the handle.
+    std::unordered_map<VkDeviceMemory, std::unordered_set<uint64_t>> memory_handle_map;
+    std::unordered_map<uint64_t, std::unordered_set<VkDeviceMemory>> handle_memory_map;
+    std::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_image_map;
+};
+
+MemBoundWarning mem_bound_warning;

--- a/layer_factory/assistant_layer/mem_bound_warning.h
+++ b/layer_factory/assistant_layer/mem_bound_warning.h
@@ -47,12 +47,9 @@ class MemBoundWarning : public layer_factory {
                                          VkResult result);
     VkResult PostCallQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo, VkFence fence,
                                      VkResult result);
-    VkResult PostCallGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
-                                           VkImage *pSwapchainImages, VkResult result);
 
     template <typename T>
     void RemoveBindedMemory(T handle);
-    void PostCallDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator);
     void PreCallDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator);
     void PreCallDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator);
     void PreCallFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator);
@@ -61,5 +58,4 @@ class MemBoundWarning : public layer_factory {
     // double linked maps from device memory to a set containing the uint64_t versions of the handle.
     std::unordered_map<VkDeviceMemory, std::unordered_set<uint64_t>> memory_handle_map;
     std::unordered_map<uint64_t, std::unordered_set<VkDeviceMemory>> handle_memory_map;
-    std::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_image_map;
 };


### PR DESCRIPTION
Resolves issue tracked in KhronosGroup/Vulkan-ValidationLayers#24 which states "Warn if memory freed while still bound to other objects. See note in core_validation.cpp CoreChecks::PreCallRecordFreeMemory related to removing the INFORMATION_BIT message".

This specific issue is located at KhronosGroup/Vulkan-ValidationLayers#872