### PR TITLE
vkvia: stderr to stdout when searching for old sdk package on arch

### DIFF
--- a/via/via_system_linux.cpp
+++ b/via/via_system_linux.cpp
@@ -1246,7 +1246,7 @@ ViaSystem::ViaResults ViaSystemLinux::PrintSystemSdkInfo() {
             }
         }
     } else if (upper_os_name.find("ARCH") != std::string::npos) {
-        FILE *dnf_output = popen("pacman -Qi lunarg-vulkan-sdk", "r");
+        FILE *dnf_output = popen("pacman -Qi lunarg-vulkan-sdk 2>&1", "r");
         if (dnf_output != nullptr) {
             char cur_line[1035];
             std::string install_name;


### PR DESCRIPTION
On Arch Linux, pacman will send an error to stderr when a package isn't found. Vkvia is supposed to see this error and handle it but doesn't because the error isn't in stdout.