### PR TITLE
apidump: optional frame and thread header

### DIFF
--- a/layersvt/api_dump_layer.md
+++ b/layersvt/api_dump_layer.md
@@ -155,3 +155,4 @@ Show Shader | `lunarg_api_dump.show_shader` | false | Output the contents of any
 Show Types | `lunarg_api_dump.show_types` | true | Output the types for each setting.
 Type Size | `lunarg_api_dump.type_size` | 0 | Set the max length to assume for written types.  This is intended to allow cleaner indenting by reserving space for types shorter than this length.  A value of 0 means no additional spacing applied.  Only valid when "Use Spaces" is enabled.
 Use Spaces| `lunarg_api_dump.use_spaces` | true | Attempt to use additional white space to produce a cleaner/easier-to-read output.
+Show Thread And Frame | `lunarg_api_dump.show_thread_and_frame` | true | Show the thread and frame of each function called.

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -844,12 +844,18 @@ std::ostream& dump_text_{unName}(const {unName}& object, const ApiDumpSettings& 
 std::ostream& dump_text_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
-    settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
-    if(settings.showTimestamp()) {{
-        settings.stream() << ", Time " << dump_inst.current_time_since_start().count() << " us:\\n";
-    }} else {{
-        settings.stream() << ":\\n";
+    if (settings.showThreadAndFrame()) {{
+        settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
+    }}
+    if(settings.showTimestamp() && settings.showThreadAndFrame()) {{
+        settings.stream() << ", ";
+    }}
+    if (settings.showTimestamp()) {{
+        settings.stream() << "Time " << dump_inst.current_time_since_start().count() << " us";
     }} 
+    if (settings.showTimestamp() || settings.showThreadAndFrame()) {{
+        settings.stream() << ":\\n";
+    }}
     settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn}";
 
     return settings.shouldFlush() ? settings.stream() << std::flush : settings.stream();
@@ -1258,8 +1264,9 @@ std::ostream& dump_html_{unName}(const {unName}& object, const ApiDumpSettings& 
 std::ostream& dump_html_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
-
-    settings.stream() << "<div class='thd'>Thread " << dump_inst.threadID() << ":</div>";
+    if (settings.showThreadAndFrame()){{
+        settings.stream() << "<div class='thd'>Thread: " << dump_inst.threadID() << "</div>";
+    }}
     if(settings.showTimestamp())
         settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " us</div>";
     settings.stream() << "<details class='fn'><summary>";
@@ -1709,7 +1716,9 @@ std::ostream& dump_json_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
     settings.stream() << settings.indentation(3) << "\\\"name\\\" : \\\"{funcName}\\\",\\n";
 
     // Display thread info
-    settings.stream() << settings.indentation(3) << "\\\"thread\\\" : \\\"Thread " << dump_inst.threadID() << "\\\",\\n";
+    if (settings.showThreadAndFrame()){{
+        settings.stream() << settings.indentation(3) << "\\\"thread\\\" : \\\"Thread " << dump_inst.threadID() << "\\\",\\n";
+    }}
 
     // Display elapsed time
     if(settings.showTimestamp()) {{

--- a/vkconfig/layer_info.json
+++ b/vkconfig/layer_info.json
@@ -172,6 +172,12 @@
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
                 "type": "string",
                 "default": "0-0"
+            },
+            "show_thread_and_frame": {
+                "name": "Show Thread and Frame counters",
+                "description": "Show the Thread and Frame before each function call",
+                "type": "bool",
+                "default": true
             }
         },
         "VK_LAYER_LUNARG_core_validation": {


### PR DESCRIPTION
This change makes the thread and frame header before each printed
function optional. By default, the output does not change, and it is an
'opt-in' only feature which requires setting the 
`lunarg_apidump.show_thread_and_frame` setting to FALSE. The default
value for the setting is TRUE, which is the current behavior

Change-Id: I5cecee34ada31f417bb7dc8a2c394498c2a19831