### PR TITLE
vkconfig: Specify minimum vkconfig versions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -273,6 +273,7 @@ Make sure the following items are installed for proper building of VkConfig:
 Please note that not building VkConfig is purely fine as well and will not
 impact the generation of any other targets.
 
+VkConfig on linux requires Qt version 5.5 and on Windows requires Qt version 5.6.
 
 ## Linux Build
 

--- a/vkconfig/vkconfig.cpp
+++ b/vkconfig/vkconfig.cpp
@@ -32,8 +32,9 @@ int main(int argc, char **argv) {
     QCoreApplication::setOrganizationName("LunarG");
     QCoreApplication::setOrganizationDomain("lunarg.com");
     QCoreApplication::setApplicationName("vkconfig");
+#if defined(_WIN32)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-
+#endif
     QApplication app(argc, argv);
     LayerManager manager;
     manager.show();

--- a/vkconfig/vkconfig.md
+++ b/vkconfig/vkconfig.md
@@ -131,7 +131,7 @@ Windows systems store files in the following paths:
 - `%TEMP%\VulkanLayerManager\VkLayerOverride.json` tells a Vulkan application which layers to use
 - `%TEMP%\VulkanLayerManager\vk_layer_settings.json` tells Vulkan layers which settings to use
 
-In addition, Windows sytem create registry entries in the following locations:
+In addition, Windows system create registry entries in the following locations:
 
 - `HKEY_CURRENT_USER\Software\Khronos\Vulkan\ImplicitLayers` will have an entry that points to the JSON file above
 - `HKEY_CURRENT_USER\Software\Khronos\Vulkan\Settings` will have an entry that points to the text file above


### PR DESCRIPTION
During testing it was found a recent vkconfig change requires
Qt version 5.6, which Ubuntu 16.04 ships with version 5.5. Since
the change only affected Windows, the offending code was put behind
and if-def.

Changes to be committed:
	modified:   BUILD.md
	modified:   vkconfig/vkconfig.cpp
	modified:   vkconfig/vkconfig.md

Change-Id: Id81dc5e287b983f9638b314c2892e8cca2e2c915