### PR TITLE
apidump: Fix json output in multithreaded apps

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -382,6 +382,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 @foreach function where('{funcName}' == 'vkQueuePresentKHR')
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
+    ApiDumpInstance::current().outputMutex()->lock();
     dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
 
     {funcReturn} result = device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
@@ -389,6 +390,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     dump_body_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
 
     ApiDumpInstance::current().nextFrame();
+    ApiDumpInstance::current().outputMutex()->unlock();
     return result;
 }}
 @end function


### PR DESCRIPTION
The call to next frame has to do setup, of which requires printing to
the output. The issue was this call happened outside of the lock,
causing corrupt output. This commit fixes it by keeping the lock while
the output occurs.

Fixes #962 

Change-Id: I6b05e53b9587f91bf7d85cee7399ca1b16d500fa