### PR TITLE
vkconfig: Final touches for SDK release

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -31,7 +31,6 @@
 #include <QLibrary>
 #include <QMessageBox>
 #include <QCheckBox>
-#include <QDebug>
 
 #ifdef _WIN32
 #include <shlobj.h>
@@ -386,6 +385,9 @@ QString Configurator::CheckVulkanSetup() const {
         return log;
     }
 
+    // if (!VK_LAYER_PATH.isEmpty())
+    log += "- Using Layers from VK_LAYER_PATH\n";
+
     // Check layer paths
     if (_custom_layers_paths.count() > 0) {
         log += "- Custom Layers Paths:\n";
@@ -731,7 +733,6 @@ void Configurator::SetPath(Path requested_path, QString path) {
         path = directory.absolutePath();
     }
 
-    qDebug() << ((path + "\n").toUtf8().constData());
     _paths[requested_path] = path;
 }
 
@@ -752,7 +753,7 @@ void Configurator::SaveCustomLayersPaths() {
 }
 
 void Configurator::RemoveCustomLayersPath(int path_index) {
-    Q_ASSERT(path_index > 0 && path_index < _custom_layers_paths.size());
+    Q_ASSERT(path_index >= 0 && path_index < _custom_layers_paths.size());
 
     _custom_layers_paths.removeAt(path_index);
 
@@ -1076,8 +1077,6 @@ void Configurator::LoadAllConfigurations() {
             // Search the list of loaded configurations
             const QString file = QString(":/resourcefiles/") + default_configurations[i].name + ".json";
 
-            qDebug() << file.toUtf8().constData();
-
             Configuration *configuration = LoadConfiguration(file);
             if (configuration != nullptr) SaveConfiguration(configuration);
         }
@@ -1099,7 +1098,6 @@ void Configurator::LoadAllConfigurations() {
         if (info.absoluteFilePath().contains("applist.json")) continue;
 
         Configuration *configuration = LoadConfiguration(info.absoluteFilePath());
-        qDebug() << ((configuration->_name).toUtf8().constData());
 
         if (configuration != nullptr) {
             configuration->_file = info.fileName();  // Easier than parsing it myself ;-)

--- a/vkconfig/dlgcustompaths.cpp
+++ b/vkconfig/dlgcustompaths.cpp
@@ -96,21 +96,13 @@ void dlgCustomPaths::on_treeWidget_itemSelectionChanged() { ui->pushButtonRemove
 /// Remove the selected custom search path
 void dlgCustomPaths::on_pushButtonRemove_clicked() {
     // Which one is selected? We need the top item too
-    QTreeWidgetItem *pSelected = ui->treeWidget->currentItem();
-    while (pSelected->parent() != nullptr) pSelected = pSelected->parent();
-
-    // Confirm?
-    QMessageBox msg;
-    msg.setText(pSelected->text(0));
-    msg.setInformativeText(tr("Delete this custom path?"));
-    msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msg.setDefaultButton(QMessageBox::Yes);
-    if (msg.exec() == QMessageBox::No) return;
+    QTreeWidgetItem *selected = ui->treeWidget->currentItem();
+    while (selected->parent() != nullptr) selected = selected->parent();
 
     Configurator &configurator = Configurator::Get();
 
     // Now actually remove it.
-    configurator.RemoveCustomLayersPath(pSelected->text(0));
+    configurator.RemoveCustomLayersPath(selected->text(0));
 
     // Update GUI and save
     RepopulateTree();

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -133,16 +133,14 @@ dlgProfileEditor::dlgProfileEditor(QWidget *parent, Configuration *configuration
     _configuration = configuration;
 
     // We never edit a profile directly, we only edit a copy of it.
-    setWindowTitle("Creating New Configuration");
+    setWindowTitle("Create a new layers configuration");
 
     // Case 1: New profile (easiest case)
-    if (_configuration->_name.isEmpty()) {
-        setWindowTitle(tr("Create new layer configuration"));
-    } else {
+    if (!_configuration->_name.isEmpty()) {
         // We are editing an exisitng profile. Make a copy of it
         _configuration = configuration->DuplicateConfiguration();
 
-        QString title = tr("Select Vulkan Layers to Override and Execution Order");
+        QString title = tr("Select Vulkan Layers");
 
         // We now have a profile ready for editing, but only the layers that
         // are actually used are attached. Now, we need to add the remaining layers

--- a/vkconfig/dlgprofileeditor.ui
+++ b/vkconfig/dlgprofileeditor.ui
@@ -140,7 +140,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1" rowspan="4">
+      <item row="2" column="1" rowspan="5">
        <widget class="QGroupBox" name="groupBox_5">
         <property name="minimumSize">
          <size>
@@ -231,7 +231,7 @@
       </size>
      </property>
      <property name="title">
-      <string>Vulkan layers custom paths</string>
+      <string>Global Vulkan layers custom paths</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="2" column="1">

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -78,9 +78,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     ///////////////////////////////////////////////
     Configurator &configurator = Configurator::Get();
 
-    if (!configurator.VK_LAYER_PATH.isEmpty())
-        ui->groupBoxProfiles->setTitle("Vulkan Layers Configurations With VK_LAYER_PATH Precedence");
-
     // We need to resetup the new profile for consistency sake.
     QString last_configuration = _settings.value(VKCONFIG_KEY_ACTIVEPROFILE, QString("Validation - Standard")).toString();
     Configuration *current_configuration = configurator.FindConfiguration(last_configuration);
@@ -519,9 +516,7 @@ void MainWindow::toolsVulkanInstallation(bool checked) {
 /// Show help, which is just a rich text file
 void MainWindow::helpShowHelp(bool checked) {
     (void)checked;
-    if (_help == nullptr) _help = new dlgHelp(nullptr);
-
-    _help->show();
+    QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/windows/vkconfig.html"));
 }
 
 ////////////////////////////////////////////////////////////////
@@ -1147,35 +1142,39 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             // Create context menu here
             QMenu menu(ui->profileTree);
 
-            QAction *edit_action = new QAction("Edit this Layers Configuration...", nullptr);
-            edit_action->setEnabled(item != nullptr);
-            menu.addAction(edit_action);
-
-            QAction *new_action = new QAction("New Layers Configuration...", nullptr);
+            QAction *new_action = new QAction("New...", nullptr);
             new_action->setEnabled(true);
             menu.addAction(new_action);
 
-            QAction *duplicate_action = new QAction("Duplicate the Layers Configuration", nullptr);
+            menu.addSeparator();
+
+            QAction *duplicate_action = new QAction("Duplicate", nullptr);
             duplicate_action->setEnabled(item != nullptr);
             menu.addAction(duplicate_action);
 
-            QAction *remove_action = new QAction("Remove the Layers Configuration", nullptr);
+            QAction *remove_action = new QAction("Remove", nullptr);
             remove_action->setEnabled(item != nullptr);
             menu.addAction(remove_action);
 
-            QAction *rename_action = new QAction("Rename the Layers Configuration", nullptr);
+            QAction *rename_action = new QAction("Rename", nullptr);
             rename_action->setEnabled(item != nullptr);
             menu.addAction(rename_action);
 
             menu.addSeparator();
 
-            QAction *import_action = new QAction("Import a Layers Configuration...", nullptr);
+            QAction *import_action = new QAction("Import...", nullptr);
             import_action->setEnabled(true);
             menu.addAction(import_action);
 
-            QAction *export_action = new QAction("Export the Layers Configuration...", nullptr);
+            QAction *export_action = new QAction("Export...", nullptr);
             export_action->setEnabled(item != nullptr);
             menu.addAction(export_action);
+
+            menu.addSeparator();
+
+            QAction *edit_action = new QAction("Select Layers...", nullptr);
+            edit_action->setEnabled(item != nullptr);
+            menu.addAction(edit_action);
 
             menu.addSeparator();
 

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -500,7 +500,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Select Vulkan Layers to Override and Execution Order</string>
+            <string>Select Layers...</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
- Fix link to online documentation
- Layer property text is no longer cropped
- Delete debug code left over
- Fix remove custom path assert
- Clean up context menu
- Add VK_LAYER_PATH to the Vulkan status on start
- More consistent custom path behavior: no message box to remove
- More consistent naming accross the tool

Change-Id: I81fba4a45663345538eeb2d898039f9fb709a332