### PR TITLE
api_dump: keep lock held between printing head and body

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -82,7 +82,7 @@ COMMON_CODEGEN = """
 inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     if (!dump_inst.shouldDumpOutput()) return ;
-    loader_platform_thread_lock_mutex(dump_inst.outputMutex());
+    dump_inst.outputMutex()->lock();
     switch(dump_inst.settings().format())
     {{
     case ApiDumpFormat::Text:
@@ -95,7 +95,7 @@ inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
         dump_json_head_{funcName}(dump_inst, {funcNamedParams});
         break;
     }}
-    loader_platform_thread_unlock_mutex(dump_inst.outputMutex());
+    //Keep lock
 }}
 @end function
 
@@ -104,7 +104,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result
 {{
     if (!dump_inst.shouldDumpOutput()) return;
 
-    loader_platform_thread_lock_mutex(dump_inst.outputMutex());
+    //Lock is already held
     switch(dump_inst.settings().format())
     {{
     case ApiDumpFormat::Text:
@@ -117,7 +117,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result
         dump_json_body_{funcName}(dump_inst, result, {funcNamedParams});
         break;
     }}
-    loader_platform_thread_unlock_mutex(dump_inst.outputMutex());
+    dump_inst.outputMutex()->unlock();
 }}
 @end function
 
@@ -125,7 +125,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result
 inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     if (!dump_inst.shouldDumpOutput()) return ;
-    loader_platform_thread_lock_mutex(dump_inst.outputMutex());
+    //Lock is already held
     switch(dump_inst.settings().format())
     {{
     case ApiDumpFormat::Text:
@@ -138,7 +138,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
         dump_json_body_{funcName}(dump_inst, {funcNamedParams});
         break;
     }}
-    loader_platform_thread_unlock_mutex(dump_inst.outputMutex());
+    dump_inst.outputMutex()->unlock();
 }}
 @end function
 
@@ -146,7 +146,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @foreach function where('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
 inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
-    loader_platform_thread_lock_mutex(dump_inst.outputMutex());
+    dump_inst.outputMutex()->lock();
 
     if (pNameInfo->pObjectName)
     {{
@@ -172,14 +172,14 @@ inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
         }}
     }}
 
-    loader_platform_thread_unlock_mutex(dump_inst.outputMutex());
+    //Keep lock
 }}
 @end function
 
 @foreach function where('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
 inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 {{
-    loader_platform_thread_lock_mutex(dump_inst.outputMutex());
+    //Lock is already held
     if (dump_inst.shouldDumpOutput()) {{
         switch(dump_inst.settings().format())
         {{
@@ -195,14 +195,14 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result
         }}
     }}
 
-    loader_platform_thread_unlock_mutex(dump_inst.outputMutex());
+    dump_inst.outputMutex()->unlock();
 }}
 @end function
 
 @foreach function where('{funcName}' == 'vkSetDebugUtilsObjectNameEXT')
 inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
-    loader_platform_thread_lock_mutex(dump_inst.outputMutex());
+    dump_inst.outputMutex()->lock();
     if (pNameInfo->pObjectName)
     {{
         dump_inst.object_name_map.insert(std::make_pair<uint64_t, std::string>((uint64_t &&)pNameInfo->objectHandle, pNameInfo->pObjectName));
@@ -225,14 +225,14 @@ inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
             break;
         }}
     }}
-    loader_platform_thread_unlock_mutex(dump_inst.outputMutex());
+    //Keep lock
 }}
 @end function
 
 @foreach function where('{funcName}' == 'vkSetDebugUtilsObjectNameEXT')
 inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 {{
-    loader_platform_thread_lock_mutex(dump_inst.outputMutex());
+    //Lock is already held
     if (dump_inst.shouldDumpOutput()) {{
         switch(dump_inst.settings().format())
         {{
@@ -247,7 +247,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result
             break;
         }}
     }}
-    loader_platform_thread_unlock_mutex(dump_inst.outputMutex());
+    dump_inst.outputMutex()->unlock();
 }}
 @end function
 


### PR DESCRIPTION
Previously, api_dump would release the output lock when finished printing
the head of a call and reaquiring it when printing the body. This enabled
multi threaded applications to interleave output resulting in garbled output.
This commit fixed that by keeping the output lock held for the duration of
the call, at the cost of serializing any calls that are made to vulkan.

This commit also switched api_dump to std::mutex & std::thread::id instead of using
vk_loader_platform.h for the threading primitives.

Changes:
	modified:   layersvt/api_dump.h
	modified:   scripts/api_dump_generator.py

Change-Id: Ia4b0cabc839c93798eeeb811d6cb322b5b197194