### PR TITLE
vkconfig gui fixes and updates

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -1049,9 +1049,9 @@ void Configurator::LoadLayersFromPath(const QString &path, QVector<LayerFile *> 
 //////////////////////////////////////////////////////////////////////////
 // Populate a tree widget with the custom layer paths and the layers that
 // are being used in them.
-void Configurator::BuildCustomLayerTree(QTreeWidget *pTreeWidget) {
+void Configurator::BuildCustomLayerTree(QTreeWidget *tree_widget) {
     // Populate the tree
-    pTreeWidget->clear();
+    tree_widget->clear();
 
     // Building the list is not obvious. Each custom path may have multiple layers and there
     // could be duplicates, which are not allowed. The layer paths are traversed in order, and
@@ -1062,23 +1062,23 @@ void Configurator::BuildCustomLayerTree(QTreeWidget *pTreeWidget) {
         // Custom path is the parent tree item
         const QString &custom_path = QDir::toNativeSeparators(GetCustomLayersPath(custom_path_index));
 
-        QTreeWidgetItem *pItem = new QTreeWidgetItem();
-        pItem->setText(0, custom_path);
-        pTreeWidget->addTopLevelItem(pItem);
+        QTreeWidgetItem *item = new QTreeWidgetItem();
+        item->setText(0, custom_path);
+        tree_widget->addTopLevelItem(item);
 
         // Look for layers that are loaded that are also from this folder
         for (int i = 0; i < _available_Layers.length(); i++) {
-            LayerFile *pCandidate = _available_Layers[i];
+            LayerFile *candidate = _available_Layers[i];
 
-            QFileInfo fileInfo = pCandidate->_layer_path;
+            QFileInfo fileInfo = candidate->_layer_path;
             QString path = QDir::toNativeSeparators(fileInfo.path());
             if (path != custom_path) continue;
 
-            QTreeWidgetItem *pChild = new QTreeWidgetItem();
-            pChild->setText(0, pCandidate->_name);
-            pItem->addChild(pChild);
+            QTreeWidgetItem *child = new QTreeWidgetItem();
+            child->setText(0, candidate->_name);
+            item->addChild(child);
         }
-        pItem->setExpanded(true);
+        item->setExpanded(true);
     }
 }
 
@@ -1348,17 +1348,17 @@ bool Configurator::SaveConfiguration(Configuration *configuration) {
     QJsonObject layer_list;  // This list of layers
 
     for (int layer_index = 0; layer_index < configuration->_layers.size(); layer_index++) {
-        LayerFile *pLayer = configuration->_layers[layer_index];
+        LayerFile *layer = configuration->_layers[layer_index];
 
         QJsonObject json_settings;
 
         // Rank goes in here with settings
-        json_settings.insert("layer_rank", pLayer->_rank);
+        json_settings.insert("layer_rank", layer->_rank);
 
         // Loop through the actual settings
-        for (int setting_index = 0; setting_index < pLayer->_layer_settings.size(); setting_index++) {
+        for (int setting_index = 0; setting_index < layer->_layer_settings.size(); setting_index++) {
             QJsonObject setting;
-            LayerSetting *layer_settings = pLayer->_layer_settings[setting_index];
+            LayerSetting *layer_settings = layer->_layer_settings[setting_index];
 
             setting.insert("name", layer_settings->label);
             setting.insert("description", layer_settings->description);
@@ -1440,7 +1440,7 @@ bool Configurator::SaveConfiguration(Configuration *configuration) {
             json_settings.insert(layer_settings->name, setting);
         }
 
-        layer_list.insert(pLayer->_name, json_settings);
+        layer_list.insert(layer->_name, json_settings);
     }
 
     //////////////////////////////////////////////////////////
@@ -1504,17 +1504,17 @@ Configuration *Configurator::CreateEmptyConfiguration() {
 
 //////////////////////////////////////////////////////////////////////////////
 /// Load the default settings into an empty layer file container
-void Configurator::LoadDefaultSettings(LayerFile *pBlankLayer) {
-    const LayerSettingsDefaults *layer_settings_defaults = FindLayerSettings(pBlankLayer->_name);
+void Configurator::LoadDefaultSettings(LayerFile *blank_layer) {
+    const LayerSettingsDefaults *layer_settings_defaults = FindLayerSettings(blank_layer->_name);
 
     if (layer_settings_defaults == nullptr)  // Did we find any?
         return;
 
     // Create and pop them in....
     for (int s = 0; s < layer_settings_defaults->default_settings.size(); s++) {
-        LayerSetting *layer_settings = new LayerSetting();
-        *layer_settings = *layer_settings_defaults->default_settings[s];
-        pBlankLayer->_layer_settings.push_back(layer_settings);
+        LayerSetting *layer_setting = new LayerSetting();
+        *layer_setting = *layer_settings_defaults->default_settings[s];
+        blank_layer->_layer_settings.push_back(layer_setting);
     }
 }
 

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -773,10 +773,10 @@ void Configurator::RemoveCustomLayersPath(const QString &path) {
     Q_ASSERT(!path.isEmpty());
 
     for (int i = 0, n = _custom_layers_paths.size(); i < n; ++i) {
-        if (_custom_layers_paths[i] != path) continue;
-
-        RemoveCustomLayersPath(i);
-        break;
+        if (QDir::toNativeSeparators(_custom_layers_paths[i]) == QDir::toNativeSeparators(path)) {
+            RemoveCustomLayersPath(i);
+            break;
+        }
     }
 }
 

--- a/vkconfig/dlgcustompaths.cpp
+++ b/vkconfig/dlgcustompaths.cpp
@@ -48,7 +48,8 @@ void dlgCustomPaths::RepopulateTree() {
 }
 
 void dlgCustomPaths::on_pushButtonAdd_clicked() {
-    QString custom_folder = QFileDialog::getExistingDirectory(this, tr("Add Custom Layer Folder"), "", QFileDialog::DontUseNativeDialog);
+    QString custom_folder =
+        QFileDialog::getExistingDirectory(this, tr("Add Custom Layer Folder"), "", QFileDialog::DontUseNativeDialog);
 
     Configurator &configurator = Configurator::Get();
 

--- a/vkconfig/dlgcustompaths.cpp
+++ b/vkconfig/dlgcustompaths.cpp
@@ -48,9 +48,7 @@ void dlgCustomPaths::RepopulateTree() {
 }
 
 void dlgCustomPaths::on_pushButtonAdd_clicked() {
-    QFileDialog dialog(this);
-    dialog.setFileMode(QFileDialog::Directory);
-    QString custom_folder = dialog.getExistingDirectory(this, tr("Add Custom Layer Folder"), "");
+    QString custom_folder = QFileDialog::getExistingDirectory(this, tr("Add Custom Layer Folder"), "", QFileDialog::DontUseNativeDialog);
 
     Configurator &configurator = Configurator::Get();
 

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -204,9 +204,8 @@ dlgProfileEditor::~dlgProfileEditor() { delete ui; }
 ////////////////////////////////////////////////////////////
 /// Add a custom layer path, and update everything accordingly
 void dlgProfileEditor::on_pushButtonAddLayers_clicked() {
-    QFileDialog dialog(this);
-    dialog.setFileMode(QFileDialog::Directory);
-    QString custom_path = dialog.getExistingDirectory(this, tr("Add Custom Layer Folder"), "");
+    QString custom_path =
+        QFileDialog::getExistingDirectory(this, tr("Add Custom Layer Folder"), "", QFileDialog::DontUseNativeDialog);
 
     if (custom_path.isEmpty()) return;
     custom_path = QDir::toNativeSeparators(custom_path);

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -287,19 +287,19 @@ void dlgProfileEditor::LoadLayerDisplay(int nSelection) {
         if (layer_index == nSelection) ui->layerTree->setCurrentItem(item);
 
         // Add a combo box. Default has gray background which looks hidious
-        TreeFriendlyComboBox *pUse = new TreeFriendlyComboBox(item);
-        ui->layerTree->setItemWidget(item, 1, pUse);
+        TreeFriendlyComboBox *use = new TreeFriendlyComboBox(item);
+        ui->layerTree->setItemWidget(item, 1, use);
         item->setSizeHint(1, QSize(comboWidth, comboHeight));
 
-        pUse->addItem("Application-Controlled");
-        pUse->addItem("Overridden / Forced On");
-        pUse->addItem("Excluded / Forced Off");
+        use->addItem("Application-Controlled");
+        use->addItem("Overridden / Forced On");
+        use->addItem("Excluded / Forced Off");
 
-        if (item->layer_file->_enabled) pUse->setCurrentIndex(1);
+        if (item->layer_file->_enabled) use->setCurrentIndex(1);
 
-        if (item->layer_file->_disabled) pUse->setCurrentIndex(2);
+        if (item->layer_file->_disabled) use->setCurrentIndex(2);
 
-        connect(pUse, SIGNAL(selectionMade(QTreeWidgetItem *, int)), this, SLOT(layerUseChanged(QTreeWidgetItem *, int)));
+        connect(use, SIGNAL(selectionMade(QTreeWidgetItem *, int)), this, SLOT(layerUseChanged(QTreeWidgetItem *, int)));
 
         ///////////////////////////////////////////////////
         // Now for the children, which is just supplimental

--- a/vkconfig/dlgvulkananalysis.cpp
+++ b/vkconfig/dlgvulkananalysis.cpp
@@ -170,9 +170,9 @@ void dlgVulkanAnalysis::RunTool() {
         ui->externalTestsTable->setColumnCount(1);
         ui->externalTestsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
         ui->externalTestsTable->setShowGrid(false);
-        QTableWidgetItem *pItem = new QTableWidgetItem();
-        pItem->setText(tr("No SDK found by VIA, skipping test section"));
-        ui->externalTestsTable->setItem(0, 0, pItem);
+        QTableWidgetItem *item = new QTableWidgetItem();
+        item->setText(tr("No SDK found by VIA, skipping test section"));
+        ui->externalTestsTable->setItem(0, 0, item);
     }
 
     show();

--- a/vkconfig/dlgvulkaninfo.cpp
+++ b/vkconfig/dlgvulkaninfo.cpp
@@ -119,27 +119,27 @@ void dlgVulkanInfo::RunTool() {
     // Setp through each major section and parse.
     // All of these are the top layer nodes on the tree.
     QJsonValue rootObject = jsonTopObject.value(QString("Instance Extensions"));
-    QTreeWidgetItem *pParentNode = new QTreeWidgetItem();
-    pParentNode->setText(0, tr("Instance Extensions"));
-    ui->treeWidget->addTopLevelItem(pParentNode);
-    BuildExtensions(rootObject, pParentNode);
+    QTreeWidgetItem *parent_node = new QTreeWidgetItem();
+    parent_node->setText(0, tr("Instance Extensions"));
+    ui->treeWidget->addTopLevelItem(parent_node);
+    BuildExtensions(rootObject, parent_node);
 
     rootObject = jsonTopObject.value("Layer Properties");
-    pParentNode = new QTreeWidgetItem();
-    BuildLayers(rootObject, pParentNode);
+    parent_node = new QTreeWidgetItem();
+    BuildLayers(rootObject, parent_node);
 
     rootObject = jsonTopObject.value("Presentable Surfaces");
-    pParentNode = new QTreeWidgetItem();
-    BuildSurfaces(rootObject, pParentNode);
+    parent_node = new QTreeWidgetItem();
+    BuildSurfaces(rootObject, parent_node);
 
     rootObject = jsonTopObject.value("Device Groups");
-    pParentNode = new QTreeWidgetItem();
-    BuildGroups(rootObject, pParentNode);
+    parent_node = new QTreeWidgetItem();
+    BuildGroups(rootObject, parent_node);
 
     rootObject = jsonTopObject.value(tr("Device Properties and Extensions"));
-    pParentNode = new QTreeWidgetItem();
-    pParentNode->setText(0, "Device Properties and Extensions");
-    BuildDevices(rootObject, pParentNode);
+    parent_node = new QTreeWidgetItem();
+    parent_node->setText(0, "Device Properties and Extensions");
+    BuildDevices(rootObject, parent_node);
 
     show();
 }
@@ -231,15 +231,15 @@ void dlgVulkanInfo::BuildExtensions(QJsonValue &jsonValue, QTreeWidgetItem *pRoo
 /// \param pRoot        - Root of GUI tree
 /// This tree section has some different "kinds" of subtrees (the extensions)
 /// and some extra text formatting requirements, so it had to be treated specially.
-void dlgVulkanInfo::BuildLayers(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
+void dlgVulkanInfo::BuildLayers(QJsonValue &jsonValue, QTreeWidgetItem *root) {
     QJsonObject layersObject = jsonValue.toObject();
     int layersCount = layersObject.size();
 
     QString output = "Layers : count = ";
     output += QString().asprintf("%d", layersCount);
 
-    pRoot->setText(0, output);
-    ui->treeWidget->addTopLevelItem(pRoot);
+    root->setText(0, output);
+    ui->treeWidget->addTopLevelItem(root);
 
     // Loop through all the layers
     QStringList layers = layersObject.keys();
@@ -253,27 +253,27 @@ void dlgVulkanInfo::BuildLayers(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
         output += ", layer version ";
         output += layerObject.value("implementation version").toVariant().toString();
 
-        QTreeWidgetItem *pLayer = new QTreeWidgetItem();
-        pLayer->setText(0, output);
+        QTreeWidgetItem *layer = new QTreeWidgetItem();
+        layer->setText(0, output);
 
         // Each layer has extensions
         QJsonValue layerExtensions = layerObject.value("Layer Extensions");
         QJsonObject layerExtensionsObject = layerExtensions.toObject();
         int nExtCount = layerExtensionsObject.size();
         output = QString().asprintf("Layer Extensions: count = %d", nExtCount);
-        QTreeWidgetItem *pExtItem = new QTreeWidgetItem();
-        pExtItem->setText(0, output);
-        pLayer->addChild(pExtItem);
+        QTreeWidgetItem *ext_item = new QTreeWidgetItem();
+        ext_item->setText(0, output);
+        layer->addChild(ext_item);
 
-        BuildExtensions(layerExtensions, pExtItem);  // Generic enough
+        BuildExtensions(layerExtensions, ext_item);  // Generic enough
 
         // Each layer has devices too
         QJsonValue devicesValue = layerObject.value("Devices");
         QJsonObject devicesObject = devicesValue.toObject();
         int devCount = devicesObject.size();
-        QTreeWidgetItem *pDeviceItem = new QTreeWidgetItem();
-        pDeviceItem->setText(0, QString().asprintf("Devices: count = %d", devCount));
-        pLayer->addChild(pDeviceItem);
+        QTreeWidgetItem *device_item = new QTreeWidgetItem();
+        device_item->setText(0, QString().asprintf("Devices: count = %d", devCount));
+        layer->addChild(device_item);
         QStringList devicesList = devicesObject.keys();
         for (int dev = 0; dev < devCount; dev++) {
             QJsonValue gpuVal = devicesObject.value(devicesList[dev]);
@@ -284,9 +284,9 @@ void dlgVulkanInfo::BuildLayers(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
             output += " (";
             output += devicesList[dev];
             output += ")";
-            QTreeWidgetItem *pNoChildren = new QTreeWidgetItem();
-            pNoChildren->setText(0, output);
-            pDeviceItem->addChild(pNoChildren);
+            QTreeWidgetItem *no_child = new QTreeWidgetItem();
+            no_child->setText(0, output);
+            device_item->addChild(no_child);
 
             QJsonValue devExtVal = gpuObject.value("Layer-Device Extensions");
             QJsonObject devExtObj = devExtVal.toObject();
@@ -294,10 +294,10 @@ void dlgVulkanInfo::BuildLayers(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
             output = QString().asprintf("Layer-Device Extensions: count = %d", extCount);
             QTreeWidgetItem *pNext = new QTreeWidgetItem();
             pNext->setText(0, output);
-            pDeviceItem->addChild(pNext);
+            device_item->addChild(pNext);
             BuildExtensions(devExtVal, pNext);  // Generic enough
         }
-        pRoot->addChild(pLayer);
+        root->addChild(layer);
     }
 }
 
@@ -338,33 +338,33 @@ void dlgVulkanInfo::BuildGroups(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
 /// There is one section that can be handled by the TraverseGenericProperties()
 /// function, and just one section that is specifially needing the
 /// extensions list parser.
-void dlgVulkanInfo::BuildDevices(QJsonValue &jsonValue, QTreeWidgetItem *pRoot) {
+void dlgVulkanInfo::BuildDevices(QJsonValue &jsonValue, QTreeWidgetItem *root) {
     QJsonObject gpuObject = jsonValue.toObject();
 
-    pRoot->setText(0, tr("Device Properties and Extensions"));
-    ui->treeWidget->addTopLevelItem(pRoot);
+    root->setText(0, tr("Device Properties and Extensions"));
+    ui->treeWidget->addTopLevelItem(root);
 
     // For each like GPU0 object
     QStringList gpuList = gpuObject.keys();
     for (int i = 0; i < gpuObject.size(); i++) {
         QTreeWidgetItem *pGPU = new QTreeWidgetItem();
         pGPU->setText(0, gpuList[i]);
-        pRoot->addChild(pGPU);
+        root->addChild(pGPU);
 
         QJsonValue properties = gpuObject.value(gpuList[i]);
         QJsonObject propertiesObject = properties.toObject();
         QStringList propertyParents = propertiesObject.keys();
 
         for (int j = 0; j < propertiesObject.size(); j++) {
-            QTreeWidgetItem *pParent = new QTreeWidgetItem();
-            pParent->setText(0, propertyParents[j]);
-            pGPU->addChild(pParent);
+            QTreeWidgetItem *parent = new QTreeWidgetItem();
+            parent->setText(0, propertyParents[j]);
+            pGPU->addChild(parent);
             QJsonValue value = propertiesObject.value(propertyParents[j]);
 
             if (propertyParents[j] == QString("Device Extensions"))
-                BuildExtensions(value, pParent);
+                BuildExtensions(value, parent);
             else
-                TraverseGenericProperties(value, pParent);
+                TraverseGenericProperties(value, parent);
         }
     }
 }

--- a/vkconfig/layerfile.cpp
+++ b/vkconfig/layerfile.cpp
@@ -148,23 +148,23 @@ void LayerFile::LoadSettingsFromJson(QJsonObject& layerSettingsDescriptors, QVec
     // Okay, how many settings do we have?
     QStringList settingsNames = layerSettingsDescriptors.keys();
 
-    for (int iSetting = 0; iSetting < settingsNames.size(); iSetting++) {
+    for (int setting_index = 0, n = settingsNames.size(); setting_index < n; setting_index++) {
         // The layer rank may or may not be here, but it is not a
         // user setting.
-        if (settingsNames[iSetting] == QString("layer_rank")) continue;
+        if (settingsNames[setting_index] == QString("layer_rank")) continue;
 
-        LayerSetting* pLayerSettings = new LayerSetting;
-        pLayerSettings->name = settingsNames[iSetting];
+        LayerSetting* layer_setting = new LayerSetting;
+        layer_setting->name = settingsNames[setting_index];
 
-        QJsonValue settingValue = layerSettingsDescriptors.value(settingsNames[iSetting]);
+        QJsonValue settingValue = layerSettingsDescriptors.value(settingsNames[setting_index]);
         QJsonObject settingObject = settingValue.toObject();
 
         // The easy stuff...
         QJsonValue value = settingObject.value("description");
-        pLayerSettings->description = value.toString();
+        layer_setting->description = value.toString();
 
         value = settingObject.value("name");
-        pLayerSettings->label = value.toString();
+        layer_setting->label = value.toString();
 
         // This is either a single value, or a comma delimted set of strings
         // selected from a nonexclusive list
@@ -172,12 +172,12 @@ void LayerFile::LoadSettingsFromJson(QJsonObject& layerSettingsDescriptors, QVec
         if (value.isArray()) {
             QJsonArray array = value.toArray();
             for (int a = 0; a < array.size(); a++) {
-                pLayerSettings->value += array[a].toString();
-                if (a != array.size() - 1) pLayerSettings->value += ",";
+                layer_setting->value += array[a].toString();
+                if (a != array.size() - 1) layer_setting->value += ",";
             }
 
         } else
-            pLayerSettings->value = value.toString();
+            layer_setting->value = value.toString();
 
         ///////////////////////////////////////////////////////////////////////
         // Everything from here down revolves around the data type
@@ -187,7 +187,7 @@ void LayerFile::LoadSettingsFromJson(QJsonObject& layerSettingsDescriptors, QVec
         QString typeString = value.toString();
         ///////////////////////////////////////////////// Exclusive Enums
         if (typeString == QString("enum")) {
-            pLayerSettings->type = SETTING_EXCLUSIVE_LIST;
+            layer_setting->type = SETTING_EXCLUSIVE_LIST;
 
             // Now we have a list of options, both the enum for the settings file, and the prompts
             value = settingObject.value("options");
@@ -195,17 +195,17 @@ void LayerFile::LoadSettingsFromJson(QJsonObject& layerSettingsDescriptors, QVec
             QStringList keys, values;
             keys = object.keys();
             for (int v = 0; v < keys.size(); v++) {
-                pLayerSettings->exclusive_values << keys[v];
-                pLayerSettings->exclusive_labels << object.value(keys[v]).toString();
+                layer_setting->exclusive_values << keys[v];
+                layer_setting->exclusive_labels << object.value(keys[v]).toString();
             }
 
-            layers.push_back(pLayerSettings);
+            layers.push_back(layer_setting);
             continue;
         }
 
         /////////////////////////////////////////////////// Pick one or more from a list
         if (typeString == QString("multi_enum")) {
-            pLayerSettings->type = SETTING_INCLUSIVE_LIST;
+            layer_setting->type = SETTING_INCLUSIVE_LIST;
 
             // Now we have a list of options, both the enum for the settings file, and the prompts
             value = settingObject.value("options");
@@ -213,60 +213,60 @@ void LayerFile::LoadSettingsFromJson(QJsonObject& layerSettingsDescriptors, QVec
             QStringList keys, values;
             keys = object.keys();
             for (int v = 0; v < keys.size(); v++) {
-                pLayerSettings->inclusive_values << keys[v];
-                pLayerSettings->inclusive_labels << object.value(keys[v]).toString();
+                layer_setting->inclusive_values << keys[v];
+                layer_setting->inclusive_labels << object.value(keys[v]).toString();
             }
 
-            layers.push_back(pLayerSettings);
+            layers.push_back(layer_setting);
             continue;
         }
 
         ////////////////////////////////////////////////////// Select a file. Nice and simple
         if (typeString == QString("save_file")) {
-            pLayerSettings->type = SETTING_SAVE_FILE;
-            layers.push_back(pLayerSettings);
+            layer_setting->type = SETTING_SAVE_FILE;
+            layers.push_back(layer_setting);
             continue;
         }
 
         ////////////////////////////////////////////////////// Load a file.
         if (typeString == QString("load_file")) {
-            pLayerSettings->type = SETTING_LOAD_FILE;
-            layers.push_back(pLayerSettings);
+            layer_setting->type = SETTING_LOAD_FILE;
+            layers.push_back(layer_setting);
             continue;
         }
 
         ////////////////////////////////////////////////////// Folder to put screen shots in
         if (typeString == QString("save_folder")) {
-            pLayerSettings->type = SETTING_SAVE_FOLDER;
-            layers.push_back(pLayerSettings);
+            layer_setting->type = SETTING_SAVE_FOLDER;
+            layers.push_back(layer_setting);
             continue;
         }
 
         ////////////////////////////////////////////////////// Bool, also nice and simple ("true"/"false")
         if (typeString == QString("bool")) {
-            pLayerSettings->type = SETTING_BOOL;
-            layers.push_back(pLayerSettings);
+            layer_setting->type = SETTING_BOOL;
+            layers.push_back(layer_setting);
             continue;
         }
 
         //////////////////////////////////////////////////// Bool, but written out as 0 or 1
         if (typeString == QString("bool_numeric")) {
-            pLayerSettings->type = SETTING_BOOL_NUMERIC;
-            layers.push_back(pLayerSettings);
+            layer_setting->type = SETTING_BOOL_NUMERIC;
+            layers.push_back(layer_setting);
             continue;
         }
 
         //////////////////////////////////////////////////// VUID Filter List
         if (typeString == QString("vuid_exclude")) {
-            pLayerSettings->type = SETTING_VUID_FILTER;
-            layers.push_back(pLayerSettings);
+            layer_setting->type = SETTING_VUID_FILTER;
+            layers.push_back(layer_setting);
             continue;
         }
 
         ////////////////////////////////////////////////////// Just a string please
-        if (typeString == QString("string")) pLayerSettings->type = SETTING_STRING;
+        if (typeString == QString("string")) layer_setting->type = SETTING_STRING;
 
-        layers.push_back(pLayerSettings);
+        layers.push_back(layer_setting);
     }
 
     return;

--- a/vkconfig/layerfile.h
+++ b/vkconfig/layerfile.h
@@ -84,9 +84,9 @@ class LayerFile : public QObject {
         destination_layer_file->_layer_path = _layer_path;
 
         for (int i = 0; i < _layer_settings.length(); i++) {
-            LayerSetting* pSettings = new LayerSetting();
-            *pSettings = *_layer_settings[i];
-            destination_layer_file->_layer_settings.push_back(pSettings);
+            LayerSetting* setting = new LayerSetting();
+            *setting = *_layer_settings[i];
+            destination_layer_file->_layer_settings.push_back(setting);
         }
     }
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -186,8 +186,8 @@ void MainWindow::LoadConfigurationList() {
         item->configuration = configurator._available_configurations[i];
         ui->profileTree->addTopLevelItem(item);
         item->radio_button = new QRadioButton();
-#ifndef _WIN32  // This is a hack to workaround a Linux layout issue
-        item->radio_button->setText("-");
+#ifdef __APPLE__  // Mac OS does not leave enough space without this
+        item->radio_button->setText(" ");
 #endif
         item->radio_button->setToolTip(configurator._available_configurations[i]->_description);
         item->setText(1, configurator._available_configurations[i]->_name);


### PR DESCRIPTION
Fixed an unreported regression that made it impossible to remove a custom layer path.
Added the ability to see files in a folder when browsing for custom layer paths. This uses a non-OS supplied file browser dialog. (See issue #1098 )
WIP, possibly done: The appearance of the radio buttons for the configuration listing (radio button selects the configuration as the active one). It turns out the visual anomalies originally worked around originated on the Mac. We've gone back and forth a few times, but it seems the Mac fix was the actual problem, and then we fixed the fix... so to speak. No additional spacing seems to be required on Window, Ubuntu OR Fedora... only on macOS. The original macOS work around seems to really wreak havok on Fedora, but not having the work around actually looks better everywhere EXCEPT macOS. So I think the final solution is to put some #defines around it, and account for the issue only on macOS.