### PR TITLE
Android: screenshot layer #965

### DIFF
--- a/layersvt/screenshot_layer.md
+++ b/layersvt/screenshot_layer.md
@@ -33,18 +33,18 @@ __Note:__ Environment variables take precedence over vk\_layer\_settings.txt opt
 
 ## Android
 
-Frame numbers can be specified with the debug.vulkan.screenshot property:
+Frame numbers can be specified with the `debug.vulkan.screenshot` property:
 
 ```
 adb shell setprop debug.vulkan.screenshot <framenumbers>
 ```
 
-The directory in which to create the image files can be specified with the debug.vulkan.dir property:
+The directory in which to create the image files can be specified with the `debug.vulkan.screenshot.dir` property:
 
 ```
-adb shell setprop debug.vulkan.dir <directory>
+adb shell setprop debug.vulkan.screenshot.dir <directory>
 ```
-If debug.vulkan.dir is not set or it is set to an empty string, the value of debug.vulkan.dir will default to "/sdcard/Android".
+If `debug.vulkan.screenshot.dir` is not set or it is set to an empty string, the value of `debug.vulkan.screenshot.dir` will default to "/sdcard/Android".
 
 For production builds, if the files are to be written to external storage, make sure your application is able to read and write external storage by adding the following to AndroidManifest.xml:
 


### PR DESCRIPTION
https://github.com/LunarG/VulkanTools/issues/965

On Android, A single static buffer was being used to hold the
results of all of the screenshot layer settings
(debug.vulkan.screenshot, debug.vulkan.screenshot.dir,
debug.vulkan.screenshot.format).  All values would appear to
be the same as the last queried value.

This fix saves separate static buffers for each setting.
It also uses the Android PROP_VALUE_MAX to indicate the
size of each buffer (the old value of 64 could be too small
in some circumstances), and uses the Android
__system_property_get() function to query each property
(rather than using the "getprop" command and reading results back
from a pipe, which is unnecessarily complicated).

Finally, the screenshot documentation was updated;
the old documentation incorrectly referred to "debug.vulkan.dir"
as the location where screenshots would be saved.