### PR TITLE
vkconfig: Improve default applications handling 

### DIFF
--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -142,7 +142,7 @@ class Configurator {
    public:
     void SelectLaunchApplication(int application_index);
     int GetLaunchApplicationIndex() const;
-    void FindVkCube();
+    void UpdateDefaultApplications(const bool add_default_applications);
 
    private:
     QString _active_launch_executable_path;  // This is to match up with the application list
@@ -170,7 +170,7 @@ class Configurator {
     /////////////////////////////////////////////////////////////////////////
     // The list of applications affected
    public:
-    QVector<Application*> _overridden_application_list;
+    QVector<Application*> _overridden_applications;
     void LoadOverriddenApplicationList();
     void SaveOverriddenApplicationList();
     bool HasOverriddenApplications() const;

--- a/vkconfig/dlgcreateassociation.cpp
+++ b/vkconfig/dlgcreateassociation.cpp
@@ -42,12 +42,12 @@ dlgCreateAssociation::dlgCreateAssociation(QWidget *parent)
         setWindowTitle("Applications Launcher Shortcuts");
     else {
         ui->treeWidget->setHeaderHidden(false);
-        ui->treeWidget->setHeaderLabel("Uncheck to use for launcher shortcut only");
+        ui->treeWidget->setHeaderLabel("Check to override Vulkan layers");
     }
 
     // Show the current list
-    for (int i = 0; i < configurator._overridden_application_list.size(); i++)
-        CreateApplicationItem(*configurator._overridden_application_list[i]);
+    for (int i = 0; i < configurator._overridden_applications.size(); i++)
+        CreateApplicationItem(*configurator._overridden_applications[i]);
 
     ui->treeWidget->installEventFilter(this);
 
@@ -89,7 +89,7 @@ void dlgCreateAssociation::closeEvent(QCloseEvent *event) {
     // When we don't use overridden list only, no need to alert the user about empty list cases.
     if (!configurator._overridden_application_list_only) return;
 
-    if (configurator._overridden_application_list.empty() || !configurator.HasOverriddenApplications()) {
+    if (configurator._overridden_applications.empty() || !configurator.HasOverriddenApplications()) {
         QMessageBox alert;
         alert.setIcon(QMessageBox::Warning);
         alert.setWindowTitle("Vulkan Layers overriding will apply globally.");
@@ -118,7 +118,7 @@ void dlgCreateAssociation::on_pushButtonAdd_clicked()  // Pick the test applicat
         }
 
         Application *new_application = new Application(executable_full_path, "");
-        configurator._overridden_application_list.push_back(new_application);
+        configurator._overridden_applications.push_back(new_application);
 
         QTreeWidgetItem *item = CreateApplicationItem(*new_application);
 
@@ -159,7 +159,7 @@ void dlgCreateAssociation::on_pushButtonRemove_clicked() {
 
     ui->treeWidget->takeTopLevelItem(iSel);
     ui->treeWidget->setCurrentItem(nullptr);
-    configurator._overridden_application_list.removeAt(iSel);
+    configurator._overridden_applications.removeAt(iSel);
 
     ui->groupLaunchInfo->setEnabled(false);
     ui->pushButtonRemove->setEnabled(false);
@@ -207,9 +207,9 @@ void dlgCreateAssociation::selectedPathChanged(QTreeWidgetItem *current_item, QT
 
     Configurator &configurator = Configurator::Get();
 
-    ui->lineEditWorkingFolder->setText(configurator._overridden_application_list[_last_selected_application_index]->working_folder);
-    ui->lineEditCmdArgs->setText(configurator._overridden_application_list[_last_selected_application_index]->arguments);
-    ui->lineEditLogFile->setText(configurator._overridden_application_list[_last_selected_application_index]->log_file);
+    ui->lineEditWorkingFolder->setText(configurator._overridden_applications[_last_selected_application_index]->working_folder);
+    ui->lineEditCmdArgs->setText(configurator._overridden_applications[_last_selected_application_index]->arguments);
+    ui->lineEditLogFile->setText(configurator._overridden_applications[_last_selected_application_index]->log_file);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -218,7 +218,7 @@ void dlgCreateAssociation::itemChanged(QTreeWidgetItem *item, int column) {
     QCheckBox *check_box = dynamic_cast<QCheckBox *>(ui->treeWidget->itemWidget(item, column));
     if (check_box != nullptr) {
         Configurator &configurator = Configurator::Get();
-        configurator._overridden_application_list[_last_selected_application_index]->override_layers = check_box->isChecked();
+        configurator._overridden_applications[_last_selected_application_index]->override_layers = check_box->isChecked();
     }
 }
 
@@ -241,8 +241,8 @@ void dlgCreateAssociation::itemClicked(bool clicked) {
         QCheckBox *check_box = dynamic_cast<QCheckBox *>(ui->treeWidget->itemWidget(item, 0));
         Q_ASSERT(check_box != nullptr);
         bool is_checked = check_box->isChecked();
-        if (configurator._overridden_application_list[i]->override_layers != is_checked) {  // We've changed
-            configurator._overridden_application_list[i]->override_layers = is_checked;
+        if (configurator._overridden_applications[i]->override_layers != is_checked) {  // We've changed
+            configurator._overridden_applications[i]->override_layers = is_checked;
             ui->treeWidget->setCurrentItem(item);
         }
     }
@@ -254,7 +254,7 @@ void dlgCreateAssociation::editCommandLine(const QString &cmdLine) {
     _last_selected_application_index = ui->treeWidget->indexOfTopLevelItem(current);
     if (_last_selected_application_index < 0) return;
 
-    Configurator::Get()._overridden_application_list[_last_selected_application_index]->arguments = cmdLine;
+    Configurator::Get()._overridden_applications[_last_selected_application_index]->arguments = cmdLine;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -263,7 +263,7 @@ void dlgCreateAssociation::editWorkingFolder(const QString &workingFolder) {
     _last_selected_application_index = ui->treeWidget->indexOfTopLevelItem(current);
     if (_last_selected_application_index < 0) return;
 
-    Configurator::Get()._overridden_application_list[_last_selected_application_index]->working_folder = workingFolder;
+    Configurator::Get()._overridden_applications[_last_selected_application_index]->working_folder = workingFolder;
 }
 
 void dlgCreateAssociation::editLogFile(const QString &logFile) {
@@ -271,7 +271,7 @@ void dlgCreateAssociation::editLogFile(const QString &logFile) {
     _last_selected_application_index = ui->treeWidget->indexOfTopLevelItem(current);
     if (_last_selected_application_index < 0) return;
 
-    Configurator::Get()._overridden_application_list[_last_selected_application_index]->log_file = logFile;
+    Configurator::Get()._overridden_applications[_last_selected_application_index]->log_file = logFile;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/vkconfig/dlgcreateassociation.ui
+++ b/vkconfig/dlgcreateassociation.ui
@@ -17,7 +17,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Applications to Override</string>
+   <string>Applications to override Vulkan Layers</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="4" column="0">
@@ -43,7 +43,7 @@
       <bool>false</bool>
      </property>
      <property name="text">
-      <string>Select This App</string>
+      <string>Ok</string>
      </property>
     </widget>
    </item>

--- a/vkconfig_core/layer_type.cpp
+++ b/vkconfig_core/layer_type.cpp
@@ -14,13 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * The vkConfig2 program monitors and adjusts the Vulkan configuration
- * environment. These settings are wrapped in this class, which serves
- * as the "model" of the system.
- *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #include "layer_type.h"
@@ -32,7 +28,7 @@
 const char* GetLayerTypeLabel(LayerType type) {
     assert(type >= LAYER_TYPE_FIRST && type <= LAYER_TYPE_LAST);
 
-    const char* table[] = {
+    static const char* table[] = {
         "Explicit",    // LAYER_TYPE_EXPLICIT
         "Implicit",    // LAYER_TYPE_IMPLICIT
         "Custom Path"  // LAYER_TYPE_CUSTOM


### PR DESCRIPTION
- If the executable doesn't exist, try to replace it.
- Handle the case where the user could include multiple versions of vkcube.
- First use the relative path to vkconfig to use the one from the SDK.
- Add vkcubepp.
- When the list is empty, add default applications.