### PR TITLE
vkconfig post sdk fixes

### DIFF
--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -71,7 +71,7 @@ class PathFinder {
 #define VKCONFIG_KEY_OVERRIDE_ACTIVE "overrideActive"
 #define VKCONFIG_KEY_APPLY_ONLY_TO_LIST "applyOnlyToList"
 #define VKCONFIG_KEY_KEEP_ACTIVE_ON_EXIT "keepActiveOnExit"
-#define VKCONFIG_KEY_INITIALIZE_FILES "Initialized"
+#define VKCONFIG_KEY_INITIALIZE_FILES "FirstTimeRun"
 #define VKCONFIG_HIDE_RESTART_WARNING "restartWarning"
 #define VKCONFIG_KEY_LAST_EXPORT_PATH "lastExportPath"
 #define VKCONFIG_KEY_LAST_IMPORT_PATH "lastImportPath"

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
                 return -1;
             }
 
-            // SDK release 1.2.148.5 and earlier had some bad tokens in the default configurations and this was the only way to
+            // SDK release 1.2.148 and earlier had some bad tokens in the default configurations and this was the only way to
             // "repair" them. In the future, we will be more surgical about this when it occurs, or when upates
             // are made to support additional validation layer settings. The initial first run key was "Initialized", which
             // set to false also was non-intuitive (it was backwards), so good to change that as well. The logic below will

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
             // "repair" them. In the future, we will be more surgical about this when it occurs, or when upates
             // are made to support additional validation layer settings. The initial first run key was "Initialized", which
             // set to false also was non-intuitive (it was backwards), so good to change that as well. The logic below will
