### PR TITLE
VulkanTools: Fix broken Windows Android build.

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -39,25 +39,6 @@ echo Entering Generated/Include Folder
 echo ********
 pushd generated\include
 
-echo Generating LVL header/source files
-echo ********
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_safe_struct.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_safe_struct.cpp
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_enum_string_helper.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_object_types.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_dispatch_table_helper.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% thread_check.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% parameter_validation.cpp
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_layer_dispatch_table.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_extension_helper.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% vk_typemap_helper.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% object_tracker.cpp
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% object_tracker.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% layer_chassis_dispatch.cpp
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% layer_chassis_dispatch.h
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% chassis.cpp
-py -3 %LVL_SCRIPTS%\lvl_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% chassis.h
-
 REM layer factory
 echo Generating VT layer factory header/source files
 echo ********

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -28,9 +28,6 @@ VT_SCRIPTS=../../../scripts
 REGISTRY_PATH=$dir/third_party/Vulkan-Headers/registry
 REGISTRY=${REGISTRY_PATH}/vk.xml
 
-# validation layers support files
-( cd generated/include; cp  $LVL_GENERATED/* .)
-
 # layer factory
 ( cd generated/include; python3 ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} layer_factory.h )
 ( cd generated/include; python3 ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} layer_factory.cpp )

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -29,7 +29,8 @@ LOCAL_SRC_FILES += $(LVL_DIR)/layers/vk_layer_utils.cpp
 LOCAL_SRC_FILES += $(LVL_DIR)/layers/vk_format_utils.cpp
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include \
-                    $(LOCAL_PATH)/$(LVL_DIR)/layers
+                    $(LOCAL_PATH)/$(LVL_DIR)/layers \
+                    $(LOCAL_PATH)/$(LVL_DIR)/layers/generated
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
 include $(BUILD_STATIC_LIBRARY)
@@ -43,6 +44,7 @@ LOCAL_SRC_FILES += $(LAYER_DIR)/include/api_dump.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layersvt/vk_layer_table.cpp
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include \
                     $(LOCAL_PATH)/$(LVL_DIR)/layers \
+                    $(LOCAL_PATH)/$(LVL_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include
 LOCAL_STATIC_LIBRARIES += layer_utils
@@ -58,6 +60,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layersvt/screenshot_parsing.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layersvt/vk_layer_table.cpp
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include \
                     $(LOCAL_PATH)/$(LVL_DIR)/layers \
+                    $(LOCAL_PATH)/$(LVL_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include
 LOCAL_STATIC_LIBRARIES += layer_utils
@@ -74,6 +77,7 @@ LOCAL_SRC_FILES += $(ANDROID_DIR)/third_party/jsoncpp/dist/jsoncpp.cpp
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(ANDROID_DIR)/third_party/jsoncpp/dist \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include \
                     $(LOCAL_PATH)/$(LVL_DIR)/layers \
+                    $(LOCAL_PATH)/$(LVL_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include
 LOCAL_STATIC_LIBRARIES += layer_utils
@@ -109,6 +113,7 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/vktrace/include \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include/vulkan \
                     $(LOCAL_PATH)/$(LVL_DIR)/layers \
+                    $(LOCAL_PATH)/$(LVL_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include \
                     $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_common \
                     $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_layer \
@@ -151,6 +156,7 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/vktrace/include \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include \
                     $(LOCAL_PATH)/$(THIRD_PARTY)/Vulkan-Headers/include/vulkan \
                     $(LOCAL_PATH)/$(LVL_DIR)/layers \
+                    $(LOCAL_PATH)/$(LVL_DIR)/layers/generated \
                     $(LOCAL_PATH)/$(SRC_DIR)/layersvt \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include \
                     $(LOCAL_PATH)/$(SRC_DIR)/vktrace/vktrace_common \

--- a/scripts/vlf_makefile_generator.py
+++ b/scripts/vlf_makefile_generator.py
@@ -84,6 +84,7 @@ if __name__ == '__main__':
             contents += 'LOCAL_C_INCLUDES += %s\n' % include_dir
             contents += 'LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(LAYER_DIR)/include\n'
             contents += 'LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(LVL_DIR)/layers\n'
+            contents += 'LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(LVL_DIR)/layers/generated\n'
             contents += 'LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/layer_factory/%s\n' % factory_layer
             contents += 'LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(LVL_DIR)/loader\n'
             contents += 'LOCAL_STATIC_LIBRARIES += layer_utils\n'


### PR DESCRIPTION
This change address VulkanTools issue #968.

A few months ago, the Vulkan-ValidationLayers build switched to
using pre-generated source files. (It used to generate some of
the source files during the build.) This broke the VulkanTools
Android build. The problem was fixed for the Linux Androld build
(but the fix was not completely correct). This  commit fixes the
Android build on Windows, and correctly fixes the Android build
for Linux.

Change-Id: Ie2051bd0229ce305bc6027ee46fdac317c141000