### PR TITLE
layers: Add settings file support to screenshot

### DIFF
--- a/vkconfig/layer_info.json
+++ b/vkconfig/layer_info.json
@@ -366,6 +366,36 @@
                 "type": "save_file",
                 "default": "stdout"
             }
+        },
+        "VK_LAYER_LUNARG_screenshot": {
+            "frames": {
+                "name": "Frames",
+                "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
+                "type": "string",
+                "default": ""
+            },
+            "dir": {
+                "name": "Directory",
+                "description": "This can be set to specify the directory in which to create the screenshot files.",
+                "type": "string",
+                "default": ""
+            },
+            "format": {
+                "name": "Format",
+                "description": "This can be set to a color space for the output.",
+                "type": "enum",
+                "options": {
+                    "UNORM": "UNORM",
+                    "SNORM": "SNORM",
+                    "USCALED": "USCALED",
+                    "SSCALED": "SSCALED",
+                    "UINT": "UINT",
+                    "SINT": "SINT",
+                    "SRGB": "SRGB",
+                    "USE_SWAPCHAIN_COLORSPACE": "USE_SWAPCHAIN_COLORSPACE"
+                },
+                "default": "USE_SWAPCHAIN_COLORSPACE"
+            }
         }
     }
 }


### PR DESCRIPTION
Added support for vk_layer_settings.txt to
VK_LAYER_LUNARG_screenshot with the following options
equivalent to the following environment variable.

lunarg_screenshot.frames -> VK_SCREENSHOT_FRAMES
lunarg_screenshot.dir -> VK_SCREENSHOT_DIR
lunarg_screenshot.format -> VK_SCREENSHOT_FORMAT

Addresses issue #872 