### PR TITLE
vkconfig: VUID enhancements and other fixes

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -414,7 +414,7 @@ QString Configurator::CheckVulkanSetup() const {
 
     // Check Vulkan Devices
 
-    VkApplicationInfo app;
+    VkApplicationInfo app = {};
     app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     app.pNext = NULL;
     app.pApplicationName = APP_SHORT_NAME;
@@ -423,7 +423,7 @@ QString Configurator::CheckVulkanSetup() const {
     app.engineVersion = 0;
     app.apiVersion = VK_API_VERSION_1_0;
 
-    VkInstanceCreateInfo inst_info;
+    VkInstanceCreateInfo inst_info = {};
     inst_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     inst_info.pNext = NULL;
     inst_info.pApplicationInfo = &app;

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -108,8 +108,14 @@ void SettingsTreeManager::BuildKhronosTree() {
 
     _validation_presets_combo_box = new QComboBox();
     _validation_presets_combo_box->blockSignals(true);
-    for (int i = ValidationPresetFirst; i <= ValidationPresetLast; ++i)
-        _validation_presets_combo_box->addItem(Configurator::Get().GetValidationPresetLabel(static_cast<ValidationPreset>(i)));
+    for (int i = ValidationPresetFirst; i <= ValidationPresetLast; ++i) {
+        QString presetName = Configurator::Get().GetValidationPresetLabel(static_cast<ValidationPreset>(i));
+
+        // There is no preset for a user defined group of settings, so watch for blank.
+        if (presetName.isEmpty()) presetName = "User Defined";
+
+        _validation_presets_combo_box->addItem(presetName);
+    }
 
     _validation_presets_combo_box->setCurrentIndex(_configuration->_preset);
 
@@ -198,7 +204,7 @@ void SettingsTreeManager::BuildKhronosTree() {
             mute_message_item->setText(0, "Mute Message VUIDs");
             _validation_tree_item->addChild(mute_message_item);
 
-            _vuid_search_widget = new VUIDSearchWidget();
+            _vuid_search_widget = new VUIDSearchWidget(_validation_layer_file->_layer_settings[settings_index]->settings_value);
             next_line = new QTreeWidgetItem();
             next_line->setSizeHint(0, QSize(0, 28));
             mute_message_item->addChild(next_line);
@@ -215,6 +221,8 @@ void SettingsTreeManager::BuildKhronosTree() {
             connect(_vuid_search_widget, SIGNAL(itemSelected(const QString &)), _mute_message_widget,
                     SLOT(addItem(const QString &)));
             connect(_vuid_search_widget, SIGNAL(itemChanged()), this, SLOT(profileEdited()));
+            connect(_mute_message_widget, SIGNAL(itemRemoved(const QString &)), _vuid_search_widget,
+                    SLOT(addToSearchList(const QString &)));
             connect(_mute_message_widget, SIGNAL(itemChanged()), this, SLOT(profileEdited()), Qt::QueuedConnection);
             continue;
         }

--- a/vkconfig/vuidsearchwidget.h
+++ b/vkconfig/vuidsearchwidget.h
@@ -33,7 +33,7 @@
 class VUIDSearchWidget : public QWidget {
     Q_OBJECT
    public:
-    explicit VUIDSearchWidget(QWidget *parent = nullptr);
+    explicit VUIDSearchWidget(const QString &valuesAlreadyPresent);
 
    private:
     QStringList _vuid_list;
@@ -49,6 +49,7 @@ class VUIDSearchWidget : public QWidget {
    public Q_SLOTS:
     void addButtonPressed(void);
     void addCompleted(const QString &addedItem);
+    void addToSearchList(const QString &newItem);
 
    Q_SIGNALS:
     void itemSelected(const QString &textSelected);


### PR DESCRIPTION
Change-Id: I27693c5163fb328ac8dd4911583f23d47db771e9
Fixed a validation error with vkCreateInstance.
VUID completer now removes items once added to the list, re-adds them when removed from the list, and on startup removes items that are already in the filter list.
Added "User Defined" text for non-existent preset for Khronos Validation layer.