### PR TITLE
vkconfig: Beta 4 updates

### DIFF
--- a/vkconfig/appsingleton.cpp
+++ b/vkconfig/appsingleton.cpp
@@ -32,14 +32,14 @@ AppSingleton::AppSingleton(QString singleAppName, int timeout) {
     QLocalSocket localSocket;
     localSocket.connectToServer(singleAppName);
     if (localSocket.waitForConnected(timeout)) {
-        is_first_app = false;
+        _is_first_app = false;
         localSocket.close();
         return;
     }
 
     // We are the first, start a server
-    is_first_app = true;
-    localServer_.listen(singleAppName);
+    _is_first_app = true;
+    _localServer.listen(singleAppName);
 }
 
-AppSingleton::~AppSingleton() { localServer_.close(); }
+AppSingleton::~AppSingleton() { _localServer.close(); }

--- a/vkconfig/appsingleton.h
+++ b/vkconfig/appsingleton.h
@@ -35,9 +35,9 @@ class AppSingleton {
    public:
     AppSingleton(QString singleAppName, int timeout = 500);
     ~AppSingleton();
-    bool IsFirstApp(void) { return is_first_app; }
+    bool IsFirstApp(void) { return _is_first_app; }
 
    protected:
-    QLocalServer localServer_;
-    bool is_first_app;
+    QLocalServer _localServer;
+    bool _is_first_app;
 };

