### PR TITLE
vkconfig2: Enable Synchronization validation default configuration

### DIFF
--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -26,8 +26,6 @@
 #include <QString>
 #include <QStringList>
 
-#define ENABLE_VALIDATION_SYNC 0
-
 // json file preset_index must match the preset enum values
 enum ValidationPreset {
     ValidationPresetNone = 0,
@@ -37,17 +35,10 @@ enum ValidationPreset {
     ValidationPresetShaderPrintf = 3,
     ValidationPresetReducedOverhead = 4,
     ValidationPresetBestPractices = 5,
-
-#if ENABLE_VALIDATION_SYNC
     ValidationPresetSynchronization = 6,
-#endif
 
     ValidationPresetFirst = ValidationPresetUserDefined,
-#if ENABLE_VALIDATION_SYNC
-    ValidationPresetLast = ValidationPresetSynchronization,
-#else
-    ValidationPresetLast = ValidationPresetBestPractices,
-#endif
+    ValidationPresetLast = ValidationPresetSynchronization
 };
 
 enum { ValidationPresetCount = ValidationPresetLast - ValidationPresetFirst + 1 };

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -91,15 +91,14 @@ static const DefaultConfiguration default_configurations[] = {
      ValidationPresetReducedOverhead},
     {"Validation - Best Practices", "VK_LAYER_KHRONOS_validation", Version("1.1.126"), "Best Practices",
      ValidationPresetBestPractices},
-#if ENABLE_VALIDATION_SYNC
-    {"Validation - Synchronization (Beta)", "VK_LAYER_KHRONOS_validation", "1.2.145", "Synchronization (Beta)",
+    {"Validation - Synchronization (Alpha)", "VK_LAYER_KHRONOS_validation", Version("1.2.147"), "Synchronization (Alpha)",
      ValidationPresetSynchronization},
-#endif
 #ifndef __APPLE__
-    {"Frame Capture - First two frames", "VK_LAYER_LUNARG_gfxreconstruct", "1.2.145", "", ValidationPresetNone},
-    {"Frame Capture - Range (F10 to start and to stop)", "VK_LAYER_LUNARG_gfxreconstruct", "1.2.145", "", ValidationPresetNone},
+    {"Frame Capture - First two frames", "VK_LAYER_LUNARG_gfxreconstruct", Version("1.2.147"), "", ValidationPresetNone},
+    {"Frame Capture - Range (F10 to start and to stop)", "VK_LAYER_LUNARG_gfxreconstruct", Version("1.2.147"), "",
+     ValidationPresetNone},
 #endif
-    {"API dump", "VK_LAYER_LUNARG_api_dump", "1.1.126", "", ValidationPresetNone}};
+    {"API dump", "VK_LAYER_LUNARG_api_dump", Version("1.1.126"), "", ValidationPresetNone}};
 
 static const DefaultConfiguration *FindDefaultConfiguration(const char *name) {
     assert(name);

--- a/vkconfig/resourcefiles/Validation - Best Practices.json
+++ b/vkconfig/resourcefiles/Validation - Best Practices.json
@@ -1,94 +1,97 @@
 {
-  "Validation - Best Practices": {
-    "preset": 5,
-    "description": "This configuration provides access to the Vulkan Best Practices check. Provides warnings about potential API misuse.",
-    "editor_state": "0111011111111111111111101111111111111",
-    "blacklisted_layers": [],
-    "layer_options": {
-      "VK_LAYER_KHRONOS_validation": {
-        "layer_rank": 0,
-        "debug_action": {
-          "name": "Debug Action",
-          "description": "This indicates what action is to be taken when a layer wants to report information",
-          "type": "enum",
-          "options": {
-            "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
-            "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-            "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
-            "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output",
-            "VK_DBG_LAYER_ACTION_BREAK": "Break"
-          },
-          "default": "VK_DBG_LAYER_ACTION_LOG_MSG"
+    "Validation - Best Practices": {
+        "blacklisted_layers": [
+        ],
+        "description": "This configuration provides access to the Vulkan Best Practices check. Provides warnings about potential API misuse.",
+        "editor_state": "01110111111111111111111001111111111110",
+        "layer_options": {
+            "VK_LAYER_KHRONOS_validation": {
+                "debug_action": {
+                    "default": "VK_DBG_LAYER_ACTION_LOG_MSG",
+                    "description": "This indicates what action is to be taken when a layer wants to report information",
+                    "name": "Debug Action",
+                    "options": {
+                        "VK_DBG_LAYER_ACTION_BREAK": "Break",
+                        "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
+                        "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
+                        "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
+                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                    },
+                    "type": "enum"
+                },
+                "disables": {
+                    "default": [
+                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
+                    ],
+                    "description": "Setting an option here will disable areas of validation",
+                    "name": "Disables",
+                    "options": {
+                        "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE": "Command Buffer State",
+                        "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set",
+                        "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION": "Image Layout Validation",
+                        "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
+                        "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE": "Push Constant Range",
+                        "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION": "Query Validation",
+                        "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Core validation checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Object lifetime validation",
+                        "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT": "Disable Shaders",
+                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Handle wrapping"
+                    },
+                    "type": "multi_enum"
+                },
+                "enables": {
+                    "default": [
+                        "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT"
+                    ],
+                    "description": "Setting an option here will enable specialized areas of validation",
+                    "name": "Enables",
+                    "options": {
+                        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific validation",
+                        "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT": "Best Practices warning checks",
+                        "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use"
+                    },
+                    "type": "multi_enum"
+                },
+                "layer_rank": 0,
+                "log_filename": {
+                    "default": "stdout",
+                    "description": "Specifies the output filename, use stdout to rely on the standard output instead.",
+                    "name": "Log Filename",
+                    "type": "save_file"
+                },
+                "message_id_filter": {
+                    "default": "",
+                    "description": "VUID's to ignore",
+                    "name": "Message Filter",
+                    "type": "vuid_exclude"
+                },
+                "report_flags": {
+                    "default": [
+                        "error",
+                        "perf",
+                        "warn"
+                    ],
+                    "description": "The message severity the layer should report back",
+                    "name": "Message Severity",
+                    "options": {
+                        "debug": "Debug",
+                        "error": "Error",
+                        "info": "Info",
+                        "perf": "Perf",
+                        "warn": "Warn"
+                    },
+                    "type": "multi_enum"
+                }
+            }
         },
-        "report_flags": {
-          "name": "Message Severity",
-          "description": "The message severity the layer should report back",
-          "type": "multi_enum",
-          "options": {
-            "info": "Info",
-            "warn": "Warn",
-            "perf": "Perf",
-            "error": "Error",
-            "debug": "Debug"
-          },
-          "default": [
-            "error",
-            "perf",
-            "warn"
-          ]
-        },
-        "log_filename": {
-          "name": "Log Filename",
-          "description": "Specifies the output filename, use stdout to rely on the standard output instead.",
-          "type": "save_file",
-          "default": "stdout"
-        },
-        "message_id_filter": {
-          "name": "Message Filter",
-          "description": "VUID's to ignore",
-          "type": "vuid_exclude",
-          "default": ""
-        },
-        "disables": {
-          "name": "Disables",
-          "description": "Setting an option here will disable areas of validation",
-          "type": "multi_enum",
-          "options": {
-            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety checks",
-            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter checks",
-            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Object lifetime validation",
-            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Core validation checks",
-            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Handle wrapping",
-            "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT": "Disable Shaders",
-            "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE": "Command Buffer State",
-            "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION": "Image Layout Validation",
-            "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION": "Query Validation",
-            "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE": "Push Constant Range",
-            "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
-            "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set"
-          },
-          "default": [
-            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT"
-          ]
-        },
-        "enables": {
-          "name": "Enables",
-          "description": "Setting an option here will enable specialized areas of validation",
-          "type": "multi_enum",
-          "options": {
-            "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use",
-            "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT": "Best Practices warning checks",
-            "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific validation"
-          },
-          "default": [ "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT" ]
-        }
-      }
+        "preset": 5
     }
-  }
 }

--- a/vkconfig/resourcefiles/Validation - GPU-Assisted.json
+++ b/vkconfig/resourcefiles/Validation - GPU-Assisted.json
@@ -1,106 +1,98 @@
 {
-  "Validation - GPU-Assisted": {
-    "preset": 2,
-    "description": "Provides easy access to gpu-assisted validation tools.",
-    "editor_state": "0111011111111111111111101111111111111",
-    "blacklisted_layers": [],
-    "layer_options": {
-      "VK_LAYER_KHRONOS_validation": {
-        "layer_rank": 0,
-        "debug_action": {
-          "name": "Debug Action",
-          "description": "This indicates what action is to be taken when a layer wants to report information",
-          "type": "enum",
-          "options": {
-            "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
-            "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-            "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
-            "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output",
-            "VK_DBG_LAYER_ACTION_BREAK": "Break"
-          },
-          "default": "VK_DBG_LAYER_ACTION_LOG_MSG"
+    "Validation - GPU-Assisted": {
+        "blacklisted_layers": [
+        ],
+        "description": "Provides easy access to gpu-assisted validation tools.",
+        "editor_state": "01110111111111111111111001111111111110",
+        "layer_options": {
+            "VK_LAYER_KHRONOS_validation": {
+                "debug_action": {
+                    "default": "VK_DBG_LAYER_ACTION_LOG_MSG",
+                    "description": "This indicates what action is to be taken when a layer wants to report information",
+                    "name": "Debug Action",
+                    "options": {
+                        "VK_DBG_LAYER_ACTION_BREAK": "Break",
+                        "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
+                        "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
+                        "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
+                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                    },
+                    "type": "enum"
+                },
+                "disables": {
+                    "default": [
+                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
+                    ],
+                    "description": "Setting an option here will disable areas of validation",
+                    "name": "Disables",
+                    "options": {
+                        "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE": "Command Buffer State",
+                        "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set",
+                        "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION": "Image Layout Validation",
+                        "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
+                        "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE": "Push Constant Range",
+                        "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION": "Query Validation",
+                        "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Core validation checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Object lifetime validation",
+                        "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT": "Disable Shaders",
+                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Handle wrapping"
+                    },
+                    "type": "multi_enum"
+                },
+                "enables": {
+                    "default": [
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT"
+                    ],
+                    "description": "Setting an option here will enable specialized areas of validation",
+                    "name": "Enables",
+                    "options": {
+                        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific validation",
+                        "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT": "Best Practices warning checks",
+                        "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use"
+                    },
+                    "type": "multi_enum"
+                },
+                "layer_rank": 0,
+                "log_filename": {
+                    "default": "stdout",
+                    "description": "Specifies the output filename, use stdout to rely on the standard output instead.",
+                    "name": "Log Filename",
+                    "type": "save_file"
+                },
+                "message_id_filter": {
+                    "default": "",
+                    "description": "VUID's to ignore",
+                    "name": "Message Filter",
+                    "type": "vuid_exclude"
+                },
+                "report_flags": {
+                    "default": [
+                        "error",
+                        "perf",
+                        "warn"
+                    ],
+                    "description": "The message severity the layer should report back",
+                    "name": "Message Severity",
+                    "options": {
+                        "debug": "Debug",
+                        "error": "Error",
+                        "info": "Info",
+                        "perf": "Perf",
+                        "warn": "Warn"
+                    },
+                    "type": "multi_enum"
+                }
+            }
         },
-        "report_flags": {
-          "name": "Message Severity",
-          "description": "The message severity the layer should report back",
-          "type": "multi_enum",
-          "options": {
-            "info": "Info",
-            "warn": "Warn",
-            "perf": "Perf",
-            "error": "Error",
-            "debug": "Debug"
-          },
-          "default": [
-            "error",
-            "perf",
-            "warn"
-          ]
-        },
-        "log_filename": {
-          "name": "Log Filename",
-          "description": "Specifies the output filename, use stdout to rely on the standard output instead.",
-          "type": "save_file",
-          "default": "stdout"
-        },
-        "message_id_filter": {
-          "name": "Message Filter",
-          "description": "VUID's to ignore",
-          "type": "vuid_exclude",
-          "default": ""
-        },
-        "disables": {
-          "name": "Disables",
-          "description": "Setting an option here will disable areas of validation",
-          "type": "multi_enum",
-          "options": {
-            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety checks",
-            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter checks",
-            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Object lifetime validation",
-            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Core validation checks",
-            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Handle wrapping",
-            "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT": "Disable Shaders",
-            "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE": "Command Buffer State",
-            "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION": "Image Layout Validation",
-            "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION": "Query Validation",
-            "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE": "Push Constant Range",
-            "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
-            "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set"
-          },
-          "default": [
-            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT"
-          ]
-        },
-        "enables": {
-          "name": "Enables",
-          "description": "Setting an option here will enable specialized areas of validation",
-          "type": "multi_enum",
-          "options": {
-            "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use",
-            "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT": "Best Practices warning checks",
-            "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific validation"
-          },
-          "default": [
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT"
-          ]
-        }
-      }
+        "preset": 2
     }
-  }
 }
-
-
-
-
-
-
-
-
-

--- a/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
+++ b/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
@@ -1,98 +1,99 @@
 {
-  "Validation - Reduced-Overhead": {
-    "preset": 4,
-    "description": "This configuration disables some of the checks of Standard Validation in the interest of performance.",
-    "editor_state": "0111011111111111111111101111111111111",
-    "blacklisted_layers": [],
-    "layer_options": {
-      "VK_LAYER_KHRONOS_validation": {
-        "layer_rank": 0,
-        "debug_action": {
-          "name": "Debug Action",
-          "description": "This indicates what action is to be taken when a layer wants to report information",
-          "type": "enum",
-          "options": {
-            "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
-            "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-            "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
-            "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output",
-            "VK_DBG_LAYER_ACTION_BREAK": "Break"
-          },
-          "default": "VK_DBG_LAYER_ACTION_LOG_MSG"
+    "Validation - Reduced-Overhead": {
+        "blacklisted_layers": [
+        ],
+        "description": "This configuration disables some of the checks of Standard Validation in the interest of performance.",
+        "editor_state": "01110111111111111111111001111111111110",
+        "layer_options": {
+            "VK_LAYER_KHRONOS_validation": {
+                "debug_action": {
+                    "default": "VK_DBG_LAYER_ACTION_LOG_MSG",
+                    "description": "This indicates what action is to be taken when a layer wants to report information",
+                    "name": "Debug Action",
+                    "options": {
+                        "VK_DBG_LAYER_ACTION_BREAK": "Break",
+                        "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
+                        "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
+                        "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
+                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                    },
+                    "type": "enum"
+                },
+                "disables": {
+                    "default": [
+                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
+                        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
+                        "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
+                        "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
+                        "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
+                        "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
+                        "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
+                        "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE"
+                    ],
+                    "description": "Setting an option here will disable areas of validation",
+                    "name": "Disables",
+                    "options": {
+                        "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE": "Command Buffer State",
+                        "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set",
+                        "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION": "Image Layout Validation",
+                        "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
+                        "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE": "Push Constant Range",
+                        "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION": "Query Validation",
+                        "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Core validation checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Object lifetime validation",
+                        "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT": "Disable Shaders",
+                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety checks",
+                        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Handle wrapping"
+                    },
+                    "type": "multi_enum"
+                },
+                "enables": {
+                    "default": [
+                    ],
+                    "description": "Setting an option here will enable specialized areas of validation",
+                    "name": "Enables",
+                    "options": {
+                        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific validation",
+                        "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT": "Best Practices warning checks",
+                        "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
+                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use"
+                    },
+                    "type": "multi_enum"
+                },
+                "layer_rank": 0,
+                "log_filename": {
+                    "default": "stdout",
+                    "description": "Specifies the output filename, use stdout to rely on the standard output instead.",
+                    "name": "Log Filename",
+                    "type": "save_file"
+                },
+                "message_id_filter": {
+                    "default": "",
+                    "description": "VUID's to ignore",
+                    "name": "Message Filter",
+                    "type": "vuid_exclude"
+                },
+                "report_flags": {
+                    "default": [
+                        "error",
+                        "perf",
+                        "warn"
+                    ],
+                    "description": "The message severity the layer should report back",
+                    "name": "Message Severity",
+                    "options": {
+                        "debug": "Debug",
+                        "error": "Error",
+                        "info": "Info",
+                        "perf": "Perf",
+                        "warn": "Warn"
+                    },
+                    "type": "multi_enum"
+                }
+            }
         },
-        "report_flags": {
-          "name": "Message Severity",
-          "description": "The message severity the layer should report back",
-          "type": "multi_enum",
-          "options": {
-            "info": "Info",
-            "warn": "Warn",
-            "perf": "Perf",
-            "error": "Error",
-            "debug": "Debug"
-          },
-          "default": [
-            "error",
-            "perf",
-            "warn"
-          ]
-        },
-        "log_filename": {
-          "name": "Log Filename",
-          "description": "Specifies the output filename, use stdout to rely on the standard output instead.",
-          "type": "save_file",
-          "default": "stdout"
-        },
-        "message_id_filter": {
-          "name": "Message Filter",
-          "description": "VUID's to ignore",
-          "type": "vuid_exclude",
-          "default": ""
-        },
-        "disables": {
-          "name": "Disables",
-          "description": "Setting an option here will disable areas of validation",
-          "type": "multi_enum",
-          "options": {
-            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety checks",
-            "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter checks",
-            "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Object lifetime validation",
-            "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Core validation checks",
-            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Handle wrapping",
-            "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT": "Disable Shaders",
-            "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE": "Command Buffer State",
-            "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION": "Image Layout Validation",
-            "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION": "Query Validation",
-            "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE": "Push Constant Range",
-            "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
-            "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set"
-          },
-          "default": [
-            "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
-            "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
-            "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
-            "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
-            "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
-            "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
-            "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
-            "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET"
-          ]
-        },
-        "enables": {
-          "name": "Enables",
-          "description": "Setting an option here will enable specialized areas of validation",
-          "type": "multi_enum",
-          "options": {
-            "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
-            "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use",
-            "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT": "Best Practices warning checks",
-            "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific validation"
-          },
-          "default": []
-        }
-      }
+        "preset": 4
     }
-  }
 }
-

--- a/vkconfig/resourcefiles/Validation - Shader Printf.json
+++ b/vkconfig/resourcefiles/Validation - Shader Printf.json
@@ -3,7 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "Provides easy access to debug-printf functionality.",
-        "editor_state": "0111011111111111111111101111111111111",
+        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Standard.json
+++ b/vkconfig/resourcefiles/Validation - Standard.json
@@ -3,7 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration is a good default validation setting and should serve most needs most of the time.",
-        "editor_state": "0111011111111111111111101111111111111",
+        "editor_state": "01110111111111111111111001011111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {
@@ -21,6 +21,7 @@
                 },
                 "disables": {
                     "default": [
+                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT"
                     ],
                     "description": "Setting an option here will disable areas of validation",
                     "name": "Disables",

--- a/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
+++ b/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
@@ -1,5 +1,5 @@
 {
-    "Validation - Synchronization (Beta)": {
+    "Validation - Synchronization (Alpha)": {
         "blacklisted_layers": [
         ],
         "description": "This configuration is a good default validation setting and should serve most needs most of the time.",
@@ -21,7 +21,6 @@
                 },
                 "disables": {
                     "default": [
-                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",
                         "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
                         "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",
                         "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",

--- a/vkconfig/resources.qrc
+++ b/vkconfig/resources.qrc
@@ -27,7 +27,7 @@
         <file>resourcefiles/Validation - Reduced-Overhead.json</file>
         <file>resourcefiles/Validation - Shader Printf.json</file>
         <file>resourcefiles/Validation - Standard.json</file>
-        <file>resourcefiles/Validation - Synchronization (Beta).json</file>
+        <file>resourcefiles/Validation - Synchronization (Alpha).json</file>
         <file>resourcefiles/Frame Capture - First two frames.json</file>
         <file>resourcefiles/Frame Capture - Range (F10 to start and to stop).json</file>
     </qresource>


### PR DESCRIPTION
    - Add Synchronization Validation default configuration
    - Add Synchronization preset
    - Show that synchronization validation is Alpha
    - Remove threading checks from standard validation configuration
    - Fix default layout of validation configurations settings

Replace #1019 PR