### PR TITLE
vkconfig: Fix inconsistant capitalization

### DIFF
--- a/vkconfig/layer_info.json
+++ b/vkconfig/layer_info.json
@@ -64,7 +64,7 @@
                 "type": "multi_enum",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Disable thread safety checks",
-                    "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Disable stateless parameter Checks",
+                    "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Disable stateless parameter checks",
                     "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Disable object lifetime validation",
                     "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Disable core validation checks",
                     "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Disable handle wrapping"


### PR DESCRIPTION
Changed "Disable stateless parameter Checks" to
"Disable stateless parameter checks" in vkconfig.