### PR TITLE
Vkconfig last minute scaling fixes

### DIFF
--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -36,7 +36,10 @@ int main(int argc, char* argv[]) {
             QCoreApplication::setOrganizationName("LunarG");
             QCoreApplication::setOrganizationDomain("lunarg.com");
             QCoreApplication::setApplicationName("Vulkan Configurator");
-#ifndef Q_OS_LINUX  // Drop this out of Qt on Linux for maximum backwards compatibility
+
+            // Older Qt versions do not need this, but Linux builds do benefit
+            // if it is present.
+#if (QT_VERSION < QT_VERSION_CHECK(5, 6, 0))
             QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
             QApplication app(argc, argv);

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
             // Older Qt versions do not need this, but Linux builds do benefit
             // if it is present.
 #if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
-           QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+            QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
             QApplication app(argc, argv);
 

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -39,17 +39,15 @@ int main(int argc, char* argv[]) {
 
             // Older Qt versions do not need this, but Linux builds do benefit
             // if it is present.
-#if (QT_VERSION < QT_VERSION_CHECK(5, 6, 0))
-            QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
+           QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
             QApplication app(argc, argv);
 
-            // Not well (if at all documented), but it appears if you do not explicitly set
-            // the font size here, it is often overriden by the default styles. The one
-            // set in the .ui file is ignored on Windows HiDPI monitors for example. Manually
-            // setting this here appears to correct scaling issues on all platforms.
-            app.setStyleSheet("QWidget{font-size:12px;}");
-
+            // macOS only, has to hold constant, or get's 'tiny' in Retina mode.
+#ifdef __APPLE__
+           app.setStyleSheet("QWidget{font-size:12px;}");
+#endif
             // This has to go after the construction of QApplication in
             // order to use a QMessageBox and avoid some QThread warnings.
             AppSingleton singleApp("vkconifg_single_instance");

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -40,9 +40,12 @@ int main(int argc, char* argv[]) {
             QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
             QApplication app(argc, argv);
-#ifdef __APPLE__
-            app.setStyleSheet("QWidget{font-size:13px;}");
-#endif
+
+            // Not well (if at all documented), but it appears if you do not explicitly set
+            // the font size here, it is often overriden by the default styles. The one
+            // set in the .ui file is ignored on Windows HiDPI monitors for example. Manually
+            // setting this here appears to correct scaling issues on all platforms.
+            app.setStyleSheet("QWidget{font-size:12px;}");
 
             // This has to go after the construction of QApplication in
             // order to use a QMessageBox and avoid some QThread warnings.

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -44,10 +44,6 @@ int main(int argc, char* argv[]) {
 #endif
             QApplication app(argc, argv);
 
-            // macOS only, has to hold constant, or get's 'tiny' in Retina mode.
-#ifdef __APPLE__
-           app.setStyleSheet("QWidget{font-size:12px;}");
-#endif
             // This has to go after the construction of QApplication in
             // order to use a QMessageBox and avoid some QThread warnings.
             AppSingleton singleApp("vkconifg_single_instance");

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -100,25 +100,6 @@
            <property name="flat">
             <bool>false</bool>
            </property>
-           <widget class="QRadioButton" name="radioOverride">
-            <property name="geometry">
-             <rect>
-              <x>12</x>
-              <y>56</y>
-              <width>391</width>
-              <height>19</height>
-             </rect>
-            </property>
-            <property name="font">
-             <font>
-              <family>Arial</family>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Overriden by the Vulkan Configurator</string>
-            </property>
-           </widget>
            <widget class="QCheckBox" name="checkBoxApplyList">
             <property name="geometry">
              <rect>
@@ -157,61 +138,74 @@
              <string>Make layers override persistent on exit</string>
             </property>
            </widget>
-           <widget class="QRadioButton" name="radioFully">
+           <widget class="QWidget" name="">
             <property name="geometry">
              <rect>
-              <x>12</x>
-              <y>31</y>
-              <width>351</width>
-              <height>19</height>
+              <x>13</x>
+              <y>30</y>
+              <width>356</width>
+              <height>54</height>
              </rect>
             </property>
-            <property name="font">
-             <font>
-              <family>Arial</family>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Fully controlled by the Vulkan applications</string>
-            </property>
-           </widget>
-           <widget class="QPushButton" name="pushButtonAppList">
-            <property name="geometry">
-             <rect>
-              <x>430</x>
-              <y>56</y>
-              <width>100</width>
-              <height>26</height>
-             </rect>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>26</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <family>Arial</family>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Edit...</string>
-            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <item row="0" column="0">
+              <widget class="QRadioButton" name="radioFully">
+               <property name="font">
+                <font>
+                 <family>Arial</family>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Fully controlled by the Vulkan applications</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QRadioButton" name="radioOverride">
+               <property name="font">
+                <font>
+                 <family>Arial</family>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Overriden by the Vulkan Configurator</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QPushButton" name="pushButtonAppList">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>80</width>
+                 <height>26</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>100</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <family>Arial</family>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Edit...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </widget>
          </item>

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -105,7 +105,7 @@
              <rect>
               <x>12</x>
               <y>56</y>
-              <width>469</width>
+              <width>391</width>
               <height>19</height>
              </rect>
             </property>
@@ -124,7 +124,7 @@
              <rect>
               <x>30</x>
               <y>81</y>
-              <width>469</width>
+              <width>391</width>
               <height>18</height>
              </rect>
             </property>
@@ -143,7 +143,7 @@
              <rect>
               <x>30</x>
               <y>105</y>
-              <width>469</width>
+              <width>371</width>
               <height>19</height>
              </rect>
             </property>
@@ -162,7 +162,7 @@
              <rect>
               <x>12</x>
               <y>31</y>
-              <width>469</width>
+              <width>351</width>
               <height>19</height>
              </rect>
             </property>
@@ -179,7 +179,7 @@
            <widget class="QPushButton" name="pushButtonAppList">
             <property name="geometry">
              <rect>
-              <x>487</x>
+              <x>430</x>
               <y>56</y>
               <width>100</width>
               <height>26</height>
@@ -619,7 +619,7 @@
      <x>0</x>
      <y>0</y>
      <width>1024</width>
-     <height>26</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuTools">

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -100,32 +100,13 @@
            <property name="flat">
             <bool>false</bool>
            </property>
-           <widget class="QRadioButton" name="radioFully">
-            <property name="geometry">
-             <rect>
-              <x>10</x>
-              <y>26</y>
-              <width>531</width>
-              <height>20</height>
-             </rect>
-            </property>
-            <property name="font">
-             <font>
-              <family>Arial</family>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Fully controlled by the Vulkan applications</string>
-            </property>
-           </widget>
            <widget class="QRadioButton" name="radioOverride">
             <property name="geometry">
              <rect>
-              <x>10</x>
-              <y>52</y>
-              <width>491</width>
-              <height>20</height>
+              <x>12</x>
+              <y>56</y>
+              <width>469</width>
+              <height>19</height>
              </rect>
             </property>
             <property name="font">
@@ -138,44 +119,13 @@
              <string>Overriden by the Vulkan Configurator</string>
             </property>
            </widget>
-           <widget class="QPushButton" name="pushButtonAppList">
-            <property name="geometry">
-             <rect>
-              <x>410</x>
-              <y>70</y>
-              <width>81</width>
-              <height>26</height>
-             </rect>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>26</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <family>Arial</family>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Edit...</string>
-            </property>
-           </widget>
            <widget class="QCheckBox" name="checkBoxApplyList">
             <property name="geometry">
              <rect>
               <x>30</x>
-              <y>73</y>
-              <width>411</width>
-              <height>20</height>
+              <y>81</y>
+              <width>469</width>
+              <height>18</height>
              </rect>
             </property>
             <property name="font">
@@ -192,9 +142,9 @@
             <property name="geometry">
              <rect>
               <x>30</x>
-              <y>100</y>
-              <width>451</width>
-              <height>20</height>
+              <y>105</y>
+              <width>469</width>
+              <height>19</height>
              </rect>
             </property>
             <property name="font">
@@ -205,6 +155,62 @@
             </property>
             <property name="text">
              <string>Make layers override persistent on exit</string>
+            </property>
+           </widget>
+           <widget class="QRadioButton" name="radioFully">
+            <property name="geometry">
+             <rect>
+              <x>12</x>
+              <y>31</y>
+              <width>469</width>
+              <height>19</height>
+             </rect>
+            </property>
+            <property name="font">
+             <font>
+              <family>Arial</family>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Fully controlled by the Vulkan applications</string>
+            </property>
+           </widget>
+           <widget class="QPushButton" name="pushButtonAppList">
+            <property name="geometry">
+             <rect>
+              <x>487</x>
+              <y>56</y>
+              <width>100</width>
+              <height>26</height>
+             </rect>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>26</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>100</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>Arial</family>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Edit...</string>
             </property>
            </widget>
           </widget>
@@ -613,7 +619,7 @@
      <x>0</x>
      <y>0</y>
      <width>1024</width>
-     <height>21</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuTools">

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -100,12 +100,31 @@
            <property name="flat">
             <bool>false</bool>
            </property>
+           <widget class="QRadioButton" name="radioOverride">
+            <property name="geometry">
+             <rect>
+              <x>14</x>
+              <y>57</y>
+              <width>321</width>
+              <height>20</height>
+             </rect>
+            </property>
+            <property name="font">
+             <font>
+              <family>Arial</family>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Overriden by the Vulkan Configurator</string>
+            </property>
+           </widget>
            <widget class="QCheckBox" name="checkBoxApplyList">
             <property name="geometry">
              <rect>
               <x>30</x>
               <y>81</y>
-              <width>391</width>
+              <width>401</width>
               <height>18</height>
              </rect>
             </property>
@@ -138,74 +157,61 @@
              <string>Make layers override persistent on exit</string>
             </property>
            </widget>
-           <widget class="QWidget" name="">
+           <widget class="QRadioButton" name="radioFully">
             <property name="geometry">
              <rect>
-              <x>13</x>
-              <y>30</y>
-              <width>356</width>
-              <height>54</height>
+              <x>14</x>
+              <y>31</y>
+              <width>331</width>
+              <height>20</height>
              </rect>
             </property>
-            <layout class="QFormLayout" name="formLayout">
-             <item row="0" column="0">
-              <widget class="QRadioButton" name="radioFully">
-               <property name="font">
-                <font>
-                 <family>Arial</family>
-                 <pointsize>10</pointsize>
-                </font>
-               </property>
-               <property name="text">
-                <string>Fully controlled by the Vulkan applications</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QRadioButton" name="radioOverride">
-               <property name="font">
-                <font>
-                 <family>Arial</family>
-                 <pointsize>10</pointsize>
-                </font>
-               </property>
-               <property name="text">
-                <string>Overriden by the Vulkan Configurator</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QPushButton" name="pushButtonAppList">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>80</width>
-                 <height>26</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>100</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="font">
-                <font>
-                 <family>Arial</family>
-                 <pointsize>10</pointsize>
-                </font>
-               </property>
-               <property name="text">
-                <string>Edit...</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <property name="font">
+             <font>
+              <family>Arial</family>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Fully controlled by the Vulkan applications</string>
+            </property>
+           </widget>
+           <widget class="QPushButton" name="pushButtonAppList">
+            <property name="geometry">
+             <rect>
+              <x>440</x>
+              <y>80</y>
+              <width>80</width>
+              <height>26</height>
+             </rect>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>26</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>100</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>Arial</family>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Edit...</string>
+            </property>
            </widget>
           </widget>
          </item>


### PR DESCRIPTION
This should address issues when HDPI screens have various scaling factors applied.
This was also previously removed for Linux, but on testing is needed. Now, the build tests for Qt versions 5.6 and greater and enables the feature if the Qt version is new enough to do so.
The UI changes are misleading, because I moved two of the checkboxes out of the layouts so they could be indented.