### PR TITLE
layers: Add tooling info support

### DIFF
--- a/layersvt/VkLayer_api_dump.json.in
+++ b/layersvt/VkLayer_api_dump.json.in
@@ -6,6 +6,14 @@
         "library_path": "@RELATIVE_LAYER_BINARY@",
         "api_version": "@VK_VERSION@",
         "implementation_version": "2",
-        "description": "LunarG API dump layer"
+        "description": "LunarG API dump layer",
+        "device_extensions": [
+            {
+                 "name": "VK_EXT_tooling_info",
+                 "spec_version": "1",
+                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
+                        ]
+            }
+        ]
     }
 }

--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -5,7 +5,16 @@
         "type": "GLOBAL",
         "library_path": "@RELATIVE_LAYER_BINARY@",
         "api_version": "@VK_VERSION@",
-        "implementation_version": "1.2.6",
-        "description": "LunarG device simulation layer"
+        "implementation_version": "1.3.0",
+        "description": "LunarG device simulation layer",
+        "device_extensions": [
+            {
+                 "name": "VK_EXT_tooling_info",
+                 "spec_version": "1",
+                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
+                        ]
+            }
+        ]
+
     }
 }

--- a/layersvt/VkLayer_monitor.json.in
+++ b/layersvt/VkLayer_monitor.json.in
@@ -6,6 +6,14 @@
         "library_path": "@RELATIVE_LAYER_BINARY@",
         "api_version": "@VK_VERSION@",
         "implementation_version": "1",
-        "description": "Execution Monitoring Layer"
+        "description": "Execution Monitoring Layer",
+        "device_extensions": [
+            {
+                 "name": "VK_EXT_tooling_info",
+                 "spec_version": "1",
+                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
+                        ]
+            }
+        ]
     }
 }

--- a/layersvt/VkLayer_screenshot.json.in
+++ b/layersvt/VkLayer_screenshot.json.in
@@ -6,6 +6,14 @@
         "library_path": "@RELATIVE_LAYER_BINARY@",
         "api_version": "@VK_VERSION@",
         "implementation_version": "1",
-        "description": "LunarG image capture layer"
+        "description": "LunarG image capture layer",
+        "device_extensions": [
+            {
+                 "name": "VK_EXT_tooling_info",
+                 "spec_version": "1",
+                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
+                        ]
+            }
+        ]
     }
 }

--- a/layersvt/monitor.cpp
+++ b/layersvt/monitor.cpp
@@ -191,8 +191,8 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, 
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t *pToolCount,
-                                                                  VkPhysicalDeviceToolPropertiesEXT *pToolProperties) {
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolPropertiesEXT(
+    VkPhysicalDevice physicalDevice, uint32_t *pToolCount, VkPhysicalDeviceToolPropertiesEXT *pToolProperties) {
     static const VkPhysicalDeviceToolPropertiesEXT monitor_layer_tool_props = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
         nullptr,
@@ -210,7 +210,8 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolProperties
     }
 
     layer_data *my_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
-    VkResult result = my_data->instance_dispatch_table->GetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties);
+    VkResult result =
+        my_data->instance_dispatch_table->GetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties);
 
     if (original_pToolProperties != nullptr) {
         pToolProperties = original_pToolProperties;

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -395,7 +395,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 
 // Autogen instance functions
 
-@foreach function where('{funcDispatchType}' == 'instance' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkCreateInstance', 'vkDestroyInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties'])
+@foreach function where('{funcDispatchType}' == 'instance' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkCreateInstance', 'vkDestroyInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties','vkGetPhysicalDeviceToolPropertiesEXT'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
     dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
@@ -438,6 +438,37 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     dump_body_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
 }}
 @end function
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t *pToolCount, VkPhysicalDeviceToolPropertiesEXT *pToolProperties)
+{{
+    dump_head_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), physicalDevice, pToolCount, pToolProperties);
+    static const VkPhysicalDeviceToolPropertiesEXT api_dump_layer_tool_props = {{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
+        nullptr,
+        "API Dump Layer",
+        "2",
+        VK_TOOL_PURPOSE_PROFILING_BIT_EXT | VK_TOOL_PURPOSE_TRACING_BIT_EXT,
+        "The VK_LAYER_LUNARG_api_dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "VK_LAYER_LUNARG_api_dump"}};
+
+    auto original_pToolProperties = pToolProperties;
+    if (pToolProperties != nullptr) {{
+        *pToolProperties = api_dump_layer_tool_props;
+        pToolProperties = ((*pToolCount > 1) ? &pToolProperties[1] : nullptr);
+        (*pToolCount)--;
+    }}
+
+    VkLayerInstanceDispatchTable *pInstanceTable = instance_dispatch_table(physicalDevice);
+    VkResult result = pInstanceTable->GetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties);
+
+    if (original_pToolProperties != nullptr) {{
+        pToolProperties = original_pToolProperties;
+    }}
+
+    (*pToolCount)++;
+    dump_body_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
+    return result;
+}}
 
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName)
 {{


### PR DESCRIPTION
Added support for VK_EXT_tooling_info for the following layers:
`VK_LAYER_LUNARG_screenshot`
`VK_LAYER_LUNARG_monitor`
`VK_LAYER_LUNARG_device_simulation`
`VK_LAYER_LUNARG_api_dump`