### PR TITLE
apidump: Remove extra space in 0-valued flags in json output

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1452,7 +1452,9 @@ std::ostream& dump_json_{enumName}({enumName} object, const ApiDumpSettings& set
 std::ostream& dump_json_{bitName}({bitName} object, const ApiDumpSettings& settings, int indents)
 {{
     bool is_first = true;
-    settings.stream() << '"' << object << ' ';
+    settings.stream() << '"' << object;
+    if (object)
+        settings.stream() << ' ';
     @foreach option
         @if('{optMultiValue}' != 'None')
             if(object == {optValue})


### PR DESCRIPTION
Changes "value": "0 " to "value" : "0"

Change-Id: Ida26a4d56ce702cca44ad96c2df854eb1ced29b5