### PR TITLE
tests: Restore original vulkaninfo behvavior

### DIFF
--- a/tests/apidump_test.ps1
+++ b/tests/apidump_test.ps1
@@ -36,7 +36,7 @@ $Env:VK_ICD_FILENAMES = "..\..\icd\$dPath\VkICD_mock_icd.json"
 $Env:VK_INSTANCE_LAYERS = "VK_LAYER_LUNARG_api_dump"
 
 # Run vulkaninfo with mock ICD and api_dump layer, capturing output
-& .\vulkaninfo.exe > apidump_temp_output_file
+& .\vulkaninfo.exe --show-formats > apidump_temp_output_file
 
 # Fail if temp file is not present, or if results do not match expectations
 if (!(Test-Path apidump_temp_output_file)) {

--- a/tests/apidump_test.sh
+++ b/tests/apidump_test.sh
@@ -57,7 +57,7 @@ pushd $(dirname "${BASH_SOURCE[0]}")
 VULKANINFO="$VULKAN_TOOLS_BUILD_DIR/install/bin/vulkaninfo"
 VK_ICD_FILENAMES="$VULKAN_TOOLS_BUILD_DIR/icd/VkICD_mock_icd.json" \
     VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_api_dump \
-    "$VULKANINFO" > apidump_file.tmp
+    "$VULKANINFO" --show-formats > apidump_file.tmp
 
 printf "$GREEN[ RUN      ]$NC $0\n"
 echo DISPLAY=$DISPLAY         # Debug

--- a/tests/vlf_test.ps1
+++ b/tests/vlf_test.ps1
@@ -38,7 +38,7 @@ $Env:VK_ICD_FILENAMES = "$env:VULKAN_TOOLS_BUILD_DIR\icd\$dPath\VkICD_mock_icd.j
 $Env:VK_INSTANCE_LAYERS = "VK_LAYER_LUNARG_demo_layer"
 
 # Run vulkaninfo with mock ICD and demo layer, capturing output
-& $Env:VULKAN_TOOLS_INSTALL_DIR\bin\vulkaninfo.exe > temp_output_file
+& $Env:VULKAN_TOOLS_INSTALL_DIR\bin\vulkaninfo.exe --show-formats > temp_output_file
 
 # Fail if temp file is not present, or if results do not match expectations
 if (!(Test-Path temp_output_file)) {

--- a/tests/vlf_test.sh
+++ b/tests/vlf_test.sh
@@ -58,7 +58,7 @@ cd $(dirname "${BASH_SOURCE[0]}")
 VULKANINFO="$VULKAN_TOOLS_BUILD_DIR/install/bin/vulkaninfo"
 VK_ICD_FILENAMES="$VULKAN_TOOLS_BUILD_DIR/icd/VkICD_mock_icd.json" \
     VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_demo_layer \
-    "$VULKANINFO" > file.tmp
+    "$VULKANINFO" --show-formats > file.tmp
 
 printf "$GREEN[ RUN      ]$NC $0\n"
 if [ -f file.tmp ]


### PR DESCRIPTION
A recent change to vulkaninfo made the extensive format
listing optional (available via the "--show-formats" switch).

The demo layer tests happen to exercise the vulkaninfo
executable, looking for and counting the number of calls
to vkGetPhysicalDeviceFormatProperties; these tests started
failing with the new vulkaninfo because the number of format
queries went from over 200 to 16.

These changes to the test scripts pass the "--show-formats"
switch to vulkaninfo, which restores the original behavior.

Change-Id: I6076c3b573751a4bfcacd552b8f6a021ec7743fd