### PR TITLE
apidump: Timestamps in dump output

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -290,7 +290,7 @@ class ApiDumpSettings {
             should_flush = !GetStringBooleanValue(env_value);
         }
 
-        show_timestamp = readBoolOption("lunarg_api_dump.show_timestamp", true);
+        show_timestamp = readBoolOption("lunarg_api_dump.show_timestamp", false);
         env_value = GetPlatformEnvVar(API_DUMP_ENV_VAR_TIMESTAMP);
         if (!env_value.empty()) {
             show_timestamp = GetStringBooleanValue(env_value);

--- a/layersvt/api_dump_layer.md
+++ b/layersvt/api_dump_layer.md
@@ -106,7 +106,7 @@ No Addresses/Handles | `VK_APIDUMP_NO_ADDR` | `lunarg_api_dump.no_addr` | false 
 Flush After Every Command | `VK_APIDUMP_FLUSH` | `lunarg_api_dump.flush` | true | Flush after every API command's output
 Output format | `VK_APIDUMP_OUTPUT_FORMAT` | `lunarg_api_dump.output_format` | `text` | Output the API Dump information as a text file (`text`), an HTML-formated file (`html`), or a json file (`json`).
 Selective Output Range | `VK_APIDUMP_OUTPUT_RANGE` | `lunarg_api_dump.output_range` | `0-0` | Only output frames within the specified range. Given by a comma separated list of frames or a range with a start, count, and optional interval separated by dashes. A count of 0 will output every frame after the start of the range. Example: "5-8-2" will output frame 5, continue until frame 13, dumping every other frame. Example: "3,8-2" will output frames 3, 8, and 9.
- 
+Show Timestamps | `VK_APIDUMP_TIMESTAMP` | `lunarg_api_dump.show_timestamp` | true | Show the timestamp of function calls since start in microseconds
 
 ### Settings Priority
 

--- a/layersvt/api_dump_layer.md
+++ b/layersvt/api_dump_layer.md
@@ -106,7 +106,7 @@ No Addresses/Handles | `VK_APIDUMP_NO_ADDR` | `lunarg_api_dump.no_addr` | false 
 Flush After Every Command | `VK_APIDUMP_FLUSH` | `lunarg_api_dump.flush` | true | Flush after every API command's output
 Output format | `VK_APIDUMP_OUTPUT_FORMAT` | `lunarg_api_dump.output_format` | `text` | Output the API Dump information as a text file (`text`), an HTML-formated file (`html`), or a json file (`json`).
 Selective Output Range | `VK_APIDUMP_OUTPUT_RANGE` | `lunarg_api_dump.output_range` | `0-0` | Only output frames within the specified range. Given by a comma separated list of frames or a range with a start, count, and optional interval separated by dashes. A count of 0 will output every frame after the start of the range. Example: "5-8-2" will output frame 5, continue until frame 13, dumping every other frame. Example: "3,8-2" will output frames 3, 8, and 9.
-Show Timestamps | `VK_APIDUMP_TIMESTAMP` | `lunarg_api_dump.show_timestamp` | true | Show the timestamp of function calls since start in microseconds
+Show Timestamps | `VK_APIDUMP_TIMESTAMP` | `lunarg_api_dump.show_timestamp` | false | Show the timestamp of function calls since start in microseconds
 
 ### Settings Priority
 

--- a/layersvt/vk_layer_settings.txt
+++ b/layersvt/vk_layer_settings.txt
@@ -97,3 +97,4 @@ lunarg_api_dump.type_size = 0
 lunarg_api_dump.use_spaces = TRUE
 lunarg_api_dump.show_shader = FALSE
 lunarg_api_dump.output_range = 0-0
+lunarg_api_dump.show_timestamp = FALSE

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -722,8 +722,11 @@ std::ostream& dump_text_{unName}(const {unName}& object, const ApiDumpSettings& 
 std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
-  
-    settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount() << ":\\n";
+    settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
+    if(settings.showTimestamp())
+        settings.stream() << ", Time " << dump_inst.current_time_since_start().count() << " μs\\n";
+    else 
+        settings.stream() << "\\n";
     settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn} ";
     dump_text_{funcReturn}(result, settings, 0) << ":\\n";
     if(settings.showParams())
@@ -750,8 +753,11 @@ std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} resu
 std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
-
-    settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount() << ":\\n";
+    settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
+    if(settings.showTimestamp())
+        settings.stream() << ", Time " << dump_inst.current_time_since_start().count() << " μs\\n";
+    else 
+        settings.stream() << "\\n";
     settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn}:\\n";
 
     if(settings.showParams())
