### PR TITLE
vkconfig: Log file location/working folder browser

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -44,7 +44,8 @@ Application::Application(const QString &executable_full_path, const QString &arg
     : executable_path(QDir::toNativeSeparators(executable_full_path)),
       working_folder(QDir::toNativeSeparators(QFileInfo(executable_full_path).path())),
       arguments(arguments),
-      log_file(QDir::toNativeSeparators(working_folder + QDir::separator() + QFileInfo(executable_full_path).baseName() + ".txt")),
+      log_file(
+          QDir::toNativeSeparators(QDir::homePath() + QDir::separator() + QFileInfo(executable_full_path).baseName() + ".txt")),
       override_layers(true) {}
 
 const char *GetPhysicalDeviceType(VkPhysicalDeviceType type) {

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -1004,11 +1004,11 @@ void MainWindow::SetupLaunchTree() {
     ui->launchTree->setItemWidget(launcher_folder_item, 1, _launcher_working);
     _launcher_working->setReadOnly(false);
 
-    // Comming soon
-    //    pLaunchWorkingFolderButton = new QPushButton();
-    //    pLaunchWorkingFolderButton->setText("...");
-    //    pLaunchWorkingFolderButton->setMinimumWidth(32);
-    //    ui->launchTree->setItemWidget(pLauncherFolder, 2, pLaunchWorkingFolderButton);
+    _launchWorkingFolderButton = new QPushButton();
+    _launchWorkingFolderButton->setText("...");
+    _launchWorkingFolderButton->setMinimumWidth(32);
+    ui->launchTree->setItemWidget(launcher_folder_item, 2, _launchWorkingFolderButton);
+    connect(_launchWorkingFolderButton, SIGNAL(clicked()), this, SLOT(launchSetWorkingFolder()));
 
     //////////////////////////////////////////////////////////////////
     // Command line arguments
@@ -1101,6 +1101,25 @@ void MainWindow::launchSetLogFile() {
     configurator._overridden_application_list[current_application_index]->log_file = log_file;
 
     _launcher_log_file_edit->setText(log_file);
+
+    configurator.SaveOverriddenApplicationList();
+}
+
+////////////////////////////////////////////////////////////////////
+void MainWindow::launchSetWorkingFolder() {
+    int current_application_index = _launcher_apps_combo->currentIndex();
+    Q_ASSERT(current_application_index >= 0);
+
+    const QString working_folder =
+        QDir::toNativeSeparators(QFileDialog::getExistingDirectory(this, tr("Set Working Folder To..."), ""));
+
+    // Do nothing if the user cancels out.
+    if (working_folder.isEmpty()) return;
+
+    Configurator &configurator = Configurator::Get();
+    configurator._overridden_application_list[current_application_index]->working_folder = working_folder;
+
+    _launcher_working->setText(working_folder);
 
     configurator.SaveOverriddenApplicationList();
 }

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -125,6 +125,7 @@ class MainWindow : public QMainWindow {
     void launchItemCollapsed(QTreeWidgetItem *item);
     void launchItemChanged(int index);
     void launchSetLogFile();
+    void launchSetWorkingFolder();
     void launchChangeLogFile(const QString &new_text);
     void launchChangeWorkingFolder(const QString &new_text);
     void launchArgsEdited(const QString &new_text);


### PR DESCRIPTION
Change-Id: Id773980a454f723163a21ef0d0386b2ce22acd1b
Address issues #1087 and #1090 
You can now browse for a working folder from the app launcher.

Policy change. Now by default the log file is put in the users home folder on all operating systems. During testing, not doing so has created issues on all three OS's (Windows, macOS, and Linux). The users home folder is the only folder we can really assume the user has write permissions.