### PR TITLE
vkconfig: API Dump is now the default configuration

### DIFF
--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -379,7 +379,7 @@ void MainWindow::toolsResetToDefault(bool checked) {
     configurator.LoadAllConfigurations();
 
     // Find the Standard Validation and make it current if we are active
-    Configuration *active_configuration = configurator.FindConfiguration(QString("Validation - Standard"));
+    Configuration *active_configuration = configurator.FindConfiguration(QString("API dump"));
     if (configurator._override_active) ChangeActiveConfiguration(active_configuration);
 
     LoadConfigurationList();
@@ -1057,13 +1057,13 @@ void MainWindow::launchSetLogFile() {
     const QString log_file =
         QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Set Log File To..."), ".", tr("Log text(*.txt)")));
 
+    // Do nothing if the user cancels out.
+    if (log_file.isEmpty()) return;
+
     Configurator &configurator = Configurator::Get();
     configurator._overridden_application_list[current_application_index]->log_file = log_file;
 
-    if (log_file.isEmpty())
-        _launcher_log_file_edit->setText("");
-    else
-        _launcher_log_file_edit->setText(log_file);
+    _launcher_log_file_edit->setText(log_file);
 
     configurator.SaveOverriddenApplicationList();
 }

--- a/vkconfig/resourcefiles/API dump.json
+++ b/vkconfig/resourcefiles/API dump.json
@@ -2,7 +2,7 @@
     "API dump": {
         "blacklisted_layers": [
         ],
-        "description": "API Dump cheap and cheerful",
+        "description": "A Simple API dump configuration",
         "layer_options": {
             "VK_LAYER_LUNARG_api_dump": {
                 "detailed": {

--- a/vkconfig/vkconfig.md
+++ b/vkconfig/vkconfig.md
@@ -149,11 +149,15 @@ We are working on defining layers development conventions to resolve this issue 
 --------------
 ## Known Issues
 
-- The UI still feels a little clunky... Need more polish.
-- Message filtering using VUID name and index is not yet fully implemented.
+- Minor GUI formating issues may still occur on some Linux distributions (Fedora particularly)
 - Layers will use the override layer settings and ignore the local file with no warning to the user.
 - Layer paths may not be duplicated in the layer override json file. They currently are.
 - Layer execution order express in the "Select Layers" window is not accurate, only ***forced on*** layers can be ordered.
 - Layers settings fields are not checked for syntax errors.
 - The user can't reorder the layers configurations in the list.
+- Vulkaninfo output is now sorted alphabetically.
+- On Linux, when run for the first time from the command line, vkcube may not be located and added to the application launcher automatically.
+- A version or build # needs to be added to the about box.
+- Layer changes are not autodetected. If changes are made to the layer environment, vkconfig must be restarted.
+- On macOS, vkcube and vkcubepp need to be run at least once to get past the security checks before they can be used from vkconfig.
 


### PR DESCRIPTION
Change-Id: I0ecda5c374a7a21b41a1ef936dd2bfdfb55442ef
API Dump is the default layer configuration
Log file browser no longer blanks edit control on cancel.
Changed description of the AP dump configuration.