--- a/vkconfig/boolsettingwidget.cpp
+++ b/vkconfig/boolsettingwidget.cpp
@@ -22,8 +22,8 @@
 #include "boolsettingwidget.h"
 
 BoolSettingWidget::BoolSettingWidget(LayerSettings *layer_settings, bool numeric) {
-    numeric_output_ = numeric;
-    layer_settings_ = layer_settings;
+    _numeric_output = numeric;
+    _layer_settings = layer_settings;
     setText(layer_settings->settings_prompt);
     setToolTip(layer_settings->settings_desc);
     setChecked(layer_settings->settings_value == QString("TRUE"));
@@ -31,16 +31,16 @@ BoolSettingWidget::BoolSettingWidget(LayerSettings *layer_settings, bool numeric
 }
 
 void BoolSettingWidget::itemToggled() {
-    if (numeric_output_) {
+    if (_numeric_output) {
         if (isChecked())
-            layer_settings_->settings_value = QString("1");
+            _layer_settings->settings_value = QString("1");
         else
-            layer_settings_->settings_value = QString("0");
+            _layer_settings->settings_value = QString("0");
     } else {
         if (isChecked())
-            layer_settings_->settings_value = QString("TRUE");
+            _layer_settings->settings_value = QString("TRUE");
         else
-            layer_settings_->settings_value = QString("FALSE");
+            _layer_settings->settings_value = QString("FALSE");
     }
 
     emit itemChanged();

--- a/vkconfig/boolsettingwidget.h
+++ b/vkconfig/boolsettingwidget.h
@@ -33,8 +33,8 @@ class BoolSettingWidget : public QCheckBox {
     BoolSettingWidget(LayerSettings *layer_settings, bool numeric = false);
 
    private:
-    bool numeric_output_;
-    LayerSettings *layer_settings_;
+    bool _numeric_output;
+    LayerSettings *_layer_settings;
 
    public Q_SLOTS:
     void itemToggled();

--- a/vkconfig/command_line.cpp
+++ b/vkconfig/command_line.cpp
@@ -24,14 +24,14 @@
 #include <string>
 #include <cstdio>
 
-CommandLine::CommandLine(int argc, char* argv[]) : mode(mode_), mode_(ModeExecute) {
+CommandLine::CommandLine(int argc, char* argv[]) : mode(_mode), _mode(ModeExecute) {
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if ((arg == "-h") || (arg == "--help")) {
-            mode_ = ModeShowUsage;
+            _mode = ModeShowUsage;
             return;
         } else if (arg == "--unit-test") {
-            mode_ = ModeRunTest;
+            _mode = ModeRunTest;
             return;
         }
     }

--- a/vkconfig/command_line.h
+++ b/vkconfig/command_line.h
@@ -32,5 +32,5 @@ class CommandLine {
     const Mode& mode;
 
    private:
-    Mode mode_;
+    Mode _mode;
 };

--- a/vkconfig/configuration.cpp
+++ b/vkconfig/configuration.cpp
@@ -26,18 +26,18 @@
 #include <QJsonArray>
 #include <QJsonObject>
 
-Configuration::Configuration() : preset(ValidationPresetNone), all_layers_available(true) {}
+Configuration::Configuration() : _preset(ValidationPresetNone), _all_layers_available(true) {}
 
 Configuration::~Configuration() {
-    qDeleteAll(layers.begin(), layers.end());
-    layers.clear();
+    qDeleteAll(_layers.begin(), _layers.end());
+    _layers.clear();
 }
 
 ///////////////////////////////////////////////////////////
 // Find the layer if it exists.
 LayerFile* Configuration::FindLayer(const QString& layer_name, const QString& full_path) const {
-    for (int i = 0; i < layers.size(); i++)
-        if (layers[i]->name == layer_name && layers[i]->layer_path == full_path) return layers[i];
+    for (int i = 0; i < _layers.size(); i++)
+        if (_layers[i]->_name == layer_name && _layers[i]->_layer_path == full_path) return _layers[i];
 
     return nullptr;
 }
@@ -45,8 +45,8 @@ LayerFile* Configuration::FindLayer(const QString& layer_name, const QString& fu
 ///////////////////////////////////////////////////////////
 // Find the layer if it exists. Only care about the name
 LayerFile* Configuration::FindLayerNamed(const QString& layer_name) const {
-    for (int i = 0; i < layers.size(); i++)
-        if (layers[i]->name == layer_name) return layers[i];
+    for (int i = 0; i < _layers.size(); i++)
+        if (_layers[i]->_name == layer_name) return _layers[i];
 
     return nullptr;
 }
@@ -60,18 +60,18 @@ LayerFile* Configuration::GetKhronosLayer() { return FindLayerNamed("VK_LAYER_KH
 // Copy a profile so we can mess with it.
 Configuration* Configuration::DuplicateConfiguration() {
     Configuration* duplicate = new Configuration;
-    duplicate->name = name;
-    duplicate->file = file;
-    duplicate->description = description;
-    duplicate->excluded_layers = excluded_layers;
-    duplicate->preset = preset;
-    duplicate->all_layers_available = all_layers_available;
+    duplicate->_name = _name;
+    duplicate->_file = _file;
+    duplicate->_description = _description;
+    duplicate->_excluded_layers = _excluded_layers;
+    duplicate->_preset = _preset;
+    duplicate->_all_layers_available = _all_layers_available;
     // Do not copy ->bFixedProfile
 
-    for (int i = 0; i < layers.size(); i++) {
+    for (int i = 0; i < _layers.size(); i++) {
         LayerFile* layer_file = new LayerFile;
-        layers[i]->CopyLayer(layer_file);
-        duplicate->layers.push_back(layer_file);
+        _layers[i]->CopyLayer(layer_file);
+        duplicate->_layers.push_back(layer_file);
     }
 
     return duplicate;
@@ -81,30 +81,30 @@ Configuration* Configuration::DuplicateConfiguration() {
 /// Remove unused layers and build the list of
 /// black listed layers.
 void Configuration::CollapseConfiguration() {
-    excluded_layers.clear();
+    _excluded_layers.clear();
 
     // Look for black listed layers, add them to the
     // string list of names, but remove them from
     // the list of layers
     int layer_index = 0;
     int nNewRank = 0;
-    while (layer_index < layers.size()) {
+    while (layer_index < _layers.size()) {
         // Remove this layer?
-        if (layers[layer_index]->disabled) {
-            excluded_layers << layers[layer_index]->name;
-            layers.removeAt(layer_index);
+        if (_layers[layer_index]->_disabled) {
+            _excluded_layers << _layers[layer_index]->_name;
+            _layers.removeAt(layer_index);
             continue;
         }
 
         // If the layer is not active, also remove it
         // Important to do black list test FIRST
-        if (!layers[layer_index]->enabled) {
-            layers.removeAt(layer_index);
+        if (!_layers[layer_index]->_enabled) {
+            _layers.removeAt(layer_index);
             continue;
         }
 
         // We are keeping this layer, reset it's rank
-        layers[layer_index]->rank = nNewRank++;
+        _layers[layer_index]->_rank = nNewRank++;
 
         layer_index++;
     }

--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -48,17 +48,17 @@ class Configuration {
     Configuration();
     ~Configuration();
 
-    QString name;                   // User readable display of the profile name (may contain spaces)
-                                    // This is the same as the filename, but with the .json stripped off.
-    QString file;                   // Root file name without path (by convention, no spaces and .profile suffix)
-    QString description;            // A friendly description of what this profile does
-    QByteArray setting_tree_state;  // Recall editor tree state
-    ValidationPreset preset;        // Khronos layer presets. 0 = none or user defined
+    QString _name;                   // User readable display of the profile name (may contain spaces)
+                                     // This is the same as the filename, but with the .json stripped off.
+    QString _file;                   // Root file name without path (by convention, no spaces and .profile suffix)
+    QString _description;            // A friendly description of what this profile does
+    QByteArray _setting_tree_state;  // Recall editor tree state
+    ValidationPreset _preset;        // Khronos layer presets. 0 = none or user defined
 
     // A configuration is nothing but a list of layers and their settings in truth
-    QVector<LayerFile *> layers;
+    QVector<LayerFile *> _layers;
 
-    QStringList excluded_layers;  // Just the names of blacklisted layers
+    QStringList _excluded_layers;  // Just the names of blacklisted layers
 
     LayerFile *FindLayer(const QString &layer_name, const QString &full_path) const;  // Find the layer if it exists
     LayerFile *FindLayerNamed(const QString &layer_name) const;  // Find the layer if it exists, only care about the name
@@ -69,7 +69,7 @@ class Configuration {
 
     LayerFile *GetKhronosLayer();  // Retrieve the Khronos validation layer if it is included
 
-    bool IsValid() { return all_layers_available; }
+    bool IsValid() { return _all_layers_available; }
 
-    bool all_layers_available;
+    bool _all_layers_available;
 };

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -125,12 +125,12 @@ class Configurator {
     bool InitializeConfigurator(void);
 
     // Need this to check vulkan loader version
-    uint32_t vulkan_instance_version;
-    bool has_old_loader;  // Older loader does not support per-application overrides
+    uint32_t _vulkan_instance_version;
+    bool _has_old_loader;  // Older loader does not support per-application overrides
 
    private:
-    bool running_as_administrator_;  // Are we being "Run as Administrator"
-    bool first_run_;                 // This is used for populating the initial set of configurations
+    bool _running_as_administrator;  // Are we being "Run as Administrator"
+    bool _first_run;                 // This is used for populating the initial set of configurations
 
     /////////////////////////////////////////////////////////////////////////
     // Just Vulkan Configurator settings
@@ -138,17 +138,17 @@ class Configurator {
     void LoadSettings();
     void SaveSettings();
     void ResetToDefaultSettings();
-    bool HasActiveOverrideOnApplicationListOnly() const { return !has_old_loader && overridden_application_list_only; }
+    bool HasActiveOverrideOnApplicationListOnly() const { return !_has_old_loader && _overridden_application_list_only; }
     QString GetPath(Path requested_path) const;
     void SetPath(Path requested_path, QString path);
 
-    bool override_active;                    // Do we have active layers override?
-    bool overridden_application_list_only;   // Apply the override only to the application list
-    bool override_permanent;                 // The override remains active when Vulkan Configurator closes
-    bool override_application_list_updated;  // The list of applications to override has possibly been updated
+    bool _override_active;                    // Do we have active layers override?
+    bool _overridden_application_list_only;   // Apply the override only to the application list
+    bool _override_permanent;                 // The override remains active when Vulkan Configurator closes
+    bool _override_application_list_updated;  // The list of applications to override has possibly been updated
 
    private:
-    QString paths_[PathCount];
+    QString _paths[PathCount];
 
     /////////////////////////////////////////////////////////////////////////
     // Validation Preset
@@ -164,7 +164,7 @@ class Configurator {
     void FindVkCube();
 
    private:
-    QString active_launch_executable_path_;  // This is to match up with the application list
+    QString _active_launch_executable_path;  // This is to match up with the application list
 
     /////////////////////////////////////////////////////////////////////////
     // Additional places to look for layers
@@ -183,12 +183,12 @@ class Configurator {
                                 // clarity as to where this comes from).
 
    private:
-    QStringList custom_layers_paths_;
+    QStringList _custom_layers_paths;
 
     /////////////////////////////////////////////////////////////////////////
     // The list of applications affected
    public:
-    QVector<Application*> overridden_application_list;
+    QVector<Application*> _overridden_application_list;
     void LoadOverriddenApplicationList();
     void SaveOverriddenApplicationList();
     bool HasOverriddenApplications() const;
@@ -197,7 +197,7 @@ class Configurator {
     // A readonly list of layer names with the associated settings
     // and their default values. This is for reference by individual profile
     // objects.
-    QVector<LayerSettingsDefaults*> default_layers_settings;
+    QVector<LayerSettingsDefaults*> _default_layers_settings;
     void LoadDefaultLayerSettings();
     const LayerSettingsDefaults* FindLayerSettings(const QString& layer_name) const;
     void LoadDefaultSettings(LayerFile* empty_layer);
@@ -208,16 +208,16 @@ class Configurator {
     // in the above (defaultLayerSettings). The binding of a layer with it's
     // particular settings is done in the profile (Configuration - in configuration list).
     // This includes all found implicit, explicit, or layers found in custom folders
-    QVector<LayerFile*> available_Layers;  // All the found layers, lumped together
+    QVector<LayerFile*> _available_Layers;  // All the found layers, lumped together
     void LoadAllInstalledLayers();
     const LayerFile* FindLayerNamed(QString layer_name);
     void LoadLayersFromPath(const QString& path, QVector<LayerFile*>& layer_list);
 
-    QVector<Configuration*> available_configurations;
+    QVector<Configuration*> _available_configurations;
 
     // We need to push and pop a temporary environment.
     // The stack is only one deep...
-    Configuration* saved_configuration;
+    Configuration* _saved_configuration;
 
     void PushConfiguration(Configuration* configuration);
     void PopConfiguration();
@@ -231,13 +231,13 @@ class Configurator {
     void ExportConfiguration(const QString& source_file, const QString& full_export_path);
 
     bool HasLayers() const;
-    bool IsRunningAsAdministrator() { return running_as_administrator_; }
+    bool IsRunningAsAdministrator() { return _running_as_administrator; }
 
     // Set this as the current override configuration
     void SetActiveConfiguration(Configuration* configuration);
-    Configuration* GetActiveConfiguration() { return active_configuration_; }
+    Configuration* GetActiveConfiguration() { return _active_configuration; }
     void RefreshConfiguration() {
-        if (active_configuration_) SetActiveConfiguration(active_configuration_);
+        if (_active_configuration) SetActiveConfiguration(_active_configuration);
     }
 
     QString CheckVulkanSetup() const;
@@ -249,7 +249,7 @@ class Configurator {
     Configurator(const Configurator&) = delete;
     Configurator& operator=(const Configurator&) = delete;
 
-    Configuration* active_configuration_;
+    Configuration* _active_configuration;
 
     void ClearLayerLists();
 

--- a/vkconfig/dlgabout.cpp
+++ b/vkconfig/dlgabout.cpp
@@ -22,12 +22,12 @@
 #include "dlgabout.h"
 #include "ui_dlgabout.h"
 
-dlgAbout::dlgAbout(QWidget *parent) : QDialog(parent), ui_(new Ui::dlgAbout) {
-    ui_->setupUi(this);
+dlgAbout::dlgAbout(QWidget *parent) : QDialog(parent), ui(new Ui::dlgAbout) {
+    ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    connect(ui_->pbAboutQt, SIGNAL(clicked()), this, SLOT(aboutQt()));
+    connect(ui->pbAboutQt, SIGNAL(clicked()), this, SLOT(aboutQt()));
 }
 
-dlgAbout::~dlgAbout() { delete ui_; }
+dlgAbout::~dlgAbout() { delete ui; }
 
 void dlgAbout::aboutQt() { qApp->aboutQt(); }

--- a/vkconfig/dlgabout.h
+++ b/vkconfig/dlgabout.h
@@ -38,5 +38,5 @@ class dlgAbout : public QDialog {
     ~dlgAbout();
 
    private:
-    Ui::dlgAbout *ui_;
+    Ui::dlgAbout *ui;
 };

--- a/vkconfig/dlgcreateassociation.h
+++ b/vkconfig/dlgcreateassociation.h
@@ -38,7 +38,7 @@ class dlgCreateAssociation : public QDialog {
     ~dlgCreateAssociation();
 
     static void GetExecutableFromAppBundle(QString &path);
-    int GetSelectedLaunchApplicationIndex() const { return last_selected_application_index_; }
+    int GetSelectedLaunchApplicationIndex() const { return _last_selected_application_index; }
 
    private:
     QTreeWidgetItem *CreateApplicationItem(const Application &application) const;
@@ -46,8 +46,8 @@ class dlgCreateAssociation : public QDialog {
     virtual void closeEvent(QCloseEvent *) override;
     virtual bool eventFilter(QObject *target, QEvent *event) override;
 
-    Ui::dlgCreateAssociation *ui_;
-    int last_selected_application_index_;
+    Ui::dlgCreateAssociation *ui;
+    int _last_selected_application_index;
 
    public Q_SLOTS:
     void on_pushButtonAdd_clicked();                                                // Pick the application

--- a/vkconfig/dlgcustompaths.cpp
+++ b/vkconfig/dlgcustompaths.cpp
@@ -27,21 +27,21 @@
 #include <QFileDialog>
 #include <QMessageBox>
 
-dlgCustomPaths::dlgCustomPaths(QWidget *parent) : QDialog(parent), ui_(new Ui::dlgCustomPaths) {
-    paths_changed_ = false;
-    ui_->setupUi(this);
+dlgCustomPaths::dlgCustomPaths(QWidget *parent) : QDialog(parent), ui(new Ui::dlgCustomPaths) {
+    _paths_changed = false;
+    ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-    ui_->treeWidget->headerItem()->setText(0, tr("Custom Search Paths & Layers"));
+    ui->treeWidget->headerItem()->setText(0, tr("Custom Search Paths & Layers"));
 
     RepopulateTree();
-    ui_->buttonBox->setEnabled(Configurator::Get().HasLayers());
+    ui->buttonBox->setEnabled(Configurator::Get().HasLayers());
 }
 
-dlgCustomPaths::~dlgCustomPaths() { delete ui_; }
+dlgCustomPaths::~dlgCustomPaths() { delete ui; }
 
 void dlgCustomPaths::RepopulateTree() {
-    ui_->treeWidget->clear();
+    ui->treeWidget->clear();
 
     Configurator &configurator = Configurator::Get();
 
@@ -51,7 +51,7 @@ void dlgCustomPaths::RepopulateTree() {
 
         QTreeWidgetItem *pItem = new QTreeWidgetItem();
         pItem->setText(0, custom_path);
-        ui_->treeWidget->addTopLevelItem(pItem);
+        ui->treeWidget->addTopLevelItem(pItem);
 
         // Look for layers that are in this folder. If any are found, add them to the tree
         QVector<LayerFile *> custom_layers;
@@ -59,7 +59,7 @@ void dlgCustomPaths::RepopulateTree() {
 
         for (int j = 0; j < custom_layers.size(); j++) {
             QTreeWidgetItem *pChild = new QTreeWidgetItem();
-            pChild->setText(0, custom_layers[j]->name);
+            pChild->setText(0, custom_layers[j]->_name);
             pItem->addChild(pChild);
         }
 
@@ -79,24 +79,24 @@ void dlgCustomPaths::on_pushButtonAdd_clicked() {
         configurator.AppendCustomLayersPath(custom_folder);
         QTreeWidgetItem *pItem = new QTreeWidgetItem();
         pItem->setText(0, custom_folder);
-        ui_->treeWidget->addTopLevelItem(pItem);
+        ui->treeWidget->addTopLevelItem(pItem);
 
-        paths_changed_ = true;
+        _paths_changed = true;
         RepopulateTree();
     }
 
-    ui_->buttonBox->setEnabled(configurator.HasLayers());
+    ui->buttonBox->setEnabled(configurator.HasLayers());
 }
 
 //////////////////////////////////////////////////////////////////////////////
 /// Don't make remove button accessable unless an item has been selected
-void dlgCustomPaths::on_treeWidget_itemSelectionChanged() { ui_->pushButtonRemove->setEnabled(true); }
+void dlgCustomPaths::on_treeWidget_itemSelectionChanged() { ui->pushButtonRemove->setEnabled(true); }
 
 //////////////////////////////////////////////////////////////////////////////
 /// Remove the selected custom search path
 void dlgCustomPaths::on_pushButtonRemove_clicked() {
     // Which one is selected? We need the top item too
-    QTreeWidgetItem *pSelected = ui_->treeWidget->currentItem();
+    QTreeWidgetItem *pSelected = ui->treeWidget->currentItem();
     while (pSelected->parent() != nullptr) pSelected = pSelected->parent();
 
     // Confirm?
@@ -114,6 +114,6 @@ void dlgCustomPaths::on_pushButtonRemove_clicked() {
 
     // Update GUI and save
     RepopulateTree();
-    ui_->buttonBox->setEnabled(configurator.HasLayers());
-    paths_changed_ = true;
+    ui->buttonBox->setEnabled(configurator.HasLayers());
+    _paths_changed = true;
 }

--- a/vkconfig/dlgcustompaths.h
+++ b/vkconfig/dlgcustompaths.h
@@ -35,8 +35,8 @@ class dlgCustomPaths : public QDialog {
     ~dlgCustomPaths();
 
    private:
-    Ui::dlgCustomPaths *ui_;
-    bool paths_changed_;
+    Ui::dlgCustomPaths *ui;
+    bool _paths_changed;
 
     void RepopulateTree();
 

--- a/vkconfig/dlghelp.cpp
+++ b/vkconfig/dlghelp.cpp
@@ -22,9 +22,9 @@
 #include "dlghelp.h"
 #include "ui_dlghelp.h"
 
-dlgHelp::dlgHelp(QWidget *parent) : QWidget(parent), ui_(new Ui::dlgHelp) {
-    ui_->setupUi(this);
+dlgHelp::dlgHelp(QWidget *parent) : QWidget(parent), ui(new Ui::dlgHelp) {
+    ui->setupUi(this);
     setWindowFlags(Qt::WindowStaysOnTopHint);
 }
 
-dlgHelp::~dlgHelp() { delete ui_; }
+dlgHelp::~dlgHelp() { delete ui; }

--- a/vkconfig/dlghelp.h
+++ b/vkconfig/dlghelp.h
@@ -35,5 +35,5 @@ class dlgHelp : public QWidget {
     ~dlgHelp();
 
    private:
-    Ui::dlgHelp *ui_;
+    Ui::dlgHelp *ui;
 };

--- a/vkconfig/dlgprofileeditor.h
+++ b/vkconfig/dlgprofileeditor.h
@@ -44,9 +44,9 @@ class dlgProfileEditor : public QDialog {
     void LoadLayerDisplay(int selection = -1);
 
    private:
-    Ui::dlgProfileEditor *ui_;
+    Ui::dlgProfileEditor *ui;
 
-    Configuration *configuration_;
+    Configuration *_configuration;
 
     virtual void resizeEvent(QResizeEvent *event) override;
     virtual void showEvent(QShowEvent *) override;

--- a/vkconfig/dlgvulkananalysis.cpp
+++ b/vkconfig/dlgvulkananalysis.cpp
@@ -30,27 +30,31 @@
 
 #include <QMessageBox>
 
-dlgVulkanAnalysis::dlgVulkanAnalysis(QWidget *parent) : QDialog(parent), ui_(new Ui::dlgVulkanAnalysis) {
-    ui_->setupUi(this);
+dlgVulkanAnalysis::dlgVulkanAnalysis(QWidget *parent) : QDialog(parent), ui(new Ui::dlgVulkanAnalysis) {
+    ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    // Hide the test widget as no test is actually run.
+    // This may be added back again later.
+    ui->tabWidget->removeTab(2);
 }
 
-dlgVulkanAnalysis::~dlgVulkanAnalysis() { delete ui_; }
+dlgVulkanAnalysis::~dlgVulkanAnalysis() { delete ui; }
 
 void dlgVulkanAnalysis::RunTool() {
-    ui_->envTable->clear();
-    ui_->cleanupTable->clear();
-    ui_->hardwareTable->clear();
-    ui_->instanceTable->clear();
-    ui_->lunarGSDKTable->clear();
-    ui_->executableTable->clear();
-    ui_->vkRuntimesTable->clear();
-    ui_->externalTestsTable->clear();
-    ui_->layerSettingsTable->clear();
-    ui_->explicitLayersTable->clear();
-    ui_->implicitLayersTable->clear();
-    ui_->logicalDevicesTable->clear();
-    ui_->physicalDevicesTable->clear();
+    ui->envTable->clear();
+    ui->cleanupTable->clear();
+    ui->hardwareTable->clear();
+    ui->instanceTable->clear();
+    ui->lunarGSDKTable->clear();
+    ui->executableTable->clear();
+    ui->vkRuntimesTable->clear();
+    ui->externalTestsTable->clear();
+    ui->layerSettingsTable->clear();
+    ui->explicitLayersTable->clear();
+    ui->implicitLayersTable->clear();
+    ui->logicalDevicesTable->clear();
+    ui->physicalDevicesTable->clear();
 
     QProcess *via = new QProcess(this);
 #ifdef __APPLE__
@@ -108,67 +112,67 @@ void dlgVulkanAnalysis::RunTool() {
     // Get the extensions object and process it's members
     QJsonValue environmentValue = jsonObject.value(QString(tr("Environment")));
     QJsonObject environmentObject = environmentValue.toObject();
-    LoadTable(environmentObject, ui_->envTable);
+    LoadTable(environmentObject, ui->envTable);
 
     QJsonValue hardwareValue = jsonObject.value(QString(tr("Hardware")));
     QJsonObject hardwareObject = hardwareValue.toObject();
-    LoadTable(hardwareObject, ui_->hardwareTable);
+    LoadTable(hardwareObject, ui->hardwareTable);
 
     QJsonValue executableValue = jsonObject.value(QString(tr("Executable Info")));
     QJsonObject executableObject = executableValue.toObject();
-    LoadTable(executableObject, ui_->executableTable);
+    LoadTable(executableObject, ui->executableTable);
 
     QJsonValue vkDriverInfo = jsonObject.value(QString(tr("Vulkan Driver Info")));
     QJsonObject vkDriverObject = vkDriverInfo.toObject();
-    LoadTable(vkDriverObject, ui_->vkDriverInfoTable);
+    LoadTable(vkDriverObject, ui->vkDriverInfoTable);
 
     QJsonValue vkRunTimeValue = jsonObject.value(QString(tr("Vulkan Runtimes")));
     QJsonObject vkRunTimeObject = vkRunTimeValue.toObject();
-    LoadTable(vkRunTimeObject, ui_->vkRuntimesTable);
+    LoadTable(vkRunTimeObject, ui->vkRuntimesTable);
 
     QJsonValue lunarGSDKValue = jsonObject.value(QString(tr("LunarG Vulkan SDKs")));
     QJsonObject lunarGSDKObject = lunarGSDKValue.toObject();
-    LoadTable(lunarGSDKObject, ui_->lunarGSDKTable);
+    LoadTable(lunarGSDKObject, ui->lunarGSDKTable);
 
     QJsonValue vkImplicitValue = jsonObject.value(QString(tr("Vulkan Implicit Layers")));
     QJsonObject vkImplicitObject = vkImplicitValue.toObject();
-    LoadTable(vkImplicitObject, ui_->implicitLayersTable);
+    LoadTable(vkImplicitObject, ui->implicitLayersTable);
 
     QJsonValue vkExplicitValue = jsonObject.value(QString(tr("Vulkan Explicit Layers")));
     QJsonObject vkExplicitObject = vkExplicitValue.toObject();
-    LoadTable(vkExplicitObject, ui_->explicitLayersTable);
+    LoadTable(vkExplicitObject, ui->explicitLayersTable);
 
     QJsonValue vkLayerSettingsValue = jsonObject.value(QString(tr("Vulkan Layer Settings File")));
     QJsonObject vkLayerSettingsObject = vkLayerSettingsValue.toObject();
-    LoadTable(vkLayerSettingsObject, ui_->layerSettingsTable);
+    LoadTable(vkLayerSettingsObject, ui->layerSettingsTable);
 
     /////////////////////////// Vulkan API Calls
     QJsonValue instanceValue = jsonObject.value(QString(tr("Instance")));
     QJsonObject instanceObject = instanceValue.toObject();
-    LoadTable(instanceObject, ui_->instanceTable);
+    LoadTable(instanceObject, ui->instanceTable);
 
     QJsonObject devicesObject = jsonObject.value(QString(tr("Physical Devices"))).toObject();
-    LoadTable(devicesObject, ui_->physicalDevicesTable);
+    LoadTable(devicesObject, ui->physicalDevicesTable);
 
     QJsonObject logicalObject = jsonObject.value(QString(tr("Logical Devices"))).toObject();
-    LoadTable(logicalObject, ui_->logicalDevicesTable);
+    LoadTable(logicalObject, ui->logicalDevicesTable);
 
     QJsonObject cleanupObject = jsonObject.value(QString(tr("Cleanup"))).toObject();
-    LoadTable(cleanupObject, ui_->cleanupTable);
+    LoadTable(cleanupObject, ui->cleanupTable);
 
     /////////////////////////////////// External Tests
     QJsonValue cubeValue = jsonObject.value(QString(tr("Cube"))).toObject();
     QJsonObject cubeObject = cubeValue.toObject();
     if (!cubeObject.isEmpty())
-        LoadTable(cubeObject, ui_->externalTestsTable);
+        LoadTable(cubeObject, ui->externalTestsTable);
     else {
-        ui_->externalTestsTable->setRowCount(1);
-        ui_->externalTestsTable->setColumnCount(1);
-        ui_->externalTestsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-        ui_->externalTestsTable->setShowGrid(false);
+        ui->externalTestsTable->setRowCount(1);
+        ui->externalTestsTable->setColumnCount(1);
+        ui->externalTestsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+        ui->externalTestsTable->setShowGrid(false);
         QTableWidgetItem *pItem = new QTableWidgetItem();
         pItem->setText(tr("No SDK found by VIA, skipping test section"));
-        ui_->externalTestsTable->setItem(0, 0, pItem);
+        ui->externalTestsTable->setItem(0, 0, pItem);
     }
 
     show();

--- a/vkconfig/dlgvulkananalysis.h
+++ b/vkconfig/dlgvulkananalysis.h
@@ -46,5 +46,5 @@ class dlgVulkanAnalysis : public QDialog {
    private:
     void LoadTable(QJsonObject& json_parent, QTableWidget* table);
 
-    Ui::dlgVulkanAnalysis* ui_;
+    Ui::dlgVulkanAnalysis* ui;
 };

--- a/vkconfig/dlgvulkananalysis.ui
+++ b/vkconfig/dlgvulkananalysis.ui
@@ -318,7 +318,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>98</width>
+              <width>89</width>
               <height>89</height>
              </rect>
             </property>
@@ -343,7 +343,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>98</width>
+              <width>89</width>
               <height>89</height>
              </rect>
             </property>
@@ -368,7 +368,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>98</width>
+              <width>89</width>
               <height>89</height>
              </rect>
             </property>

--- a/vkconfig/dlgvulkaninfo.cpp
+++ b/vkconfig/dlgvulkaninfo.cpp
@@ -37,15 +37,15 @@
 #include <QMessageBox>
 #include <QStringList>
 
-dlgVulkanInfo::dlgVulkanInfo(QWidget *parent) : QDialog(parent), ui_(new Ui::dlgVulkanInfo) {
-    ui_->setupUi(this);
+dlgVulkanInfo::dlgVulkanInfo(QWidget *parent) : QDialog(parent), ui(new Ui::dlgVulkanInfo) {
+    ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
-dlgVulkanInfo::~dlgVulkanInfo() { delete ui_; }
+dlgVulkanInfo::~dlgVulkanInfo() { delete ui; }
 
 void dlgVulkanInfo::RunTool() {
-    ui_->treeWidget->clear();
+    ui->treeWidget->clear();
 
     QProcess *vulkan_info = new QProcess(this);
 #ifdef _WIN32
@@ -112,7 +112,7 @@ void dlgVulkanInfo::RunTool() {
     QJsonValue instance = jsonTopObject.value(QString("Vulkan Instance Version"));
     QString output = "Vulkan Instance Version: " + instance.toString();
 
-    QTreeWidgetItem *header = ui_->treeWidget->headerItem();
+    QTreeWidgetItem *header = ui->treeWidget->headerItem();
     header->setText(0, output);
 
     ////////////////////////////////////////////////////////////
@@ -121,7 +121,7 @@ void dlgVulkanInfo::RunTool() {
     QJsonValue rootObject = jsonTopObject.value(QString("Instance Extensions"));
     QTreeWidgetItem *pParentNode = new QTreeWidgetItem();
     pParentNode->setText(0, tr("Instance Extensions"));
-    ui_->treeWidget->addTopLevelItem(pParentNode);
+    ui->treeWidget->addTopLevelItem(pParentNode);
     BuildExtensions(rootObject, pParentNode);
 
     rootObject = jsonTopObject.value("Layer Properties");
@@ -239,7 +239,7 @@ void dlgVulkanInfo::BuildLayers(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
     output += QString().asprintf("%d", layersCount);
 
     pRoot->setText(0, output);
-    ui_->treeWidget->addTopLevelItem(pRoot);
+    ui->treeWidget->addTopLevelItem(pRoot);
 
     // Loop through all the layers
     QStringList layers = layersObject.keys();
@@ -313,7 +313,7 @@ void dlgVulkanInfo::BuildSurfaces(QJsonValue &jsonValue, QTreeWidgetItem *pRoot)
     QStringList GPUs = surfaces.keys();
 
     pRoot->setText(0, tr("Presentable Surfaces"));
-    ui_->treeWidget->addTopLevelItem(pRoot);
+    ui->treeWidget->addTopLevelItem(pRoot);
 
     for (int i = 0; i < surfaceCount; i++) {
         TraverseGenericProperties(jsonValue, pRoot);
@@ -329,7 +329,7 @@ void dlgVulkanInfo::BuildSurfaces(QJsonValue &jsonValue, QTreeWidgetItem *pRoot)
 void dlgVulkanInfo::BuildGroups(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
     QJsonObject groupsObject = jsonValue.toObject();
     pRoot->setText(0, tr("Device Groups"));
-    ui_->treeWidget->addTopLevelItem(pRoot);
+    ui->treeWidget->addTopLevelItem(pRoot);
 
     TraverseGenericProperties(jsonValue, pRoot);
 }
@@ -346,7 +346,7 @@ void dlgVulkanInfo::BuildDevices(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) 
     QJsonObject gpuObject = jsonValue.toObject();
 
     pRoot->setText(0, tr("Device Properties and Extensions"));
-    ui_->treeWidget->addTopLevelItem(pRoot);
+    ui->treeWidget->addTopLevelItem(pRoot);
 
     // For each like GPU0 object
     QStringList gpuList = gpuObject.keys();

--- a/vkconfig/dlgvulkaninfo.h
+++ b/vkconfig/dlgvulkaninfo.h
@@ -45,5 +45,5 @@ class dlgVulkanInfo : public QDialog {
     void RunTool();
 
    private:
-    Ui::dlgVulkanInfo *ui_;
+    Ui::dlgVulkanInfo *ui;
 };

--- a/vkconfig/enumsettingwidget.cpp
+++ b/vkconfig/enumsettingwidget.cpp
@@ -22,7 +22,7 @@
 #include "enumsettingwidget.h"
 
 EnumSettingWidget::EnumSettingWidget(QTreeWidgetItem* item, LayerSettings* layers_settings) {
-    layer_settings_ = layers_settings;
+    _layer_settings = layers_settings;
     item->setText(0, layers_settings->settings_prompt);
     item->setToolTip(0, layers_settings->settings_desc);
 
@@ -38,6 +38,6 @@ EnumSettingWidget::EnumSettingWidget(QTreeWidgetItem* item, LayerSettings* layer
 }
 
 void EnumSettingWidget::indexChanged(int index) {
-    layer_settings_->settings_value = layer_settings_->settings_list_exclusive_value[index];
+    _layer_settings->settings_value = _layer_settings->settings_list_exclusive_value[index];
     emit itemChanged();
 }

--- a/vkconfig/enumsettingwidget.h
+++ b/vkconfig/enumsettingwidget.h
@@ -34,7 +34,7 @@ class EnumSettingWidget : public QComboBox {
     EnumSettingWidget(QTreeWidgetItem *item, LayerSettings *layer_settings);
 
    private:
-    LayerSettings *layer_settings_;
+    LayerSettings *_layer_settings;
 
    public Q_SLOTS:
     void indexChanged(int index);

--- a/vkconfig/filenamesettingwidget.cpp
+++ b/vkconfig/filenamesettingwidget.cpp
@@ -23,47 +23,47 @@
 #include "filenamesettingwidget.h"
 
 FilenameSettingWidget::FilenameSettingWidget(QTreeWidgetItem* item, LayerSettings* layer_settings) : QWidget(nullptr) {
-    layer_settings_ = layer_settings;
+    _layer_settings = layer_settings;
 
     item->setText(0, layer_settings->settings_prompt);
     item->setToolTip(0, layer_settings->settings_desc);
 
-    line_edit_ = new QLineEdit(this);
-    line_edit_->setText(layer_settings_->settings_value);
-    line_edit_->show();
+    _line_edit = new QLineEdit(this);
+    _line_edit->setText(_layer_settings->settings_value);
+    _line_edit->show();
 
-    push_button_ = new QPushButton(this);
-    push_button_->setText("...");
-    push_button_->show();
+    _push_button = new QPushButton(this);
+    _push_button->setText("...");
+    _push_button->show();
 
-    connect(push_button_, SIGNAL(clicked()), this, SLOT(browseButtonClicked()));
-    connect(line_edit_, SIGNAL(textEdited(const QString&)), this, SLOT(textFieldChanged(const QString&)));
+    connect(_push_button, SIGNAL(clicked()), this, SLOT(browseButtonClicked()));
+    connect(_line_edit, SIGNAL(textEdited(const QString&)), this, SLOT(textFieldChanged(const QString&)));
 }
 
 void FilenameSettingWidget::resizeEvent(QResizeEvent* event) {
-    if (line_edit_ == nullptr) return;
+    if (_line_edit == nullptr) return;
 
     QSize parentSize = event->size();
 
     // Button takes up the last 32 pixels
     QRect buttonRect = QRect(parentSize.width() - 32, 0, 32, parentSize.height());
     QRect editRect = QRect(0, 0, parentSize.width() - 32, parentSize.height());
-    line_edit_->setGeometry(editRect);
-    push_button_->setGeometry(buttonRect);
+    _line_edit->setGeometry(editRect);
+    _push_button->setGeometry(buttonRect);
 }
 
 void FilenameSettingWidget::browseButtonClicked() {
-    QString file = QFileDialog::getSaveFileName(push_button_, tr("Select File"), ".");
+    QString file = QFileDialog::getSaveFileName(_push_button, tr("Select File"), ".");
 
     if (!file.isEmpty()) {
         file = QDir::toNativeSeparators(file);
-        layer_settings_->settings_value = file;
-        line_edit_->setText(file);
+        _layer_settings->settings_value = file;
+        _line_edit->setText(file);
         emit itemChanged();
     }
 }
 
 void FilenameSettingWidget::textFieldChanged(const QString& newText) {
-    layer_settings_->settings_value = newText;
+    _layer_settings->settings_value = newText;
     emit itemChanged();
 }

--- a/vkconfig/filenamesettingwidget.h
+++ b/vkconfig/filenamesettingwidget.h
@@ -38,9 +38,9 @@ class FilenameSettingWidget : public QWidget {
    private:
     virtual void resizeEvent(QResizeEvent *event) override;
 
-    LayerSettings *layer_settings_;
-    QLineEdit *line_edit_;
-    QPushButton *push_button_;
+    LayerSettings *_layer_settings;
+    QLineEdit *_line_edit;
+    QPushButton *_push_button;
 
    public Q_SLOTS:
     void browseButtonClicked();

--- a/vkconfig/foldersettingwidget.cpp
+++ b/vkconfig/foldersettingwidget.cpp
@@ -22,47 +22,47 @@
 #include "foldersettingwidget.h"
 
 FolderSettingWidget::FolderSettingWidget(QTreeWidgetItem* item, LayerSettings* layer_settings) : QWidget(nullptr) {
-    layer_settings_ = layer_settings;
+    _layer_settings = layer_settings;
 
     item->setText(0, layer_settings->settings_prompt);
     item->setToolTip(0, layer_settings->settings_desc);
 
-    line_edit_ = new QLineEdit(this);
-    line_edit_->setText(layer_settings_->settings_value);
-    line_edit_->show();
+    _line_edit = new QLineEdit(this);
+    _line_edit->setText(_layer_settings->settings_value);
+    _line_edit->show();
 
-    push_button_ = new QPushButton(this);
-    push_button_->setText("...");
-    push_button_->show();
+    _push_button = new QPushButton(this);
+    _push_button->setText("...");
+    _push_button->show();
 
-    connect(push_button_, SIGNAL(clicked()), this, SLOT(browseButtonClicked()));
-    connect(line_edit_, SIGNAL(textEdited(const QString&)), this, SLOT(textFieldChanged(const QString&)));
+    connect(_push_button, SIGNAL(clicked()), this, SLOT(browseButtonClicked()));
+    connect(_line_edit, SIGNAL(textEdited(const QString&)), this, SLOT(textFieldChanged(const QString&)));
 }
 
 void FolderSettingWidget::resizeEvent(QResizeEvent* event) {
-    if (line_edit_ == nullptr) return;
+    if (_line_edit == nullptr) return;
 
     QSize parentSize = event->size();
 
     // Button takes up the last 32 pixels
     QRect buttonRect = QRect(parentSize.width() - 32, 0, 32, parentSize.height());
     QRect editRect = QRect(0, 0, parentSize.width() - 32, parentSize.height());
-    line_edit_->setGeometry(editRect);
-    push_button_->setGeometry(buttonRect);
+    _line_edit->setGeometry(editRect);
+    _push_button->setGeometry(buttonRect);
 }
 
 void FolderSettingWidget::browseButtonClicked(void) {
-    QString file = QFileDialog::getExistingDirectory(push_button_, tr("Select Folder"), ".");
+    QString file = QFileDialog::getExistingDirectory(_push_button, tr("Select Folder"), ".");
 
     if (!file.isEmpty()) {
         file = QDir::toNativeSeparators(file);
-        layer_settings_->settings_value = file;
-        line_edit_->setText(file);
+        _layer_settings->settings_value = file;
+        _line_edit->setText(file);
         emit itemChanged();
     }
 }
 
 void FolderSettingWidget::textFieldChanged(const QString& newText) {
-    layer_settings_->settings_value = newText;
+    _layer_settings->settings_value = newText;
     emit itemChanged();
 }

--- a/vkconfig/foldersettingwidget.h
+++ b/vkconfig/foldersettingwidget.h
@@ -38,9 +38,9 @@ class FolderSettingWidget : public QWidget {
     virtual void resizeEvent(QResizeEvent *event) override;
 
    private:
-    LayerSettings *layer_settings_;
-    QLineEdit *line_edit_;
-    QPushButton *push_button_;
+    LayerSettings *_layer_settings;
+    QLineEdit *_line_edit;
+    QPushButton *_push_button;
 
    public Q_SLOTS:
     void browseButtonClicked();

--- a/vkconfig/khronossettingsadvanced.cpp
+++ b/vkconfig/khronossettingsadvanced.cpp
@@ -153,47 +153,47 @@ QString GetSettingDetails(QString qsSetting, QString &url) {
 ///////////////////////////////////////////////////////////////////////////////
 KhronosSettingsAdvanced::KhronosSettingsAdvanced(QTreeWidget *main_tree, QTreeWidgetItem *parent,
                                                  QVector<LayerSettings *> &layer_settings) {
-    main_tree_widget_ = main_tree;
-    main_parent_ = parent;
+    _main_tree_widget = main_tree;
+    _main_parent = parent;
 
     // Find the enables
-    enables_ = nullptr;
+    _enables = nullptr;
     for (int i = 0; i < layer_settings.size(); i++)
         if (layer_settings[i]->settings_name == QString("enables")) {
-            enables_ = layer_settings[i];
+            _enables = layer_settings[i];
             break;
         }
-    Q_ASSERT(enables_ != nullptr);
+    Q_ASSERT(_enables != nullptr);
 
     // Find the disables
-    disables_ = nullptr;
+    _disables = nullptr;
     for (int i = 0; i < layer_settings.size(); i++)
         if (layer_settings[i]->settings_name == QString("disables")) {
-            disables_ = layer_settings[i];
+            _disables = layer_settings[i];
             break;
         }
-    Q_ASSERT(disables_ != nullptr);
+    Q_ASSERT(_disables != nullptr);
 
     ///////////////////////////////////////////////////////////////
     /// If this is off, everyone below is disabled
-    bool core_validation_disabled = disables_->settings_value.contains("VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT");
-    core_checks_parent_ = new QTreeWidgetItem();
-    core_checks_parent_->setText(0, "Core Validation Checks");
-    core_checks_parent_->setCheckState(0, (core_validation_disabled) ? Qt::Unchecked : Qt::Checked);
-    parent->addChild(core_checks_parent_);
+    bool core_validation_disabled = _disables->settings_value.contains("VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT");
+    _core_checks_parent = new QTreeWidgetItem();
+    _core_checks_parent->setText(0, "Core Validation Checks");
+    _core_checks_parent->setCheckState(0, (core_validation_disabled) ? Qt::Unchecked : Qt::Checked);
+    parent->addChild(_core_checks_parent);
 
     QTreeWidgetItem *core_child_item;
     for (std::size_t i = 0, n = vku::countof(coreChecks); i < n; i++) {
         core_child_item = new QTreeWidgetItem();
         core_child_item->setText(0, coreChecks[i].prompt);
-        if (disables_->settings_value.contains(coreChecks[i].token) || core_validation_disabled)
+        if (_disables->settings_value.contains(coreChecks[i].token) || core_validation_disabled)
             core_child_item->setCheckState(0, Qt::Unchecked);
         else
             core_child_item->setCheckState(0, Qt::Checked);
 
         if (core_validation_disabled) core_child_item->setFlags(core_child_item->flags() & ~Qt::ItemIsEnabled);
 
-        core_checks_parent_->addChild(core_child_item);
+        _core_checks_parent->addChild(core_child_item);
         coreChecks[i].item = core_child_item;
     }
 
@@ -203,7 +203,7 @@ KhronosSettingsAdvanced::KhronosSettingsAdvanced(QTreeWidget *main_tree, QTreeWi
     for (std::size_t i = 0, n = vku::countof(miscDisables); i < n; i++) {
         item = new QTreeWidgetItem();
         item->setText(0, miscDisables[i].prompt);
-        if (disables_->settings_value.contains(miscDisables[i].token))
+        if (_disables->settings_value.contains(miscDisables[i].token))
             item->setCheckState(0, Qt::Unchecked);
         else
             item->setCheckState(0, Qt::Checked);
@@ -214,81 +214,81 @@ KhronosSettingsAdvanced::KhronosSettingsAdvanced(QTreeWidget *main_tree, QTreeWi
 
     ///////////////////////////////////////////////////////////////
     // Now for the GPU specific stuff
-    bool shader_based = enables_->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT") ||
-                        enables_->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT");
+    bool shader_based = _enables->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT") ||
+                        _enables->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT");
 
-    shader_based_box_ = new QTreeWidgetItem();
-    shader_based_box_->setText(0, "Shader-Based Validation");
+    _shader_based_box = new QTreeWidgetItem();
+    _shader_based_box->setText(0, "Shader-Based Validation");
     if (shader_based)
-        shader_based_box_->setCheckState(0, Qt::Checked);
+        _shader_based_box->setCheckState(0, Qt::Checked);
     else
-        shader_based_box_->setCheckState(0, Qt::Unchecked);
+        _shader_based_box->setCheckState(0, Qt::Unchecked);
 
-    parent->addChild(shader_based_box_);
+    parent->addChild(_shader_based_box);
 
-    gpu_assisted_box_ = new QTreeWidgetItem();
-    gpu_assisted_box_->setText(0, "     GPU-Assisted");
-    shader_based_box_->addChild(gpu_assisted_box_);
+    _gpu_assisted_box = new QTreeWidgetItem();
+    _gpu_assisted_box->setText(0, "     GPU-Assisted");
+    _shader_based_box->addChild(_gpu_assisted_box);
 
-    gpu_assisted_ratio_ = new QRadioButton();
-    main_tree_widget_->setItemWidget(gpu_assisted_box_, 0, gpu_assisted_ratio_);
+    _gpu_assisted_radio = new QRadioButton();
+    _main_tree_widget->setItemWidget(_gpu_assisted_box, 0, _gpu_assisted_radio);
 
-    reserve_box_ = new QTreeWidgetItem();
-    reserve_box_->setText(0, "Reserve Descriptor Set Binding");
-    if (enables_->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT"))
-        reserve_box_->setCheckState(0, Qt::Checked);
+    _reserve_box = new QTreeWidgetItem();
+    _reserve_box->setText(0, "Reserve Descriptor Set Binding");
+    if (_enables->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT"))
+        _reserve_box->setCheckState(0, Qt::Checked);
     else
-        reserve_box_->setCheckState(0, Qt::Unchecked);
+        _reserve_box->setCheckState(0, Qt::Unchecked);
 
-    gpu_assisted_box_->addChild(reserve_box_);
+    _gpu_assisted_box->addChild(_reserve_box);
 
-    debug_printf_box_ = new QTreeWidgetItem();
-    debug_printf_box_->setText(0, "     Debug printf");
-    shader_based_box_->addChild(debug_printf_box_);
+    _debug_printf_box = new QTreeWidgetItem();
+    _debug_printf_box->setText(0, "     Debug printf");
+    _shader_based_box->addChild(_debug_printf_box);
 
-    debug_printf_radio_ = new QRadioButton();
-    main_tree_widget_->setItemWidget(debug_printf_box_, 0, debug_printf_radio_);
-    if (enables_->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT")) {
-        debug_printf_radio_->setChecked(true);
-        reserve_box_->setFlags(reserve_box_->flags() & ~Qt::ItemIsEnabled);
+    _debug_printf_radio = new QRadioButton();
+    _main_tree_widget->setItemWidget(_debug_printf_box, 0, _debug_printf_radio);
+    if (_enables->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT")) {
+        _debug_printf_radio->setChecked(true);
+        _reserve_box->setFlags(_reserve_box->flags() & ~Qt::ItemIsEnabled);
     } else
-        gpu_assisted_ratio_->setChecked(true);
+        _gpu_assisted_radio->setChecked(true);
 
     if (!shader_based) {
-        debug_printf_radio_->setEnabled(false);
-        gpu_assisted_ratio_->setEnabled(false);
-        debug_printf_box_->setFlags(debug_printf_box_->flags() & ~Qt::ItemIsEnabled);
-        reserve_box_->setFlags(reserve_box_->flags() & ~Qt::ItemIsEnabled);
-        gpu_assisted_box_->setFlags(gpu_assisted_box_->flags() & ~Qt::ItemIsEnabled);
+        _debug_printf_radio->setEnabled(false);
+        _gpu_assisted_radio->setEnabled(false);
+        _debug_printf_box->setFlags(_debug_printf_box->flags() & ~Qt::ItemIsEnabled);
+        _reserve_box->setFlags(_reserve_box->flags() & ~Qt::ItemIsEnabled);
+        _gpu_assisted_box->setFlags(_gpu_assisted_box->flags() & ~Qt::ItemIsEnabled);
     }
 
     ///////////////////////////////////////////////////////////////
     // Synchronization
 
-    bool synchronization = enables_->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION");
-    synchronization_box_ = new QTreeWidgetItem();
-    synchronization_box_->setText(0, syncChecks[0].prompt);
+    bool synchronization = _enables->settings_value.contains("VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION");
+    _synchronization_box = new QTreeWidgetItem();
+    _synchronization_box->setText(0, syncChecks[0].prompt);
     if (synchronization)
-        synchronization_box_->setCheckState(0, Qt::Checked);
+        _synchronization_box->setCheckState(0, Qt::Checked);
     else
-        synchronization_box_->setCheckState(0, Qt::Unchecked);
-    parent->addChild(synchronization_box_);
+        _synchronization_box->setCheckState(0, Qt::Unchecked);
+    parent->addChild(_synchronization_box);
 
-    syncChecks[0].item = synchronization_box_;
+    syncChecks[0].item = _synchronization_box;
 
     //////////////////////////////////////////////////////////////////////
     // Best Practices - one parent/child, but we want to be able
     // to go back to these
     core_child_item = new QTreeWidgetItem();
     core_child_item->setText(0, bestPractices[1].prompt);
-    if (enables_->settings_value.contains(bestPractices[1].token))
+    if (_enables->settings_value.contains(bestPractices[1].token))
         core_child_item->setCheckState(0, Qt::Checked);
     else
         core_child_item->setCheckState(0, Qt::Unchecked);
 
     item = new QTreeWidgetItem();
     item->setText(0, bestPractices[0].prompt);
-    if (enables_->settings_value.contains(bestPractices[0].token))
+    if (_enables->settings_value.contains(bestPractices[0].token))
         item->setCheckState(0, Qt::Checked);
     else {
         item->setCheckState(0, Qt::Unchecked);
@@ -301,10 +301,10 @@ KhronosSettingsAdvanced::KhronosSettingsAdvanced(QTreeWidget *main_tree, QTreeWi
     item->addChild(core_child_item);
     bestPractices[1].item = core_child_item;
 
-    connect(main_tree_widget_, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this, SLOT(itemChanged(QTreeWidgetItem *, int)));
-    connect(main_tree_widget_, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this, SLOT(itemClicked(QTreeWidgetItem *, int)));
-    connect(gpu_assisted_ratio_, SIGNAL(toggled(bool)), this, SLOT(gpuToggled(bool)));
-    connect(debug_printf_radio_, SIGNAL(toggled(bool)), this, SLOT(printfToggled(bool)));
+    connect(_main_tree_widget, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this, SLOT(itemChanged(QTreeWidgetItem *, int)));
+    connect(_main_tree_widget, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this, SLOT(itemClicked(QTreeWidgetItem *, int)));
+    connect(_gpu_assisted_radio, SIGNAL(toggled(bool)), this, SLOT(gpuToggled(bool)));
+    connect(_debug_printf_radio, SIGNAL(toggled(bool)), this, SLOT(printfToggled(bool)));
 }
 
 KhronosSettingsAdvanced::~KhronosSettingsAdvanced() {}
@@ -320,7 +320,7 @@ void KhronosSettingsAdvanced::itemClicked(QTreeWidgetItem *item, int column) {
     emit settingChanged();
 
     // Check for core validation checks
-    if (item == core_checks_parent_) {
+    if (item == _core_checks_parent) {
         description = GetSettingDetails("VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT", url);
         // ui->labelSettingInfo->setText(description);
         return;
@@ -359,25 +359,25 @@ void KhronosSettingsAdvanced::itemClicked(QTreeWidgetItem *item, int column) {
     }
 
     // GPU Stuff
-    if (item == gpu_assisted_box_) {
+    if (item == _gpu_assisted_box) {
         description = GetSettingDetails("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT", url);
         // ui->labelSettingInfo->setText(description);
         return;
     }
 
-    if (item == reserve_box_) {
+    if (item == _reserve_box) {
         description = GetSettingDetails("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT", url);
         // ui->labelSettingInfo->setText(description);
         return;
     }
 
-    if (item == debug_printf_box_) {
+    if (item == _debug_printf_box) {
         description = GetSettingDetails("VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT", url);
         // ui->labelSettingInfo->setText(description);
         return;
     }
 
-    if (item == synchronization_box_) {
+    if (item == _synchronization_box) {
         description = GetSettingDetails("VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION", url);
         // ui->labelSettingInfo->setText(description);
         return;
@@ -396,10 +396,10 @@ void KhronosSettingsAdvanced::itemChanged(QTreeWidgetItem *item, int nColumn) {
 
     // Anything toggled needs to be selected in order to work well with the
     // information display.
-    main_tree_widget_->setCurrentItem(item);
+    _main_tree_widget->setCurrentItem(item);
 
     // Best Practices
-    main_tree_widget_->blockSignals(true);
+    _main_tree_widget->blockSignals(true);
     if (item == bestPractices[0].item) {
         // If we turned it on, we need to enable AMD
         if (item->checkState(0) == Qt::Checked) {
@@ -411,7 +411,7 @@ void KhronosSettingsAdvanced::itemChanged(QTreeWidgetItem *item, int nColumn) {
     }
 
     // Core Validation.
-    if (item == core_checks_parent_) {
+    if (item == _core_checks_parent) {
         // If checked, enable all below it.
         if (item->checkState(0) == Qt::Checked) {
             for (int i = 0; i < 7; i++) {
@@ -427,35 +427,35 @@ void KhronosSettingsAdvanced::itemChanged(QTreeWidgetItem *item, int nColumn) {
     }
 
     // Shader based stuff
-    if (item == shader_based_box_) {  // Just enable/disable the items below it
-        if (shader_based_box_->checkState(0) == Qt::Checked) {
-            debug_printf_radio_->setEnabled(true);
-            gpu_assisted_ratio_->setEnabled(true);
-            debug_printf_box_->setFlags(debug_printf_box_->flags() | Qt::ItemIsEnabled);
-            reserve_box_->setFlags(reserve_box_->flags() | Qt::ItemIsEnabled);
-            gpu_assisted_box_->setFlags(gpu_assisted_box_->flags() | Qt::ItemIsEnabled);
+    if (item == _shader_based_box) {  // Just enable/disable the items below it
+        if (_shader_based_box->checkState(0) == Qt::Checked) {
+            _debug_printf_radio->setEnabled(true);
+            _gpu_assisted_radio->setEnabled(true);
+            _debug_printf_box->setFlags(_debug_printf_box->flags() | Qt::ItemIsEnabled);
+            _reserve_box->setFlags(_reserve_box->flags() | Qt::ItemIsEnabled);
+            _gpu_assisted_box->setFlags(_gpu_assisted_box->flags() | Qt::ItemIsEnabled);
         } else {
-            debug_printf_radio_->setEnabled(false);
-            gpu_assisted_ratio_->setEnabled(false);
-            debug_printf_box_->setFlags(debug_printf_box_->flags() & ~Qt::ItemIsEnabled);
-            reserve_box_->setFlags(reserve_box_->flags() & ~Qt::ItemIsEnabled);
-            gpu_assisted_box_->setFlags(gpu_assisted_box_->flags() & ~Qt::ItemIsEnabled);
+            _debug_printf_radio->setEnabled(false);
+            _gpu_assisted_radio->setEnabled(false);
+            _debug_printf_box->setFlags(_debug_printf_box->flags() & ~Qt::ItemIsEnabled);
+            _reserve_box->setFlags(_reserve_box->flags() & ~Qt::ItemIsEnabled);
+            _gpu_assisted_box->setFlags(_gpu_assisted_box->flags() & ~Qt::ItemIsEnabled);
         }
     }
 
     // Debug printf or GPU based also enables/disables the checkbox for reserving a slot
-    if (item == debug_printf_box_ && debug_printf_radio_->isChecked())
-        reserve_box_->setFlags(reserve_box_->flags() & ~Qt::ItemIsEnabled);
+    if (item == _debug_printf_box && _debug_printf_radio->isChecked())
+        _reserve_box->setFlags(_reserve_box->flags() & ~Qt::ItemIsEnabled);
 
-    main_tree_widget_->blockSignals(false);
+    _main_tree_widget->blockSignals(false);
 
     // Check for performance issues. There are three different variations, and I think
     // we should alert the user to all three exactly/explicitly to what they are
     QSettings settings;
 
     const bool features_to_run_alone[] = {
-        core_checks_parent_->checkState(0) == Qt::Checked, synchronization_box_->checkState(0) == Qt::Checked,
-        shader_based_box_->checkState(0) == Qt::Checked, bestPractices[0].item->checkState(0) == Qt::Checked};
+        _core_checks_parent->checkState(0) == Qt::Checked, _synchronization_box->checkState(0) == Qt::Checked,
+        _shader_based_box->checkState(0) == Qt::Checked, bestPractices[0].item->checkState(0) == Qt::Checked};
 
     int count_enabled_features = 0;
     for (std::size_t i = 0, n = vku::countof(features_to_run_alone); i < n; ++i)
@@ -463,9 +463,9 @@ void KhronosSettingsAdvanced::itemChanged(QTreeWidgetItem *item, int nColumn) {
 
     if (count_enabled_features > 1) {
         if (settings.value("VKCONFIG_WARN_CORE_SHADER_IGNORE").toBool() == false) {
-            QMessageBox alert(main_tree_widget_);
+            QMessageBox alert(_main_tree_widget);
             alert.setText(
-                "<i>Core Validation</i>, <i>Shader Based Validation</i>, <i>Synchronization Validation</i> and <i>Best Pracstices "
+                "<i>Core Validation</i>, <i>Shader Based Validation</i>, <i>Synchronization Validation</i> and <i>Best Practices "
                 "Warnings</i> require a state "
                 "tracking object each.\n\n<br><br> Combining two of these options will result in high performance degradation.");
             alert.setWindowTitle(tr("High Validation Layer Overhead"));
@@ -481,7 +481,7 @@ void KhronosSettingsAdvanced::itemChanged(QTreeWidgetItem *item, int nColumn) {
 }
 
 void KhronosSettingsAdvanced::gpuToggled(bool toggle) {
-    if (toggle) reserve_box_->setFlags(reserve_box_->flags() | Qt::ItemIsEnabled);
+    if (toggle) _reserve_box->setFlags(_reserve_box->flags() | Qt::ItemIsEnabled);
 
     CollectSettings();
     emit settingChanged();
@@ -489,8 +489,8 @@ void KhronosSettingsAdvanced::gpuToggled(bool toggle) {
 
 void KhronosSettingsAdvanced::printfToggled(bool toggle) {
     if (toggle) {
-        reserve_box_->setFlags(reserve_box_->flags() & ~Qt::ItemIsEnabled);
-        reserve_box_->setCheckState(0, Qt::Unchecked);
+        _reserve_box->setFlags(_reserve_box->flags() & ~Qt::ItemIsEnabled);
+        _reserve_box->setCheckState(0, Qt::Unchecked);
     }
 
     CollectSettings();
@@ -504,11 +504,11 @@ bool KhronosSettingsAdvanced::CollectSettings() {
     QString disables;
 
     // GPU stuff
-    if (shader_based_box_->checkState(0) == Qt::Checked) {
-        if (gpu_assisted_ratio_->isChecked()) {
+    if (_shader_based_box->checkState(0) == Qt::Checked) {
+        if (_gpu_assisted_radio->isChecked()) {
             enables = "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT";
 
-            if (reserve_box_->checkState(0) == Qt::Checked)
+            if (_reserve_box->checkState(0) == Qt::Checked)
                 enables += ",VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT";
         } else  // Debug printf must be checked
             enables = "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT";
@@ -533,14 +533,14 @@ bool KhronosSettingsAdvanced::CollectSettings() {
     }
 
     // Core checks. If unchecked, then individual ones might still be checked
-    if (core_checks_parent_->checkState(0) == Qt::Checked) {
+    if (_core_checks_parent->checkState(0) == Qt::Checked) {
         for (std::size_t i = 0, n = vku::countof(coreChecks); i < n; i++)
             if (coreChecks[i].item->checkState(0) == Qt::Unchecked) AddString(disables, coreChecks[i].token);
     } else  // Not checked, turn them all off
         AddString(disables, "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT");
 
-    disables_->settings_value = disables;
-    enables_->settings_value = enables;
+    _disables->settings_value = disables;
+    _enables->settings_value = enables;
 
     return true;
 }

--- a/vkconfig/khronossettingsadvanced.h
+++ b/vkconfig/khronossettingsadvanced.h
@@ -38,21 +38,21 @@ class KhronosSettingsAdvanced : public QObject {
     bool CollectSettings();
 
    private:
-    QTreeWidget *main_tree_widget_;
-    QTreeWidgetItem *main_parent_;
-    QTreeWidgetItem *core_checks_parent_;
+    QTreeWidget *_main_tree_widget;
+    QTreeWidgetItem *_main_parent;
+    QTreeWidgetItem *_core_checks_parent;
 
-    LayerSettings *disables_;
-    LayerSettings *enables_;
+    LayerSettings *_disables;
+    LayerSettings *_enables;
 
-    QTreeWidgetItem *synchronization_box_;
-    QTreeWidgetItem *shader_based_box_;
-    QTreeWidgetItem *gpu_assisted_box_;
-    QRadioButton *gpu_assisted_ratio_;
-    QTreeWidgetItem *reserve_box_;
-    QTreeWidgetItem *debug_printf_box_;
-    QRadioButton *debug_printf_radio_;
-    MuteMessageWidget *mute_message_widget_;
+    QTreeWidgetItem *_synchronization_box;
+    QTreeWidgetItem *_shader_based_box;
+    QTreeWidgetItem *_gpu_assisted_box;
+    QRadioButton *_gpu_assisted_radio;
+    QTreeWidgetItem *_reserve_box;
+    QTreeWidgetItem *_debug_printf_box;
+    QRadioButton *_debug_printf_radio;
+    MuteMessageWidget *_mute_message_widget;
 
    public Q_SLOTS:
     void itemChanged(QTreeWidgetItem *item, int column);

--- a/vkconfig/layerfile.cpp
+++ b/vkconfig/layerfile.cpp
@@ -55,14 +55,14 @@ void AddString(QString& delimitedString, QString value) {
 }
 
 LayerFile::LayerFile() {
-    enabled = false;
-    disabled = false;
-    rank = 0;
+    _enabled = false;
+    _disabled = false;
+    _rank = 0;
 }
 
 LayerFile::~LayerFile() {
-    qDeleteAll(layer_settings.begin(), layer_settings.end());
-    layer_settings.clear();
+    qDeleteAll(_layer_settings.begin(), _layer_settings.end());
+    _layer_settings.clear();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -72,7 +72,7 @@ LayerFile::~LayerFile() {
 /// Reports errors via a message box. This might be a bad idea?
 /// //////////////////////////////////////////////////////////////////////////
 bool LayerFile::ReadLayerFile(QString qsFullPathToFile, LayerType layerKind) {
-    layer_type = layerKind;  // Set layer type, no way to know this from the json file
+    _layer_type = layerKind;  // Set layer type, no way to know this from the json file
 
     // Open the file, should be text. Read it into a
     // temporary string.
@@ -90,7 +90,7 @@ bool LayerFile::ReadLayerFile(QString qsFullPathToFile, LayerType layerKind) {
     QString jsonText = file.readAll();
     file.close();
 
-    layer_path = qsFullPathToFile;
+    _layer_path = qsFullPathToFile;
 
     //////////////////////////////////////////////////////
     // Convert the text to a JSON document & validate it.
@@ -116,28 +116,28 @@ bool LayerFile::ReadLayerFile(QString qsFullPathToFile, LayerType layerKind) {
     // Populate key items about the layer
     QJsonObject jsonObject = jsonDoc.object();
     QJsonValue jsonValue = jsonObject.value("file_format_version");
-    file_format_version = jsonValue.toString();
+    _file_format_version = jsonValue.toString();
 
     QJsonValue layerValue = jsonObject.value("layer");
     QJsonObject layerObject = layerValue.toObject();
 
     jsonValue = layerObject.value("name");
-    name = jsonValue.toString();
+    _name = jsonValue.toString();
 
     jsonValue = layerObject.value("type");
-    type = jsonValue.toString();
+    _type = jsonValue.toString();
 
     jsonValue = layerObject.value("library_path");
-    library_path = jsonValue.toString();
+    _library_path = jsonValue.toString();
 
     jsonValue = layerObject.value("api_version");
-    api_version = jsonValue.toString();
+    _api_version = jsonValue.toString();
 
     jsonValue = layerObject.value("implementation_version");
-    implementation_version = jsonValue.toString();
+    _implementation_version = jsonValue.toString();
 
     jsonValue = layerObject.value("description");
-    description = jsonValue.toString();
+    _description = jsonValue.toString();
 
     // The layer file is loaded
     return true;

--- a/vkconfig/layerfile.h
+++ b/vkconfig/layerfile.h
@@ -71,25 +71,25 @@ class LayerFile : public QObject {
     Q_OBJECT
    public:
     // Standard pieces of a layer
-    QString file_format_version;
-    QString name;
-    QString type;
-    QString library_path;  // This is a relative path, straight out of the json
-    QString api_version;
-    QString implementation_version;
-    QString description;
+    QString _file_format_version;
+    QString _name;
+    QString _type;
+    QString _library_path;  // This is a relative path, straight out of the json
+    QString _api_version;
+    QString _implementation_version;
+    QString _description;
 
-    QString layer_path;  // Actual path to the folder that contains the layer (this is important!)
-    LayerType layer_type;
+    QString _layer_path;  // Actual path to the folder that contains the layer (this is important!)
+    LayerType _layer_type;
 
     // This layers settings. This will be used to build the editor
     // as well as create settings files. This CAN be empty if the
     // layer doens't have any settings.
-    QVector<LayerSettings*> layer_settings;
+    QVector<LayerSettings*> _layer_settings;
 
-    bool enabled;   // When used in a profile, is this one active?
-    bool disabled;  // When used in a profile, is this one disabled?
-    int rank;       // When used in a profile, what is the rank? (0 being first layer)
+    bool _enabled;   // When used in a profile, is this one active?
+    bool _disabled;  // When used in a profile, is this one disabled?
+    int _rank;       // When used in a profile, what is the rank? (0 being first layer)
 
    public:
     LayerFile();
@@ -98,23 +98,23 @@ class LayerFile : public QObject {
     // No.. I do not like operator overloading. It's a bad idea.
     // Inlined here just so I can see all the variables that need to be copied.
     void CopyLayer(LayerFile* destination_layer_file) const {
-        destination_layer_file->file_format_version = file_format_version;
-        destination_layer_file->name = name;
-        destination_layer_file->type = type;
-        destination_layer_file->library_path = library_path;
-        destination_layer_file->api_version = api_version;
-        destination_layer_file->implementation_version = implementation_version;
-        destination_layer_file->description = description;
-        destination_layer_file->layer_type = layer_type;
-        destination_layer_file->enabled = enabled;
-        destination_layer_file->rank = rank;
-        destination_layer_file->disabled = disabled;
-        destination_layer_file->layer_path = layer_path;
+        destination_layer_file->_file_format_version = _file_format_version;
+        destination_layer_file->_name = _name;
+        destination_layer_file->_type = _type;
+        destination_layer_file->_library_path = _library_path;
+        destination_layer_file->_api_version = _api_version;
+        destination_layer_file->_implementation_version = _implementation_version;
+        destination_layer_file->_description = _description;
+        destination_layer_file->_layer_type = _layer_type;
+        destination_layer_file->_enabled = _enabled;
+        destination_layer_file->_rank = _rank;
+        destination_layer_file->_disabled = _disabled;
+        destination_layer_file->_layer_path = _layer_path;
 
-        for (int i = 0; i < layer_settings.length(); i++) {
+        for (int i = 0; i < _layer_settings.length(); i++) {
             LayerSettings* pSettings = new LayerSettings();
-            *pSettings = *layer_settings[i];
-            destination_layer_file->layer_settings.push_back(pSettings);
+            *pSettings = *_layer_settings[i];
+            destination_layer_file->_layer_settings.push_back(pSettings);
         }
     }
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -61,113 +61,113 @@ static const int LAUNCH_ROW_HEIGHT = 26;
 static const int LAUNCH_ROW_HEIGHT = 28;
 #endif
 
-MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui_(new Ui::MainWindow) {
-    ui_->setupUi(this);
-    ui_->launchTree->installEventFilter(this);
-    ui_->profileTree->installEventFilter(this);
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
+    ui->setupUi(this);
+    ui->launchTree->installEventFilter(this);
+    ui->profileTree->installEventFilter(this);
 
-    selected_configuration_item_ = nullptr;
-    vk_via_ = nullptr;
-    vk_info_ = nullptr;
-    help_ = nullptr;
-    launch_application_ = nullptr;
-    log_file_ = nullptr;
-    launcher_apps_combo_ = nullptr;
-    launch_arguments_ = nullptr;
+    _selected_configuration_item = nullptr;
+    _vk_via = nullptr;
+    _vk_info = nullptr;
+    _help = nullptr;
+    _launch_application = nullptr;
+    _log_file = nullptr;
+    _launcher_apps_combo = nullptr;
+    _launch_arguments = nullptr;
 
     ///////////////////////////////////////////////
     Configurator &configurator = Configurator::Get();
 
     if (!configurator.VK_LAYER_PATH.isEmpty())
-        ui_->groupBoxProfiles->setTitle("Vulkan Layers Configurations With VK_LAYER_PATH Precedence");
+        ui->groupBoxProfiles->setTitle("Vulkan Layers Configurations With VK_LAYER_PATH Precedence");
 
     // We need to resetup the new profile for consistency sake.
-    QString last_configuration = settings_.value(VKCONFIG_KEY_ACTIVEPROFILE, QString("Validation - Standard")).toString();
+    QString last_configuration = _settings.value(VKCONFIG_KEY_ACTIVEPROFILE, QString("Validation - Standard")).toString();
     Configuration *current_configuration = configurator.FindConfiguration(last_configuration);
-    if (configurator.override_active) ChangeActiveConfiguration(current_configuration);
+    if (configurator._override_active) ChangeActiveConfiguration(current_configuration);
 
     LoadConfigurationList();
     SetupLaunchTree();
 
-    connect(ui_->actionAbout, SIGNAL(triggered(bool)), this, SLOT(aboutVkConfig(bool)));
-    connect(ui_->actionVulkan_Info, SIGNAL(triggered(bool)), this, SLOT(toolsVulkanInfo(bool)));
-    connect(ui_->actionHelp, SIGNAL(triggered(bool)), this, SLOT(helpShowHelp(bool)));
-    connect(ui_->actionVulkan_specification, SIGNAL(triggered(bool)), this, SLOT(helpShowVulkanSpec(bool)));
-    connect(ui_->actionVulkan_Layer_Specification, SIGNAL(triggered(bool)), this, SLOT(helpShowLayerSpec(bool)));
+    connect(ui->actionAbout, SIGNAL(triggered(bool)), this, SLOT(aboutVkConfig(bool)));
+    connect(ui->actionVulkan_Info, SIGNAL(triggered(bool)), this, SLOT(toolsVulkanInfo(bool)));
+    connect(ui->actionHelp, SIGNAL(triggered(bool)), this, SLOT(helpShowHelp(bool)));
+    connect(ui->actionVulkan_specification, SIGNAL(triggered(bool)), this, SLOT(helpShowVulkanSpec(bool)));
+    connect(ui->actionVulkan_Layer_Specification, SIGNAL(triggered(bool)), this, SLOT(helpShowLayerSpec(bool)));
 
-    connect(ui_->actionCustom_Layer_Paths, SIGNAL(triggered(bool)), this, SLOT(toolsSetCustomPaths(bool)));
+    connect(ui->actionCustom_Layer_Paths, SIGNAL(triggered(bool)), this, SLOT(toolsSetCustomPaths(bool)));
 
-    connect(ui_->actionVulkan_Installation, SIGNAL(triggered(bool)), this, SLOT(toolsVulkanInstallation(bool)));
-    connect(ui_->actionRestore_Default_Configurations, SIGNAL(triggered(bool)), this, SLOT(toolsResetToDefault(bool)));
+    connect(ui->actionVulkan_Installation, SIGNAL(triggered(bool)), this, SLOT(toolsVulkanInstallation(bool)));
+    connect(ui->actionRestore_Default_Configurations, SIGNAL(triggered(bool)), this, SLOT(toolsResetToDefault(bool)));
 
-    connect(ui_->profileTree, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this, SLOT(profileItemChanged(QTreeWidgetItem *, int)));
-    connect(ui_->profileTree, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this,
+    connect(ui->profileTree, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this, SLOT(profileItemChanged(QTreeWidgetItem *, int)));
+    connect(ui->profileTree, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this,
             SLOT(profileTreeChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
-    connect(ui_->profileTree, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this,
+    connect(ui->profileTree, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this,
             SLOT(OnConfigurationTreeClicked(QTreeWidgetItem *, int)));
 
-    connect(ui_->layerSettingsTree, SIGNAL(itemExpanded(QTreeWidgetItem *)), this, SLOT(editorExpanded(QTreeWidgetItem *)));
-    connect(ui_->layerSettingsTree, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this,
+    connect(ui->layerSettingsTree, SIGNAL(itemExpanded(QTreeWidgetItem *)), this, SLOT(editorExpanded(QTreeWidgetItem *)));
+    connect(ui->layerSettingsTree, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this,
             SLOT(OnConfigurationSettingsTreeClicked(QTreeWidgetItem *, int)));
 
-    connect(ui_->launchTree, SIGNAL(itemCollapsed(QTreeWidgetItem *)), this, SLOT(launchItemCollapsed(QTreeWidgetItem *)));
-    connect(ui_->launchTree, SIGNAL(itemExpanded(QTreeWidgetItem *)), this, SLOT(launchItemExpanded(QTreeWidgetItem *)));
+    connect(ui->launchTree, SIGNAL(itemCollapsed(QTreeWidgetItem *)), this, SLOT(launchItemCollapsed(QTreeWidgetItem *)));
+    connect(ui->launchTree, SIGNAL(itemExpanded(QTreeWidgetItem *)), this, SLOT(launchItemExpanded(QTreeWidgetItem *)));
 
-    if (!configurator.HasOverriddenApplications() || configurator.overridden_application_list.empty())
-        configurator.overridden_application_list_only = false;
+    if (!configurator.HasOverriddenApplications() || configurator._overridden_application_list.empty())
+        configurator._overridden_application_list_only = false;
 
-    ui_->pushButtonAppList->setEnabled(configurator.overridden_application_list_only);
-    ui_->checkBoxApplyList->setChecked(configurator.overridden_application_list_only);
-    ui_->checkBoxPersistent->setChecked(configurator.override_permanent);
+    ui->pushButtonAppList->setEnabled(configurator._overridden_application_list_only);
+    ui->checkBoxApplyList->setChecked(configurator._overridden_application_list_only);
+    ui->checkBoxPersistent->setChecked(configurator._override_permanent);
 
-    if (configurator.override_active) {
-        ui_->radioOverride->setChecked(true);
-        ui_->groupBoxProfiles->setEnabled(true);
-        ui_->groupBoxEditor->setEnabled(true);
+    if (configurator._override_active) {
+        ui->radioOverride->setChecked(true);
+        ui->groupBoxProfiles->setEnabled(true);
+        ui->groupBoxEditor->setEnabled(true);
     } else {
-        ui_->radioFully->setChecked(true);
-        ui_->checkBoxApplyList->setEnabled(false);
-        ui_->checkBoxPersistent->setEnabled(false);
-        ui_->pushButtonAppList->setEnabled(false);
-        ui_->groupBoxProfiles->setEnabled(false);
-        ui_->groupBoxEditor->setEnabled(false);
+        ui->radioFully->setChecked(true);
+        ui->checkBoxApplyList->setEnabled(false);
+        ui->checkBoxPersistent->setEnabled(false);
+        ui->pushButtonAppList->setEnabled(false);
+        ui->groupBoxProfiles->setEnabled(false);
+        ui->groupBoxEditor->setEnabled(false);
     }
 
     QSettings settings;
     if (settings.value(VKCONFIG_KEY_RESTORE_GEOMETRY).toBool()) {
-        restoreGeometry(settings_.value("geometry").toByteArray());
-        restoreState(settings_.value("windowState").toByteArray());
-        ui_->splitter->restoreState(settings_.value("splitter1State").toByteArray());
-        ui_->splitter_2->restoreState(settings_.value("splitter2State").toByteArray());
-        ui_->splitter_3->restoreState(settings_.value("splitter3State").toByteArray());
+        restoreGeometry(_settings.value("geometry").toByteArray());
+        restoreState(_settings.value("windowState").toByteArray());
+        ui->splitter->restoreState(_settings.value("splitter1State").toByteArray());
+        ui->splitter_2->restoreState(_settings.value("splitter2State").toByteArray());
+        ui->splitter_3->restoreState(_settings.value("splitter3State").toByteArray());
     }
     settings.setValue(VKCONFIG_KEY_RESTORE_GEOMETRY, true);
 
     // All else is done, highlight and activeate the current profile on startup
     Configuration *configuration = configurator.GetActiveConfiguration();
     if (configuration != nullptr) {
-        for (int i = 0; i < ui_->profileTree->topLevelItemCount(); i++) {
-            ConfigurationListItem *pItem = dynamic_cast<ConfigurationListItem *>(ui_->profileTree->topLevelItem(i));
+        for (int i = 0; i < ui->profileTree->topLevelItemCount(); i++) {
+            ConfigurationListItem *pItem = dynamic_cast<ConfigurationListItem *>(ui->profileTree->topLevelItem(i));
             if (pItem != nullptr)
                 if (pItem->configuration == configuration) {  // Ding ding ding... we have a winner
-                    ui_->profileTree->setCurrentItem(pItem);
+                    ui->profileTree->setCurrentItem(pItem);
                 }
         }
     }
-    ui_->groupBoxEditor->setEnabled(configuration != nullptr);
+    ui->groupBoxEditor->setEnabled(configuration != nullptr);
 
-    ui_->logBrowser->append("Vulkan Development Status:");
-    ui_->logBrowser->append(configurator.CheckVulkanSetup());
-    ui_->profileTree->scrollToItem(ui_->profileTree->topLevelItem(0), QAbstractItemView::PositionAtTop);
+    ui->logBrowser->append("Vulkan Development Status:");
+    ui->logBrowser->append(configurator.CheckVulkanSetup());
+    ui->profileTree->scrollToItem(ui->profileTree->topLevelItem(0), QAbstractItemView::PositionAtTop);
 
     // Resetting this from the default prevents the log window (a QTextEdit) from overflowing.
     // Whenever the control surpasses this block count, old blocks are discarded.
     // Note: We could make this a user configurable setting down the road should this be
     // insufficinet.
-    ui_->logBrowser->document()->setMaximumBlockCount(2048);
+    ui->logBrowser->document()->setMaximumBlockCount(2048);
 }
 
-MainWindow::~MainWindow() { delete ui_; }
+MainWindow::~MainWindow() { delete ui; }
 
 ///////////////////////////////////////////////////////////////////////////////
 // Load or refresh the list of profiles. Any profile that uses a layer that
@@ -175,26 +175,26 @@ MainWindow::~MainWindow() { delete ui_; }
 void MainWindow::LoadConfigurationList() {
     // There are lots of ways into this, and in none of them
     // can we have an active editor running.
-    settings_tree_manager_.CleanupGUI();
-    ui_->profileTree->blockSignals(true);  // No signals firing off while we do this
-    ui_->profileTree->clear();
+    _settings_tree_manager.CleanupGUI();
+    ui->profileTree->blockSignals(true);  // No signals firing off while we do this
+    ui->profileTree->clear();
 
     // Who is the currently active profile?
-    QString active_configuration_name = settings_.value(VKCONFIG_KEY_ACTIVEPROFILE).toString();
+    QString active_configuration_name = _settings.value(VKCONFIG_KEY_ACTIVEPROFILE).toString();
 
     Configurator &configurator = Configurator::Get();
 
-    for (int i = 0, n = configurator.available_configurations.size(); i < n; i++) {
+    for (int i = 0, n = configurator._available_configurations.size(); i < n; i++) {
         // Add to list
         ConfigurationListItem *item = new ConfigurationListItem();
-        item->configuration = configurator.available_configurations[i];
-        ui_->profileTree->addTopLevelItem(item);
-        item->setText(1, configurator.available_configurations[i]->name);
-        item->setToolTip(1, configurator.available_configurations[i]->description);
+        item->configuration = configurator._available_configurations[i];
+        ui->profileTree->addTopLevelItem(item);
+        item->setText(1, configurator._available_configurations[i]->_name);
+        item->setToolTip(1, configurator._available_configurations[i]->_description);
         item->radio_button = new QRadioButton();
         item->radio_button->setText("");
 
-        if (!configurator.available_configurations[i]->IsValid()) {
+        if (!configurator._available_configurations[i]->IsValid()) {
             item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
             item->radio_button->setEnabled(false);
             item->radio_button->setChecked(false);
@@ -205,38 +205,38 @@ void MainWindow::LoadConfigurationList() {
         // function, this configuration may no longer be active. So double check that. Simply,
         // if you make a current config invalid and come back in... it can't be active any
         // longer
-        if (active_configuration_name == configurator.available_configurations[i]->name) {
-            if (configurator.available_configurations[i]->IsValid())
+        if (active_configuration_name == configurator._available_configurations[i]->_name) {
+            if (configurator._available_configurations[i]->IsValid())
                 item->radio_button->setChecked(true);
             else
                 configurator.SetActiveConfiguration(nullptr);
         }
 
         item->setFlags(item->flags() | Qt::ItemIsEditable);
-        ui_->profileTree->setItemWidget(item, 0, item->radio_button);
+        ui->profileTree->setItemWidget(item, 0, item->radio_button);
         connect(item->radio_button, SIGNAL(clicked(bool)), this, SLOT(profileItemClicked(bool)));
     }
 
-    ui_->profileTree->blockSignals(false);
+    ui->profileTree->blockSignals(false);
     ChangeActiveConfiguration(configurator.GetActiveConfiguration());
-    ui_->profileTree->setColumnWidth(0, 24);
-    ui_->profileTree->resizeColumnToContents(1);
-    ui_->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
+    ui->profileTree->setColumnWidth(0, 24);
+    ui->profileTree->resizeColumnToContents(1);
+    ui->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
 }
 
 //////////////////////////////////////////////////////////
 // No override at all, fully controlled by the application
 void MainWindow::on_radioFully_clicked() {
-    ui_->checkBoxApplyList->setEnabled(false);
-    ui_->checkBoxPersistent->setEnabled(false);
+    ui->checkBoxApplyList->setEnabled(false);
+    ui->checkBoxPersistent->setEnabled(false);
 
     Configurator &configurator = Configurator::Get();
 
-    configurator.override_active = false;
-    ui_->groupBoxProfiles->setEnabled(false);
-    ui_->groupBoxEditor->setEnabled(false);
+    configurator._override_active = false;
+    ui->groupBoxProfiles->setEnabled(false);
+    ui->groupBoxEditor->setEnabled(false);
 
-    ui_->pushButtonAppList->setEnabled(false);
+    ui->pushButtonAppList->setEnabled(false);
 
     configurator.SaveSettings();
     ChangeActiveConfiguration(nullptr);
@@ -250,8 +250,8 @@ void MainWindow::on_radioFully_clicked() {
 /// when an event occurs. This unambigously answers that question.
 ConfigurationListItem *MainWindow::GetCheckedItem() {
     // Just go through all the top level items
-    for (int i = 0; i < ui_->profileTree->topLevelItemCount(); i++) {
-        ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui_->profileTree->topLevelItem(i));
+    for (int i = 0; i < ui->profileTree->topLevelItemCount(); i++) {
+        ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui->profileTree->topLevelItem(i));
 
         if (item != nullptr)
             if (item->radio_button->isChecked()) return item;
@@ -265,14 +265,14 @@ ConfigurationListItem *MainWindow::GetCheckedItem() {
 void MainWindow::on_radioOverride_clicked() {
     Configurator &configurator = Configurator::Get();
 
-    bool use = (!configurator.has_old_loader || !been_warned_about_old_loader);
-    ui_->checkBoxApplyList->setEnabled(use);
-    ui_->pushButtonAppList->setEnabled(use && configurator.overridden_application_list_only);
+    bool use = (!configurator._has_old_loader || !been_warned_about_old_loader);
+    ui->checkBoxApplyList->setEnabled(use);
+    ui->pushButtonAppList->setEnabled(use && configurator._overridden_application_list_only);
 
-    ui_->checkBoxPersistent->setEnabled(true);
-    configurator.override_active = true;
-    ui_->groupBoxProfiles->setEnabled(true);
-    ui_->groupBoxEditor->setEnabled(true);
+    ui->checkBoxPersistent->setEnabled(true);
+    configurator._override_active = true;
+    ui->groupBoxProfiles->setEnabled(true);
+    ui->groupBoxEditor->setEnabled(true);
     configurator.SaveSettings();
 
     // This just doesn't work. Make a function to look for the radio button checked.
@@ -282,7 +282,7 @@ void MainWindow::on_radioOverride_clicked() {
     else
         ChangeActiveConfiguration(configuration_item->configuration);
 
-    ui_->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
+    ui->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -291,8 +291,8 @@ void MainWindow::on_radioOverride_clicked() {
 void MainWindow::on_checkBoxApplyList_clicked() {
     Configurator &configurator = Configurator::Get();
 
-    if (configurator.has_old_loader && !been_warned_about_old_loader) {
-        uint32_t version = configurator.vulkan_instance_version;
+    if (configurator._has_old_loader && !been_warned_about_old_loader) {
+        uint32_t version = configurator._vulkan_instance_version;
         QString message;
         message = QString().asprintf(
             "The detected Vulkan Loader version is %d.%d.%d but version 1.2.141 or newer is required in order to apply layers "
@@ -306,38 +306,38 @@ void MainWindow::on_checkBoxApplyList_clicked() {
         alert.setWindowTitle(tr("Layers override of a selected list of Vulkan Applications is not available"));
         alert.exec();
 
-        ui_->pushButtonAppList->setEnabled(false);
-        ui_->checkBoxApplyList->setEnabled(false);
-        ui_->checkBoxApplyList->setChecked(false);
+        ui->pushButtonAppList->setEnabled(false);
+        ui->checkBoxApplyList->setEnabled(false);
+        ui->checkBoxApplyList->setChecked(false);
         QString messageToolTip;
         messageToolTip =
             QString().asprintf("The detected Vulkan loader version is %d.%d.%d but version 1.2.141 or newer is required",
                                VK_VERSION_MAJOR(version), VK_VERSION_MINOR(version), VK_VERSION_PATCH(version));
-        ui_->checkBoxApplyList->setToolTip(messageToolTip);
-        ui_->pushButtonAppList->setToolTip(messageToolTip);
+        ui->checkBoxApplyList->setToolTip(messageToolTip);
+        ui->pushButtonAppList->setToolTip(messageToolTip);
         been_warned_about_old_loader = true;
     }
 
-    configurator.overridden_application_list_only = ui_->checkBoxApplyList->isChecked();
+    configurator._overridden_application_list_only = ui->checkBoxApplyList->isChecked();
     configurator.SaveSettings();
-    ui_->pushButtonAppList->setEnabled(configurator.overridden_application_list_only);
+    ui->pushButtonAppList->setEnabled(configurator._overridden_application_list_only);
 
-    if (configurator.overridden_application_list_only &&
-        (configurator.overridden_application_list.empty() || !configurator.HasOverriddenApplications())) {
+    if (configurator._overridden_application_list_only &&
+        (configurator._overridden_application_list.empty() || !configurator.HasOverriddenApplications())) {
         on_pushButtonAppList_clicked();
     } else {
         // Checking the list, the configuration need to be updated to the system
         if (configurator.GetActiveConfiguration()) ChangeActiveConfiguration(configurator.GetActiveConfiguration());
     }
 
-    ui_->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
+    ui->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
 }
 
 //////////////////////////////////////////////////////////
 void MainWindow::on_checkBoxPersistent_clicked() {
     Configurator &configurator = Configurator::Get();
 
-    configurator.override_permanent = ui_->checkBoxPersistent->isChecked();
+    configurator._override_permanent = ui->checkBoxPersistent->isChecked();
     configurator.SaveSettings();
 }
 
@@ -376,47 +376,47 @@ void MainWindow::toolsResetToDefault(bool checked) {
     }
 
     // Reset to recopy from resource file
-    settings_.setValue(VKCONFIG_KEY_INITIALIZE_FILES, true);
+    _settings.setValue(VKCONFIG_KEY_INITIALIZE_FILES, true);
 
     // Now we need to kind of restart everything
-    settings_tree_manager_.CleanupGUI();
+    _settings_tree_manager.CleanupGUI();
     configurator.LoadAllConfigurations();
 
     // Find the Standard Validation and make it current if we are active
     Configuration *active_configuration = configurator.FindConfiguration(QString("Validation - Standard"));
-    if (configurator.override_active) ChangeActiveConfiguration(active_configuration);
+    if (configurator._override_active) ChangeActiveConfiguration(active_configuration);
 
     LoadConfigurationList();
 
     // Active or not, set it in the tree so we can see the settings.
-    for (int i = 0; i < ui_->profileTree->topLevelItemCount(); i++) {
-        ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui_->profileTree->topLevelItem(i));
+    for (int i = 0; i < ui->profileTree->topLevelItemCount(); i++) {
+        ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui->profileTree->topLevelItem(i));
         if (item != nullptr)
-            if (item->configuration == active_configuration) ui_->profileTree->setCurrentItem(item);
+            if (item->configuration == active_configuration) ui->profileTree->setCurrentItem(item);
     }
 
     configurator.FindVkCube();
     ResetLaunchOptions();
 
-    ui_->logBrowser->clear();
-    ui_->logBrowser->append("Vulkan Development Status:");
-    ui_->logBrowser->append(configurator.CheckVulkanSetup());
+    ui->logBrowser->clear();
+    ui->logBrowser->append("Vulkan Development Status:");
+    ui->logBrowser->append(configurator.CheckVulkanSetup());
 
-    if (configurator.override_active) {
-        ui_->radioOverride->setChecked(true);
-        ui_->checkBoxApplyList->setEnabled(true);
-        ui_->pushButtonAppList->setEnabled(false);
-        ui_->checkBoxPersistent->setEnabled(true);
-        ui_->groupBoxProfiles->setEnabled(true);
-        ui_->groupBoxEditor->setEnabled(true);
+    if (configurator._override_active) {
+        ui->radioOverride->setChecked(true);
+        ui->checkBoxApplyList->setEnabled(true);
+        ui->pushButtonAppList->setEnabled(false);
+        ui->checkBoxPersistent->setEnabled(true);
+        ui->groupBoxProfiles->setEnabled(true);
+        ui->groupBoxEditor->setEnabled(true);
     } else {
-        ui_->radioFully->setChecked(true);
-        ui_->checkBoxApplyList->setEnabled(false);
-        ui_->pushButtonAppList->setEnabled(false);
-        ui_->checkBoxPersistent->setEnabled(false);
-        ui_->pushButtonAppList->setEnabled(false);
-        ui_->groupBoxProfiles->setEnabled(false);
-        ui_->groupBoxEditor->setEnabled(false);
+        ui->radioFully->setChecked(true);
+        ui->checkBoxApplyList->setEnabled(false);
+        ui->pushButtonAppList->setEnabled(false);
+        ui->checkBoxPersistent->setEnabled(false);
+        ui->pushButtonAppList->setEnabled(false);
+        ui->groupBoxProfiles->setEnabled(false);
+        ui->groupBoxEditor->setEnabled(false);
     }
 }
 
@@ -433,7 +433,7 @@ void MainWindow::profileItemClicked(bool checked) {
     Configurator &configurator = Configurator::Get();
 
     // Do we go ahead and activate it?
-    if (configurator.override_active) {
+    if (configurator._override_active) {
         ChangeActiveConfiguration(configuration_item->configuration);
     }
 }
@@ -447,16 +447,18 @@ void MainWindow::profileItemChanged(QTreeWidgetItem *item, int column) {
     if (configuration_item == nullptr) return;
 
     if (column == 1) {  // Profile name
+        _settings_tree_manager.CleanupGUI();
         Configurator &configurator = Configurator::Get();
 
         // We are renaming the file. Just delete the old one and save this
         const QString full_path =
-            configurator.GetPath(Configurator::ConfigurationPath) + "/" + configuration_item->configuration->file;
+            configurator.GetPath(Configurator::ConfigurationPath) + "/" + configuration_item->configuration->_file;
         remove(full_path.toUtf8().constData());
 
-        configuration_item->configuration->name = configuration_item->text(1);
-        configuration_item->configuration->file = configuration_item->text(1) + QString(".json");
+        configuration_item->configuration->_name = configuration_item->text(1);
+        configuration_item->configuration->_file = configuration_item->text(1) + QString(".json");
         configurator.SaveConfiguration(configuration_item->configuration);
+        PopCurrentItem(configuration_item->configuration->_name.toUtf8().constData());
     }
 }
 
@@ -466,22 +468,22 @@ void MainWindow::profileItemChanged(QTreeWidgetItem *item, int column) {
 /// for the radio button, and one to change the editor/information at lower right.
 void MainWindow::profileTreeChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous) {
     (void)previous;
-    settings_tree_manager_.CleanupGUI();
+    _settings_tree_manager.CleanupGUI();
     // This pointer will only be valid if it's one of the elements with
     // the radio button
     ConfigurationListItem *configuration_item = dynamic_cast<ConfigurationListItem *>(current);
     if (configuration_item == nullptr) return;
 
-    if (!Preferences::Get().use_separated_select_and_activate) {
+    if (!Preferences::Get()._use_separated_select_and_activate) {
         configuration_item->radio_button->setChecked(true);
         ChangeActiveConfiguration(configuration_item->configuration);
     }
 
-    settings_tree_manager_.CreateGUI(ui_->layerSettingsTree, configuration_item->configuration);
-    QString title = configuration_item->configuration->name;
+    _settings_tree_manager.CreateGUI(ui->layerSettingsTree, configuration_item->configuration);
+    QString title = configuration_item->configuration->_name;
     title += " Settings";
-    ui_->groupBoxEditor->setTitle(title);
-    ui_->layerSettingsTree->resizeColumnToContents(0);
+    ui->groupBoxEditor->setTitle(title);
+    ui->layerSettingsTree->resizeColumnToContents(0);
 }
 
 ////////////////////////////////////////////////////
@@ -498,9 +500,9 @@ void MainWindow::aboutVkConfig(bool checked) {
 void MainWindow::toolsVulkanInfo(bool checked) {
     (void)checked;
 
-    if (vk_info_ == nullptr) vk_info_ = new dlgVulkanInfo(this);
+    if (_vk_info == nullptr) _vk_info = new dlgVulkanInfo(this);
 
-    vk_info_->RunTool();
+    _vk_info->RunTool();
 }
 
 //////////////////////////////////////////////////////////
@@ -508,18 +510,18 @@ void MainWindow::toolsVulkanInfo(bool checked) {
 /// exist & show it.
 void MainWindow::toolsVulkanInstallation(bool checked) {
     (void)checked;
-    if (vk_via_ == nullptr) vk_via_ = new dlgVulkanAnalysis(this);
+    if (_vk_via == nullptr) _vk_via = new dlgVulkanAnalysis(this);
 
-    vk_via_->RunTool();
+    _vk_via->RunTool();
 }
 
 ////////////////////////////////////////////////////////////////
 /// Show help, which is just a rich text file
 void MainWindow::helpShowHelp(bool checked) {
     (void)checked;
-    if (help_ == nullptr) help_ = new dlgHelp(nullptr);
+    if (_help == nullptr) _help = new dlgHelp(nullptr);
 
-    help_->show();
+    _help->show();
 }
 
 ////////////////////////////////////////////////////////////////
@@ -552,20 +554,22 @@ void MainWindow::helpShowLayerSpec(bool checked) {
 /// The only thing we need to do here is clear the profile if
 /// the user does not want it active.
 void MainWindow::closeEvent(QCloseEvent *event) {
+    _settings_tree_manager.CleanupGUI();
     Configurator &configurator = Configurator::Get();
 
     // Alert the user to the current state of the vulkan configurator and
     // give them the option to not shutdown.
-    if (settings_.value(VKCONFIG_WARN_SHUTDOWNSTATE).toBool() == false) {
+    if (_settings.value(VKCONFIG_WARN_SHUTDOWNSTATE).toBool() == false) {
         QMessageBox alert(nullptr);
         QString shut_down_state;
 
-        if (!configurator.override_permanent || !configurator.override_active)
+        if (!configurator._override_permanent || !configurator._override_active)
             shut_down_state = "No Vulkan layers override will be active when Vulkan Configurator closes.";
+
         else {
             shut_down_state = "Vulkan Layers override will remain in effect when Vulkan Configurator closes.";
 
-            if (configurator.overridden_application_list_only)
+            if (configurator._overridden_application_list_only)
                 shut_down_state += " Overrides will be applied only to the application list.";
             else
                 shut_down_state += " Overrides will be applied to ALL Vulkan applications.";
@@ -580,23 +584,23 @@ void MainWindow::closeEvent(QCloseEvent *event) {
         alert.setCheckBox(new QCheckBox("Do not show again."));
 
         int ret_val = alert.exec();
-        if (alert.checkBox()->isChecked()) settings_.setValue(VKCONFIG_WARN_SHUTDOWNSTATE, true);
+        if (alert.checkBox()->isChecked()) _settings.setValue(VKCONFIG_WARN_SHUTDOWNSTATE, true);
         if (ret_val == QMessageBox::No) {
             event->ignore();
             return;
         }
     }
 
-    if (!configurator.override_permanent) configurator.SetActiveConfiguration(nullptr);
+    if (!configurator._override_permanent) configurator.SetActiveConfiguration(nullptr);
 
     configurator.SaveOverriddenApplicationList();
     configurator.SaveSettings();
 
-    settings_.setValue("geometry", saveGeometry());
-    settings_.setValue("windowState", saveState());
-    settings_.setValue("splitter1State", ui_->splitter->saveState());
-    settings_.setValue("splitter2State", ui_->splitter_2->saveState());
-    settings_.setValue("splitter3State", ui_->splitter_3->saveState());
+    _settings.setValue("geometry", saveGeometry());
+    _settings.setValue("windowState", saveState());
+    _settings.setValue("splitter1State", ui->splitter->saveState());
+    _settings.setValue("splitter2State", ui->splitter_2->saveState());
+    _settings.setValue("splitter3State", ui->splitter_3->saveState());
 
     QMainWindow::closeEvent(event);
 }
@@ -622,7 +626,7 @@ void MainWindow::on_pushButtonAppList_clicked() {
 
     Configurator &configurator = Configurator::Get();
 
-    if (Preferences::Get().use_last_selected_application_in_launcher) {
+    if (Preferences::Get()._use_last_selected_application_in_launcher) {
         configurator.SelectLaunchApplication(dlg.GetSelectedLaunchApplicationIndex());
     }
 
@@ -632,55 +636,81 @@ void MainWindow::on_pushButtonAppList_clicked() {
     // Also, we may have changed exclusion flags, so reset override
     Configuration *active_configuration = configurator.GetActiveConfiguration();
     if (active_configuration != nullptr) configurator.SetActiveConfiguration(active_configuration);
-    ui_->groupBoxEditor->setEnabled(active_configuration != nullptr);
+    ui->groupBoxEditor->setEnabled(active_configuration != nullptr);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Just resave the list anytime we go into the editor
 void MainWindow::on_pushButtonEditProfile_clicked() {
-    // Who is selected?
-    ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui_->profileTree->currentItem());
-    if (item == nullptr) return;
+    ConfigurationListItem *item = PushCurrentItem();
 
     // Save current state before we go in
-    settings_tree_manager_.CleanupGUI();
+    _settings_tree_manager.CleanupGUI();
 
     dlgProfileEditor dlg(this, item->configuration);
     dlg.exec();
 
     // 'item' will be invalid after LoadAllConfigurations, but I still -  // need the pointer to the configuration
-    const QString edited_configuration_name = item->configuration->name;
+    const QString edited_configuration_name = item->configuration->_name;
 
     Configurator::Get().LoadAllConfigurations();
     LoadConfigurationList();
 
+    PopCurrentItem();
+}
+
+///////////////////////////////////////////////////////////////
+// When changes are made to the layer list, it forces a reload
+// of the configuration list. This wipes everything out, so we
+// need a way to restore the currently selected item whenever
+// certain kinds of edits occur. These push/pop functions
+// accomplish that. If nothing can be found it should simply
+// leave nothing selected.
+ConfigurationListItem *MainWindow::PushCurrentItem(void) {
+    // Who is selected?
+    ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui->profileTree->currentItem());
+    if (item == nullptr) return nullptr;
+
+    _lastItem = item->configuration->_name;
+    return item;
+}
+
+////////////////////////////////////////////////////////////////
+// Partner for above function. Returns false if the last config
+// could not be found.
+bool MainWindow::PopCurrentItem(const char *szRenamed) {
+    if (szRenamed != nullptr) _lastItem = szRenamed;
+
     // Reset the current item
-    for (int i = 0; i < ui_->profileTree->topLevelItemCount(); i++) {
-        item = dynamic_cast<ConfigurationListItem *>(ui_->profileTree->topLevelItem(i));
+    for (int i = 0; i < ui->profileTree->topLevelItemCount(); i++) {
+        ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui->profileTree->topLevelItem(i));
         if (item != nullptr)
-            if (item->configuration->name == edited_configuration_name) {
-                ui_->profileTree->setCurrentItem(item);
-                break;
+            if (item->configuration->_name == _lastItem) {
+                ui->profileTree->setCurrentItem(item);
+                return true;
             }
     }
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Edit the layers for the given profile.
 void MainWindow::EditClicked(ConfigurationListItem *item) {
+    PushCurrentItem();
+    _settings_tree_manager.CleanupGUI();
     dlgProfileEditor dlg(this, item->configuration);
     dlg.exec();
 
-    // 'item' will be invalid after LoadAllConfigurations, but I still -  // need the pointer to the configuration
-    const QString edited_configuration_name = item->configuration->name;
-
     Configurator::Get().LoadAllConfigurations();
     LoadConfigurationList();
+    PopCurrentItem();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Create a new blank profile
 void MainWindow::NewClicked() {
+    PushCurrentItem();
+    _settings_tree_manager.CleanupGUI();
     Configurator &configurator = Configurator::Get();
 
     Configuration *configuration = configurator.CreateEmptyConfiguration();
@@ -689,6 +719,7 @@ void MainWindow::NewClicked() {
         configurator.LoadAllConfigurations();
         LoadConfigurationList();
     }
+    PopCurrentItem();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -697,7 +728,7 @@ void MainWindow::NewClicked() {
 /// of loaded layers, but only if something was changed.
 void MainWindow::addCustomPaths() {
     // Get the tree state and clear it.
-    settings_tree_manager_.CleanupGUI();
+    _settings_tree_manager.CleanupGUI();
 
     dlgCustomPaths dlg(this);
     dlg.exec();
@@ -706,38 +737,48 @@ void MainWindow::addCustomPaths() {
 
 //////////////////////////////////////////////////////////////////////////////
 /// Remove the currently selected user defined profile.
+// This option does not automatically select another profile when you
+// delete the current one. Since it's not possible to select it without
+// making it current, this is the only reasonable option I see.
 void MainWindow::RemoveClicked(ConfigurationListItem *item) {
     // Let make sure...
     QMessageBox msg;
-    msg.setInformativeText(item->configuration->name);
+    msg.setInformativeText(item->configuration->_name);
     msg.setText(tr("Are you sure you want to remove this configuration?"));
     msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msg.setDefaultButton(QMessageBox::Yes);
     if (msg.exec() == QMessageBox::No) return;
 
+    PushCurrentItem();
+    _settings_tree_manager.CleanupGUI();
     // What if this is the active profile? We will go boom boom soon...
     Configurator &configurator = Configurator::Get();
     if (configurator.GetActiveConfiguration() == item->configuration) configurator.SetActiveConfiguration(nullptr);
 
     // Delete the file
-    const QString full_path = configurator.GetPath(Configurator::ConfigurationPath) + "/" + item->configuration->file;
+    const QString full_path = configurator.GetPath(Configurator::ConfigurationPath) + "/" + item->configuration->_file;
     remove(full_path.toUtf8().constData());
 
     // Reload profiles
     configurator.LoadAllConfigurations();
     LoadConfigurationList();
+    if (!PopCurrentItem()) ui->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
 }
 
 /////////////////////////////////////////////////////////////////////////////
-void MainWindow::RenameClicked(ConfigurationListItem *item) { ui_->profileTree->editItem(item, 1); }
+void MainWindow::RenameClicked(ConfigurationListItem *item) {
+    PushCurrentItem();
+    ui->profileTree->editItem(item, 1);
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // Copy the current configuration
 void MainWindow::DuplicateClicked(ConfigurationListItem *item) {
-    QString new_name = item->configuration->name;
+    PushCurrentItem();
+    QString new_name = item->configuration->_name;
     new_name += "2";
-    settings_tree_manager_.CleanupGUI();
-    item->configuration->name = new_name;
+    _settings_tree_manager.CleanupGUI();
+    item->configuration->_name = new_name;
 
     Configurator &configurator = Configurator::Get();
     configurator.SaveConfiguration(item->configuration);
@@ -746,10 +787,10 @@ void MainWindow::DuplicateClicked(ConfigurationListItem *item) {
 
     // Good enough? Nope, I want to select it and edit the name.
     // Find it.
-    for (int i = 0; i < ui_->profileTree->topLevelItemCount(); i++) {
-        ConfigurationListItem *pItem = dynamic_cast<ConfigurationListItem *>(ui_->profileTree->topLevelItem(i));
-        if (pItem->configuration->name == new_name) {
-            ui_->profileTree->editItem(pItem, 1);
+    for (int i = 0; i < ui->profileTree->topLevelItemCount(); i++) {
+        ConfigurationListItem *pItem = dynamic_cast<ConfigurationListItem *>(ui->profileTree->topLevelItem(i));
+        if (pItem->configuration->_name == new_name) {
+            ui->profileTree->editItem(pItem, 1);
             return;
         }
     }
@@ -759,18 +800,22 @@ void MainWindow::DuplicateClicked(ConfigurationListItem *item) {
 // Import a configuration file. File copy followed by a reload.
 void MainWindow::ImportClicked(ConfigurationListItem *item) {
     (void)item;  // We don't need this
-
+    PushCurrentItem();
     Configurator &configurator = Configurator::Get();
 
     QString full_suggested_path = configurator.GetPath(Configurator::LastImportPath);
     QString full_import_path =
         QFileDialog::getOpenFileName(this, "Import Layers Configuration File", full_suggested_path, "*.json");
-    if (full_import_path.isEmpty()) return;
+    {
+        PopCurrentItem();
+        if (full_import_path.isEmpty()) return;
+    }
 
-    settings_tree_manager_.CleanupGUI();
+    _settings_tree_manager.CleanupGUI();
     Configurator::Get().ImportConfiguration(full_import_path);
     LoadConfigurationList();
     configurator.SaveSettings();
+    PopCurrentItem();
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -779,12 +824,12 @@ void MainWindow::ExportClicked(ConfigurationListItem *item) {
     Configurator &configurator = Configurator::Get();
 
     // Where to put it and what to call it
-    QString full_suggested_path = configurator.GetPath(Configurator::LastExportPath) + "/" + item->configuration->file;
+    QString full_suggested_path = configurator.GetPath(Configurator::LastExportPath) + "/" + item->configuration->_file;
     QString full_export_path =
         QFileDialog::getSaveFileName(this, "Export Layers Configuration File", full_suggested_path, "*.json");
     if (full_export_path.isEmpty()) return;
 
-    configurator.ExportConfiguration(item->configuration->file, full_export_path);
+    configurator.ExportConfiguration(item->configuration->_file, full_export_path);
     configurator.SaveSettings();
 }
 
@@ -807,12 +852,12 @@ void MainWindow::toolsSetCustomPaths(bool checked) {
 void MainWindow::ChangeActiveConfiguration(Configuration *configuration) {
     Configurator &configurator = Configurator::Get();
 
-    if (configuration == nullptr || !configurator.override_active) {
+    if (configuration == nullptr || !configurator._override_active) {
         configurator.SetActiveConfiguration(nullptr);
 
         setWindowTitle("Vulkan Configurator <VULKAN APPLICATION CONTROLLED>");
     } else {
-        QString newCaption = configuration->name;
+        QString newCaption = configuration->_name;
         if (!configuration->IsValid()) newCaption += " (DISABLED)";
         newCaption += " - Vulkan Configurator ";
         configurator.SetActiveConfiguration(configuration);
@@ -821,18 +866,18 @@ void MainWindow::ChangeActiveConfiguration(Configuration *configuration) {
         setWindowTitle(newCaption);
     }
 
-    ui_->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
+    ui->groupBoxEditor->setEnabled(configurator.GetActiveConfiguration() != nullptr);
 }
 
 void MainWindow::editorExpanded(QTreeWidgetItem *item) {
     (void)item;
-    ui_->layerSettingsTree->resizeColumnToContents(0);
+    ui->layerSettingsTree->resizeColumnToContents(0);
 }
 
 void MainWindow::profileItemExpanded(QTreeWidgetItem *item) {
     (void)item;
-    ui_->layerSettingsTree->resizeColumnToContents(0);
-    ui_->layerSettingsTree->resizeColumnToContents(1);
+    ui->layerSettingsTree->resizeColumnToContents(0);
+    ui->layerSettingsTree->resizeColumnToContents(1);
 }
 
 void MainWindow::OnConfigurationTreeClicked(QTreeWidgetItem *item, int column) {
@@ -852,20 +897,20 @@ void MainWindow::OnConfigurationSettingsTreeClicked(QTreeWidgetItem *item, int c
 /// Reload controls for launch control
 void MainWindow::ResetLaunchOptions() {
     Configurator &configurator = Configurator::Get();
-    ui_->pushButtonLaunch->setEnabled(!configurator.overridden_application_list.empty());
+    ui->pushButtonLaunch->setEnabled(!configurator._overridden_application_list.empty());
 
     // Reload launch apps selections
-    launcher_apps_combo_->blockSignals(true);
-    launcher_apps_combo_->clear();
+    _launcher_apps_combo->blockSignals(true);
+    _launcher_apps_combo->clear();
 
-    for (int i = 0; i < configurator.overridden_application_list.size(); i++) {
-        launcher_apps_combo_->addItem(configurator.overridden_application_list[i]->executable_path);
+    for (int i = 0; i < configurator._overridden_application_list.size(); i++) {
+        _launcher_apps_combo->addItem(configurator._overridden_application_list[i]->executable_path);
     }
 
-    if (configurator.overridden_application_list.isEmpty()) {
-        launch_arguments_->setText("");
-        launcher_working_->setText("");
-        launcher_log_file_edit_->setText("");
+    if (configurator._overridden_application_list.isEmpty()) {
+        _launch_arguments->setText("");
+        _launcher_working->setText("");
+        _launcher_log_file_edit->setText("");
         return;
     }
 
@@ -873,13 +918,13 @@ void MainWindow::ResetLaunchOptions() {
     Q_ASSERT(launch_application_index >= 0);
 
     configurator.SelectLaunchApplication(launch_application_index);
-    launcher_apps_combo_->setCurrentIndex(launch_application_index);
+    _launcher_apps_combo->setCurrentIndex(launch_application_index);
 
     // Reset working folder and command line choices
-    launch_arguments_->setText(configurator.overridden_application_list[launch_application_index]->arguments);
-    launcher_working_->setText(configurator.overridden_application_list[launch_application_index]->working_folder);
-    launcher_log_file_edit_->setText(configurator.overridden_application_list[launch_application_index]->log_file);
-    launcher_apps_combo_->blockSignals(false);
+    _launch_arguments->setText(configurator._overridden_application_list[launch_application_index]->arguments);
+    _launcher_working->setText(configurator._overridden_application_list[launch_application_index]->working_folder);
+    _launcher_log_file_edit->setText(configurator._overridden_application_list[launch_application_index]->log_file);
+    _launcher_apps_combo->blockSignals(false);
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -889,22 +934,22 @@ void MainWindow::SetupLaunchTree() {
     // Executable
     QTreeWidgetItem *launcher_parent = new QTreeWidgetItem();
     launcher_parent->setText(0, "Executable Path");
-    ui_->launchTree->addTopLevelItem(launcher_parent);
+    ui->launchTree->addTopLevelItem(launcher_parent);
 
-    launcher_apps_combo_ = new QComboBox();
-    launcher_apps_combo_->setMinimumHeight(LAUNCH_ROW_HEIGHT);
-    launcher_apps_combo_->setMaximumHeight(LAUNCH_ROW_HEIGHT);
-    ui_->launchTree->setItemWidget(launcher_parent, 1, launcher_apps_combo_);
+    _launcher_apps_combo = new QComboBox();
+    _launcher_apps_combo->setMinimumHeight(LAUNCH_ROW_HEIGHT);
+    _launcher_apps_combo->setMaximumHeight(LAUNCH_ROW_HEIGHT);
+    ui->launchTree->setItemWidget(launcher_parent, 1, _launcher_apps_combo);
 
-    launcher_apps_browse_button_ = new QPushButton();
-    launcher_apps_browse_button_->setText("...");
-    launcher_apps_browse_button_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    launcher_apps_browse_button_->setMaximumWidth(LAUNCH_COLUMN2_SIZE);
-    launcher_apps_browse_button_->setMinimumHeight(LAUNCH_ROW_HEIGHT);
-    launcher_apps_browse_button_->setMaximumHeight(LAUNCH_ROW_HEIGHT);
-    ui_->launchTree->setItemWidget(launcher_parent, 2, launcher_apps_browse_button_);
-    connect(launcher_apps_combo_, SIGNAL(currentIndexChanged(int)), this, SLOT(launchItemChanged(int)));
-    connect(launcher_apps_browse_button_, SIGNAL(clicked()), this, SLOT(on_pushButtonAppList_clicked()));
+    _launcher_apps_browse_button = new QPushButton();
+    _launcher_apps_browse_button->setText("...");
+    _launcher_apps_browse_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    _launcher_apps_browse_button->setMaximumWidth(LAUNCH_COLUMN2_SIZE);
+    _launcher_apps_browse_button->setMinimumHeight(LAUNCH_ROW_HEIGHT);
+    _launcher_apps_browse_button->setMaximumHeight(LAUNCH_ROW_HEIGHT);
+    ui->launchTree->setItemWidget(launcher_parent, 2, _launcher_apps_browse_button);
+    connect(_launcher_apps_combo, SIGNAL(currentIndexChanged(int)), this, SLOT(launchItemChanged(int)));
+    connect(_launcher_apps_browse_button, SIGNAL(clicked()), this, SLOT(on_pushButtonAppList_clicked()));
 
     //////////////////////////////////////////////////////////////////
     // Working folder
@@ -912,11 +957,11 @@ void MainWindow::SetupLaunchTree() {
     launcher_folder_item->setText(0, "Working Directory");
     launcher_parent->addChild(launcher_folder_item);
 
-    launcher_working_ = new QLineEdit();
-    launcher_working_->setMinimumHeight(LAUNCH_ROW_HEIGHT);
-    launcher_working_->setMaximumHeight(LAUNCH_ROW_HEIGHT);
-    ui_->launchTree->setItemWidget(launcher_folder_item, 1, launcher_working_);
-    launcher_working_->setReadOnly(false);
+    _launcher_working = new QLineEdit();
+    _launcher_working->setMinimumHeight(LAUNCH_ROW_HEIGHT);
+    _launcher_working->setMaximumHeight(LAUNCH_ROW_HEIGHT);
+    ui->launchTree->setItemWidget(launcher_folder_item, 1, _launcher_working);
+    _launcher_working->setReadOnly(false);
 
     // Comming soon
     //    pLaunchWorkingFolderButton = new QPushButton();
@@ -930,11 +975,11 @@ void MainWindow::SetupLaunchTree() {
     launcher_arguments_item->setText(0, "Command-line Arguments");
     launcher_parent->addChild(launcher_arguments_item);
 
-    launch_arguments_ = new QLineEdit();
-    launch_arguments_->setMinimumHeight(LAUNCH_ROW_HEIGHT);
-    launch_arguments_->setMaximumHeight(LAUNCH_ROW_HEIGHT);
-    ui_->launchTree->setItemWidget(launcher_arguments_item, 1, launch_arguments_);
-    connect(launch_arguments_, SIGNAL(textEdited(const QString &)), this, SLOT(launchArgsEdited(const QString &)));
+    _launch_arguments = new QLineEdit();
+    _launch_arguments->setMinimumHeight(LAUNCH_ROW_HEIGHT);
+    _launch_arguments->setMaximumHeight(LAUNCH_ROW_HEIGHT);
+    ui->launchTree->setItemWidget(launcher_arguments_item, 1, _launch_arguments);
+    connect(_launch_arguments, SIGNAL(textEdited(const QString &)), this, SLOT(launchArgsEdited(const QString &)));
 
     // Comming soon
     //    pButton = new QPushButton();
@@ -947,35 +992,35 @@ void MainWindow::SetupLaunchTree() {
     launcher_log_file_item->setText(0, "Output Log");
     launcher_parent->addChild(launcher_log_file_item);
 
-    launcher_log_file_edit_ = new QLineEdit();
-    launcher_log_file_edit_->setMinimumHeight(LAUNCH_ROW_HEIGHT);
-    launcher_log_file_edit_->setMaximumHeight(LAUNCH_ROW_HEIGHT);
-    ui_->launchTree->setItemWidget(launcher_log_file_item, 1, launcher_log_file_edit_);
-    connect(launcher_log_file_edit_, SIGNAL(textEdited(const QString &)), this, SLOT(launchChangeLogFile(const QString &)));
+    _launcher_log_file_edit = new QLineEdit();
+    _launcher_log_file_edit->setMinimumHeight(LAUNCH_ROW_HEIGHT);
+    _launcher_log_file_edit->setMaximumHeight(LAUNCH_ROW_HEIGHT);
+    ui->launchTree->setItemWidget(launcher_log_file_item, 1, _launcher_log_file_edit);
+    connect(_launcher_log_file_edit, SIGNAL(textEdited(const QString &)), this, SLOT(launchChangeLogFile(const QString &)));
 
-    launcher_log_file_button_ = new QPushButton();
-    launcher_log_file_button_->setText("...");
-    launcher_log_file_button_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    launcher_log_file_button_->setMaximumWidth(LAUNCH_COLUMN2_SIZE);
-    ui_->launchTree->setItemWidget(launcher_log_file_item, 2, launcher_log_file_button_);
-    connect(launcher_log_file_button_, SIGNAL(clicked()), this, SLOT(launchSetLogFile()));
+    _launcher_log_file_button = new QPushButton();
+    _launcher_log_file_button->setText("...");
+    _launcher_log_file_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    _launcher_log_file_button->setMaximumWidth(LAUNCH_COLUMN2_SIZE);
+    ui->launchTree->setItemWidget(launcher_log_file_item, 2, _launcher_log_file_button);
+    connect(_launcher_log_file_button, SIGNAL(clicked()), this, SLOT(launchSetLogFile()));
 
     //////////////////////////////////////////////////////////////////
-    ui_->launchTree->setMinimumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
-    ui_->launchTree->setMaximumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
+    ui->launchTree->setMinimumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
+    ui->launchTree->setMaximumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
 
-    ui_->launchTree->setColumnWidth(0, LAUNCH_COLUMN0_SIZE);
-    ui_->launchTree->setColumnWidth(
-        1, ui_->launchTree->rect().width() - LAUNCH_COLUMN0_SIZE - LAUNCH_COLUMN2_SIZE - LAUNCH_SPACING_SIZE);
-    ui_->launchTree->setColumnWidth(2, LAUNCH_COLUMN2_SIZE);
+    ui->launchTree->setColumnWidth(0, LAUNCH_COLUMN0_SIZE);
+    ui->launchTree->setColumnWidth(
+        1, ui->launchTree->rect().width() - LAUNCH_COLUMN0_SIZE - LAUNCH_COLUMN2_SIZE - LAUNCH_SPACING_SIZE);
+    ui->launchTree->setColumnWidth(2, LAUNCH_COLUMN2_SIZE);
 
-    if (settings_.value("launcherCollapsed").toBool())
+    if (_settings.value("launcherCollapsed").toBool())
         launchItemCollapsed(nullptr);
     else
-        ui_->launchTree->expandItem(launcher_parent);
+        ui->launchTree->expandItem(launcher_parent);
 
-    ui_->launchTree->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    ui_->launchTree->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    ui->launchTree->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    ui->launchTree->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     ResetLaunchOptions();
 }
@@ -984,9 +1029,9 @@ void MainWindow::SetupLaunchTree() {
 // Expanding the tree also grows the tree to match
 void MainWindow::launchItemExpanded(QTreeWidgetItem *item) {
     (void)item;
-    ui_->launchTree->setMinimumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
-    ui_->launchTree->setMaximumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
-    settings_.setValue("launcherCollapsed", false);
+    ui->launchTree->setMinimumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
+    ui->launchTree->setMaximumHeight(LAUNCH_ROW_HEIGHT * 4 + 6);
+    _settings.setValue("launcherCollapsed", false);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -994,26 +1039,26 @@ void MainWindow::launchItemExpanded(QTreeWidgetItem *item) {
 // the first line
 void MainWindow::launchItemCollapsed(QTreeWidgetItem *item) {
     (void)item;
-    ui_->launchTree->setMinimumHeight(LAUNCH_ROW_HEIGHT + 6);
-    ui_->launchTree->setMaximumHeight(LAUNCH_ROW_HEIGHT + 6);
-    settings_.setValue("launcherCollapsed", true);
+    ui->launchTree->setMinimumHeight(LAUNCH_ROW_HEIGHT + 6);
+    ui->launchTree->setMaximumHeight(LAUNCH_ROW_HEIGHT + 6);
+    _settings.setValue("launcherCollapsed", true);
 }
 
 ////////////////////////////////////////////////////////////////////
 void MainWindow::launchSetLogFile() {
-    int current_application_index = launcher_apps_combo_->currentIndex();
+    int current_application_index = _launcher_apps_combo->currentIndex();
     Q_ASSERT(current_application_index >= 0);
 
     const QString log_file =
         QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Set Log File To..."), ".", tr("Log text(*.txt)")));
 
     Configurator &configurator = Configurator::Get();
-    configurator.overridden_application_list[current_application_index]->log_file = log_file;
+    configurator._overridden_application_list[current_application_index]->log_file = log_file;
 
     if (log_file.isEmpty())
-        launcher_log_file_edit_->setText("");
+        _launcher_log_file_edit->setText("");
     else
-        launcher_log_file_edit_->setText(log_file);
+        _launcher_log_file_edit->setText(log_file);
 
     configurator.SaveOverriddenApplicationList();
 }
@@ -1021,11 +1066,11 @@ void MainWindow::launchSetLogFile() {
 ///////////////////////////////////////////////////////////////////
 // Log file path edited manually.
 void MainWindow::launchChangeLogFile(const QString &new_text) {
-    int current_application_index = launcher_apps_combo_->currentIndex();
+    int current_application_index = _launcher_apps_combo->currentIndex();
     Q_ASSERT(current_application_index >= 0);
 
     Configurator &configurator = Configurator::Get();
-    configurator.overridden_application_list[current_application_index]->log_file = new_text;
+    configurator._overridden_application_list[current_application_index]->log_file = new_text;
     configurator.SaveOverriddenApplicationList();
 }
 
@@ -1034,11 +1079,11 @@ void MainWindow::launchChangeLogFile(const QString &new_text) {
 void MainWindow::launchItemChanged(int application_index) {
     Configurator &configurator = Configurator::Get();
 
-    if (application_index < 0 || application_index >= configurator.overridden_application_list.size()) return;
+    if (application_index < 0 || application_index >= configurator._overridden_application_list.size()) return;
 
-    launch_arguments_->setText(configurator.overridden_application_list[application_index]->arguments);
-    launcher_working_->setText(configurator.overridden_application_list[application_index]->working_folder);
-    launcher_log_file_edit_->setText(configurator.overridden_application_list[application_index]->log_file);
+    _launch_arguments->setText(configurator._overridden_application_list[application_index]->arguments);
+    _launcher_working->setText(configurator._overridden_application_list[application_index]->working_folder);
+    _launcher_log_file_edit->setText(configurator._overridden_application_list[application_index]->log_file);
 
     configurator.SelectLaunchApplication(application_index);
     configurator.SaveSettings();
@@ -1047,20 +1092,20 @@ void MainWindow::launchItemChanged(int application_index) {
 /////////////////////////////////////////////////////////////////////
 /// New command line arguments. Update them.
 void MainWindow::launchArgsEdited(const QString &arguments) {
-    int application_index = launcher_apps_combo_->currentIndex();
+    int application_index = _launcher_apps_combo->currentIndex();
     if (application_index < 0) return;
 
     Configurator &configurator = Configurator::Get();
-    configurator.overridden_application_list[application_index]->arguments = arguments;
+    configurator._overridden_application_list[application_index]->arguments = arguments;
     configurator.SaveOverriddenApplicationList();
 }
 
 //////////////////////////////////////////////////////////////////////
 // Clear the browser window
 void MainWindow::on_pushButtonClearLog_clicked() {
-    ui_->logBrowser->clear();
-    ui_->logBrowser->update();
-    ui_->pushButtonClearLog->setEnabled(false);
+    ui->logBrowser->clear();
+    ui->logBrowser->update();
+    ui->pushButtonClearLog->setEnabled(false);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1070,39 +1115,39 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
     // When no application are overridden in the application list,
     // we disable override_application_list_only to reflect to the
     // user that overrides will apply to all applications.
-    if (configurator.override_application_list_updated && configurator.overridden_application_list_only) {
-        configurator.override_application_list_updated = false;
+    if (configurator._override_application_list_updated && configurator._overridden_application_list_only) {
+        configurator._override_application_list_updated = false;
 
         if (!configurator.HasOverriddenApplications()) {
-            configurator.overridden_application_list_only = false;
-            ui_->checkBoxApplyList->setChecked(false);
-            ui_->pushButtonAppList->setEnabled(false);
+            configurator._overridden_application_list_only = false;
+            ui->checkBoxApplyList->setChecked(false);
+            ui->pushButtonAppList->setEnabled(false);
         }
     }
 
     // Launch tree does some fancy resizing and since it's down in
     // layouts and splitters, we can't just relay on the resize method
     // of this window.
-    if (target == ui_->launchTree) {
+    if (target == ui->launchTree) {
         if (event->type() == QEvent::Resize) {
-            QRect rect = ui_->launchTree->rect();
-            ui_->launchTree->setColumnWidth(0, LAUNCH_COLUMN0_SIZE);
-            ui_->launchTree->setColumnWidth(1, rect.width() - LAUNCH_COLUMN0_SIZE - LAUNCH_COLUMN2_SIZE - LAUNCH_SPACING_SIZE);
-            ui_->launchTree->setColumnWidth(2, LAUNCH_COLUMN2_SIZE);
+            QRect rect = ui->launchTree->rect();
+            ui->launchTree->setColumnWidth(0, LAUNCH_COLUMN0_SIZE);
+            ui->launchTree->setColumnWidth(1, rect.width() - LAUNCH_COLUMN0_SIZE - LAUNCH_COLUMN2_SIZE - LAUNCH_SPACING_SIZE);
+            ui->launchTree->setColumnWidth(2, LAUNCH_COLUMN2_SIZE);
             return false;
         }
     }
 
     // Context menus for layer configuration files
-    if (target == ui_->profileTree) {
+    if (target == ui->profileTree) {
         QContextMenuEvent *right_click = dynamic_cast<QContextMenuEvent *>(event);
         if (right_click && event->type() == QEvent::ContextMenu) {
             // Which item were we over?
-            QTreeWidgetItem *configuration_item = ui_->profileTree->itemAt(right_click->pos());
+            QTreeWidgetItem *configuration_item = ui->profileTree->itemAt(right_click->pos());
             ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(configuration_item);
 
             // Create context menu here
-            QMenu menu(ui_->profileTree);
+            QMenu menu(ui->profileTree);
 
             QAction *edit_action = new QAction("Edit this Layers Configuration...", nullptr);
             edit_action->setEnabled(item != nullptr);
@@ -1150,66 +1195,52 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
 
             // Edit the selected profile
             if (action == edit_action) {
-                settings_tree_manager_.CleanupGUI();
                 EditClicked(item);
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
             // New Profile...
             if (action == new_action) {
-                settings_tree_manager_.CleanupGUI();
                 NewClicked();
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
             // Duplicate
             if (action == duplicate_action) {
-                settings_tree_manager_.CleanupGUI();
                 DuplicateClicked(item);
-                settings_tree_manager_.CleanupGUI();
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
             // Remove this profile....
             if (action == remove_action) {
-                settings_tree_manager_.CleanupGUI();
                 RemoveClicked(item);
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
             // Rename this profile...
             if (action == rename_action) {
                 RenameClicked(item);
-                settings_tree_manager_.CleanupGUI();
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
             // Export this profile (copy the .json)
             if (action == export_action) {
-                settings_tree_manager_.CleanupGUI();
                 ExportClicked(item);
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
+                ui->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
             // Import a profile (copy a json)
             if (action == import_action) {
-                settings_tree_manager_.CleanupGUI();
                 ImportClicked(item);
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
             // Edit Layer custom paths
             if (action == custom_path_action) {
-                settings_tree_manager_.CleanupGUI();
+                _settings_tree_manager.CleanupGUI();
                 EditCustomPathsClicked(item);
-                ui_->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
+                ui->groupBoxEditor->setTitle(tr(EDITOR_CAPTION_EMPTY));
                 return true;
             }
 
@@ -1237,59 +1268,59 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
 /// is also opened.
 void MainWindow::on_pushButtonLaunch_clicked() {
     // Are we already monitoring a running app? If so, terminate it
-    if (launch_application_ != nullptr) {
-        launch_application_->terminate();
-        launch_application_->deleteLater();
-        launch_application_ = nullptr;
-        ui_->pushButtonLaunch->setText(tr("Launch"));
+    if (_launch_application != nullptr) {
+        _launch_application->terminate();
+        _launch_application->deleteLater();
+        _launch_application = nullptr;
+        ui->pushButtonLaunch->setText(tr("Launch"));
         return;
     }
 
     // Is there an app selected?
-    int current_application_index = launcher_apps_combo_->currentIndex();
+    int current_application_index = _launcher_apps_combo->currentIndex();
 
     // Launch the test application
-    launch_application_ = new QProcess(this);
-    connect(launch_application_, SIGNAL(readyReadStandardOutput()), this, SLOT(standardOutputAvailable()));
+    _launch_application = new QProcess(this);
+    connect(_launch_application, SIGNAL(readyReadStandardOutput()), this, SLOT(standardOutputAvailable()));
 
-    connect(launch_application_, SIGNAL(readyReadStandardError()), this, SLOT(errorOutputAvailable()));
+    connect(_launch_application, SIGNAL(readyReadStandardError()), this, SLOT(errorOutputAvailable()));
 
-    connect(launch_application_, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(processClosed(int, QProcess::ExitStatus)));
+    connect(_launch_application, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(processClosed(int, QProcess::ExitStatus)));
 
     Configurator &configurator = Configurator::Get();
-    launch_application_->setProgram(configurator.overridden_application_list[current_application_index]->executable_path);
-    launch_application_->setWorkingDirectory(configurator.overridden_application_list[current_application_index]->working_folder);
+    _launch_application->setProgram(configurator._overridden_application_list[current_application_index]->executable_path);
+    _launch_application->setWorkingDirectory(configurator._overridden_application_list[current_application_index]->working_folder);
 
-    if (!configurator.overridden_application_list[current_application_index]->arguments.isEmpty()) {
-        const QStringList args = configurator.overridden_application_list[current_application_index]->arguments.split(" ");
-        launch_application_->setArguments(args);
+    if (!configurator._overridden_application_list[current_application_index]->arguments.isEmpty()) {
+        const QStringList args = configurator._overridden_application_list[current_application_index]->arguments.split(" ");
+        _launch_application->setArguments(args);
     }
 
     // Some of these may have changed
     configurator.SaveSettings();
 
-    launch_application_->start(QIODevice::ReadOnly | QIODevice::Unbuffered);
-    launch_application_->setProcessChannelMode(QProcess::MergedChannels);
-    launch_application_->closeWriteChannel();
+    _launch_application->start(QIODevice::ReadOnly | QIODevice::Unbuffered);
+    _launch_application->setProcessChannelMode(QProcess::MergedChannels);
+    _launch_application->closeWriteChannel();
 
     // We are logging, let's add that we've launched a new application
     QString launch_log = "Launching Vulkan Application:\n";
 
-    const Application &current_application = *configurator.overridden_application_list[current_application_index];
+    const Application &current_application = *configurator._overridden_application_list[current_application_index];
 
     if (configurator.GetActiveConfiguration() == nullptr) {
         launch_log += QString().asprintf("- Layers fully controlled by the application.\n");
     } else if (!configurator.GetActiveConfiguration()->IsValid()) {
         launch_log += QString().asprintf("- No layers override. The active \"%s\" configuration is missing a layer.\n",
-                                         configurator.GetActiveConfiguration()->name.toUtf8().constData());
-    } else if (configurator.override_active) {
-        if (configurator.overridden_application_list_only && configurator.HasOverriddenApplications() &&
+                                         configurator.GetActiveConfiguration()->_name.toUtf8().constData());
+    } else if (configurator._override_active) {
+        if (configurator._overridden_application_list_only && configurator.HasOverriddenApplications() &&
             !current_application.override_layers) {
             launch_log +=
                 QString().asprintf("- Layers fully controlled by the application. Application excluded from layers override.\n");
         } else {
             launch_log += QString().asprintf("- Layers overridden by \"%s\" configuration.\n",
-                                             configurator.GetActiveConfiguration()->name.toUtf8().constData());
+                                             configurator.GetActiveConfiguration()->_name.toUtf8().constData());
         }
     }
 
@@ -1301,54 +1332,54 @@ void MainWindow::on_pushButtonLaunch_clicked() {
     if (!current_application.log_file.isEmpty()) {
         // This should never happen... but things that should never happen do in
         // fact happen... so just a sanity check.
-        if (log_file_ != nullptr) {
-            log_file_->close();
-            log_file_ = nullptr;
+        if (_log_file != nullptr) {
+            _log_file->close();
+            _log_file = nullptr;
         }
 
         // Start logging
-        log_file_ = new QFile(current_application.log_file);
+        _log_file = new QFile(current_application.log_file);
 
         // Open and append, or open and truncate?
         QIODevice::OpenMode mode = QIODevice::WriteOnly | QIODevice::Text;
-        if (!ui_->checkBoxClearOnLaunch->isChecked()) mode |= QIODevice::Append;
+        if (!ui->checkBoxClearOnLaunch->isChecked()) mode |= QIODevice::Append;
 
         if (!current_application.log_file.isEmpty()) {
-            if (!log_file_->open(mode)) {
+            if (!_log_file->open(mode)) {
                 QMessageBox err;
                 err.setText(tr("Cannot open log file"));
                 err.setIcon(QMessageBox::Warning);
                 err.exec();
-                delete log_file_;
-                log_file_ = nullptr;
+                delete _log_file;
+                _log_file = nullptr;
             }
         }
 
-        if (log_file_) {
-            log_file_->write((launch_log + "\n").toUtf8().constData(), launch_log.length());
+        if (_log_file) {
+            _log_file->write((launch_log + "\n").toUtf8().constData(), launch_log.length());
         }
     }
 
-    if (ui_->checkBoxClearOnLaunch->isChecked()) ui_->logBrowser->clear();
-    ui_->logBrowser->append(launch_log);
-    ui_->pushButtonClearLog->setEnabled(true);
+    if (ui->checkBoxClearOnLaunch->isChecked()) ui->logBrowser->clear();
+    ui->logBrowser->append(launch_log);
+    ui->pushButtonClearLog->setEnabled(true);
 
     // Wait... did we start? Give it 4 seconds, more than enough time
-    if (!launch_application_->waitForStarted(4000)) {
-        launch_application_->waitForStarted();
-        launch_application_->deleteLater();
-        launch_application_ = nullptr;
+    if (!_launch_application->waitForStarted(4000)) {
+        _launch_application->waitForStarted();
+        _launch_application->deleteLater();
+        _launch_application = nullptr;
 
         QString failed_log = QString().asprintf("Failed to launch %s!\n", current_application.executable_path.toUtf8().constData());
 
-        ui_->logBrowser->append(failed_log);
-        if (log_file_) log_file_->write(failed_log.toUtf8().constData(), failed_log.length());
+        ui->logBrowser->append(failed_log);
+        if (_log_file) _log_file->write(failed_log.toUtf8().constData(), failed_log.length());
 
         return;
     }
 
     // We are off to the races....
-    ui_->pushButtonLaunch->setText(tr("Terminate"));
+    ui->pushButtonLaunch->setText(tr("Terminate"));
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1361,25 +1392,25 @@ void MainWindow::processClosed(int exit_code, QProcess::ExitStatus status) {
     (void)status;
 
     // Not likely, but better to be sure...
-    if (launch_application_ == nullptr) return;
+    if (_launch_application == nullptr) return;
 
-    disconnect(launch_application_, SIGNAL(finished(int, QProcess::ExitStatus)), this,
+    disconnect(_launch_application, SIGNAL(finished(int, QProcess::ExitStatus)), this,
                SLOT(processClosed(int, QProcess::ExitStatus)));
 
-    disconnect(launch_application_, SIGNAL(readyReadStandardError()), this, SLOT(errorOutputAvailable()));
+    disconnect(_launch_application, SIGNAL(readyReadStandardError()), this, SLOT(errorOutputAvailable()));
 
-    disconnect(launch_application_, SIGNAL(readyReadStandardOutput()), this, SLOT(standardOutputAvailable()));
+    disconnect(_launch_application, SIGNAL(readyReadStandardOutput()), this, SLOT(standardOutputAvailable()));
 
-    ui_->pushButtonLaunch->setText(tr("Launch"));
+    ui->pushButtonLaunch->setText(tr("Launch"));
 
-    if (log_file_) {
-        log_file_->close();
-        delete log_file_;
-        log_file_ = nullptr;
+    if (_log_file) {
+        _log_file->close();
+        delete _log_file;
+        _log_file = nullptr;
     }
 
-    delete launch_application_;
-    launch_application_ = nullptr;
+    delete _launch_application;
+    _launch_application = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1389,24 +1420,24 @@ void MainWindow::processClosed(int exit_code, QProcess::ExitStatus status) {
 /// the string and append it to the text browser.
 /// If a log file is open, we also write the output to the log.
 void MainWindow::standardOutputAvailable() {
-    if (launch_application_ == nullptr) return;
+    if (_launch_application == nullptr) return;
 
-    QString log = launch_application_->readAllStandardOutput();
-    ui_->logBrowser->append(log);
-    ui_->pushButtonClearLog->setEnabled(true);
+    QString log = _launch_application->readAllStandardOutput();
+    ui->logBrowser->append(log);
+    ui->pushButtonClearLog->setEnabled(true);
 
     // Are we logging?
-    if (log_file_) log_file_->write(log.toUtf8().constData(), log.length());
+    if (_log_file) _log_file->write(log.toUtf8().constData(), log.length());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void MainWindow::errorOutputAvailable() {
-    if (launch_application_ == nullptr) return;
+    if (_launch_application == nullptr) return;
 
-    QString log = launch_application_->readAllStandardError();
-    ui_->logBrowser->append(log);
-    ui_->pushButtonClearLog->setEnabled(true);
+    QString log = _launch_application->readAllStandardError();
+    ui->logBrowser->append(log);
+    ui->pushButtonClearLog->setEnabled(true);
 
     // Are we logging?
-    if (log_file_) log_file_->write(log.toUtf8().constData(), log.length());
+    if (_log_file) _log_file->write(log.toUtf8().constData(), log.length());
 }

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -554,7 +554,6 @@ void MainWindow::helpShowLayerSpec(bool checked) {
 /// The only thing we need to do here is clear the profile if
 /// the user does not want it active.
 void MainWindow::closeEvent(QCloseEvent *event) {
-    _settings_tree_manager.CleanupGUI();
     Configurator &configurator = Configurator::Get();
 
     // Alert the user to the current state of the vulkan configurator and
@@ -591,6 +590,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
         }
     }
 
+    _settings_tree_manager.CleanupGUI();
     if (!configurator._override_permanent) configurator.SetActiveConfiguration(nullptr);
 
     configurator.SaveOverriddenApplicationList();

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -59,11 +59,11 @@ class MainWindow : public QMainWindow {
     ~MainWindow();
 
    protected:
-    SettingsTreeManager settings_tree_manager_;
-    QSettings settings_;
+    SettingsTreeManager _settings_tree_manager;
+    QSettings _settings;
 
-    QProcess *launch_application_;  // Keeps track of the monitored app
-    QFile *log_file_;               // Log file for layer output
+    QProcess *_launch_application;  // Keeps track of the monitored app
+    QFile *_log_file;               // Log file for layer output
 
     void LoadConfigurationList();
     void SetupLaunchTree();
@@ -76,24 +76,28 @@ class MainWindow : public QMainWindow {
 
     virtual bool eventFilter(QObject *target, QEvent *event) override;
 
-    dlgVulkanAnalysis *vk_via_;
-    dlgVulkanInfo *vk_info_;
-    dlgHelp *help_;
+    dlgVulkanAnalysis *_vk_via;
+    dlgVulkanInfo *_vk_info;
+    dlgHelp *_help;
 
    private:
-    Ui::MainWindow *ui_;
-    ConfigurationListItem *selected_configuration_item_;
+    Ui::MainWindow *ui;
+    ConfigurationListItem *_selected_configuration_item;
     ConfigurationListItem *GetCheckedItem();
 
-    QComboBox *launcher_apps_combo_;
-    QLineEdit *launch_arguments_;
-    QLineEdit *launcher_working_;
-    QLineEdit *launcher_log_file_edit_;
-    QPushButton *launcher_apps_browse_button_;
-    QPushButton *pLaunchWorkingFolderButton_;
-    QPushButton *launcher_log_file_button_;
+    QComboBox *_launcher_apps_combo;
+    QLineEdit *_launch_arguments;
+    QLineEdit *_launcher_working;
+    QLineEdit *_launcher_log_file_edit;
+    QPushButton *_launcher_apps_browse_button;
+    QPushButton *_launchWorkingFolderButton;
+    QPushButton *_launcher_log_file_button;
 
     void ResetLaunchOptions();
+
+    ConfigurationListItem *PushCurrentItem(void);
+    bool PopCurrentItem(const char *szRenamed = nullptr);
+    QString _lastItem;
 
     void RemoveClicked(ConfigurationListItem *item);
     void RenameClicked(ConfigurationListItem *item);

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -95,8 +95,8 @@ class MainWindow : public QMainWindow {
 
     void ResetLaunchOptions();
 
-    ConfigurationListItem *PushCurrentItem(void);
-    bool PopCurrentItem(const char *szRenamed = nullptr);
+    ConfigurationListItem *SaveLastItem(void);
+    bool RestoreLastItem(const char *szOverride = nullptr);
     QString _lastItem;
 
     void RemoveClicked(ConfigurationListItem *item);

--- a/vkconfig/multienumsetting.cpp
+++ b/vkconfig/multienumsetting.cpp
@@ -22,19 +22,19 @@
 #include "multienumsetting.h"
 
 MultiEnumSetting::MultiEnumSetting(LayerSettings *pLayerSetting, QString thisSetting) {
-    layer_settings_ = pLayerSetting;
-    my_setting_ = thisSetting;
+    _layer_settings = pLayerSetting;
+    _my_setting = thisSetting;
 
-    if (pLayerSetting->settings_value.contains(my_setting_)) this->setChecked(true);
+    if (pLayerSetting->settings_value.contains(_my_setting)) this->setChecked(true);
 
     connect(this, SIGNAL(clicked(bool)), this, SLOT(itemChecked(bool)));
 }
 
 void MultiEnumSetting::itemChecked(bool bChecked) {
     if (bChecked)
-        AddString(layer_settings_->settings_value, my_setting_);
+        AddString(_layer_settings->settings_value, _my_setting);
     else
-        RemoveString(layer_settings_->settings_value, my_setting_);
+        RemoveString(_layer_settings->settings_value, _my_setting);
 
     emit itemChanged();
 }

--- a/vkconfig/multienumsetting.h
+++ b/vkconfig/multienumsetting.h
@@ -34,8 +34,8 @@ class MultiEnumSetting : public QCheckBox {
     MultiEnumSetting(LayerSettings *layer_settings, QString thiss_setting);
 
    private:
-    LayerSettings *layer_settings_;
-    QString my_setting_;
+    LayerSettings *_layer_settings;
+    QString _my_setting;
 
    public Q_SLOTS:
     void itemChecked(bool bChecked);

--- a/vkconfig/mutemessagewidget.cpp
+++ b/vkconfig/mutemessagewidget.cpp
@@ -22,51 +22,52 @@
 #include "mutemessagewidget.h"
 
 MuteMessageWidget::MuteMessageWidget(LayerSettings *layer_settings) : QWidget(nullptr) {
-    layer_settings_ = layer_settings;
-    list_widget_ = new QListWidget(this);
-    list_widget_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    list_widget_->show();
-    remove_button_ = new QPushButton(this);
-    remove_button_->setText("Remove");
-    remove_button_->show();
+    _layer_settings = layer_settings;
+    _list_widget = new QListWidget(this);
+    _list_widget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    _list_widget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    _list_widget->show();
+    _remove_button = new QPushButton(this);
+    _remove_button->setText("Remove");
+    _remove_button->show();
 
     // Load with existing settings
-    if (!layer_settings_->settings_value.isEmpty()) {
-        QStringList list = layer_settings_->settings_value.split(",");
-        list_widget_->addItems(list);
-        list_widget_->setCurrentRow(list_widget_->count() - 1);
+    if (!_layer_settings->settings_value.isEmpty()) {
+        QStringList list = _layer_settings->settings_value.split(",");
+        _list_widget->addItems(list);
+        _list_widget->setCurrentRow(_list_widget->count() - 1);
     } else
-        remove_button_->setEnabled(false);
+        _remove_button->setEnabled(false);
 
-    connect(remove_button_, SIGNAL(pressed()), this, SLOT(removePushed()));
+    connect(_remove_button, SIGNAL(pressed()), this, SLOT(removePushed()));
 }
 
 void MuteMessageWidget::resizeEvent(QResizeEvent *event) {
     int nButtonHeight = 26;
     QSize parentSize = event->size();
-    list_widget_->setGeometry(0, 0, parentSize.width(), parentSize.height() - nButtonHeight);
-    remove_button_->setGeometry(0, parentSize.height() - nButtonHeight, parentSize.width(), nButtonHeight);
+    _list_widget->setGeometry(0, 0, parentSize.width(), parentSize.height() - nButtonHeight);
+    _remove_button->setGeometry(0, parentSize.height() - nButtonHeight, parentSize.width(), nButtonHeight);
 }
 
 void MuteMessageWidget::addItem(const QString &item) {
-    list_widget_->addItem(item);
-    list_widget_->setCurrentRow(list_widget_->count() - 1);
+    _list_widget->addItem(item);
+    _list_widget->setCurrentRow(_list_widget->count() - 1);
 
     // Update Setting
-    AddString(layer_settings_->settings_value, item);
-    remove_button_->setEnabled(true);
+    AddString(_layer_settings->settings_value, item);
+    _remove_button->setEnabled(true);
     emit itemChanged();
 }
 
 void MuteMessageWidget::removePushed() {
-    int nRow = list_widget_->currentRow();
+    int nRow = _list_widget->currentRow();
     if (nRow < 0) return;
 
-    QString itemName = list_widget_->currentItem()->text();
-    list_widget_->takeItem(nRow);
+    QString itemName = _list_widget->currentItem()->text();
+    _list_widget->takeItem(nRow);
 
     // Update Setting
-    RemoveString(layer_settings_->settings_value, itemName);
+    RemoveString(_layer_settings->settings_value, itemName);
     emit itemChanged();
     emit itemRemoved(itemName);
 }

--- a/vkconfig/mutemessagewidget.h
+++ b/vkconfig/mutemessagewidget.h
@@ -35,9 +35,9 @@ class MuteMessageWidget : public QWidget {
     explicit MuteMessageWidget(LayerSettings *layer_settings);
 
    private:
-    LayerSettings *layer_settings_;
-    QListWidget *list_widget_;
-    QPushButton *remove_button_;
+    LayerSettings *_layer_settings;
+    QListWidget *_list_widget;
+    QPushButton *_remove_button;
 
     void resizeEvent(QResizeEvent *event) override;
 

--- a/vkconfig/preferences.cpp
+++ b/vkconfig/preferences.cpp
@@ -30,6 +30,6 @@ const Preferences& Preferences::Get() {
     return instance;
 }
 
-Preferences::Preferences() : use_separated_select_and_activate(false), use_last_selected_application_in_launcher(false) {}
+Preferences::Preferences() : _use_separated_select_and_activate(false), _use_last_selected_application_in_launcher(false) {}
 
 Preferences::~Preferences() {}

--- a/vkconfig/preferences.h
+++ b/vkconfig/preferences.h
@@ -33,11 +33,11 @@ class Preferences {
     // the user has to click on the ratio button is used to activate the configuration
     // and the row is used to edit the configuration.
     // Alternatively, selection and activation is done together wherever we click.
-    bool use_separated_select_and_activate;
+    bool _use_separated_select_and_activate;
 
     // Change the current launcher application when selecting an application in the list
     // Disable by default at the feature is not ready.
-    bool use_last_selected_application_in_launcher;
+    bool _use_last_selected_application_in_launcher;
 
    private:
     Preferences();

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -430,11 +430,6 @@ void SettingsTreeManager::CleanupGUI() {
     GetTreeState(_configuration->_setting_tree_state, _configuration_settings_tree->invisibleRootItem());
     Configurator::Get().SaveConfiguration(_configuration);
 
-    disconnect(_configuration_settings_tree, SIGNAL(itemCollapsed(QTreeWidgetItem *)), this,
-               SLOT(settingsItemCollapsed(QTreeWidgetItem *)));
-    disconnect(_configuration_settings_tree, SIGNAL(itemExpanded(QTreeWidgetItem *)), this,
-               SLOT(settingsItemExpanded(QTreeWidgetItem *)));
-
     // If a Khronos layer is present, it needs cleanup up from custom controls before
     // it's cleared or deleted.
     if (_validation_layer_file) _configuration_settings_tree->setItemWidget(_validation_file_item, 1, nullptr);

--- a/vkconfig/settingstreemanager.h
+++ b/vkconfig/settingstreemanager.h
@@ -48,26 +48,26 @@ class SettingsTreeManager : QObject {
     int SetTreeState(QByteArray &byte_array, int index, QTreeWidgetItem *top_item);
 
    protected:
-    QTreeWidget *configuration_settings_tree_;
-    Configuration *configuration_;
-    QVector<QTreeWidgetItem *> compound_widgets_;  // These have special cleanup requirements
+    QTreeWidget *_configuration_settings_tree;
+    Configuration *_configuration;
+    QVector<QTreeWidgetItem *> _compound_widgets;  // These have special cleanup requirements
 
     void BuildKhronosTree();
     void BuildGenericTree(QTreeWidgetItem *parent, LayerFile *layer_file);
 
-    QVector<QTreeWidgetItem *> layer_items_;  // These parallel the  profiles layers
+    QVector<QTreeWidgetItem *> _layer_items;  // These parallel the  profiles layers
 
-    QComboBox *validation_presets_combo_box_;
-    LayerFile *validation_layer_file_;
-    QTreeWidgetItem *validation_tree_item_;
-    QTreeWidgetItem *validation_file_item_;
-    QTreeWidgetItem *validation_preset_item_;
-    QTreeWidgetItem *validation_log_file_item_;
-    FilenameSettingWidget *validation_log_file_widget_;
-    EnumSettingWidget *validation_debug_action_;
-    KhronosSettingsAdvanced *validation_settings_;
-    MuteMessageWidget *mute_message_widget_;
-    VUIDSearchWidget *vuid_search_widget_;
+    QComboBox *_validation_presets_combo_box;
+    LayerFile *_validation_layer_file;
+    QTreeWidgetItem *_validation_tree_item;
+    QTreeWidgetItem *_validation_file_item;
+    QTreeWidgetItem *_validation_preset_item;
+    QTreeWidgetItem *_validation_log_file_item;
+    FilenameSettingWidget *_validation_log_file_widget;
+    EnumSettingWidget *_validation_debug_action;
+    KhronosSettingsAdvanced *_validation_settings;
+    MuteMessageWidget *_mute_message_widget;
+    VUIDSearchWidget *_vuid_search_widget;
 
    public Q_SLOTS:
     void khronosDebugChanged(int index);

--- a/vkconfig/stringsettingwidget.cpp
+++ b/vkconfig/stringsettingwidget.cpp
@@ -22,7 +22,7 @@
 #include "stringsettingwidget.h"
 
 StringSettingWidget::StringSettingWidget(QTreeWidgetItem* pItem, LayerSettings* pLayerSetting) {
-    layer_settings_ = pLayerSetting;
+    _layer_settings = pLayerSetting;
     pItem->setText(0, pLayerSetting->settings_prompt);
     pItem->setToolTip(0, pLayerSetting->settings_desc);
     this->setText(pLayerSetting->settings_value);
@@ -30,6 +30,6 @@ StringSettingWidget::StringSettingWidget(QTreeWidgetItem* pItem, LayerSettings* 
 }
 
 void StringSettingWidget::itemEdited(const QString& newString) {
-    layer_settings_->settings_value = newString;
+    _layer_settings->settings_value = newString;
     emit itemChanged();
 }

--- a/vkconfig/stringsettingwidget.h
+++ b/vkconfig/stringsettingwidget.h
@@ -34,7 +34,7 @@ class StringSettingWidget : public QLineEdit {
     StringSettingWidget(QTreeWidgetItem* item, LayerSettings* layer_settings);
 
    private:
-    LayerSettings* layer_settings_;
+    LayerSettings* _layer_settings;
 
    public Q_SLOTS:
     void itemEdited(const QString& newString);

--- a/vkconfig/treefriendlycombobox.cpp
+++ b/vkconfig/treefriendlycombobox.cpp
@@ -21,9 +21,9 @@
 
 #include "treefriendlycombobox.h"
 TreeFriendlyComboBox::TreeFriendlyComboBox(QTreeWidgetItem *pItem) : QComboBox() {
-    tree_widget_ = pItem;
+    _tree_widget = pItem;
     connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(indexChanged(int)));
 }
 
 ///////////////////////////////////////////////////////////////////
-void TreeFriendlyComboBox::indexChanged(int nIndex) { emit selectionMade(tree_widget_, nIndex); }
+void TreeFriendlyComboBox::indexChanged(int nIndex) { emit selectionMade(_tree_widget, nIndex); }

--- a/vkconfig/treefriendlycombobox.h
+++ b/vkconfig/treefriendlycombobox.h
@@ -31,7 +31,7 @@ class TreeFriendlyComboBox : public QComboBox {
     TreeFriendlyComboBox(QTreeWidgetItem *item);
 
    protected:
-    QTreeWidgetItem *tree_widget_;
+    QTreeWidgetItem *_tree_widget;
 
    public Q_SLOTS:
     void indexChanged(int nIndex);

--- a/vkconfig/vku.cpp
+++ b/vkconfig/vku.cpp
@@ -46,9 +46,9 @@ std::string format(const char* message, ...) {
 const Version Version::header_version(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE), VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
                                       VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
 
-Version::Version(const char* version) { sscanf(version, "%d.%d.%d", &vku_major, &vku_minor, &vku_patch); }
+Version::Version(const char* version) { sscanf(version, "%d.%d.%d", &_vku_major, &_vku_minor, &_vku_patch); }
 
-std::string Version::str() const { return format("%d.%d.%d", vku_major, vku_minor, vku_patch); }
+std::string Version::str() const { return format("%d.%d.%d", _vku_major, _vku_minor, _vku_patch); }
 
 }  // namespace vku
 

--- a/vkconfig/vku.h
+++ b/vkconfig/vku.h
@@ -38,7 +38,7 @@ struct Version {
     static const Version header_version;
 
     Version(int major_version, int minor_version, int patch_version)
-        : vku_major(major_version), vku_minor(minor_version), vku_patch(patch_version) {}
+        : _vku_major(major_version), _vku_minor(minor_version), _vku_patch(patch_version) {}
     Version(const char *version);
 
     std::string str() const;
@@ -46,31 +46,31 @@ struct Version {
     bool operator!=(const Version &other_version) const { return !(*this == other_version); }
 
     bool operator==(const Version &other_version) const {
-        if (vku_major != other_version.vku_major) return false;
-        if (vku_minor != other_version.vku_minor) return false;
-        if (vku_patch != other_version.vku_patch) return false;
+        if (_vku_major != other_version._vku_major) return false;
+        if (_vku_minor != other_version._vku_minor) return false;
+        if (_vku_patch != other_version._vku_patch) return false;
         return true;
     }
 
     bool operator<(const Version &other_version) const {
-        if (vku_major < other_version.vku_major) return true;
-        if (vku_minor < other_version.vku_minor) return true;
-        if (vku_patch < other_version.vku_patch) return true;
+        if (_vku_major < other_version._vku_major) return true;
+        if (_vku_minor < other_version._vku_minor) return true;
+        if (_vku_patch < other_version._vku_patch) return true;
         return false;
     }
 
     bool operator>=(const Version &other_version) const { return !(*this < other_version); }
 
     bool operator>(const Version &other_version) const {
-        if (vku_major > other_version.vku_major) return true;
-        if (vku_minor > other_version.vku_minor) return true;
-        if (vku_patch > other_version.vku_patch) return true;
+        if (_vku_major > other_version._vku_major) return true;
+        if (_vku_minor > other_version._vku_minor) return true;
+        if (_vku_patch > other_version._vku_patch) return true;
         return false;
     }
 
     bool operator<=(const Version &other_version) const { return !(*this > other_version); }
 
-    int vku_major, vku_minor, vku_patch;
+    int _vku_major, _vku_minor, _vku_patch;
 };
 
 }  // namespace vku

--- a/vkconfig/vuidsearchwidget.cpp
+++ b/vkconfig/vuidsearchwidget.cpp
@@ -19,72 +19,80 @@
  * - Christophe Riccio <christophe@lunarg.com>
  */
 
+#include <QTimer>
+
 #include "vuidsearchwidget.h"
 #include "vk_vuids.h"
 
 VUIDSearchWidget::VUIDSearchWidget(QWidget *parent) : QWidget(parent) {
     int nNumElements = sizeof(vuids) / sizeof(vuids[0]);
-    for (int i = 0; i < nNumElements; i++) vuid_list_ << vuids[i];
+    for (int i = 0; i < nNumElements; i++) _vuid_list << vuids[i];
 
     // Completer does not need this sorted, but we do
-    vuid_list_.sort();
+    _vuid_list.sort();
 
-    user_box_ = new QLineEdit(this);
-    user_box_->setFocusPolicy(Qt::StrongFocus);
+    _user_box = new QLineEdit(this);
+    _user_box->setFocusPolicy(Qt::StrongFocus);
 
-    add_button_ = new QPushButton(this);
-    add_button_->setText("Add");
+    _add_button = new QPushButton(this);
+    _add_button->setText("Add");
 
-    user_box_->show();
-    user_box_->setText("");
-    user_box_->installEventFilter(this);
+    _user_box->show();
+    _user_box->setText("");
+    _user_box->installEventFilter(this);
 
-    search_vuid_ = nullptr;  // Safe to delete a pointer
+    _search_vuid = nullptr;  // Safe to delete a pointer
     ResetCompleter();
 
-    connect(add_button_, SIGNAL(pressed()), this, SLOT(addButtonPressed()));
-    connect(user_box_, SIGNAL(returnPressed()), this, SLOT(addButtonPressed()));
+    connect(_add_button, SIGNAL(pressed()), this, SLOT(addButtonPressed()));
+    // connect(_user_box, SIGNAL(returnPressed()), this, SLOT(addButtonPressed()));
 }
 
 void VUIDSearchWidget::resizeEvent(QResizeEvent *event) {
     const int button_size = 52;
     QSize parentSize = event->size();
-    user_box_->setGeometry(0, 0, parentSize.width() - 2 - button_size, parentSize.height());
-    add_button_->setGeometry(parentSize.width() - button_size, 0, button_size, parentSize.height());
+    _user_box->setGeometry(0, 0, parentSize.width() - 2 - button_size, parentSize.height());
+    _add_button->setGeometry(parentSize.width() - button_size, 0, button_size, parentSize.height());
 }
 
 /////////////////////////////////////////////////////////////////////
 /// Reload the completer with a revised list of VUID's.
 void VUIDSearchWidget::ResetCompleter(void) {
-    if (search_vuid_ != nullptr) search_vuid_->deleteLater();
+    if (_search_vuid != nullptr) _search_vuid->deleteLater();
 
-    search_vuid_ = new QCompleter(vuid_list_, this);
-    search_vuid_->setCaseSensitivity(Qt::CaseSensitive);
-    search_vuid_->setCompletionMode(QCompleter::PopupCompletion);
-    search_vuid_->setModelSorting(QCompleter::CaseSensitivelySortedModel);
-    search_vuid_->setFilterMode(Qt::MatchContains);
-    search_vuid_->setMaxVisibleItems(15);
-    search_vuid_->setCaseSensitivity(Qt::CaseInsensitive);
-    user_box_->setCompleter(search_vuid_);
-    connect(search_vuid_, SIGNAL(activated(const QString &)), this, SLOT(addCompleted(const QString &)), Qt::QueuedConnection);
+    _search_vuid = new QCompleter(_vuid_list, this);
+    _search_vuid->setCaseSensitivity(Qt::CaseSensitive);
+    _search_vuid->setCompletionMode(QCompleter::PopupCompletion);
+    _search_vuid->setModelSorting(QCompleter::CaseSensitivelySortedModel);
+    _search_vuid->setFilterMode(Qt::MatchContains);
+    _search_vuid->setMaxVisibleItems(15);
+    _search_vuid->setCaseSensitivity(Qt::CaseInsensitive);
+    _user_box->setCompleter(_search_vuid);
+    connect(_search_vuid, SIGNAL(activated(const QString &)), this, SLOT(addCompleted(const QString &)), Qt::QueuedConnection);
 }
 
 ///////////////////////////////////////////////////////////////////////
 // Add the text in the edit control to the list, and clear the control
+// This is not really used much, only if they want to add something
+// that is not in the completer list.
 void VUIDSearchWidget::addButtonPressed(void) {
-    QString entry = user_box_->text();
+    QString entry = _user_box->text();
     if (entry.isEmpty()) return;
 
     emit itemSelected(entry);  // Triggers update of GUI
     emit itemChanged();        // Triggers save of profile
-    user_box_->setText("");
+    _user_box->setText("");
 }
 
 //////////////////////////////////////////////////////////////////////
 // Clear the edit control after the completer is finished.
 void VUIDSearchWidget::addCompleted(const QString &addedItem) {
     (void)addedItem;
-    user_box_->setText("");
+    // We can't do this right away, the completer emits it's signal
+    // before it's really "complete". If we clear the control too soon
+    // it clears the completers value too. This might be a Qt bug, but this
+    // works really well as a work-a-round
+    addButtonPressed();
 }
 
 // Ignore mouse wheel events in combo box, otherwise, it fills the list box with ID's
@@ -95,5 +103,5 @@ bool VUIDSearchWidget::eventFilter(QObject *target, QEvent *event) {
         return true;
     }
 
-    return user_box_->eventFilter(target, event);
+    return _user_box->eventFilter(target, event);
 }

--- a/vkconfig/vuidsearchwidget.cpp
+++ b/vkconfig/vuidsearchwidget.cpp
@@ -45,7 +45,6 @@ VUIDSearchWidget::VUIDSearchWidget(QWidget *parent) : QWidget(parent) {
     ResetCompleter();
 
     connect(_add_button, SIGNAL(pressed()), this, SLOT(addButtonPressed()));
-    // connect(_user_box, SIGNAL(returnPressed()), this, SLOT(addButtonPressed()));
 }
 
 void VUIDSearchWidget::resizeEvent(QResizeEvent *event) {

--- a/vkconfig/vuidsearchwidget.h
+++ b/vkconfig/vuidsearchwidget.h
@@ -36,10 +36,10 @@ class VUIDSearchWidget : public QWidget {
     explicit VUIDSearchWidget(QWidget *parent = nullptr);
 
    private:
-    QStringList vuid_list_;
-    QCompleter *search_vuid_;
-    QLineEdit *user_box_;
-    QPushButton *add_button_;
+    QStringList _vuid_list;
+    QCompleter *_search_vuid;
+    QLineEdit *_user_box;
+    QPushButton *_add_button;
 
     void ResetCompleter();
 
@@ -48,7 +48,7 @@ class VUIDSearchWidget : public QWidget {
 
    public Q_SLOTS:
     void addButtonPressed(void);
-    void addCompleted(const QString &itemAdded);
+    void addCompleted(const QString &addedItem);
 
    Q_SIGNALS:
     void itemSelected(const QString &textSelected);


### PR DESCRIPTION
Change-Id: I023ae6f9654de74b69b66b3b0fb2ac1581d7e067
Cleanup for beta 4
Class member variables are prefixed with _ rather than suffix (discussed with larger LunarG team)
Removed unused test tab from vkvia output dialog.
Settings tree properly saved/restored after configuration edit operations and on program shutdown/restart.
VUID fixes after regression. Still a WIP, but better and works correctly for beta 4.