### PR TITLE
vkconfig: .pro file fix and description editiong

### DIFF
--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -135,7 +135,7 @@ dlgProfileEditor::dlgProfileEditor(QWidget *parent, Configuration *configuration
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     _configuration = configuration;
 
-    // We never edit a profile directly, we only edit a copy of it.
+    // Default, but may not be entirely true
     setWindowTitle("Create a new layers configuration");
 
     // Case 1: New profile (easiest case)
@@ -155,6 +155,7 @@ dlgProfileEditor::dlgProfileEditor(QWidget *parent, Configuration *configuration
     }
 
     ui->lineEditName->setText(_configuration->_name);
+    ui->lineEditDescription->setText(_configuration->_description);
 
     QTreeWidgetItem *header_item = ui->layerTree->headerItem();
 
@@ -412,6 +413,7 @@ void dlgProfileEditor::layerUseChanged(QTreeWidgetItem *item, int selection) {
 /// We are either saving an exisitng profile, or creating a new one.
 void dlgProfileEditor::accept() {
     _configuration->_name = ui->lineEditName->text();
+    _configuration->_description = ui->lineEditDescription->text();
 
     // Hard Fail: Name must not be blank
     if (_configuration->_name.isEmpty()) {

--- a/vkconfig/dlgprofileeditor.ui
+++ b/vkconfig/dlgprofileeditor.ui
@@ -317,10 +317,17 @@
       </size>
      </property>
      <property name="title">
-      <string>Layers Configuration Name</string>
+      <string>Layers Configuration Information</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineEditDescription">
+        <property name="placeholderText">
+         <string>Description of your user-defined configuration</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
        <widget class="QLineEdit" name="lineEditName">
         <property name="minimumSize">
          <size>
@@ -336,13 +343,26 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Description:</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>lineEditName</tabstop>
   <tabstop>layerTree</tabstop>
  </tabstops>
  <resources/>

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -39,7 +39,6 @@ SOURCES += \
     widget_tree_friendly_combobox.cpp \
     widget_vuid_search.cpp \
     appsingleton.cpp \
-    boolsettingwidget.cpp \
     dlgabout.cpp \
     dlgcreateassociation.cpp \
     dlgcustompaths.cpp \


### PR DESCRIPTION
Change-Id: I4a32b7fd8998a69225324057442ce8e30f089097
This addresses the issue #1091 and fixes a regression in the .pro file (CI builds with cmake, and the .pro file was broken for QtCreator builds.
Basic description editing was added to the layer editor dialog, as this was where it was originally. This can be iterated and/moved if needed, but seemed a good place to put this to me.