### PR TITLE
vkconfig: added path manager with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ build-android/external
 *.files
 *.includes
 .vscode/
+helper.cmake
+Vulkan-Headers/
+Vulkan-Tools/
+Vulkan-ValidationLayers/
+build-vkconfig*/

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -1613,8 +1613,6 @@ void Configurator::ImportConfiguration(const QString &full_import_path) {
         return;
     }
 
-    path.SetPath(PATH_IMPORT_CONFIGURATION, full_import_path);
-
     QTextStream in(&input);
     QTextStream out(&output);
 
@@ -1655,8 +1653,6 @@ void Configurator::ExportConfiguration(const QString &source_file, const QString
         msg.exec();
         return;
     }
-
-    path.SetPath(PATH_EXPORT_CONFIGURATION, full_export_path);
 
     QTextStream in(&input);
     QTextStream out(&output);

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -37,7 +37,6 @@
 
 #ifdef _WIN32
 #include <shlobj.h>
-#include <windows.h>
 #endif
 
 #include <vulkan/vulkan.h>
@@ -211,21 +210,10 @@ Configurator::Configurator()
     }
 
     SetPath(ConfigurationPath, main_path + "LunarG/vkconfig");
-    SetPath(OverrideLayersPath, main_path + "LunarG/vkconfig/override/VkLayer_override.json");
-    SetPath(OverrideSettingsPath, main_path + "LunarG/vkconfig/override/vk_layer_settings.txt");
-/*
-    _path.SetPath(PATH_CONFIGURATION, main_path + "LunarG/vkconfig");
+
+    //_path.SetPath(PATH_CONFIGURATION, main_path + "LunarG/vkconfig");
     _path.SetPath(PATH_OVERRIDE_LAYERS, main_path + "LunarG/vkconfig/override");
     _path.SetPath(PATH_OVERRIDE_SETTINGS, main_path + "LunarG/vkconfig/override");
-
-    OutputDebugString("Paths:\n");
-    OutputDebugString(GetPath(ConfigurationPath).toUtf8().constData());
-    OutputDebugString("\n");
-    OutputDebugString(GetPath(OverrideSettingsPath).toUtf8().constData());
-    OutputDebugString("\n");
-    OutputDebugString(GetPath(OverrideLayersPath).toUtf8().constData());
-    OutputDebugString("\n");
-*/
 #else
     QDir home = QDir::home();
     if (!home.cd(".local")) {
@@ -263,11 +251,11 @@ Configurator::Configurator()
     home = QDir::home();
     QString main_path = home.path() + QString("/.local/share/vulkan/");
     SetPath(ConfigurationPath, main_path + QString("lunarg-vkconfig/"));
-    SetPath(OverrideLayersPath, main_path + "implicit_layer.d/VkLayer_override.json");
-    SetPath(OverrideSettingsPath, main_path + "settings.d/vk_layer_settings.txt");
+    // SetPath(OverrideLayersPath, main_path + "implicit_layer.d/VkLayer_override.json");
+    // SetPath(OverrideSettingsPath, main_path + "settings.d/vk_layer_settings.txt");
 
-    //_path.SetPath(PATH_OVERRIDE_LAYERS, main_path + "implicit_layer.d");
-    //_path.SetPath(PATH_OVERRIDE_SETTINGS, main_path + "settings.d");
+    _path.SetPath(PATH_OVERRIDE_LAYERS, main_path + "implicit_layer.d");
+    _path.SetPath(PATH_OVERRIDE_SETTINGS, main_path + "settings.d");
 #endif
 
 // Check loader version
@@ -1521,8 +1509,8 @@ void Configurator::SetActiveConfiguration(Configuration *configuration) {
     _active_configuration = configuration;
     QSettings settings;
 
-    const QString override_settings_path = GetPath(OverrideSettingsPath);
-    const QString override_layers_path = GetPath(OverrideLayersPath);
+    const QString override_settings_path = path.GetFullPath(PATH_OVERRIDE_SETTINGS);
+    const QString override_layers_path = path.GetFullPath(PATH_OVERRIDE_LAYERS);
 
     // Clear the profile if null
     if (configuration == nullptr) {

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -112,8 +112,6 @@ class Configurator {
    public:
     enum Path {
         ConfigurationPath = 0,  // Where config working files live
-        OverrideSettingsPath,   // Where settings go when profile is active
-        OverrideLayersPath,     // Where json goes when profile is active
         LastImportPath,         // The last path used by the user to import a configuration
         LastExportPath,         // The last path used by the user to export a configuration
         LastExecutablePath,     // The last path used by the user when adding an executable to the application list

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -114,10 +114,9 @@ class Configurator {
         ConfigurationPath = 0,  // Where config working files live
         LastImportPath,         // The last path used by the user to import a configuration
         LastExportPath,         // The last path used by the user to export a configuration
-        LastExecutablePath,     // The last path used by the user when adding an executable to the application list
 
         FirstPath = ConfigurationPath,
-        LastPath = LastExecutablePath
+        LastPath = LastExportPath
     };
     enum { PathCount = LastPath - FirstPath + 1 };
 
@@ -255,9 +254,6 @@ class Configurator {
     void RemoveRegistryEntriesForLayers(QString qsJSONFile, QString qsSettingsFile);
 #endif
 
-   private:
-    PathManager _path;
-
    public:
-    const PathManager& path;
+    PathManager path;
 };

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -110,18 +110,8 @@ struct Application {
 
 class Configurator {
    public:
-    enum Path {
-        ConfigurationPath = 0,  // Where config working files live
-        LastImportPath,         // The last path used by the user to import a configuration
-        LastExportPath,         // The last path used by the user to export a configuration
-
-        FirstPath = ConfigurationPath,
-        LastPath = LastExportPath
-    };
-    enum { PathCount = LastPath - FirstPath + 1 };
-
     static Configurator& Get();
-    bool InitializeConfigurator(void);
+    bool Init();
 
     // Need this to check vulkan loader version
     uint32_t _vulkan_instance_version;
@@ -138,16 +128,11 @@ class Configurator {
     void SaveSettings();
     void ResetToDefaultSettings();
     bool HasActiveOverrideOnApplicationListOnly() const { return !_has_old_loader && _overridden_application_list_only; }
-    QString GetPath(Path requested_path) const;
-    void SetPath(Path requested_path, QString path);
 
     bool _override_active;                    // Do we have active layers override?
     bool _overridden_application_list_only;   // Apply the override only to the application list
     bool _override_permanent;                 // The override remains active when Vulkan Configurator closes
     bool _override_application_list_updated;  // The list of applications to override has possibly been updated
-
-   private:
-    QString _paths[PathCount];
 
     /////////////////////////////////////////////////////////////////////////
     // Validation Preset

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "../vkconfig_core/layer.h"
+#include "../vkconfig_core/path_manager.h"
 #include "configuration.h"
 
 #ifdef _WIN32
@@ -110,12 +111,12 @@ struct Application {
 class Configurator {
    public:
     enum Path {
-        ConfigurationPath = 0,     // Where config working files live
-        OverrideSettingsPath = 1,  // Where settings go when profile is active
-        OverrideLayersPath = 2,    // Where json goes when profile is active
-        LastImportPath = 3,        // The last path used by the user to import a configuration
-        LastExportPath = 4,        // The last path used by the user to export a configuration
-        LastExecutablePath = 5,    // The last path used by the user when adding an executable to the application list
+        ConfigurationPath = 0,  // Where config working files live
+        OverrideSettingsPath,   // Where settings go when profile is active
+        OverrideLayersPath,     // Where json goes when profile is active
+        LastImportPath,         // The last path used by the user to import a configuration
+        LastExportPath,         // The last path used by the user to export a configuration
+        LastExecutablePath,     // The last path used by the user when adding an executable to the application list
 
         FirstPath = ConfigurationPath,
         LastPath = LastExecutablePath
@@ -255,4 +256,10 @@ class Configurator {
     void AddRegistryEntriesForLayers(QString qsJSONFile, QString qsSettingsFile);
     void RemoveRegistryEntriesForLayers(QString qsJSONFile, QString qsSettingsFile);
 #endif
+
+   private:
+    PathManager _path;
+
+   public:
+    const PathManager& path;
 };

--- a/vkconfig/dlgcreateassociation.cpp
+++ b/vkconfig/dlgcreateassociation.cpp
@@ -105,23 +105,23 @@ void dlgCreateAssociation::on_pushButtonAdd_clicked()  // Pick the test applicat
 {
     Configurator &configurator = Configurator::Get();
 
-    QString filter = ("Applications (*)");  // Linux default
-
 #ifdef __APPLE__
-    filter = QString("Applications (*.app, *");
-#endif
-
-#ifdef _WIN32
-    filter = QString("Applications (*.exe)");
+    const QString filter("Applications (*.app, *)");
+#elif defined(_WIN32)
+    const QString filter("Applications (*.exe)");
+#elif defined __linux__
+    const QString filter("Applications (*)");
+#else
+#error "Unknown platform"
 #endif
 
     // Go get it.
-    QString full_suggested_path = configurator.GetPath(Configurator::LastExecutablePath);
+    QString full_suggested_path(configurator.path.GetPath(PATH_EXECUTABLE));
     QString executable_full_path = QFileDialog::getOpenFileName(this, "Select a Vulkan Executable", full_suggested_path, filter);
 
     // If they have selected something!
     if (!executable_full_path.isEmpty()) {
-        configurator.SetPath(Configurator::LastExecutablePath, executable_full_path);
+        configurator.path.SetPath(PATH_EXECUTABLE, executable_full_path);
 
         // On macOS, they may have selected a binary, or they may have selected an app bundle.
         // If the later, we need to drill down to the actuall applicaiton

--- a/vkconfig/dlgcreateassociation.cpp
+++ b/vkconfig/dlgcreateassociation.cpp
@@ -105,24 +105,11 @@ void dlgCreateAssociation::on_pushButtonAdd_clicked()  // Pick the test applicat
 {
     Configurator &configurator = Configurator::Get();
 
-#ifdef __APPLE__
-    const QString filter("Applications (*.app, *)");
-#elif defined(_WIN32)
-    const QString filter("Applications (*.exe)");
-#elif defined __linux__
-    const QString filter("Applications (*)");
-#else
-#error "Unknown platform"
-#endif
-
-    // Go get it.
-    QString full_suggested_path(configurator.path.GetPath(PATH_EXECUTABLE));
-    QString executable_full_path = QFileDialog::getOpenFileName(this, "Select a Vulkan Executable", full_suggested_path, filter);
+    const QString suggested_path = configurator.path.GetPath(PATH_EXECUTABLE);
+    QString executable_full_path = configurator.path.SelectPath(this, PATH_EXECUTABLE, suggested_path);
 
     // If they have selected something!
     if (!executable_full_path.isEmpty()) {
-        configurator.path.SetPath(PATH_EXECUTABLE, executable_full_path);
-
         // On macOS, they may have selected a binary, or they may have selected an app bundle.
         // If the later, we need to drill down to the actuall applicaiton
         if (executable_full_path.right(4) == QString(".app")) {
@@ -293,7 +280,8 @@ void dlgCreateAssociation::editLogFile(const QString &logFile) {
 /// you find in the /MacOS folder is the executable.
 /// The initial path is the folder where info.plist resides, and the
 /// path is completed to the executable upon completion.
-void dlgCreateAssociation::GetExecutableFromAppBundle(QString &path) {
+void dlgCreateAssociation::GetExecutableFromAppBundle(QString &app_path) {
+    QString path = app_path;
     path += "/Contents/";
     QString list_file = path + "Info.plist";
     QFile file(list_file);

--- a/vkconfig/dlgcustompaths.cpp
+++ b/vkconfig/dlgcustompaths.cpp
@@ -48,15 +48,14 @@ void dlgCustomPaths::RepopulateTree() {
 }
 
 void dlgCustomPaths::on_pushButtonAdd_clicked() {
-    QString custom_folder =
-        QFileDialog::getExistingDirectory(this, tr("Add Custom Layer Folder"), "", QFileDialog::DontUseNativeDialog);
-
     Configurator &configurator = Configurator::Get();
+    const QString custom_path = configurator.path.SelectPath(this, PATH_CUSTOM_LAYER_PATH);
 
-    if (!custom_folder.isEmpty()) {
-        configurator.AppendCustomLayersPath(custom_folder);
+    if (!custom_path.isEmpty()) {
+        configurator.AppendCustomLayersPath(custom_path);
+
         QTreeWidgetItem *item = new QTreeWidgetItem();
-        item->setText(0, custom_folder);
+        item->setText(0, custom_path);
         ui->treeWidget->addTopLevelItem(item);
 
         _paths_changed = true;

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -468,7 +468,7 @@ void dlgProfileEditor::accept() {
 
     // Prepare... get fully qualified file name, and double check if overwriting
     _configuration->_file = _configuration->_name + ".json";
-    const QString save_path = Configurator::Get().GetPath(Configurator::ConfigurationPath) + "/" + _configuration->_file;
+    const QString save_path = Configurator::Get().path.GetFullPath(PATH_CONFIGURATION, _configuration->_name);
 
     if (QDir().exists(save_path)) {
         QMessageBox warning;

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -211,13 +211,14 @@ dlgProfileEditor::~dlgProfileEditor() { delete ui; }
 ////////////////////////////////////////////////////////////
 /// Add a custom layer path, and update everything accordingly
 void dlgProfileEditor::on_pushButtonAddLayers_clicked() {
-    QString custom_path =
-        QFileDialog::getExistingDirectory(this, tr("Add Custom Layer Folder"), "", QFileDialog::DontUseNativeDialog);
+    Configurator &configurator = Configurator::Get();
+    const QString custom_path = configurator.path.SelectPath(this, PATH_CUSTOM_LAYER_PATH);
 
-    if (custom_path.isEmpty()) return;
-    custom_path = QDir::toNativeSeparators(custom_path);
+    if (custom_path.isEmpty()) {
+        return;
+    }
 
-    Configurator::Get().AppendCustomLayersPath(custom_path);
+    configurator.AppendCustomLayersPath(custom_path);
 
     _configuration->CollapseConfiguration();
     AddMissingLayers(_configuration);

--- a/vkconfig/dlgvulkaninfo.cpp
+++ b/vkconfig/dlgvulkaninfo.cpp
@@ -48,16 +48,15 @@ void dlgVulkanInfo::RunTool() {
     ui->treeWidget->clear();
 
     QProcess *vulkan_info = new QProcess(this);
+
 #ifdef _WIN32
     vulkan_info->setProgram("vulkaninfoSDK");
-#endif
-
-#ifdef __linux__
+#elif defined(__linux__)
     vulkan_info->setProgram("vulkaninfo");
-#endif
-
-#ifdef __APPLE__
+#elif defined(__APPLE__)
     vulkan_info->setProgram("/usr/local/bin/vulkaninfo");
+#else
+#error "Unknown platform"
 #endif
     QString filePath = QDir::temp().path();
 

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
             }
 
             // We simply cannot run without any layers
-            if (Configurator::Get().InitializeConfigurator() == false) return -1;
+            if (Configurator::Get().Init() == false) return -1;
 
             // The main GUI is driven here
             MainWindow main_window;

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -957,7 +957,7 @@ void MainWindow::ResetLaunchOptions() {
     _launcher_apps_combo->blockSignals(true);
     _launcher_apps_combo->clear();
 
-    for (int i = 0; i < configurator._overridden_application_list.size(); i++) {
+    for (int i = 0, n = configurator._overridden_application_list.size(); i < n; i++) {
         _launcher_apps_combo->addItem(configurator._overridden_application_list[i]->executable_path);
     }
 
@@ -969,15 +969,17 @@ void MainWindow::ResetLaunchOptions() {
     }
 
     int launch_application_index = configurator.GetLaunchApplicationIndex();
-    Q_ASSERT(launch_application_index >= 0);
+    assert(launch_application_index >= 0);
 
     configurator.SelectLaunchApplication(launch_application_index);
     _launcher_apps_combo->setCurrentIndex(launch_application_index);
 
+    const Application &application = *configurator._overridden_application_list[launch_application_index];
+
     // Reset working folder and command line choices
-    _launch_arguments->setText(configurator._overridden_application_list[launch_application_index]->arguments);
-    _launcher_working->setText(configurator._overridden_application_list[launch_application_index]->working_folder);
-    _launcher_log_file_edit->setText(configurator._overridden_application_list[launch_application_index]->log_file);
+    _launch_arguments->setText(application.arguments);
+    _launcher_working->setText(application.working_folder);
+    _launcher_log_file_edit->setText(application.log_file);
     _launcher_apps_combo->blockSignals(false);
 }
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -1105,15 +1105,15 @@ void MainWindow::launchItemCollapsed(QTreeWidgetItem *item) {
 ////////////////////////////////////////////////////////////////////
 void MainWindow::launchSetLogFile() {
     int current_application_index = _launcher_apps_combo->currentIndex();
-    Q_ASSERT(current_application_index >= 0);
-
-    const QString log_file =
-        QDir::toNativeSeparators(QFileDialog::getSaveFileName(this, tr("Set Log File To..."), ".", tr("Log text(*.txt)")));
-
-    // Do nothing if the user cancels out.
-    if (log_file.isEmpty()) return;
+    assert(current_application_index >= 0);
 
     Configurator &configurator = Configurator::Get();
+    const QString log_file = configurator.path.SelectPath(
+        this, PATH_LAUNCHER_LOG_FILE, configurator._overridden_application_list[current_application_index]->log_file);
+
+    // The user has cancel the operation
+    if (log_file.isEmpty()) return;
+
     configurator._overridden_application_list[current_application_index]->log_file = log_file;
 
     _launcher_log_file_edit->setText(log_file);
@@ -1124,15 +1124,15 @@ void MainWindow::launchSetLogFile() {
 ////////////////////////////////////////////////////////////////////
 void MainWindow::launchSetWorkingFolder() {
     int current_application_index = _launcher_apps_combo->currentIndex();
-    Q_ASSERT(current_application_index >= 0);
-
-    const QString working_folder =
-        QDir::toNativeSeparators(QFileDialog::getExistingDirectory(this, tr("Set Working Folder To..."), ""));
-
-    // Do nothing if the user cancels out.
-    if (working_folder.isEmpty()) return;
+    assert(current_application_index >= 0);
 
     Configurator &configurator = Configurator::Get();
+    const QString working_folder = configurator.path.SelectPath(
+        this, PATH_EXECUTABLE, configurator._overridden_application_list[current_application_index]->working_folder);
+
+    // The user has cancel the operation
+    if (working_folder.isEmpty()) return;
+
     configurator._overridden_application_list[current_application_index]->working_folder = working_folder;
 
     _launcher_working->setText(working_folder);
@@ -1142,22 +1142,22 @@ void MainWindow::launchSetWorkingFolder() {
 
 ///////////////////////////////////////////////////////////////////
 // Log file path edited manually.
-void MainWindow::launchChangeLogFile(const QString &new_text) {
+void MainWindow::launchChangeLogFile(const QString &log_file) {
     int current_application_index = _launcher_apps_combo->currentIndex();
-    Q_ASSERT(current_application_index >= 0);
+    assert(current_application_index >= 0);
 
     Configurator &configurator = Configurator::Get();
-    configurator._overridden_application_list[current_application_index]->log_file = new_text;
+    configurator._overridden_application_list[current_application_index]->log_file = log_file;
     configurator.SaveOverriddenApplicationList();
 }
 
 ////////////////////////////////////////////////////////////////////
-void MainWindow::launchChangeWorkingFolder(const QString &new_text) {
+void MainWindow::launchChangeWorkingFolder(const QString &working_folder) {
     int current_application_index = _launcher_apps_combo->currentIndex();
-    Q_ASSERT(current_application_index >= 0);
+    assert(current_application_index >= 0);
 
     Configurator &configurator = Configurator::Get();
-    configurator._overridden_application_list[current_application_index]->working_folder = new_text;
+    configurator._overridden_application_list[current_application_index]->working_folder = working_folder;
     configurator.SaveOverriddenApplicationList();
 }
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -553,8 +553,10 @@ void MainWindow::helpShowVulkanSpec(bool checked) {
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/windows/1.2-extensions/vkspec.html"));
 #elif defined(__APPLE__)
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/mac/1.2-extensions/vkspec.html"));
-#else
+#elif defined(__linux__)
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/linux/1.2-extensions/vkspec.html"));
+#else
+#error "Unknown platform"
 #endif
 }
 
@@ -566,8 +568,10 @@ void MainWindow::helpShowLayerSpec(bool checked) {
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/windows/layer_configuration.html"));
 #elif defined(__APPLE__)
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/mac/layer_configuration.html"));
-#else
+#elif defined(__linux__)
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/linux/layer_configuration.html"));
+#else
+#error "Unknown platform"
 #endif
 }
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -858,10 +858,7 @@ void MainWindow::ImportClicked(ConfigurationListItem *item) {
     (void)item;  // We don't need this
     Configurator &configurator = Configurator::Get();
 
-    QString full_suggested_path = configurator.path.GetPath(PATH_IMPORT_CONFIGURATION);
-    QString full_import_path =
-        QFileDialog::getOpenFileName(this, "Import Layers Configuration File", full_suggested_path, "*.json");
-
+    const QString full_import_path = configurator.path.SelectPath(this, PATH_IMPORT_CONFIGURATION);
     if (full_import_path.isEmpty()) return;
 
     SaveLastItem();
@@ -879,10 +876,8 @@ void MainWindow::ExportClicked(ConfigurationListItem *item) {
 
     Configurator &configurator = Configurator::Get();
 
-    // Where to put it and what to call it
-    QString full_suggested_path = configurator.path.GetFullPath(PATH_EXPORT_CONFIGURATION, item->configuration._name);
-    QString full_export_path =
-        QFileDialog::getSaveFileName(this, "Export Layers Configuration File", full_suggested_path, "*.json");
+    const QString full_suggested_path = configurator.path.GetFullPath(PATH_EXPORT_CONFIGURATION, item->configuration._name);
+    const QString full_export_path = configurator.path.SelectPath(this, PATH_EXPORT_CONFIGURATION, full_suggested_path);
     if (full_export_path.isEmpty()) return;
 
     configurator.ExportConfiguration(item->configuration._file, full_export_path);

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -30,6 +30,7 @@ SOURCES += \
     ..\vkconfig_core\layer.cpp \
     ..\vkconfig_core\layer_setting.cpp \
     ..\vkconfig_core\layer_type.cpp \
+    ..\vkconfig_core\path_manager.cpp \
     widget_bool_setting.cpp \
     widget_enum_setting.cpp \
     widget_multi_enum_setting.cpp \
@@ -60,6 +61,7 @@ HEADERS += \
     ..\vkconfig_core\layer.h \
     ..\vkconfig_core\layer_setting.h \
     ..\vkconfig_core\layer_type.h \
+    ..\vkconfig_core\path_manager.h \
     widget_bool_setting.h \
     widget_enum_setting.h \
     widget_multi_enum_setting.h \

--- a/vkconfig_core/command_line.h
+++ b/vkconfig_core/command_line.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #pragma once

--- a/vkconfig_core/path_manager.cpp
+++ b/vkconfig_core/path_manager.cpp
@@ -24,12 +24,12 @@
 #include <cassert>
 #include <cstddef>
 
-#include <QDir.h>
-#include <QFileInfo.h>
-#include <QString.h>
-#include <QSettings.h>
-#include <QWidget.h>
-#include <QFileDialog.h>
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+#include <QSettings>
+#include <QWidget>
+#include <QFileDialog>
 
 struct DirectoryDesc {
     const char* label;

--- a/vkconfig_core/path_manager.cpp
+++ b/vkconfig_core/path_manager.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#include "path_manager.h"
+#include "util.h"
+
+#include <cassert>
+#include <cstddef>
+
+#include <QDir.h>
+#include <QFileInfo.h>
+#include <QString.h>
+#include <QSettings.h>
+
+#include <windows.h>
+
+struct DirectoryDesc {
+    const char* label;
+    const char* default_extension;  // file extension
+    const char* setting;            // system token to store the path, if empty the directory is not saved
+    const char* default_filename;   // a default filename, if empty there is no default filename
+    const bool resettable;
+    Path alternative;
+};
+
+static const DirectoryDesc& GetDesc(Path directory) {
+    assert(directory >= PATH_FIRST && directory <= PATH_LAST);
+
+    static const DirectoryDesc table[] = {
+        // label, extension, setting, default_filename, resettable, alternative
+        {"configuration", ".json", nullptr, nullptr, false, PATH_CONFIGURATION},                        // PATH_CONFIGURATION
+        {"override settings", ".txt", nullptr, "vk_layer_settings", false, PATH_OVERRIDE_SETTINGS},     // PATH_OVERRIDE_SETTINGS
+        {"override layers", ".json", nullptr, "VkLayer_override", false, PATH_OVERRIDE_LAYERS},         // PATH_OVERRIDE_LAYERS
+        {"configuration import", ".json", "lastImportPath", nullptr, true, PATH_EXPORT_CONFIGURATION},  // PATH_IMPORT
+        {"configuration export", ".json", "lastExportPath", nullptr, true, PATH_IMPORT_CONFIGURATION},  // PATH_EXPORT
+#ifdef _WIN32
+        {"executable", ".exe", "lastExecutablePath", nullptr, true, PATH_EXECUTABLE},  // PATH_EXECUTABLE
+#else
+        {"executable", "", "lastExecutablePath", nullptr, true, PATH_EXECUTABLE},  // PATH_EXECUTABLE
+#endif
+        {"home path", "", nullptr, nullptr, false, PATH_HOME},  // PATH_HOME
+    };
+    static_assert(countof(table) == PATH_COUNT, "The tranlation table size doesn't match the enum number of elements");
+
+    return table[directory];
+}
+
+struct FilenameDesc {
+    const char* filename;
+};
+
+static const FilenameDesc& GetDesc(Filename filename) {
+    static const FilenameDesc table[] = {"applist.json"};
+
+    return table[filename];
+}
+
+PathManager::PathManager() {
+    paths[PATH_HOME] = QDir::toNativeSeparators(QDir::homePath()).toStdString();
+
+    QSettings settings;
+    for (std::size_t i = 0; i < PATH_COUNT; ++i) {
+        const Path type = static_cast<Path>(i);
+        if (GetDesc(type).setting == nullptr) continue;
+        paths[type] = settings.value(GetDesc(type).setting).toString().toUtf8().constData();
+    }
+}
+
+PathManager::~PathManager() {
+    QSettings settings;
+    for (std::size_t i = 0; i < PATH_COUNT; ++i) {
+        const Path type = static_cast<Path>(i);
+        if (GetDesc(type).setting == nullptr) continue;
+        settings.setValue(GetDesc(type).setting, paths[type].c_str());
+    }
+}
+
+void PathManager::Clear() {
+    for (std::size_t i = 0; i < PATH_COUNT; ++i) {
+        const Path type = static_cast<Path>(i);
+        paths[type].clear();
+    }
+
+    paths[PATH_HOME] = QDir::toNativeSeparators(QDir::homePath()).toStdString();
+}
+
+void PathManager::Reset() {
+    for (std::size_t i = 0; i < PATH_COUNT; ++i) {
+        const Path type = static_cast<Path>(i);
+
+        if (GetDesc(type).resettable) {
+            paths[type].clear();
+        }
+    }
+}
+
+const char* PathManager::GetPath(Path path) const {
+    assert(path >= PATH_FIRST && path <= PATH_LAST);
+
+    if (!paths[path].empty()) {
+        return paths[path].c_str();
+    }
+
+    const Path alternative_path = GetDesc(path).alternative;
+    if (!paths[alternative_path].empty()) {
+        return paths[alternative_path].c_str();
+    }
+
+    // No path found, return home directory
+    assert(!paths[PATH_HOME].empty());
+    return paths[PATH_HOME].c_str();
+}
+
+void PathManager::SetPath(Path path, const char* path_value) {
+    assert(path >= PATH_FIRST && path <= PATH_LAST);
+    assert(path_value);
+
+    const QDir directory(path_value);
+    const QString native_path = QDir::toNativeSeparators(directory.absolutePath());
+    paths[path] = native_path.toUtf8().constData();
+}
+
+void PathManager::SetPath(Path directory, const QString& path_value) {
+    assert(!path_value.isEmpty());
+
+    SetPath(directory, path_value.toStdString().c_str());
+}
+
+QString PathManager::GetFullPath(Path path, const char* filename) const {
+    const QFileInfo file_info(filename);
+
+    const QString path_base = GetPath(path);
+
+    const QString path_filename = filename != nullptr ? filename : GetDesc(path).default_filename;
+    assert(!path_filename.isEmpty());
+
+    const QString path_suffix =
+        !file_info.completeSuffix().isEmpty() ? file_info.completeSuffix() : GetDesc(path).default_extension;
+    assert(!path_suffix.isEmpty());
+
+    const QString full_path = QDir::toNativeSeparators(path_base + "/" + path_filename + path_suffix);
+    return full_path;
+}
+
+QString PathManager::GetFullPath(Path path, const QString& filename) const {
+    return GetFullPath(path, filename.toStdString().c_str());
+}
+
+QString PathManager::GetFullPath(Filename filename) const {
+    const QString path = GetPath(PATH_CONFIGURATION);
+
+    const QString full_path = QDir::toNativeSeparators(path + "/" + GetDesc(filename).filename);
+    return full_path;
+}
+
+QString PathManager::GetFilename(const char* full_path) const {
+    assert(full_path);
+
+    return QFileInfo(full_path).fileName();
+}

--- a/vkconfig_core/path_manager.cpp
+++ b/vkconfig_core/path_manager.cpp
@@ -29,8 +29,6 @@
 #include <QString.h>
 #include <QSettings.h>
 
-#include <windows.h>
-
 struct DirectoryDesc {
     const char* label;
     const char* default_extension;  // file extension

--- a/vkconfig_core/path_manager.h
+++ b/vkconfig_core/path_manager.h
@@ -35,9 +35,10 @@ enum Path {
     PATH_EXECUTABLE,            // The last path used by the user when adding an executable to the application list
     PATH_HOME,                  // The user home directory
     PATH_LAUNCHER_LOG_FILE,     // The last path used by the user to set the launcher log file
+    PATH_CUSTOM_LAYER_PATH,     // The last custom layer path
 
     PATH_FIRST = PATH_CONFIGURATION,
-    PATH_LAST = PATH_LAUNCHER_LOG_FILE
+    PATH_LAST = PATH_CUSTOM_LAYER_PATH
 };
 
 enum { PATH_COUNT = PATH_LAST - PATH_FIRST + 1 };
@@ -65,6 +66,7 @@ class PathManager {
     QString GetFilename(const char* full_path) const;
 
     QString SelectPath(QWidget* parent, Path path, const QString& suggested_path);
+    QString SelectPath(QWidget* parent, Path path);
 
     void Clear();
     void Reset();

--- a/vkconfig_core/path_manager.h
+++ b/vkconfig_core/path_manager.h
@@ -33,6 +33,7 @@ enum Path {
     PATH_IMPORT_CONFIGURATION,  // The last path used by the user to import a configuration
     PATH_EXPORT_CONFIGURATION,  // The last path used by the user to export a configuration
     PATH_EXECUTABLE,            // The last path used by the user when adding an executable to the application list
+    PATH_WORKING_DIR,           // The last path used as a working directory
     PATH_HOME,                  // The user home directory
     PATH_LAUNCHER_LOG_FILE,     // The last path used by the user to set the launcher log file
     PATH_CUSTOM_LAYER_PATH,     // The last custom layer path
@@ -42,6 +43,12 @@ enum Path {
 };
 
 enum { PATH_COUNT = PATH_LAST - PATH_FIRST + 1 };
+
+enum PathMode {
+    PATH_MODE_OPEN_DIRECTORY = 0,
+    PATH_MODE_OPEN_FILENAME,
+    PATH_MODE_SAVE_FILENAME,
+};
 
 enum Filename { FILENAME_APPLIST };
 

--- a/vkconfig_core/path_manager.h
+++ b/vkconfig_core/path_manager.h
@@ -26,13 +26,13 @@
 #include <string>
 
 enum Path {
-    PATH_CONFIGURATION = 0,         // Where config working files live
-    PATH_OVERRIDE_SETTINGS = 1,     // Where settings go when profile is active
-    PATH_OVERRIDE_LAYERS = 2,       // Where json goes when profile is active
-    PATH_IMPORT_CONFIGURATION = 3,  // The last path used by the user to import a configuration
-    PATH_EXPORT_CONFIGURATION = 4,  // The last path used by the user to export a configuration
-    PATH_EXECUTABLE = 5,            // The last path used by the user when adding an executable to the application list
-    PATH_HOME = 6,
+    PATH_CONFIGURATION = 0,     // Where config working files live
+    PATH_OVERRIDE_SETTINGS,     // Where settings go when profile is active
+    PATH_OVERRIDE_LAYERS,       // Where json goes when profile is active
+    PATH_IMPORT_CONFIGURATION,  // The last path used by the user to import a configuration
+    PATH_EXPORT_CONFIGURATION,  // The last path used by the user to export a configuration
+    PATH_EXECUTABLE,            // The last path used by the user when adding an executable to the application list
+    PATH_HOME,
 
     PATH_FIRST = PATH_CONFIGURATION,
     PATH_LAST = PATH_HOME

--- a/vkconfig_core/path_manager.h
+++ b/vkconfig_core/path_manager.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <QString>
+#include <QWidget>
 
 #include <array>
 #include <string>
@@ -32,10 +33,11 @@ enum Path {
     PATH_IMPORT_CONFIGURATION,  // The last path used by the user to import a configuration
     PATH_EXPORT_CONFIGURATION,  // The last path used by the user to export a configuration
     PATH_EXECUTABLE,            // The last path used by the user when adding an executable to the application list
-    PATH_HOME,
+    PATH_HOME,                  // The user home directory
+    PATH_LAUNCHER_LOG_FILE,     // The last path used by the user to set the launcher log file
 
     PATH_FIRST = PATH_CONFIGURATION,
-    PATH_LAST = PATH_HOME
+    PATH_LAST = PATH_LAUNCHER_LOG_FILE
 };
 
 enum { PATH_COUNT = PATH_LAST - PATH_FIRST + 1 };
@@ -56,11 +58,13 @@ class PathManager {
     void SetPath(Path path, const QString& path_value);
 
     // When filename is set to nullptr, the function will try to use the default filename if there is one for the DirectoryType
-    QString GetFullPath(Path directory, const char* filename = nullptr) const;
-    QString GetFullPath(Path directory, const QString& filename) const;
+    QString GetFullPath(Path path, const char* filename = nullptr) const;
+    QString GetFullPath(Path path, const QString& filename) const;
     QString GetFullPath(Filename filename) const;
 
     QString GetFilename(const char* full_path) const;
+
+    QString SelectPath(QWidget* parent, Path path, const QString& suggested_path);
 
     void Clear();
     void Reset();

--- a/vkconfig_core/path_manager.h
+++ b/vkconfig_core/path_manager.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#pragma once
+
+#include <QString>
+
+#include <array>
+#include <string>
+
+enum Path {
+    PATH_CONFIGURATION = 0,         // Where config working files live
+    PATH_OVERRIDE_SETTINGS = 1,     // Where settings go when profile is active
+    PATH_OVERRIDE_LAYERS = 2,       // Where json goes when profile is active
+    PATH_IMPORT_CONFIGURATION = 3,  // The last path used by the user to import a configuration
+    PATH_EXPORT_CONFIGURATION = 4,  // The last path used by the user to export a configuration
+    PATH_EXECUTABLE = 5,            // The last path used by the user when adding an executable to the application list
+    PATH_HOME = 6,
+
+    PATH_FIRST = PATH_CONFIGURATION,
+    PATH_LAST = PATH_HOME
+};
+
+enum { PATH_COUNT = PATH_LAST - PATH_FIRST + 1 };
+
+enum Filename { FILENAME_APPLIST };
+
+class PathManager {
+   public:
+    PathManager();
+    ~PathManager();
+
+    const char* GetPath(Path path) const;
+
+    // The path value should not have the filename
+    void SetPath(Path path, const char* path_value);
+
+    // The path value should not have the filename
+    void SetPath(Path path, const QString& path_value);
+
+    // When filename is set to nullptr, the function will try to use the default filename if there is one for the DirectoryType
+    QString GetFullPath(Path directory, const char* filename = nullptr) const;
+    QString GetFullPath(Path directory, const QString& filename) const;
+    QString GetFullPath(Filename filename) const;
+
+    QString GetFilename(const char* full_path) const;
+
+    void Clear();
+    void Reset();
+
+   private:
+    std::array<std::string, PATH_COUNT> paths;
+};

--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -20,8 +20,12 @@ vkConfigTest(test_util)
 vkConfigTest(test_version)
 vkConfigTest(test_command_line)
 vkConfigTest(test_layer)
+vkConfigTest(test_layer_manager)
 vkConfigTest(test_layer_setting)
 vkConfigTest(test_layer_type)
+vkConfigTest(test_configuration)
+vkConfigTest(test_configuration_manager)
+vkConfigTest(test_path_manager)
 
 
 

--- a/vkconfig_core/test/test_command_line.cpp
+++ b/vkconfig_core/test/test_command_line.cpp
@@ -27,7 +27,7 @@
 #include <gtest/gtest.h>
 
 TEST(test_command_line, execute_mode) {
-    char* argv[] = {"vkconfig"};
+    static char* argv[] = {"vkconfig"};
     int argc = static_cast<int>(countof(argv));
 
     CommandLine command_line(argc, argv);
@@ -36,7 +36,7 @@ TEST(test_command_line, execute_mode) {
 }
 
 TEST(test_command_line, usage_mode_help) {
-    char* argv[] = {"vkconfig", "--help"};
+    static char* argv[] = {"vkconfig", "--help"};
     int argc = static_cast<int>(countof(argv));
 
     CommandLine command_line(argc, argv);
@@ -45,7 +45,7 @@ TEST(test_command_line, usage_mode_help) {
 }
 
 TEST(test_command_line, usage_mode_h) {
-    char* argv[] = {"vkconfig", "-h"};
+    static char* argv[] = {"vkconfig", "-h"};
     int argc = static_cast<int>(countof(argv));
 
     CommandLine command_line(argc, argv);
@@ -54,7 +54,7 @@ TEST(test_command_line, usage_mode_h) {
 }
 
 TEST(test_command_line, usage_mode_invalid) {
-    char* argv[] = {"vkconfig", "--dfhsjfgasjkgf"};
+    static char* argv[] = {"vkconfig", "--dfhsjfgasjkgf"};
     int argc = static_cast<int>(countof(argv));
 
     CommandLine command_line(argc, argv);

--- a/vkconfig_core/test/test_configuration_manager.cpp
+++ b/vkconfig_core/test/test_configuration_manager.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Richard S. Wright Jr.
+ * - Christophe Riccio
+ */

--- a/vkconfig_core/test/test_layer_manager.cpp
+++ b/vkconfig_core/test/test_layer_manager.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Richard S. Wright Jr.
+ * - Christophe Riccio
+ */

--- a/vkconfig_core/test/test_path_manager.cpp
+++ b/vkconfig_core/test/test_path_manager.cpp
@@ -136,8 +136,7 @@ TEST(test_path_manager, check_default_filename) {
 
     const QString string = paths.GetFullPath(PATH_OVERRIDE_SETTINGS);
 
-    EXPECT_TRUE(string.contains("vk_layer_settings"));
-    EXPECT_TRUE(string.contains("txt"));
+    EXPECT_TRUE(string.endsWith("vk_layer_settings.txt"));
 }
 
 TEST(test_path_manager, check_default_suffix) {
@@ -146,6 +145,14 @@ TEST(test_path_manager, check_default_suffix) {
 
     const QString string = paths.GetFullPath(PATH_EXPORT_CONFIGURATION, "my_configuration");
 
-    EXPECT_TRUE(string.contains("my_configuration"));
-    EXPECT_TRUE(string.contains("json"));
+    EXPECT_TRUE(string.endsWith("my_configuration.json"));
+}
+
+TEST(test_path_manager, check_with_suffix) {
+    PathManager paths;
+    paths.Clear();
+
+    const QString string = paths.GetFullPath(PATH_EXPORT_CONFIGURATION, "my_configuration.json");
+
+    EXPECT_TRUE(string.endsWith("my_configuration.json"));
 }

--- a/vkconfig_core/test/test_path_manager.cpp
+++ b/vkconfig_core/test/test_path_manager.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#include "../path_manager.h"
+#include "../util.h"
+
+#include <QDir.h>
+#include <QFileInfo.h>
+
+#include <gtest/gtest.h>
+
+#include <windows.h>
+
+static PathManager CreatePathManager(const QString& path_value) {
+    PathManager paths;
+    for (int i = 0, n = PATH_COUNT; i < n; ++i) {
+        const Path path = static_cast<Path>(i);
+        paths.SetPath(path, path_value);
+    }
+    return paths;
+}
+
+static QString InitPath(const char* tail) {
+    const QDir dir(QString("vkconfig/test_path_manager/") + tail);
+    const QString native_path = QDir::toNativeSeparators(dir.absolutePath());
+    return native_path;
+}
+
+TEST(test_path_manager, init_first) {
+    const QString path_value = InitPath("init_first");
+    const PathManager& paths = CreatePathManager(path_value);
+
+    EXPECT_STREQ(path_value.toUtf8().constData(), paths.GetPath(PATH_FIRST));
+}
+
+TEST(test_path_manager, init_last) {
+    const QString path_value = InitPath("init_last");
+    const PathManager& paths = CreatePathManager(path_value);
+
+    EXPECT_STREQ(path_value.toUtf8().constData(), paths.GetPath(PATH_LAST));
+}
+
+TEST(test_path_manager, init_all) {
+    PathManager paths;
+    paths.Clear();
+
+    for (int i = PATH_FIRST, n = PATH_LAST; i <= n; ++i) {
+        const Path path = static_cast<Path>(i);
+
+        QString init_path = InitPath("init_all_%d");
+        std::string path_string = format(init_path.toUtf8().constData(), i);
+
+        paths.SetPath(path, path_string.c_str());
+
+        EXPECT_STREQ(path_string.c_str(), paths.GetPath(path));
+    }
+}
+
+TEST(test_path_manager, path_format) {
+    static const char* table[] = {
+        "/vkconfig/test\\path/format/",  "/vkconfig/test\\path/format\\", "/vkconfig\\test/path/format/",
+        "/vkconfig\\test/path\\format/", "/vkconfig\\test/path/format",   "/vkconfig/test/path/format",
+        "\\vkconfig\\test/path\\format", "/vkconfig/test/path/format/",   "\\vkconfig\\test/path\\format\\"};
+
+    for (std::size_t i = 0, n = countof(table); i < n; ++i) {
+        PathManager paths;
+        paths.Clear();
+        paths.SetPath(PATH_CONFIGURATION, QDir::homePath() + table[i]);
+
+        const QString path = paths.GetPath(PATH_CONFIGURATION);
+        const QString home_path(paths.GetPath(PATH_HOME));
+
+        const bool is_windows_path = path == (home_path + "\\vkconfig\\test\\path\\format");
+        const bool is_unix_path = path == (home_path + "/vkconfig/test/path/format");
+
+        EXPECT_NE(is_windows_path, is_unix_path);
+        EXPECT_TRUE(is_windows_path || is_unix_path);
+    }
+}
+
+// Test that GetPath return the home directory when the stored path is empty
+TEST(test_path_manager, empty_home) {
+    PathManager paths;
+    paths.Clear();
+
+    EXPECT_STRNE(paths.GetPath(PATH_HOME), "");
+    EXPECT_STREQ(paths.GetPath(PATH_HOME), paths.GetPath(PATH_FIRST));
+}
+
+// Test that export path is used as an alternative to import path when import path is empty
+TEST(test_path_manager, empty_import) {
+    PathManager paths;
+    paths.Clear();
+    paths.SetPath(PATH_EXPORT_CONFIGURATION, InitPath("empty_import"));
+
+    EXPECT_STRNE(paths.GetPath(PATH_IMPORT_CONFIGURATION), paths.GetPath(PATH_HOME));
+    EXPECT_STREQ(paths.GetPath(PATH_EXPORT_CONFIGURATION), paths.GetPath(PATH_IMPORT_CONFIGURATION));
+}
+
+// Test that import path is used as an alternative to export path when export path is empty
+TEST(test_path_manager, empty_export) {
+    PathManager paths;
+    paths.Clear();
+    paths.SetPath(PATH_IMPORT_CONFIGURATION, InitPath("empty_export"));
+
+    EXPECT_STRNE(paths.GetPath(PATH_EXPORT_CONFIGURATION), paths.GetPath(PATH_HOME));
+    EXPECT_STREQ(paths.GetPath(PATH_IMPORT_CONFIGURATION), paths.GetPath(PATH_EXPORT_CONFIGURATION));
+}
+
+TEST(test_path_manager, check_missing_dir) {
+    PathManager paths;
+    paths.Clear();
+    paths.SetPath(PATH_CONFIGURATION, InitPath("check_missing_dir"));
+
+    EXPECT_TRUE(strstr(paths.GetPath(PATH_CONFIGURATION), "check_missing_dir") != nullptr);
+}
+
+TEST(test_path_manager, check_default_filename) {
+    PathManager paths;
+    paths.Clear();
+
+    const QString string = paths.GetFullPath(PATH_OVERRIDE_SETTINGS);
+
+    EXPECT_TRUE(string.contains("vk_layer_settings"));
+    EXPECT_TRUE(string.contains("txt"));
+}
+
+TEST(test_path_manager, check_default_suffix) {
+    PathManager paths;
+    paths.Clear();
+
+    const QString string = paths.GetFullPath(PATH_EXPORT_CONFIGURATION, "my_configuration");
+
+    EXPECT_TRUE(string.contains("my_configuration"));
+    EXPECT_TRUE(string.contains("json"));
+}

--- a/vkconfig_core/test/test_path_manager.cpp
+++ b/vkconfig_core/test/test_path_manager.cpp
@@ -21,12 +21,10 @@
 #include "../path_manager.h"
 #include "../util.h"
 
-#include <QDir.h>
-#include <QFileInfo.h>
+#include <QDir>
+#include <QFileInfo>
 
 #include <gtest/gtest.h>
-
-#include <windows.h>
 
 static PathManager CreatePathManager(const QString& path_value) {
     PathManager paths;

--- a/vkconfig_core/util.h
+++ b/vkconfig_core/util.h
@@ -27,6 +27,10 @@
 #include <array>
 #include <vector>
 
+#if defined(_WIN32) && defined(_DEBUG)
+#include <windows.h>  // For OutputDebugString
+#endif
+
 // Based on https://www.g-truc.net/post-0708.html#menu
 template <typename T, std::size_t N>
 inline constexpr std::size_t countof(T const (&)[N]) noexcept {


### PR DESCRIPTION
- Added path manager with unit tests
- Removed VulkanLayerManager temp directory
- Added cache of browsed paths
- Fixed display of path not necessarily using the system separator (using the path_manager)
- Updated .gitignore
- Fixed popup error window on unsupported Json files

Change-Id: I6d274b75a2b2cedf54c01db2058e727b533ea8b4