### PR TITLE
layersvt: Fix layer versions

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -73,10 +73,10 @@ const uint32_t kVersionDevsimImplementation = VK_MAKE_VERSION(kVersionDevsimMajo
 
 // Properties of this layer:
 const VkLayerProperties kLayerProperties[] = {{
-    "VK_LAYER_LUNARG_device_simulation",       // layerName
-    VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION),  // specVersion
-    kVersionDevsimImplementation,              // implementationVersion
-    "LunarG device simulation layer"           // description
+    "VK_LAYER_LUNARG_device_simulation",  // layerName
+    VK_MAKE_VERSION(1, 0, 68),            // specVersion (clamped to final 1.0 spec version)
+    kVersionDevsimImplementation,         // implementationVersion
+    "LunarG device simulation layer"      // description
 }};
 const uint32_t kLayerPropertiesCount = (sizeof(kLayerProperties) / sizeof(kLayerProperties[0]));
 

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -1353,10 +1353,10 @@ VKAPI_ATTR VkResult VKAPI_CALL SpecifyScreenshotFrames(const char *frameList) {
 }
 
 static const VkLayerProperties global_layer = {
-    "VK_LAYER_LUNARG_screenshot",
-    VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION),
-    1,
-    "Layer: screenshot",
+    "VK_LAYER_LUNARG_screenshot",  // layerName
+    VK_MAKE_VERSION(1, 0, 68),     // specVersion (clamped to final 1.0 spec version)
+    1,                             // implementationVersion
+    "Layer: screenshot",           // description
 };
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {


### PR DESCRIPTION
Layers hardcoded to specVersion 1.0 should not use VK_HEADER_VERSION as
the patchlevel.  Hardcoding the patchlevel to 1.0.68.

Change-Id: I469eeb44d84facea8c0c4b28b97d9589fb364406