@@ -1130,6 +1136,8 @@ std::ostream& dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} resu
     const ApiDumpSettings& settings(dump_inst.settings());
 
     settings.stream() << "<div class='thd'>Thread " << dump_inst.threadID() << ":</div>";
+    if(settings.showTimestamp())
+        settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " μs</div>";
     settings.stream() << "<details class='fn'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), "{funcName}({funcNamedParams})", "{funcReturn}");
     dump_html_{funcReturn}(result, settings, 0);
@@ -1161,6 +1169,8 @@ std::ostream& dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams}
     const ApiDumpSettings& settings(dump_inst.settings());
 
     settings.stream() << "<div class='thd'>Thread " << dump_inst.threadID() << ":</div>";
+    if(settings.showTimestamp())
+        settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " μs</div>";
     settings.stream() << "<details class='fn'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), "{funcName}({funcNamedParams})", "{funcReturn}");
     settings.stream() << "</summary>";
@@ -1569,6 +1579,10 @@ std::ostream& dump_json_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams}
 
     // Display thread info
     settings.stream() << settings.indentation(3) << "\\\"thread\\\" : \\\"Thread " << dump_inst.threadID() << "\\\",\\n";
+
+    // Display elapsed time
+    if(settings.showTimestamp())
+    settings.stream() << settings.indentation(3) << "\\\"time\\\" : \\\""<< dump_inst.current_time_since_start().count() << " μs\\\",\\n";
 
     // Display return value
     settings.stream() << settings.indentation(3) << "\\\"returnType\\\" : " << "\\\"{funcReturn}\\\",\\n";

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -723,10 +723,11 @@ std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} resu
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
     settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
-    if(settings.showTimestamp())
-        settings.stream() << ", Time " << dump_inst.current_time_since_start().count() << " μs\\n";
-    else 
-        settings.stream() << "\\n";
+    if(settings.showTimestamp()) {{
+        settings.stream() << ", Time " << dump_inst.current_time_since_start().count() << " us:\\n";
+    }} else {{
+        settings.stream() << ":\\n";
+    }} 
     settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn} ";
     dump_text_{funcReturn}(result, settings, 0) << ":\\n";
     if(settings.showParams())
@@ -754,10 +755,11 @@ std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams}
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
     settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
-    if(settings.showTimestamp())
-        settings.stream() << ", Time " << dump_inst.current_time_since_start().count() << " μs\\n";
-    else 
-        settings.stream() << "\\n";
+    if(settings.showTimestamp()) {{
+        settings.stream() << ", Time " << dump_inst.current_time_since_start().count() << " us:\\n";
+    }} else {{
+        settings.stream() << ":\\n";
+    }} 
     settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn}:\\n";
 
     if(settings.showParams())
@@ -1137,7 +1139,7 @@ std::ostream& dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} resu
 
     settings.stream() << "<div class='thd'>Thread " << dump_inst.threadID() << ":</div>";
     if(settings.showTimestamp())
-        settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " μs</div>";
+        settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " us</div>";
     settings.stream() << "<details class='fn'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), "{funcName}({funcNamedParams})", "{funcReturn}");
     dump_html_{funcReturn}(result, settings, 0);
@@ -1170,7 +1172,7 @@ std::ostream& dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams}
 
     settings.stream() << "<div class='thd'>Thread " << dump_inst.threadID() << ":</div>";
     if(settings.showTimestamp())
-        settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " μs</div>";
+        settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " us</div>";
     settings.stream() << "<details class='fn'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), "{funcName}({funcNamedParams})", "{funcReturn}");
     settings.stream() << "</summary>";
@@ -1581,8 +1583,9 @@ std::ostream& dump_json_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams}
     settings.stream() << settings.indentation(3) << "\\\"thread\\\" : \\\"Thread " << dump_inst.threadID() << "\\\",\\n";
 
     // Display elapsed time
-    if(settings.showTimestamp())
-    settings.stream() << settings.indentation(3) << "\\\"time\\\" : \\\""<< dump_inst.current_time_since_start().count() << " μs\\\",\\n";
+    if(settings.showTimestamp()) {{
+        settings.stream() << settings.indentation(3) << "\\\"time\\\" : \\\""<< dump_inst.current_time_since_start().count() << " us\\\",\\n";
+    }}
 
     // Display return value
     settings.stream() << settings.indentation(3) << "\\\"returnType\\\" : " << "\\\"{funcReturn}\\\",\\n";

