### PR TITLE
vkconfig: Warnings, misspellings, singleton fix

### DIFF
--- a/vkconfig/appsingleton.cpp
+++ b/vkconfig/appsingleton.cpp
@@ -31,12 +31,19 @@ AppSingleton::AppSingleton(QString singleAppName, int timeout) {
     // If we can connect to the server, it means there is another copy running
     QLocalSocket localSocket;
     localSocket.connectToServer(singleAppName);
+
+    // The default timeout is 5 seconds, which should be enough under
+    // the most extreme circumstances. Note, that it will actually
+    // only time out if the server exists and for some reason it can't
+    // connect. Too small a timeout on the other hand can give false
+    // assurance that another copy is not running.
     if (localSocket.waitForConnected(timeout)) {
         _is_first_app = false;
         localSocket.close();
         return;
     }
 
+    // Not connected, OR timed out
     // We are the first, start a server
     _is_first_app = true;
     _localServer.listen(singleAppName);

--- a/vkconfig/appsingleton.h
+++ b/vkconfig/appsingleton.h
@@ -33,7 +33,7 @@
 
 class AppSingleton {
    public:
-    AppSingleton(QString singleAppName, int timeout = 500);
+    AppSingleton(QString singleAppName, int timeout = 5000);
     ~AppSingleton();
     bool IsFirstApp(void) { return _is_first_app; }
 

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -227,6 +227,12 @@ Configurator::Configurator()
         home.cd("vulkan");
     }
 
+    if (!home.cd("implicit_layer.d")) {
+        home.mkpath("implicit_layer.d");
+        home.cd("implicit_layer.d");
+    }
+
+    home.cd("..");
     if (!home.cd("settings.d")) {
         home.mkpath("settings.d");
         home.cd("settings.d");

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -354,7 +354,7 @@ QString Configurator::CheckVulkanSetup() const {
     if (local.exists())
         log += QString().asprintf("- SDK path: %s\n", search_path.toUtf8().constData());
     else
-        log += "- SDK path: Not detected\n";
+        log += "- VULKAN_SDK environment variable not set\n";
 
         // Check loader version
         // Different names and rules for each OS
@@ -708,7 +708,7 @@ QString Configurator::GetPath(Path requested_path) const {
     const QString path = _paths[requested_path];
 
     if (!path.isEmpty()) {
-        return path;
+        return QDir::toNativeSeparators(path);
     }
 
     // Use export path when import path is empty and import path when export path is empty
@@ -852,12 +852,14 @@ void Configurator::FindVkCube() {
 /// file.
 void Configurator::LoadOverriddenApplicationList() {
     /////////////////////////////////////////////////////////////
-    // Now, use the list
-    QString application_list_json = GetPath(ConfigurationPath) + "/applist.json";
+    // Now, use the list. If the file doesn't exist, this is not an error
+    QString data;
+    QString application_list_json = GetPath(ConfigurationPath) + QDir::toNativeSeparators("/applist.json");
     QFile file(application_list_json);
-    file.open(QFile::ReadOnly);
-    QString data = file.readAll();
-    file.close();
+    if (file.open(QFile::ReadOnly)) {
+        data = file.readAll();
+        file.close();
+    }
 
     QJsonDocument json_app_list;
     json_app_list = QJsonDocument::fromJson(data.toLocal8Bit());
@@ -931,7 +933,7 @@ void Configurator::SaveOverriddenApplicationList() {
         root.insert(QFileInfo(_overridden_application_list[i]->executable_path).fileName(), application_object);
     }
 
-    QString app_list_json = GetPath(ConfigurationPath) + "/applist.json";
+    QString app_list_json = GetPath(ConfigurationPath) + QDir::toNativeSeparators("/applist.json");
     QFile file(app_list_json);
     file.open(QFile::WriteOnly);
     QJsonDocument doc(root);

--- a/vkconfig/dlgvulkananalysis.ui
+++ b/vkconfig/dlgvulkananalysis.ui
@@ -41,7 +41,7 @@
          <item>
           <widget class="QToolBox" name="systemInfo">
            <property name="currentIndex">
-            <number>0</number>
+            <number>5</number>
            </property>
            <widget class="QWidget" name="environment">
             <property name="geometry">
@@ -184,7 +184,7 @@
              </rect>
             </property>
             <attribute name="label">
-             <string>LunarG Vulkan SDKs</string>
+             <string>Vulkan SDKs</string>
             </attribute>
             <layout class="QHBoxLayout" name="horizontalLayout_6">
              <item>
@@ -318,7 +318,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>89</width>
+              <width>98</width>
               <height>89</height>
              </rect>
             </property>
@@ -343,7 +343,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>89</width>
+              <width>98</width>
               <height>89</height>
              </rect>
             </property>
@@ -368,7 +368,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>89</width>
+              <width>98</width>
               <height>89</height>
              </rect>
             </property>

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
 
             // This has to go after the construction of QApplication in
             // order to use a QMessageBox and avoid some QThread warnings.
-            AppSingleton singleApp("vkconifg_single_instance");
+            AppSingleton singleApp("vkconfig_single_instance");
             if (!singleApp.IsFirstApp()) {
                 QMessageBox alert(nullptr);
                 alert.setWindowTitle("Cannot start another instance of vkconfig");

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -35,9 +35,15 @@ int main(int argc, char* argv[]) {
         case CommandLine::ModeExecute: {
             QCoreApplication::setOrganizationName("LunarG");
             QCoreApplication::setOrganizationDomain("lunarg.com");
-            QCoreApplication::setApplicationName("Vulkan Configurator");
 
-            // Older Qt versions do not need this, but Linux builds do benefit
+            // This is used by QSettings for .ini, registry, and .plist files.
+            // It needs to not have spaces in it, and by default is the same as
+            // the executable name. If we rename the executable at a later date,
+            // keeping this as 'vkconfig' will ensure that it picks up the
+            // settings from the previous version (assuming that's ever an issue)
+            QCoreApplication::setApplicationName("vkconfig");
+
+            // Older Qt versions do not have this, but Linux builds do benefit
             // if it is present.
 #if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
             QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -123,7 +123,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Overriden by the Vulkan Configurator</string>
+               <string>Overridden by the Vulkan Configurator</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Change-Id: I960be1345af8562be34a881238dba897bef17737
Spelling errors, etc. Biggest change is to the app singleton feature.
Also, checked for file not existing, as failure was not as silent as thought; prevents warning output to console.
Less "scary" text when $VULKAN_SDK is not set.