### PR TITLE
FindVulkanHeaders: Match header lines more precisely

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -113,7 +113,7 @@ foreach(VulkanHeader_line ${VulkanHeader_lines})
     #   Format is:
     #      #define VK_HEADER_VERSION Z
     #   Where Z is the patch version which we just grab off the end
-    string(REGEX MATCH "define.*VK_HEADER_VERSION.*[0-9]+" VulkanHeaders_out ${VulkanHeader_line})
+    string(REGEX MATCH "define.*VK_HEADER_VERSION[^_].*[0-9]+" VulkanHeaders_out ${VulkanHeader_line})
     list(LENGTH VulkanHeaders_out VulkanHeaders_len)
     if (VulkanHeaders_len)
         string(REGEX MATCH "[0-9]+" VulkanHeaders_VERSION_PATCH "${VulkanHeaders_out}")


### PR DESCRIPTION
Bring over the commit from Vulkan-Loader repo:
https://github.com/KhronosGroup/Vulkan-Loader/commit/63db609ca1c040bacc25c11fdea7571d1dd86b1f

With the recent addition of VK_HEADER_VERSION_COMPLETE, the regex code in CMakeLists was extracting the wrong value.

Internal and external CI in-process

Change-Id: I1ba9d5b4b986ed2c1904c53ada011989a8a4f1dc