### PR TITLE
scripts: Fix api_dump layer version

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -353,7 +353,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     static const VkLayerProperties layerProperties[] = {{
         {{
             "VK_LAYER_LUNARG_api_dump",
-            VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), // specVersion
+            VK_MAKE_VERSION(1, 2, VK_HEADER_VERSION), // specVersion
             VK_MAKE_VERSION(0, 2, 0), // implementationVersion
             "layer: api_dump",
         }}
@@ -369,7 +369,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     static const VkLayerProperties layerProperties[] = {{
         {{
             "VK_LAYER_LUNARG_api_dump",
-            VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION),
+            VK_MAKE_VERSION(1, 2, VK_HEADER_VERSION),
             VK_MAKE_VERSION(0, 2, 0),
             "layer: api_dump",
         }}


### PR DESCRIPTION
Update codegen layer using VK_HEADER_VERSION to 1.2

Change-Id: I7c85b418439b2812acd0e64ddcb8ddb31a1e140a