### PR TITLE
Richard vkconfig layer discovery rebase

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -146,8 +146,7 @@ Configurator::Configurator()
       active_configuration_(nullptr) {
     available_Layers.reserve(10);
 
-#ifdef _WIN32
-    // Note: This is a Win32 function, not a Qt function
+#if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     running_as_administrator_ = IsUserAnAdmin();
 #else
     running_as_administrator_ = false;

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -120,6 +120,7 @@ class Configurator {
     enum { PathCount = LastPath - FirstPath + 1 };
 
     static Configurator& Get();
+    bool InitializeConfigurator(void);
 
     // Need this to check vulkan loader version
     uint32_t vulkan_instance_version;
@@ -174,6 +175,11 @@ class Configurator {
     int GetCustomLayersPathSize() const;
     const QString& GetCustomLayersPath(int path_index) const;
 
+    QStringList VK_LAYER_PATH;  // If this environment variable is set, this contains
+                                // a list of paths that should be searched first for
+                                // Vulkan layers. (Named as environment variable for
+                                // clarity as to where this comes from).
+
    private:
     QStringList custom_layers_paths_;
 
@@ -203,7 +209,7 @@ class Configurator {
     QVector<LayerFile*> available_Layers;  // All the found layers, lumped together
     void LoadAllInstalledLayers();
     const LayerFile* FindLayerNamed(QString layer_name, const char* location = nullptr);
-    void LoadLayersFromPath(const QString& path, QVector<LayerFile*>& layer_list, LayerType type);
+    void LoadLayersFromPath(const QString& path, QVector<LayerFile*>& layer_list);
 
     QVector<Configuration*> available_configurations;
 

--- a/vkconfig/dlgcustompaths.cpp
+++ b/vkconfig/dlgcustompaths.cpp
@@ -55,7 +55,7 @@ void dlgCustomPaths::RepopulateTree() {
 
         // Look for layers that are in this folder. If any are found, add them to the tree
         QVector<LayerFile *> custom_layers;
-        configurator.LoadLayersFromPath(custom_path, custom_layers, LAYER_TYPE_CUSTOM);
+        configurator.LoadLayersFromPath(custom_path, custom_layers);
 
         for (int j = 0; j < custom_layers.size(); j++) {
             QTreeWidgetItem *pChild = new QTreeWidgetItem();

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -258,7 +258,7 @@ void dlgProfileEditor::PopulateCustomTree() {
 
         // Look for layers that are in this folder. If any are found, add them to the tree
         QVector<LayerFile *> custom_layers;
-        configurator.LoadLayersFromPath(custom_path, custom_layers, LAYER_TYPE_CUSTOM);
+        configurator.LoadLayersFromPath(custom_path, custom_layers);
 
         for (int layer_index = 0; layer_index < custom_layers.size(); ++layer_index) {
             QTreeWidgetItem *child = new QTreeWidgetItem();

--- a/vkconfig/dlgvulkaninfo.cpp
+++ b/vkconfig/dlgvulkaninfo.cpp
@@ -74,9 +74,6 @@ void dlgVulkanInfo::RunTool() {
     vulkan_info->start();
     vulkan_info->waitForFinished();
 
-    QProcess::ProcessError error = vulkan_info->error();
-    printf("Error code: %d\n", error);
-
     // Check for the output file
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {

--- a/vkconfig/layerfile.cpp
+++ b/vkconfig/layerfile.cpp
@@ -153,10 +153,6 @@ void LayerFile::LoadSettingsFromJson(QJsonObject& layerSettingsDescriptors, QVec
         // user setting.
         if (settingsNames[iSetting] == QString("layer_rank")) continue;
 
-        // Layer path is in this JSON, do not add it as a setting,
-        // it is also not a user editable setting.
-        if (settingsNames[iSetting] == QString("layer_path")) continue;
-
         LayerSettings* pLayerSettings = new LayerSettings;
         pLayerSettings->settings_name = settingsNames[iSetting];
 

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
 #endif
 
     // We simply cannot run without any layers
-    if (!Configurator::Get().HasLayers()) return -1;
+    if (Configurator::Get().InitializeConfigurator() == false) return -1;
 
     // The main GUI is driven here
     MainWindow main_window;

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -78,6 +78,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui_(new Ui::MainW
     ///////////////////////////////////////////////
     Configurator &configurator = Configurator::Get();
 
+    if (!configurator.VK_LAYER_PATH.isEmpty())
+        ui_->groupBoxProfiles->setTitle("Vulkan Layers Configurations With VK_LAYER_PATH Precedence");
+
     // We need to resetup the new profile for consistency sake.
     QString last_configuration = settings_.value(VKCONFIG_KEY_ACTIVEPROFILE, QString("Validation - Standard")).toString();
     Configuration *current_configuration = configurator.FindConfiguration(last_configuration);


### PR DESCRIPTION
This addresses the remaining issues discussed here:
https://github.com/LunarG/Projects/issues/378

Layer discovery from vkconfig is as follows:
VK_LAYER_PATH (if it is present)
User defined layer search paths
Standard Layer Paths for the given OS
VULKAN_SDK path if present

No two layers with the same name may be used with vkconfig. So if there are duplicates, the above order is used as precedence for which one's are used. The specific path for each layer is displayed in layer editor dialog (select which layers to override).
Also, a visual indicator on the main screen is shown if the VK_LAYER_PATH environment variable is detected.
