### PR TITLE
vkreplay: Change algorithm when searching for queue family index

### DIFF
--- a/vktrace/vktrace_replay/vkreplay_vkreplay.h
+++ b/vktrace/vktrace_replay/vkreplay_vkreplay.h
@@ -380,12 +380,11 @@ class vkReplay {
 
     std::unordered_set<VkDeviceMemory> traceSkippedDeviceMemories;
 
-    bool getMemoryTypeIdx(VkDevice traceDevice, VkDevice replayDevice, uint32_t traceIdx, VkMemoryRequirements* memRequirements,
-                          uint32_t* pReplayIdx);
+    bool getReplayMemoryTypeIdx(VkDevice traceDevice, VkDevice replayDevice, uint32_t traceIdx,
+                                VkMemoryRequirements* memRequirements, uint32_t* pReplayIdx);
 
-    bool getQueueFamilyIdx(VkPhysicalDevice tracePhysicalDevice, VkPhysicalDevice replayPhysicalDevice, uint32_t traceIdx,
-                           uint32_t* pReplayIdx);
-    bool getQueueFamilyIdx(VkDevice traceDevice, VkDevice replayDevice, uint32_t traceIdx, uint32_t* pReplayIdx);
+    void getReplayQueueFamilyIdx(VkPhysicalDevice tracePhysicalDevice, VkPhysicalDevice replayPhysicalDevice, uint32_t* pIdx);
+    void getReplayQueueFamilyIdx(VkDevice traceDevice, VkDevice replayDevice, uint32_t* pIdx);
 
     void remapHandlesInDescriptorSetWithTemplateData(VkDescriptorUpdateTemplateKHR remappedDescriptorUpdateTemplate, char* pData);
 };


### PR DESCRIPTION
Changed algorithm when searching for a replay device queue family index
when in portability mode. The search starts with the queue family index
in the trace file so as to increase the probablily that the queue
family index selected will work.

Also changed the name of the method getQueueFamilyIdx to getReplayQueueFamilyIdx,
changed it to have no return value, and removed one arg. This simplified code
that calls getReplayQueueFamilyIdx.

Change-Id: Ic09ac4bff3bfff7330c229c3279ac3cbdb65e87b