### PR TITLE
vkconfig: Fixed log window overflow issue

### DIFF
--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -149,6 +149,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui_(new Ui::MainW
     ui_->logBrowser->append("Vulkan Development Status:");
     ui_->logBrowser->append(configurator.CheckVulkanSetup());
     ui_->profileTree->scrollToItem(ui_->profileTree->topLevelItem(0), QAbstractItemView::PositionAtTop);
+
+    // Resetting this from the default prevents the log window (a QTextEdit) from overflowing.
+    // Whenever the control surpasses this block count, old blocks are discarded.
+    // Note: We could make this a user configurable setting down the road should this be
+    // insufficinet.
+    ui_->logBrowser->document()->setMaximumBlockCount(2048);
 }
 
 MainWindow::~MainWindow() { delete ui_; }


### PR DESCRIPTION
Change-Id: I067f94aac44519b6ab28488d75ee91fa457e93f9

Simple fix to prevent log window from overflowing when too much log text is added.