### PR TITLE
Vulkan Configurator: Default settings

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -175,7 +175,7 @@ Configurator::Configurator()
         // We reinitialize state to reset any previous configuration and start fresh.
         if (saved_version < vku::Version::header_version) {
             settings.setValue(VKCONFIG_KEY_VKCONFIG_VERSION, vku::Version::header_version.str().c_str());
-            settings.setValue(VKCONFIG_KEY_ACTIVEPROFILE, "API dump");
+            settings.setValue(VKCONFIG_KEY_ACTIVEPROFILE, "Validation - Standard");
             settings.setValue(VKCONFIG_KEY_RESTORE_GEOMETRY, false);
         }
     }

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -377,8 +377,8 @@ void MainWindow::toolsResetToDefault(bool checked) {
     _settings_tree_manager.CleanupGUI();
     configurator.LoadAllConfigurations();
 
-    // Find the API dump and make it current if we are active
-    Configuration *active_configuration = configurator.FindConfiguration(QString("API dump"));
+    // Find the "Validation - Standard" configuration and make it current if we are active
+    Configuration *active_configuration = configurator.FindConfiguration(QString("Validation - Standard"));
     if (configurator._override_active) ChangeActiveConfiguration(active_configuration);
 
     LoadConfigurationList();

--- a/vkconfig/resourcefiles/Frame Capture - First two frames.json
+++ b/vkconfig/resourcefiles/Frame Capture - First two frames.json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "Capture the applications first two frames",
+        "editor_state": "01111111111111111111111",
         "layer_options": {
             "VK_LAYER_LUNARG_gfxreconstruct": {
                 "capture_file": {

--- a/vkconfig/resourcefiles/Frame Capture - Range (F10 to start and to stop).json
+++ b/vkconfig/resourcefiles/Frame Capture - Range (F10 to start and to stop).json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "Capture a range of frames",
+        "editor_state": "011111111111111111111111111",
         "layer_options": {
             "VK_LAYER_LUNARG_gfxreconstruct": {
                 "capture_compression_type": {

--- a/vkconfig/resourcefiles/Validation - Best Practices.json
+++ b/vkconfig/resourcefiles/Validation - Best Practices.json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration provides access to the Vulkan Best Practices check. Provides warnings about potential API misuse.",
+        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Best Practices.json
+++ b/vkconfig/resourcefiles/Validation - Best Practices.json
@@ -77,6 +77,7 @@
                     "default": [
                         "error",
                         "perf",
+                        "info",
                         "warn"
                     ],
                     "description": "The message severity the layer should report back",

--- a/vkconfig/resourcefiles/Validation - GPU-Assisted.json
+++ b/vkconfig/resourcefiles/Validation - GPU-Assisted.json
@@ -78,6 +78,7 @@
                     "default": [
                         "error",
                         "perf",
+                        "info",
                         "warn"
                     ],
                     "description": "The message severity the layer should report back",

--- a/vkconfig/resourcefiles/Validation - GPU-Assisted.json
+++ b/vkconfig/resourcefiles/Validation - GPU-Assisted.json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "Provides easy access to gpu-assisted validation tools.",
+        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
+++ b/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
@@ -79,6 +79,7 @@
                     "default": [
                         "error",
                         "perf",
+                        "info",
                         "warn"
                     ],
                     "description": "The message severity the layer should report back",

--- a/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
+++ b/vkconfig/resourcefiles/Validation - Reduced-Overhead.json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration disables some of the checks of Standard Validation in the interest of performance.",
+        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Shader Printf.json
+++ b/vkconfig/resourcefiles/Validation - Shader Printf.json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "Provides easy access to debug-printf functionality.",
+        "editor_state": "01110111111111111111111001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Shader Printf.json
+++ b/vkconfig/resourcefiles/Validation - Shader Printf.json
@@ -77,6 +77,7 @@
                     "default": [
                         "error",
                         "perf",
+                        "info",
                         "warn"
                     ],
                     "description": "The message severity the layer should report back",

--- a/vkconfig/resourcefiles/Validation - Standard.json
+++ b/vkconfig/resourcefiles/Validation - Standard.json
@@ -72,6 +72,7 @@
                     "default": [
                         "error",
                         "perf",
+                        "info",
                         "warn"
                     ],
                     "description": "The message severity the layer should report back",

--- a/vkconfig/resourcefiles/Validation - Standard.json
+++ b/vkconfig/resourcefiles/Validation - Standard.json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration is a good default validation setting and should serve most needs most of the time.",
+        "editor_state": "01110111111111111111111001011111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
+++ b/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
@@ -3,6 +3,7 @@
         "blacklisted_layers": [
         ],
         "description": "This configuration is a good default validation setting and should serve most needs most of the time.",
+        "editor_state": "01110011111111111011110001111111111110",
         "layer_options": {
             "VK_LAYER_KHRONOS_validation": {
                 "debug_action": {

--- a/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
+++ b/vkconfig/resourcefiles/Validation - Synchronization (Alpha).json
@@ -76,6 +76,7 @@
                     "default": [
                         "error",
                         "perf",
+                        "info",
                         "warn"
                     ],
                     "description": "The message severity the layer should report back",

--- a/vkconfig/vkconfig.md
+++ b/vkconfig/vkconfig.md
@@ -149,7 +149,7 @@ We are working on defining layers development conventions to resolve this issue 
 --------------
 ## Known Issues
 
-- The UI still feels a little clunky... Need more polish.
+- UI still needs some refinement in some areas...
 - Message filtering using VUID name and index is not yet fully implemented.
 - Minor GUI formating issues may still occur on some Linux distributions (Fedora particularly)
 - Layers will use the override layer settings and ignore the local file with no warning to the user.

--- a/vkconfig/vkconfig.md
+++ b/vkconfig/vkconfig.md
@@ -149,6 +149,8 @@ We are working on defining layers development conventions to resolve this issue 
 --------------
 ## Known Issues
 
+- The UI still feels a little clunky... Need more polish.
+- Message filtering using VUID name and index is not yet fully implemented.
 - Minor GUI formating issues may still occur on some Linux distributions (Fedora particularly)
 - Layers will use the override layer settings and ignore the local file with no warning to the user.
 - Layer paths may not be duplicated in the layer override json file. They currently are.


### PR DESCRIPTION
- Bring back "Validation - Standard" as the default configuration
=> This is done by enabling "Info" messages to systematically getting something out of the validation layers

- Bring back editor settings states presets
=> This is to make sure that the users are exposed first to the most important settings: Presets, message filtering.