### PR TITLE
via: change location of vkcube for linux tar SDK

### DIFF
--- a/via/via_system.cpp
+++ b/via/via_system.cpp
@@ -1870,7 +1870,7 @@ ViaSystem::ViaResults ViaSystem::GenerateTestInfo(void) {
             if (!_is_system_installed_sdk) {
                 cube_exe = "./" + cube_exe;
                 path = _sdk_path;
-                path += "/../examples/build";
+                path += "/bin";
             }
 #endif
 


### PR DESCRIPTION
The location of vkcube for the Linux Tar SDK has changed