### PR TITLE
vkvia: Fix issue 861

### DIFF
--- a/via/via_system_windows.hpp
+++ b/via/via_system_windows.hpp
@@ -26,6 +26,8 @@
 #pragma warning(disable : 4996)
 #include <shlwapi.h>
 #include <Cfgmgr32.h>
+#include <psapi.h>
+#include <windows.h>
 
 #include "via_system.hpp"
 


### PR DESCRIPTION
Fixes via32 displaying the wrong Vulkan runtime on
Windows.

Resolves issue #861 