### PR TITLE
vkconfig: Fix CMake Link Errors macOS

### DIFF
--- a/vkconfig/macOS/vkconfig.cmake
+++ b/vkconfig/macOS/vkconfig.cmake
@@ -29,7 +29,7 @@ set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/macOS/Resources/LunarGIc
                             PROPERTIES
                             MACOSX_PACKAGE_LOCATION
                             "Resources")
-target_link_libraries(vkconfig Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(vkconfig Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
 target_link_libraries(vkconfig "-framework Cocoa -framework QuartzCore")
 
 get_target_property(QMAKE_EXE Qt5::qmake IMPORTED_LOCATION)


### PR DESCRIPTION
Added Qt::Network library to `vkconfig.cmake`