### PR TITLE
vktrace: fix type mismatch on error message

### DIFF
--- a/vktrace/vktrace_common/vktrace_trace_packet_utils.c
+++ b/vktrace/vktrace_common/vktrace_trace_packet_utils.c
@@ -455,8 +455,8 @@ vktrace_trace_packet_header* vktrace_read_trace_packet(FileLike* pFile) {
         pHeader->size = total_packet_size;
         if (vktrace_FileLike_ReadRaw(pFile, (char*)pHeader + sizeof(uint64_t), (size_t)total_packet_size - sizeof(uint64_t)) ==
             FALSE) {
-            vktrace_LogError("Failed to read trace packet with size of %u from %s source.", 
-                total_packet_size, FILELIKE_MODE_NAME(pFile->mMode));
+            vktrace_LogError("Failed to read trace packet with size of %ju from %s source.", (intmax_t)total_packet_size,
+                             FILELIKE_MODE_NAME(pFile->mMode));
             return NULL;
         }
 


### PR DESCRIPTION
"%u" is a format reference to a 32-bit unsigned integer.
We're passing a uint64_t for formatting, which is unlikely
to work correctly.

"%ju" is a conversion for an intmax_t on both Windows and
Linux.  Casting the corresponding argument to this type
ensures that the format string and argument are in sync
regardless of how uint64_t is defined.

Change-Id: I92381b3b20d1c356fcf7b2df23834f9aaec03b8e