### PR TITLE
vkconfig: Fix cmake regression for macOS builds

### DIFF
--- a/vkconfig/macOS/vkconfig.cmake
+++ b/vkconfig/macOS/vkconfig.cmake
@@ -19,7 +19,7 @@
 
 add_executable(vkconfig
     MACOSX_BUNDLE
-    ${LAYERMGR_SRCS}
+    ${FILES_ALL}
     ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vkconfig.sh
     ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Resources/LunarGIcon.icns
     )


### PR DESCRIPTION
Change-Id: I4f5f42f9d5d79b0075516533bf15282ccff54020
Fixed regression for cmake on macOS.