### PR TITLE
vkreplay: Use CMAKE_BUILD_RPATH instead of setting linker flags

### DIFF
--- a/vktrace/vktrace_replay/CMakeLists.txt
+++ b/vktrace/vktrace_replay/CMakeLists.txt
@@ -48,8 +48,8 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
 
     # Make sure the exe directory is searched when loading libraries with dlopen
-    SET(CMAKE_EXE_LINKER_FLAGS
-        "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,'$ORIGIN'")
+    set(CMAKE_BUILD_RPATH $ORIGIN)
+    
 endif()
 
 

--- a/vktrace/vktrace_viewer/CMakeLists.txt
+++ b/vktrace/vktrace_viewer/CMakeLists.txt
@@ -9,8 +9,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(OS_REPLAYER_LIBS xcb  ${LIBRARIES})
 
     # Make sure the exe directory is searched when loading libraries with dlopen
-    SET(CMAKE_EXE_LINKER_FLAGS
-        "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,'$ORIGIN'")
+    set(CMAKE_BUILD_RPATH $ORIGIN)
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR


### PR DESCRIPTION
The RPATH will not be stripped if `make install` is ran when setting RPATH with linker flags. 

Using CMAKE_BUILD_RPATH to set RPATH to $ORIGIN will have RPATH set to $ORIGIN in the build directory, and the RPATH will be stripped if `make install` is ran.