### PR TITLE
Fix generator scripts

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1957,9 +1957,19 @@ class ApiDumpGeneratorOptions(GeneratorOptions):
                  alignFuncParam = 0,
                  expandEnumerants = True,
                  ):
-        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
-            versions, emitversions, defaultExtensions,
-            addExtensions, removeExtensions, emitExtensions, sortProcedure)
+        GeneratorOptions.__init__(self,
+                                  conventions=conventions,
+                                  filename=filename,
+                                  directory=directory,
+                                  apiname=apiname,
+                                  profile=profile,
+                                  versions=versions,
+                                  emitversions=emitversions,
+                                  defaultExtensions=defaultExtensions,
+                                  addExtensions=addExtensions,
+                                  removeExtensions=removeExtensions,
+                                  emitExtensions=emitExtensions,
+                                  sortProcedure=sortProcedure)
         self.input           = input
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers

--- a/scripts/layer_factory_generator.py
+++ b/scripts/layer_factory_generator.py
@@ -86,9 +86,19 @@ class LayerFactoryGeneratorOptions(GeneratorOptions):
                  alignFuncParam = 0,
                  helper_file_type = '',
                  expandEnumerants = True):
-        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
-                                  versions, emitversions, defaultExtensions,
-                                  addExtensions, removeExtensions, emitExtensions, sortProcedure)
+        GeneratorOptions.__init__(self,
+                                  conventions=conventions,
+                                  filename=filename,
+                                  directory=directory,
+                                  apiname=apiname,
+                                  profile=profile,
+                                  versions=versions,
+                                  emitversions=emitversions,
+                                  defaultExtensions=defaultExtensions,
+                                  addExtensions=addExtensions,
+                                  removeExtensions=removeExtensions,
+                                  emitExtensions=emitExtensions,
+                                  sortProcedure=sortProcedure)
         self.prefixText      = prefixText
         self.genFuncPointers = genFuncPointers
         self.protectFile     = protectFile

--- a/scripts/tool_helper_file_generator.py
+++ b/scripts/tool_helper_file_generator.py
@@ -54,9 +54,19 @@ class ToolHelperFileOutputGeneratorOptions(GeneratorOptions):
                  alignFuncParam = 0,
                  library_name = '',
                  helper_file_type = ''):
-        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
-                                  versions, emitversions, defaultExtensions,
-                                  addExtensions, removeExtensions, emitExtensions, sortProcedure)
+        GeneratorOptions.__init__(self,
+                                  conventions=conventions,
+                                  filename=filename,
+                                  directory=directory,
+                                  apiname=apiname,
+                                  profile=profile,
+                                  versions=versions,
+                                  emitversions=emitversions,
+                                  defaultExtensions=defaultExtensions,
+                                  addExtensions=addExtensions,
+                                  removeExtensions=removeExtensions,
+                                  emitExtensions=emitExtensions,
+                                  sortProcedure=sortProcedure)
         self.prefixText       = prefixText
         self.genFuncPointers  = genFuncPointers
         self.protectFile      = protectFile

--- a/scripts/vktrace_file_generator.py
+++ b/scripts/vktrace_file_generator.py
@@ -186,9 +186,19 @@ class VkTraceFileOutputGeneratorOptions(GeneratorOptions):
                  expandEnumerants = True,
                  library_name = '',
                  vktrace_file_type = ''):
-        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
-                                  versions, emitversions, defaultExtensions,
-                                  addExtensions, removeExtensions, emitExtensions, sortProcedure)
+        GeneratorOptions.__init__(self,
+                                  conventions=conventions,
+                                  filename=filename,
+                                  directory=directory,
+                                  apiname=apiname,
+                                  profile=profile,
+                                  versions=versions,
+                                  emitversions=emitversions,
+                                  defaultExtensions=defaultExtensions,
+                                  addExtensions=addExtensions,
+                                  removeExtensions=removeExtensions,
+                                  emitExtensions=emitExtensions,
+                                  sortProcedure=sortProcedure)
         self.prefixText       = prefixText
         self.genFuncPointers  = genFuncPointers
         self.protectFile      = protectFile


### PR DESCRIPTION
Using positional arguments instead of named ones leads to desynchro
between the Vulkan-Headers repo and this one. Since all arguments are
named, better use names and avoid breakage.