### PR TITLE
apidump: fix text dump formatting for void functions

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -806,7 +806,7 @@ std::ostream& dump_text_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
     }} else {{
         settings.stream() << ":\\n";
     }} 
-    settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn} ";
+    settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn}";
 
     return settings.shouldFlush() ? settings.stream() << std::flush : settings.stream();
 }}
@@ -823,8 +823,10 @@ std::ostream& dump_text_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
     const ApiDumpSettings& settings(dump_inst.settings());
     
     @if('{funcReturn}' != 'void')
-    dump_text_{funcReturn}(result, settings, 0) << ":\\n";
+    settings.stream() << " ";
+    dump_text_{funcReturn}(result, settings, 0);
     @end if
+    settings.stream() << ":\\n";
     if(settings.showParams())
     {{
         @foreach parameter


### PR DESCRIPTION
Splitting the function dump function into two introduced a formatting error for functions that returned void. 

Change-Id: I43528703091f079c27cb1bb1beb7e686c43f4e24