### PR TITLE
devsim: Fixed new warning from gcc-8

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -83,11 +83,11 @@ const uint32_t kLayerPropertiesCount = (sizeof(kLayerProperties) / sizeof(kLayer
 const char *kOurLayerName = kLayerProperties[0].layerName;
 
 // Instance extensions that this layer provides:
-const std::array<VkExtensionProperties,16> kInstanceExtensionProperties = {};
+const std::array<VkExtensionProperties, 0> kInstanceExtensionProperties = {};
 const uint32_t kInstanceExtensionPropertiesCount = kInstanceExtensionProperties.size();
 
 // Device extensions that this layer provides:
-const std::array<VkExtensionProperties, 15> kDeviceExtensionProperties = {};
+const std::array<VkExtensionProperties, 0> kDeviceExtensionProperties = {};
 const uint32_t kDeviceExtensionPropertiesCount = kDeviceExtensionProperties.size();
 
 // The "standard" core VkFormat enum values:
@@ -1309,7 +1309,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceExtensionProperties(const char *
     DebugPrintf("vkEnumerateInstanceExtensionProperties \"%s\" %s n", (pLayerName ? pLayerName : ""),
                 (pProperties ? "VALUES" : "COUNT"));
     if (pLayerName && !strcmp(pLayerName, kOurLayerName)) {
-        return EnumerateProperties(kInstanceExtensionPropertiesCount, kInstanceExtensionProperties, pCount, pProperties);
+        return EnumerateProperties(kInstanceExtensionPropertiesCount, kInstanceExtensionProperties.data(), pCount, pProperties);
     }
     return VK_ERROR_LAYER_NOT_PRESENT;
 }
@@ -1323,7 +1323,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
     const auto dt = instance_dispatch_table(physicalDevice);
 
     if (pLayerName && !strcmp(pLayerName, kOurLayerName)) {
-        result = EnumerateProperties(kDeviceExtensionPropertiesCount, kDeviceExtensionProperties, pCount, pProperties);
+        result = EnumerateProperties(kDeviceExtensionPropertiesCount, kDeviceExtensionProperties.data(), pCount, pProperties);
     } else {
         result = dt->EnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pCount, pProperties);
     }

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -82,11 +82,11 @@ const uint32_t kLayerPropertiesCount = (sizeof(kLayerProperties) / sizeof(kLayer
 const char *kOurLayerName = kLayerProperties[0].layerName;
 
 // Instance extensions that this layer provides:
-const VkExtensionProperties *kInstanceExtensionProperties = {};
+const VkExtensionProperties kInstanceExtensionProperties[] = {};
 const uint32_t kInstanceExtensionPropertiesCount = (sizeof(kInstanceExtensionProperties) / sizeof(kInstanceExtensionProperties[0]));
 
 // Device extensions that this layer provides:
-const VkExtensionProperties *kDeviceExtensionProperties = {};
+const VkExtensionProperties kDeviceExtensionProperties[] = {};
 const uint32_t kDeviceExtensionPropertiesCount = (sizeof(kDeviceExtensionProperties) / sizeof(kDeviceExtensionProperties[0]));
 
 // The "standard" core VkFormat enum values:

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -46,6 +46,7 @@
 #include <functional>
 #include <unordered_map>
 #include <vector>
+#include <array>
 #include <fstream>
 #include <mutex>
 #include <sstream>
@@ -82,12 +83,12 @@ const uint32_t kLayerPropertiesCount = (sizeof(kLayerProperties) / sizeof(kLayer
 const char *kOurLayerName = kLayerProperties[0].layerName;
 
 // Instance extensions that this layer provides:
-const VkExtensionProperties kInstanceExtensionProperties[] = {};
-const uint32_t kInstanceExtensionPropertiesCount = (sizeof(kInstanceExtensionProperties) / sizeof(kInstanceExtensionProperties[0]));
+const std::array<VkExtensionProperties,16> kInstanceExtensionProperties = {};
+const uint32_t kInstanceExtensionPropertiesCount = kInstanceExtensionProperties.size();
 
 // Device extensions that this layer provides:
-const VkExtensionProperties kDeviceExtensionProperties[] = {};
-const uint32_t kDeviceExtensionPropertiesCount = (sizeof(kDeviceExtensionProperties) / sizeof(kDeviceExtensionProperties[0]));
+const std::array<VkExtensionProperties, 15> kDeviceExtensionProperties = {};
+const uint32_t kDeviceExtensionPropertiesCount = kDeviceExtensionProperties.size();
 
 // The "standard" core VkFormat enum values:
 const VkFormat StandardVkFormatEnumList[] = {


### PR DESCRIPTION
    Using `(sizeof(array) / sizeof(array[0])) to get the size of an array on a pointer
    creates a new warning with gcc-8. Warning is -Wsizeof-pointer-div.

    changes:
            layersvt/device_simulation.cpp

Change-Id: I29b668c3f3e2e60739710b0ba9180933763866ab