### PR TITLE
vkconfig: Filter out VK_DBG_LAYER_ACTION_DEBUG_OUTPUT on Linux and macOS #1086

### DIFF
--- a/vkconfig/dlgvulkananalysis.cpp
+++ b/vkconfig/dlgvulkananalysis.cpp
@@ -57,7 +57,7 @@ void dlgVulkanAnalysis::RunTool() {
     ui->physicalDevicesTable->clear();
 
     QProcess *via = new QProcess(this);
-#ifdef __APPLE__
+#if PLATFORM_MACOS
     via->setProgram("/usr/local/bin/vkvia");
 #else
     via->setProgram("vkvia");

--- a/vkconfig/dlgvulkaninfo.cpp
+++ b/vkconfig/dlgvulkaninfo.cpp
@@ -22,8 +22,10 @@
 #include "dlgvulkaninfo.h"
 #include "ui_dlgvulkaninfo.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include "../vkconfig_core/platform.h"
+
+#include <cstdio>
+#include <cstdlib>
 
 #include <QProcess>
 #include <QFile>
@@ -49,11 +51,11 @@ void dlgVulkanInfo::RunTool() {
 
     QProcess *vulkan_info = new QProcess(this);
 
-#ifdef _WIN32
+#if PLATFORM_WINDOWS
     vulkan_info->setProgram("vulkaninfoSDK");
-#elif defined(__linux__)
+#elif PLATFORM_LINUX
     vulkan_info->setProgram("vulkaninfo");
-#elif defined(__APPLE__)
+#elif PLATFORM_MACOS
     vulkan_info->setProgram("/usr/local/bin/vulkaninfo");
 #else
 #error "Unknown platform"

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -31,6 +31,7 @@
 
 #include "../vkconfig_core/util.h"
 #include "../vkconfig_core/version.h"
+#include "../vkconfig_core/platform.h"
 
 #include "ui_mainwindow.h"
 
@@ -46,7 +47,7 @@
 #include <QLineEdit>
 #include <QDesktopServices>
 
-#ifndef _WIN32
+#if PLATFORM_LINUX || PLATFORM_MACOS
 #include <unistd.h>
 #endif
 
@@ -60,7 +61,7 @@ const char *EDITOR_CAPTION_EMPTY = "Configuration Layer Settings";
 static const int LAUNCH_COLUMN0_SIZE = 220;
 static const int LAUNCH_COLUMN2_SIZE = 32;
 static const int LAUNCH_SPACING_SIZE = 2;
-#ifdef __APPLE__
+#if PLATFORM_MACOS
 static const int LAUNCH_ROW_HEIGHT = 26;
 #else
 static const int LAUNCH_ROW_HEIGHT = 28;
@@ -190,7 +191,7 @@ void MainWindow::LoadConfigurationList() {
         ConfigurationListItem *item = new ConfigurationListItem(*configurator._available_configurations[i]);
         ui->profileTree->addTopLevelItem(item);
         item->radio_button = new QRadioButton();
-#ifdef __APPLE__  // Mac OS does not leave enough space without this
+#if PLATFORM_MACOS  // Mac OS does not leave enough space without this
         item->radio_button->setText(" ");
 #endif
         item->radio_button->setToolTip(configurator._available_configurations[i]->_description);
@@ -551,11 +552,11 @@ void MainWindow::helpShowHelp(bool checked) {
 // Open the web browser to the Vulkan specification
 void MainWindow::helpShowVulkanSpec(bool checked) {
     (void)checked;
-#ifdef _WIN32
+#if PLATFORM_WINDOWS
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/windows/1.2-extensions/vkspec.html"));
-#elif defined(__APPLE__)
+#elif PLATFORM_MACOS
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/mac/1.2-extensions/vkspec.html"));
-#elif defined(__linux__)
+#elif PLATFORM_LINUX
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/linux/1.2-extensions/vkspec.html"));
 #else
 #error "Unknown platform"
@@ -566,11 +567,11 @@ void MainWindow::helpShowVulkanSpec(bool checked) {
 // Open the web browser to the Vulkan Layers specification
 void MainWindow::helpShowLayerSpec(bool checked) {
     (void)checked;
-#ifdef _WIN32
+#if PLATFORM_WINDOWS
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/windows/layer_configuration.html"));
-#elif defined(__APPLE__)
+#elif PLATFORM_MACOS
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/mac/layer_configuration.html"));
-#elif defined(__linux__)
+#elif PLATFORM_LINUX
     QDesktopServices::openUrl(QUrl("https://vulkan.lunarg.com/doc/view/latest/linux/layer_configuration.html"));
 #else
 #error "Unknown platform"

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "../vkconfig_core/layer.h"
+#include "../vkconfig_core/platform.h"
 
 #include <QFile>
 #include <QMessageBox>
@@ -199,6 +200,7 @@ void Layer::LoadSettingsFromJson(QJsonObject& json_layer_settings, QVector<Layer
                 QStringList keys, values;
                 keys = object.keys();
                 for (int v = 0; v < keys.size(); v++) {
+                    if (!PLATFORM_WINDOWS && keys[v] == "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT") continue;
                     setting->exclusive_values << keys[v];
                     setting->exclusive_labels << object.value(keys[v]).toString();
                 }
@@ -210,6 +212,7 @@ void Layer::LoadSettingsFromJson(QJsonObject& json_layer_settings, QVector<Layer
                 QStringList keys, values;
                 keys = object.keys();
                 for (int v = 0; v < keys.size(); v++) {
+                    if (!PLATFORM_WINDOWS && keys[v] == "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT") continue;
                     setting->inclusive_values << keys[v];
                     setting->inclusive_labels << object.value(keys[v]).toString();
                 }

--- a/vkconfig_core/path_manager.cpp
+++ b/vkconfig_core/path_manager.cpp
@@ -20,6 +20,7 @@
 
 #include "path_manager.h"
 #include "util.h"
+#include "platform.h"
 
 #include <cassert>
 #include <cstddef>
@@ -211,11 +212,11 @@ QString PathManager::SelectPathImpl(QWidget* parent, Path path, const QString& s
             return GetFullPath(path, QFileInfo(selected_path).baseName());
         } break;
         case PATH_EXECUTABLE: {
-#ifdef __APPLE__
+#if PLATFORM_MACOS
             const QString filter("Applications (*.app, *)");
-#elif defined(_WIN32)
+#elif PLATFORM_WINDOWS
             const QString filter("Applications (*.exe)");
-#elif defined __linux__
+#elif PLATFORM_LINUX
             const QString filter("Applications (*)");
 #else
 #error "Unknown platform"

--- a/vkconfig_core/platform.h
+++ b/vkconfig_core/platform.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#pragma once
+
+#ifdef _WIN32
+#define PLATFORM_WINDOWS 1
+#define PLATFORM_LINUX 0
+#define PLATFORM_MACOS 0
+
+#elif defined(__linux__)
+#define PLATFORM_WINDOWS 0
+#define PLATFORM_LINUX 1
+#define PLATFORM_MACOS 0
+
+#elif defined(__APPLE__)
+#define PLATFORM_WINDOWS 0
+#define PLATFORM_LINUX 0
+#define PLATFORM_MACOS 1
+
+#else
+#error "Unknown platform"
+#endif


### PR DESCRIPTION
Also add vkconfig dedicated PLATFORM_ define to allow using them within C++ expression to catch more build errors on all platforms.

Change-Id: I56bbaf013e69675f5284d59aed1e0c4645539e1e