--- a/vkconfig/layer_info.json
+++ b/vkconfig/layer_info.json
@@ -21,7 +21,6 @@
         }
     },
     "layer_options": {
-
         "VK_LAYER_KHRONOS_validation": {
             "debug_action": {
                 "name": "Debug Action",
@@ -47,7 +46,11 @@
                     "error": "Error",
                     "debug": "Debug"
                 },
-                "default": [ "error", "warn", "perf" ]
+                "default": [
+                    "error",
+                    "warn",
+                    "perf"
+                ]
             },
             "log_filename": {
                 "name": "Log Filename",
@@ -66,13 +69,16 @@
                 "default": []
             }
         },
-
         "VK_LAYER_LUNARG_api_dump": {
             "output_format": {
                 "name": "Output Format",
                 "description": "Specifies the format used for output; can be Text (default -- outputs plain text), Html, or Json",
                 "type": "enum",
-                "options": [ "Text", "Html", "Json" ],
+                "options": [
+                    "Text",
+                    "Html",
+                    "Json"
+                ],
                 "default": "Text"
             },
             "detailed": {
@@ -135,6 +141,12 @@
                 "type": "bool",
                 "default": true
             },
+            "show_timestamp": {
+                "name": "Show Timestamp",
+                "description": "Show the timestamp of function calls since start in microseconds",
+                "type": "bool",
+                "default": false
+            },
             "show_shader": {
                 "name": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
@@ -148,7 +160,6 @@
                 "default": "0-0"
             }
         },
-
         "VK_LAYER_LUNARG_core_validation": {
             "debug_action": {
                 "name": "Debug Action",
@@ -174,7 +185,11 @@
                     "error": "Error",
                     "debug": "Debug"
                 },
-                "default": [ "error", "warn", "perf" ]
+                "default": [
+                    "error",
+                    "warn",
+                    "perf"
+                ]
             },
             "log_filename": {
                 "name": "Log Filename",
@@ -183,7 +198,6 @@
                 "default": "stdout"
             }
         },
-
         "VK_LAYER_LUNARG_device_simulation": {
             "filename": {
                 "name": "Filename",
@@ -201,7 +215,6 @@
                 "default": false
             }
         },
-
         "VK_LAYER_LUNARG_object_tracker": {
             "debug_action": {
                 "name": "Debug Action",
@@ -227,7 +240,11 @@
                     "error": "Error",
                     "debug": "Debug"
                 },
-                "default": [ "error", "warn", "perf" ]
+                "default": [
+                    "error",
+                    "warn",
+                    "perf"
+                ]
             },
             "log_filename": {
                 "name": "Log Filename",
@@ -236,7 +253,6 @@
                 "default": "stdout"
             }
         },
-
         "VK_LAYER_LUNARG_parameter_validation": {
             "debug_action": {
                 "name": "Debug Action",
@@ -262,7 +278,11 @@
                     "error": "Error",
                     "debug": "Debug"
                 },
-                "default": [ "error", "warn", "perf" ]
+                "default": [
+                    "error",
+                    "warn",
+                    "perf"
+                ]
             },
             "log_filename": {
                 "name": "Log Filename",
@@ -271,7 +291,6 @@
                 "default": "stdout"
             }
         },
-
         "VK_LAYER_GOOGLE_threading": {
             "debug_action": {
                 "name": "Debug Action",
@@ -297,7 +316,11 @@
                     "error": "Error",
                     "debug": "Debug"
                 },
-                "default": [ "error", "warn", "perf" ]
+                "default": [
+                    "error",
+                    "warn",
+                    "perf"
+                ]
             },
             "log_filename": {
                 "name": "Log Filename",
@@ -306,7 +329,6 @@
                 "default": "stdout"
             }
         },
-
         "VK_LAYER_GOOGLE_unique_objects": {
             "debug_action": {
                 "name": "Debug Action",
@@ -332,7 +354,11 @@
                     "error": "Error",
                     "debug": "Debug"
                 },
-                "default": [ "error", "warn", "perf" ]
+                "default": [
+                    "error",
+                    "warn",
+                    "perf"
+                ]
             },
             "log_filename": {
                 "name": "Log Filename",


### PR DESCRIPTION
apidump will now show the time a function was called since start
in microseconds. This is useful to determine which functions are
taking significant time to execute.

Added the VK_APIDUMP_TIMESTAMP environmental variable and the
lunarg_api_dump.show_timestamp setting to the api_dump settings file

changed files:
	layersvt/api_dump.h
	layersvt/api_dump_layer.md
	layersvt/vk_layer_settings.txt
	scripts/api_dump_generator.py
	vkconfig/layer_info.json

Change-Id: Ie223747d947c803617018034b7c5f66d3a243d9b