### PR TITLE
CMake regression fix for Qt libraries.

### DIFF
--- a/vkconfig/CMakeLists.txt
+++ b/vkconfig/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-find_package(Qt5 COMPONENTS Core Gui QWidgets Network QUIET)
+find_package(Qt5 COMPONENTS Core Gui Widgets Network QUIET)
 
 if(NOT Qt5_FOUND)
     message("WARNING: vkconfig will be excluded because Qt5 was not found. Please add Qt5 into the PATH environment variable")

--- a/vkconfig/CMakeLists.txt
+++ b/vkconfig/CMakeLists.txt
@@ -45,7 +45,7 @@ else()
             add_executable(vkconfig ${FILES_ALL} ${FILES_UI})
         endif()
         target_include_directories(vkconfig PRIVATE "${Vulkan_INCLUDE_DIR}")
-        target_link_libraries(vkconfig Qt5::Core Qt5::Gui Qt5::Widgets)
+        target_link_libraries(vkconfig Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
         target_compile_definitions(vkconfig PRIVATE ${VKCONFIG_DEFINITIONS})
 
         install(TARGETS vkconfig DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
A regression occurred when the CMakeLists.txt file was updated to include the network modules (now needed for the single instance feature). This corrects the erroneous error message that "QT could not be found"