-            // not show this dialog to everyone, only those who installed the SDK on the first week of release.
+            // not show this dialog to everyone, only those who installed the SDK that was posted the first week of release.
             QSettings settings;
             if (!settings.value("Initialized", true).toBool() && settings.value(VKCONFIG_KEY_INITIALIZE_FILES, true).toBool()) {
                 QMessageBox alert;

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -70,6 +70,24 @@ int main(int argc, char* argv[]) {
                 return -1;
             }
 
+            // SDK release 1.2.148.5 and earlier had some bad tokens in the default configurations and this was the only way to
+            // "repair" them. In the future, we will be more surgical about this when it occurs, or when upates
+            // are made to support additional validation layer settings. The initial first run key was "Initialized", which
+            // set to false also was non-intuitive (it was backwards), so good to change that as well. The logic below will
+            // not show this dialog to everyone, only those who installed the SDK on the first week of release.
+            QSettings settings;
+            if (!settings.value("Initialized", true).toBool() && settings.value(VKCONFIG_KEY_INITIALIZE_FILES, true).toBool()) {
+                QMessageBox alert;
+                alert.setText(
+                    "Vulkan Configurator needs to be reset. "
+                    "All standard configurations are being reset to their default state, and user "
+                    "configurations need to be recreated. Future releases will allow for repair of faulty configuration files.");
+                alert.setWindowTitle("Vulkan Configurator");
+                alert.setIcon(QMessageBox::Warning);
+                alert.exec();
+                // DO NOT set VKCONFIG_KEY_INITIALIZED_FILES to false here
+            }
+
             // We simply cannot run without any layers
             if (Configurator::Get().InitializeConfigurator() == false) return -1;
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -425,6 +425,10 @@ void MainWindow::profileItemClicked(bool checked) {
     ConfigurationListItem *configuration_item = GetCheckedItem();
     if (configuration_item == nullptr) return;
 
+    // This appears redundant on Windows, but under linux it is needed
+    // to ensure the new item is "selected"
+    ui->profileTree->setCurrentItem(configuration_item);
+
     Configurator &configurator = Configurator::Get();
 
     // Do we go ahead and activate it?

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -377,7 +377,7 @@ void MainWindow::toolsResetToDefault(bool checked) {
     _settings_tree_manager.CleanupGUI();
     configurator.LoadAllConfigurations();
 
-    // Find the API dump  and make it current if we are active
+    // Find the API dump and make it current if we are active
     Configuration *active_configuration = configurator.FindConfiguration(QString("API dump"));
     if (configurator._override_active) ChangeActiveConfiguration(active_configuration);
 

--- a/vkconfig/resourcefiles/Frame Capture - First two frames.json
+++ b/vkconfig/resourcefiles/Frame Capture - First two frames.json
@@ -3,7 +3,6 @@
         "blacklisted_layers": [
         ],
         "description": "Capture the applications first two frames",
-        "editor_state": "01111111111111111111111",
         "layer_options": {
             "VK_LAYER_LUNARG_gfxreconstruct": {
                 "capture_file": {

--- a/vkconfig/resourcefiles/Frame Capture - Range (F10 to start and to stop).json
+++ b/vkconfig/resourcefiles/Frame Capture - Range (F10 to start and to stop).json
@@ -3,7 +3,6 @@
         "blacklisted_layers": [
         ],
         "description": "Capture a range of frames",
-        "editor_state": "011111111111111111111111111",
         "layer_options": {
             "VK_LAYER_LUNARG_gfxreconstruct": {
                 "capture_compression_type": {

--- a/vkconfig/resourcefiles/Validation - Best Practices.json
+++ b/vkconfig/resourcefiles/Validation - Best Practices.json
@@ -3,7 +3,6 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration provides access to the Vulkan Best Practices check. Provides warnings about potential API misuse.",
-        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Best Practices.json
+++ b/vkconfig/resourcefiles/Validation - Best Practices.json
@@ -15,7 +15,7 @@
                         "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
                         "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
                         "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                        "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output"
                     },
                     "type": "enum"
                 },

--- a/vkconfig/resourcefiles/Validation - GPU-Assisted.json
+++ b/vkconfig/resourcefiles/Validation - GPU-Assisted.json
@@ -3,7 +3,6 @@
         "blacklisted_layers": [
         ],
         "description": "Provides easy access to gpu-assisted validation tools.",
-        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - GPU-Assisted.json
+++ b/vkconfig/resourcefiles/Validation - GPU-Assisted.json
@@ -15,7 +15,7 @@
                         "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
                         "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
                         "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                        "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output"
                     },
                     "type": "enum"
                 },

--- a/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
+++ b/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
@@ -15,7 +15,7 @@
                         "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
                         "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
                         "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                        "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output"
                     },
                     "type": "enum"
                 },

--- a/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
+++ b/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
@@ -3,7 +3,6 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration disables some of the checks of Standard Validation in the interest of performance.",
-        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Shader Printf.json
+++ b/vkconfig/resourcefiles/Validation - Shader Printf.json
@@ -15,7 +15,7 @@
                         "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
                         "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
                         "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                        "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output"
                     },
                     "type": "enum"
                 },

--- a/vkconfig/resourcefiles/Validation - Shader Printf.json
+++ b/vkconfig/resourcefiles/Validation - Shader Printf.json
@@ -3,7 +3,6 @@
         "blacklisted_layers": [
         ],
         "description": "Provides easy access to debug-printf functionality.",
-        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Shader Printf.json
+++ b/vkconfig/resourcefiles/Validation - Shader Printf.json
@@ -46,11 +46,10 @@
                     "type": "multi_enum"
                 },
                 "enables": {
-                    "default": [
-                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
-                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT"
-                    ],
-                    "description": "Setting an option here will enable specialized areas of validation",
+                "default": [
+                     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT"
+                     ],
+                "description": "Setting an option here will enable specialized areas of validation",
                     "name": "Enables",
                     "options": {
                         "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific validation",

--- a/vkconfig/resourcefiles/Validation - Standard.json
+++ b/vkconfig/resourcefiles/Validation - Standard.json
@@ -3,11 +3,10 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration is a good default validation setting and should serve most needs most of the time.",
-        "editor_state": "01110111111111111111111001011111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {
-                    "default": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
+                    "default": "VK_DBG_LAYER_ACTION_LOG_MSG",
                     "description": "This indicates what action is to be taken when a layer wants to report information",
                     "name": "Debug Action",
                     "options": {

--- a/vkconfig/resourcefiles/Validation - Standard.json
+++ b/vkconfig/resourcefiles/Validation - Standard.json
@@ -7,7 +7,7 @@
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {
-                    "default": "VK_DBG_LAYER_ACTION_LOG_MSG",
+                    "default": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
                     "description": "This indicates what action is to be taken when a layer wants to report information",
                     "name": "Debug Action",
                     "options": {
@@ -15,7 +15,7 @@
                         "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
                         "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
                         "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                        "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output"
                     },
                     "type": "enum"
                 },

--- a/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
+++ b/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
@@ -7,7 +7,7 @@
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {
-                    "default": "VK_DBG_LAYER_DEBUG_OUTPUT",
+                    "default": "VK_DBG_LAYER_ACTION_LOG_MSG",
                     "description": "This indicates what action is to be taken when a layer wants to report information",
                     "name": "Debug Action",
                     "options": {
@@ -15,7 +15,7 @@
                         "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
                         "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
                         "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-                        "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output"
+                        "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output"
                     },
                     "type": "enum"
                 },

--- a/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
+++ b/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
@@ -3,7 +3,6 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration is a good default validation setting and should serve most needs most of the time.",
-        "editor_state": "01110011111111111011110001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/layer_info.json
+++ b/vkconfig/resourcefiles/layer_info.json
@@ -30,7 +30,7 @@
                     "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
-                    "VK_DBG_LAYER_DEBUG_OUTPUT": "Debug Output",
+                    "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output",
                     "VK_DBG_LAYER_ACTION_BREAK": "Break"
                 },
                 "default": "VK_DBG_LAYER_ACTION_LOG_MSG"


### PR DESCRIPTION
Corrected spacing issue described here:
https://github.com/LunarG/Projects/issues/448
This required changing the two column approach in the main config tree to a one column approach. Better spacing behavior on all platforms.

Debug-printf configuration was actually identical to GPU-Assisted. Changed default to use debug-printf instead for this config.

Fixed issue where a MessageBox was stalling code flow when a log file could not be opened. Meanwhile, log messages came through in the background and tried writing to the unopened log file.

This PR additionally removes the editor state field from the .json's which should not have been in the template in the first place.
A message box that warns the user is displayed if this is the first post 1.2.148 install that the default configurations must be removed and user configs recreated. This is not displayed if it is a true first time run of Vulkan Configurator.