### PR TITLE
vkconfig: Mostly mac fixes, one log file issue

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -247,11 +247,19 @@ Configurator::Configurator()
 #endif
 
 // Check loader version
+// Different names and rules for each OS
 #ifdef WIN32
     QLibrary library("vulkan-1.dll");
-#else
+#endif
+
+#ifdef __APPLE__
+    QLibrary library("/usr/local/lib/libvulkan");
+#endif
+
+#ifdef __linux__
     QLibrary library("libvulkan");
 #endif
+
     if (!(library.load())) {
         QMessageBox dlg(NULL);
         dlg.setText("Could not find a Vulkan Loader!");
@@ -350,9 +358,16 @@ QString Configurator::CheckVulkanSetup() const {
         log += "- SDK path: Not detected\n";
 
         // Check loader version
+        // Different names and rules for each OS
 #ifdef WIN32
     QLibrary library("vulkan-1.dll");
-#else
+#endif
+
+#ifdef __APPLE__
+    QLibrary library("/usr/local/lib/libvulkan");
+#endif
+
+#ifdef __linux__
     QLibrary library("libvulkan");
 #endif
 

--- a/vkconfig/macOS/vkconfig.cmake
+++ b/vkconfig/macOS/vkconfig.cmake
@@ -20,7 +20,6 @@
 add_executable(vkconfig
     MACOSX_BUNDLE
     ${FILES_ALL}
-    ${CMAKE_CURRENT_SOURCE_DIR}/macOS/vkconfig.sh
     ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Resources/LunarGIcon.icns
     )
 #set_target_properties(vkconfig PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Info.plist)

--- a/vkconfig/macOS/vkconfig.sh
+++ b/vkconfig/macOS/vkconfig.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-BASEDIR=`dirname $0`
-
-if [ -d /System/Applications/Utilities/Terminal.app ]
-then
-    open /System/Applications/Utilities/Terminal.app $BASEDIR/vkconfig
-else
-    open /Applications/Utilities/Terminal.app $BASEDIR/vkconfig
-fi

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -151,6 +151,7 @@ void SettingsTreeManager::BuildKhronosTree() {
     _validation_log_file_item = new QTreeWidgetItem();
     next_line = new QTreeWidgetItem();
     _validation_log_file_widget = new FilenameSettingWidget(_validation_log_file_item, log_file);
+    connect(_validation_log_file_widget, SIGNAL(itemChanged()), this, SLOT(profileEdited()));
     debug_action_item->addChild(_validation_log_file_item);
     _validation_log_file_item->addChild(next_line);
     _configuration_settings_tree->setItemWidget(next_line, 0, _validation_log_file_widget);


### PR DESCRIPTION
Change-Id: Iaec0274a8209da495654305566fee30d0ebf77e0
Corrections to locate loader on macOS.
Removed vkconfig.sh as it's no longer needed or used.
Corrected failed flush notification to write config when filenames edited in settings.