### PR TITLE
vkconfig: layer configuration versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 CMakeCache.txt
 CMakeLists.txt.user
 CMakeFiles/
+Testing/
 cmake_install.cmake
 Makefile
 scripts/__pycache__

--- a/vkconfig/appsingleton.cpp
+++ b/vkconfig/appsingleton.cpp
@@ -25,12 +25,15 @@
  * Authors:
  * - Richard S. Wright Jr. <richard@lunarg.com>
  */
+
 #include "appsingleton.h"
 
-AppSingleton::AppSingleton(QString singleAppName, int timeout) {
+#include <QtNetwork/QLocalSocket>
+
+AppSingleton::AppSingleton(const QString& application_name, int timeout) {
     // If we can connect to the server, it means there is another copy running
     QLocalSocket localSocket;
-    localSocket.connectToServer(singleAppName);
+    localSocket.connectToServer(application_name);
 
     // The default timeout is 5 seconds, which should be enough under
     // the most extreme circumstances. Note, that it will actually
@@ -38,15 +41,15 @@ AppSingleton::AppSingleton(QString singleAppName, int timeout) {
     // connect. Too small a timeout on the other hand can give false
     // assurance that another copy is not running.
     if (localSocket.waitForConnected(timeout)) {
-        _is_first_app = false;
+        _is_first_instance = false;
         localSocket.close();
         return;
     }
 
     // Not connected, OR timed out
     // We are the first, start a server
-    _is_first_app = true;
-    _localServer.listen(singleAppName);
+    _is_first_instance = true;
+    _localServer.listen(application_name);
 }
 
 AppSingleton::~AppSingleton() { _localServer.close(); }

--- a/vkconfig/appsingleton.h
+++ b/vkconfig/appsingleton.h
@@ -24,20 +24,25 @@
  *
  * Authors:
  * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #pragma once
 
 #include <QtNetwork/QLocalServer>
-#include <QtNetwork/QLocalSocket>
 
 class AppSingleton {
    public:
-    AppSingleton(QString singleAppName, int timeout = 5000);
+    AppSingleton(const QString &application_name, int timeout = 5000);
     ~AppSingleton();
-    bool IsFirstApp(void) { return _is_first_app; }
+
+    bool IsFirstInstance() { return _is_first_instance; }
 
    protected:
     QLocalServer _localServer;
-    bool _is_first_app;
+    bool _is_first_instance;
+
+   private:
+    AppSingleton(const AppSingleton &) = delete;
+    AppSingleton &operator=(const AppSingleton &) = delete;
 };

--- a/vkconfig/configuration.cpp
+++ b/vkconfig/configuration.cpp
@@ -70,7 +70,6 @@ Layer* Configuration::FindLayerNamed(const QString& layer_name) const {
 Configuration* Configuration::DuplicateConfiguration() {
     Configuration* duplicate = new Configuration;
     duplicate->_name = _name;
-    duplicate->_file = _file;
     duplicate->_description = _description;
     duplicate->_excluded_layers = _excluded_layers;
     duplicate->_preset = _preset;
@@ -149,7 +148,7 @@ bool Configuration::Load(const QString& path_to_configuration) {
     if (parse_error.error != QJsonParseError::NoError) return nullptr;
 
     // Allocate a new profile container
-    const QString& filename = _file = QFileInfo(path_to_configuration).fileName();
+    const QString& filename = QFileInfo(path_to_configuration).fileName();
 
     QJsonObject json_top_object = json_doc.object();
     QStringList key = json_top_object.keys();
@@ -248,7 +247,7 @@ bool Configuration::Load(const QString& path_to_configuration) {
     return true;
 }
 
-bool Configuration::Save() const {
+bool Configuration::Save(const char* full_path) const {
     QJsonObject root;
     root.insert("file_format_version", FILE_FORMAT_VERSION.str().c_str());
 
@@ -343,9 +342,8 @@ bool Configuration::Save() const {
     ///////////////////////////////////////////////////////////
     // Write it out - file name is same as name. If it's been
     // changed, this corrects the behavior.
-    const QString path_to_configuration = Configurator::Get().path.GetFullPath(PATH_CONFIGURATION, _name);
 
-    QFile json_file(path_to_configuration);
+    QFile json_file(full_path);
     if (!json_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QMessageBox alert;
         alert.setText("Could not save configuration file!");
@@ -358,4 +356,8 @@ bool Configuration::Save() const {
     json_file.write(doc.toJson());
     json_file.close();
     return true;
+}
+
+bool Configuration::Save() const {
+    return Save(Configurator::Get().path.GetFullPath(PATH_CONFIGURATION, _name).toUtf8().constData());
 }

--- a/vkconfig/configuration.cpp
+++ b/vkconfig/configuration.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "configuration.h"
+#include "configurator.h"
 
 #include <QFile>
 #include <QJsonDocument>
@@ -28,7 +29,7 @@
 
 #include <cassert>
 
-Configuration::Configuration() : _preset(ValidationPresetNone), _all_layers_available(true) {}
+Configuration::Configuration() : _preset(ValidationPresetNone) {}
 
 Configuration::~Configuration() {
     qDeleteAll(_layers.begin(), _layers.end());
@@ -67,7 +68,6 @@ Configuration* Configuration::DuplicateConfiguration() {
     duplicate->_description = _description;
     duplicate->_excluded_layers = _excluded_layers;
     duplicate->_preset = _preset;
-    duplicate->_all_layers_available = _all_layers_available;
     // Do not copy ->bFixedProfile
 
     for (int i = 0; i < _layers.size(); i++) {
@@ -112,4 +112,20 @@ void Configuration::CollapseConfiguration() {
 
         layer_index++;
     }
+}
+
+bool Configuration::IsValid() const {
+    Configurator& configurator = Configurator::Get();
+
+    if (_excluded_layers.empty() && _layers.empty()) return false;
+
+    for (int i = 0, n = _layers.size(); i < n; ++i) {
+        if (configurator.FindLayerNamed(_layers[i]->_name) == nullptr) return false;
+    }
+
+    for (int i = 0, n = _excluded_layers.size(); i < n; ++i) {
+        if (configurator.FindLayerNamed(_excluded_layers[i]) == nullptr) return false;
+    }
+
+    return true;
 }

--- a/vkconfig/configuration.cpp
+++ b/vkconfig/configuration.cpp
@@ -163,6 +163,11 @@ bool Configuration::Load(const QString& path_to_configuration) {
 
     if (version <= Version("1.1.0")) {
         _name = filename.left(filename.length() - 5);
+        if (_name == "Validation - Shader Printf") {
+            _name = "Validation - Debug Printf";
+            QFile file(path_to_configuration);
+            file.remove();
+        }
     } else {
         const QJsonValue& json_name_value = configuration_entry_object.value("name");
         assert(json_name_value != QJsonValue::Undefined);

--- a/vkconfig/configuration.cpp
+++ b/vkconfig/configuration.cpp
@@ -68,14 +68,7 @@ Configuration* Configuration::DuplicateConfiguration() {
     duplicate->_description = _description;
     duplicate->_excluded_layers = _excluded_layers;
     duplicate->_preset = _preset;
-    // Do not copy ->bFixedProfile
-
-    for (int i = 0; i < _layers.size(); i++) {
-        Layer* layer_file = new Layer;
-        _layers[i]->CopyLayer(layer_file);
-        duplicate->_layers.push_back(layer_file);
-    }
-
+    duplicate->_layers = _layers;
     return duplicate;
 }
 

--- a/vkconfig/configuration.cpp
+++ b/vkconfig/configuration.cpp
@@ -132,7 +132,7 @@ bool Configuration::IsValid() const {
 // Load from a configuration file (.json really)
 bool Configuration::Load(const QString& path_to_configuration) {
     // Just load the name for now, and if it's read only
-    if (path_to_configuration.isEmpty()) return nullptr;
+    if (path_to_configuration.isEmpty()) return false;
 
     QFile file(path_to_configuration);
     bool result = file.open(QIODevice::ReadOnly | QIODevice::Text);
@@ -145,7 +145,7 @@ bool Configuration::Load(const QString& path_to_configuration) {
     QJsonParseError parse_error;
     json_doc = QJsonDocument::fromJson(json_text.toUtf8(), &parse_error);
 
-    if (parse_error.error != QJsonParseError::NoError) return nullptr;
+    if (parse_error.error != QJsonParseError::NoError) return false;
 
     // Allocate a new profile container
     const QString& filename = QFileInfo(path_to_configuration).fileName();
@@ -208,7 +208,7 @@ bool Configuration::Load(const QString& path_to_configuration) {
         alert.setInformativeText("Use Vulkan Configurator from the latest Vulkan SDK to resolve the issue.");
         alert.setIcon(QMessageBox::Critical);
         alert.exec();
-        return nullptr;
+        return false;
     }
 
     // Build the list of layers with their settings. If both the layers and

--- a/vkconfig/configuration.cpp
+++ b/vkconfig/configuration.cpp
@@ -22,12 +22,18 @@
 #include "configuration.h"
 #include "configurator.h"
 
+#include "../vkconfig_core/util.h"
+#include "../vkconfig_core/version.h"
+
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QMessageBox>
 
 #include <cassert>
+
+static const Version FILE_FORMAT_VERSION("1.2.0");
 
 Configuration::Configuration() : _preset(ValidationPresetNone) {}
 
@@ -120,5 +126,232 @@ bool Configuration::IsValid() const {
         if (configurator.FindLayerNamed(_excluded_layers[i]) == nullptr) return false;
     }
 
+    return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Load from a configuration file (.json really)
+Configuration* Configuration::Load(const QString& path_to_configuration) {
+    // Just load the name for now, and if it's read only
+    if (path_to_configuration.isEmpty()) return nullptr;
+
+    QFile file(path_to_configuration);
+    bool result = file.open(QIODevice::ReadOnly | QIODevice::Text);
+    assert(result);
+    QString json_text = file.readAll();
+    file.close();
+
+    // Tease it apart, get the name of the profile
+    QJsonDocument json_doc;
+    QJsonParseError parse_error;
+    json_doc = QJsonDocument::fromJson(json_text.toUtf8(), &parse_error);
+
+    if (parse_error.error != QJsonParseError::NoError) return nullptr;
+
+    // Allocate a new profile container
+    Configuration* configuration = new Configuration();
+    const QString& filename = configuration->_file = QFileInfo(path_to_configuration).fileName();
+
+    QJsonObject json_top_object = json_doc.object();
+    QStringList key = json_top_object.keys();
+
+    const QJsonValue& json_file_format_version = json_top_object.value("file_format_version");
+    const Version version = Version(
+        json_file_format_version == QJsonValue::Undefined ? "1.1.0" : json_file_format_version.toString().toUtf8().constData());
+
+    QJsonValue configuration_entry_value = json_top_object.value(key[0]);
+    QJsonObject configuration_entry_object = configuration_entry_value.toObject();
+
+    if (version <= Version("1.1.0")) {
+        configuration->_name = filename.left(filename.length() - 5);
+    } else {
+        const QJsonValue& json_name_value = configuration_entry_object.value("name");
+        assert(json_name_value != QJsonValue::Undefined);
+        configuration->_name = json_name_value.toString();
+    }
+
+    const QJsonValue& excluded_value = configuration_entry_object.value("blacklisted_layers");
+    assert(excluded_value != QJsonValue::Undefined);
+
+    QJsonArray excluded_array = excluded_value.toArray();
+    for (int i = 0; i < excluded_array.size(); i++) {
+        configuration->_excluded_layers << excluded_array[i].toString();
+    }
+
+    const QJsonValue& preset_index = configuration_entry_object.value("preset");
+    configuration->_preset = static_cast<ValidationPreset>(preset_index.toInt());
+
+    const QJsonValue& editor_state = configuration_entry_object.value("editor_state");
+    configuration->_setting_tree_state = editor_state.toVariant().toByteArray();
+
+    const QJsonValue& description = configuration_entry_object.value("description");
+    assert(description != QJsonValue::Undefined);
+    configuration->_description = description.toString();
+
+    QJsonValue options_value = configuration_entry_object.value("layer_options");
+    assert(options_value != QJsonValue::Undefined);
+
+    QJsonObject layer_objects = options_value.toObject();
+    const QStringList& layers = layer_objects.keys();
+
+    if (options_value != QJsonValue::Undefined && version > FILE_FORMAT_VERSION) {
+        QMessageBox alert;
+        alert.setWindowTitle("Could not load configuration file!");
+        alert.setText(
+            format(
+                "The \"%s\" configuration was created with a newer version of Vulkan Configurator. The configuration is discarded",
+                configuration->_name.toUtf8().constData())
+                .c_str());
+        alert.setInformativeText("Use Vulkan Configurator from the latest Vulkan SDK to resolve the issue.");
+        alert.setIcon(QMessageBox::Critical);
+        alert.exec();
+        return nullptr;
+    }
+
+    // Build the list of layers with their settings. If both the layers and
+    // the blacklist are emtpy, then automatic fail
+
+    for (int layer_index = 0; layer_index < layers.length(); layer_index++) {
+        const Layer* layer = nullptr;
+        QJsonValue layer_value = layer_objects.value(layers[layer_index]);
+        QJsonObject layer_object = layer_value.toObject();
+
+        // To match the layer we just need the name, paths are not
+        // hard-matched to the configuration.
+        // Find this in our lookup of layers. The standard layers are listed first
+        layer = Configurator::Get().FindLayerNamed(layers[layer_index]);
+        if (layer == nullptr) {  // If not found, we have a layer missing....
+            continue;
+        }
+
+        assert(layer->IsValid());
+
+        // Make a copy add it to this layer
+        Layer* layer_copy = new Layer(*layer);
+
+        QJsonValue layerRank = layer_object.value("layer_rank");
+        layer_copy->_rank = layerRank.toInt();
+        layer_copy->_state = LAYER_STATE_OVERRIDDEN;  // Always because it's present in the file
+
+        configuration->_layers.push_back(layer_copy);
+
+        // Load the layer
+        LoadSettings(layer_object, layer_copy->_layer_settings);
+    }
+
+    SortByRank(configuration->_layers);
+
+    return configuration;
+}
+
+bool Configuration::Save() const {
+    QJsonObject root;
+    root.insert("file_format_version", FILE_FORMAT_VERSION.str().c_str());
+
+    // Build the json document
+    QJsonArray excluded_list;
+    for (int i = 0, n = _excluded_layers.size(); i < n; i++) excluded_list.append(_excluded_layers[i]);
+
+    QJsonObject layer_list;  // This list of layers
+
+    for (int layer_index = 0, layer_count = _layers.size(); layer_index < layer_count; ++layer_index) {
+        const Layer& layer = *_layers[layer_index];
+        assert(layer.IsValid());
+
+        QJsonObject json_settings;
+
+        // Rank goes in here with settings
+        json_settings.insert("layer_rank", layer._rank);
+
+        // Loop through the actual settings
+        for (std::size_t setting_index = 0, setting_count = layer._layer_settings.size(); setting_index < setting_count;
+             setting_index++) {
+            QJsonObject setting;
+            const LayerSetting& layer_setting = layer._layer_settings[setting_index];
+
+            setting.insert("name", layer_setting.label);
+            setting.insert("description", layer_setting.description);
+
+            switch (layer_setting.type) {
+                case SETTING_STRING:
+                case SETTING_SAVE_FILE:
+                case SETTING_LOAD_FILE:
+                case SETTING_SAVE_FOLDER:
+                case SETTING_BOOL:
+                case SETTING_BOOL_NUMERIC:
+                case SETTING_VUID_FILTER:
+                    setting.insert("type", GetSettingTypeToken(layer_setting.type));
+                    setting.insert("default", layer_setting.value);
+                    break;
+
+                case SETTING_EXCLUSIVE_LIST: {
+                    setting.insert("type", GetSettingTypeToken(layer_setting.type));
+                    setting.insert("default", layer_setting.value);
+
+                    QJsonObject options;
+                    for (int i = 0; i < layer_setting.exclusive_labels.size(); i++)
+                        options.insert(layer_setting.exclusive_values[i], layer_setting.exclusive_labels[i]);
+                    setting.insert("options", options);
+                } break;
+
+                case SETTING_INCLUSIVE_LIST: {
+                    setting.insert("type", GetSettingTypeToken(layer_setting.type));
+
+                    QJsonObject options;
+                    for (int i = 0; i < layer_setting.inclusive_labels.size(); i++)
+                        options.insert(layer_setting.inclusive_values[i], layer_setting.inclusive_labels[i]);
+                    setting.insert("options", options);
+
+                    QJsonArray defaults;
+                    if (!layer_setting.value.isEmpty()) {
+                        QStringList list = layer_setting.value.split(",");
+                        for (int i = 0; i < list.size(); i++) defaults.append(list[i]);
+                    }
+
+                    setting.insert("default", defaults);
+                } break;
+
+                // There is a string field that is actually a complicted series of number or
+                // ranges of numbers. We should at some point add this to allow more error free editing of it.
+                case SETTING_RANGE_INT:
+                default:
+                    assert(0);
+                    break;
+            }
+
+            json_settings.insert(layer_setting.name, setting);
+        }
+
+        layer_list.insert(layer._name, json_settings);
+    }
+
+    QJsonObject json_configuration;
+    json_configuration.insert("name", _name);
+    json_configuration.insert("blacklisted_layers", excluded_list);
+    json_configuration.insert("description", _description);
+    json_configuration.insert("preset", _preset);
+    json_configuration.insert("editor_state", _setting_tree_state.data());
+    json_configuration.insert("layer_options", layer_list);
+    root.insert("configuration", json_configuration);
+
+    QJsonDocument doc(root);
+
+    ///////////////////////////////////////////////////////////
+    // Write it out - file name is same as name. If it's been
+    // changed, this corrects the behavior.
+    const QString path_to_configuration = Configurator::Get().path.GetFullPath(PATH_CONFIGURATION, _name);
+
+    QFile json_file(path_to_configuration);
+    if (!json_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox alert;
+        alert.setText("Could not save configuration file!");
+        alert.setWindowTitle(_name);
+        alert.setIcon(QMessageBox::Warning);
+        alert.exec();
+        return false;
+    }
+
+    json_file.write(doc.toJson());
+    json_file.close();
     return true;
 }

--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -48,8 +48,8 @@ class Configuration {
     Configuration();
     ~Configuration();
 
-    bool Load();
-    bool Save();
+    Configuration *Load(const QString &path_to_configuration);
+    bool Save() const;
 
     QString _name;                   // User readable display of the profile name (may contain spaces)
                                      // This is the same as the filename, but with the .json stripped off.

--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -67,7 +67,5 @@ class Configuration {
 
     void CollapseConfiguration();  // Remove unused layers and settings, set blacklist
 
-    bool IsValid() { return _all_layers_available; }
-
-    bool _all_layers_available;
+    bool IsValid() const;
 };

--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -48,7 +48,7 @@ class Configuration {
     Configuration();
     ~Configuration();
 
-    Configuration *Load(const QString &path_to_configuration);
+    bool Load(const QString &path_to_configuration);
     bool Save() const;
 
     QString _name;                   // User readable display of the profile name (may contain spaces)

--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -50,10 +50,10 @@ class Configuration {
 
     bool Load(const QString &path_to_configuration);
     bool Save() const;
+    bool Save(const char *full_path) const;
 
     QString _name;                   // User readable display of the profile name (may contain spaces)
                                      // This is the same as the filename, but with the .json stripped off.
-    QString _file;                   // Root file name without path (by convention, no spaces and .profile suffix)
     QString _description;            // A friendly description of what this profile does
     QByteArray _setting_tree_state;  // Recall editor tree state
     ValidationPreset _preset;        // Khronos layer presets. 0 = none or user defined

--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -48,6 +48,9 @@ class Configuration {
     Configuration();
     ~Configuration();
 
+    bool Load();
+    bool Save();
+
     QString _name;                   // User readable display of the profile name (may contain spaces)
                                      // This is the same as the filename, but with the .json stripped off.
     QString _file;                   // Root file name without path (by convention, no spaces and .profile suffix)

--- a/vkconfig/configuration.h
+++ b/vkconfig/configuration.h
@@ -25,6 +25,7 @@
 
 #include <QString>
 #include <QStringList>
+#include <QVector>
 
 // json file preset_index must match the preset enum values
 enum ValidationPreset {

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -1123,10 +1123,10 @@ void Configurator::LoadAllConfigurations() {
             // Search the list of loaded configurations
             const QString file = QString(":/resourcefiles/") + default_configurations[i].name + ".json";
 
-            Configuration *configuration = nullptr;
-            configuration = configuration->Load(file);
-            if (configuration != nullptr) {
-                const bool result = configuration->Save();
+            Configuration configuration;
+            const bool result = configuration.Load(file);
+            if (result) {
+                const bool result = configuration.Save();
                 assert(result);
             }
         }
@@ -1147,9 +1147,9 @@ void Configurator::LoadAllConfigurations() {
         QFileInfo info = configuration_files.at(i);
         if (info.absoluteFilePath().contains("applist.json")) continue;
 
-        Configuration *configuration = nullptr;
-        configuration = configuration->Load(info.absoluteFilePath());
-        if (configuration != nullptr) {
+        Configuration *configuration = new Configuration;
+        const bool result = configuration->Load(info.absoluteFilePath());
+        if (result) {
             configuration->_file = info.fileName();  // Easier than parsing it myself ;-)
             _available_configurations.push_back(configuration);
         }

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -1309,17 +1309,7 @@ Configuration *Configurator::LoadConfiguration(const QString &path_to_configurat
         Layer::LoadSettingsFromJson(layer_object, layer_copy->_layer_settings);
     }
 
-    // We need to sort the layers by their rank. The json sorts alphebetically and we
-    // need to undo it.... A bubble quick sort is fine, it's a small list
-    if (configuration->_layers.size() > 1) {
-        for (int i = 0, m = configuration->_layers.size() - 1; i < m; i++) {
-            for (int j = i + 1, n = configuration->_layers.size(); j < n; j++) {
-                if (configuration->_layers[i]->_rank > configuration->_layers[j]->_rank) {
-                    std::swap(configuration->_layers[i], configuration->_layers[j]);
-                }
-            }
-        }
-    }
+    SortByRank(configuration->_layers);
 
     return configuration;
 }

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -1259,7 +1259,6 @@ Configuration *Configurator::LoadConfiguration(const QString &path_to_configurat
     QJsonArray excluded_array = excluded_value.toArray();
     for (int i = 0; i < excluded_array.size(); i++) {
         configuration->_excluded_layers << excluded_array[i].toString();
-        if (!FindLayerNamed(configuration->_excluded_layers[i])) configuration->_all_layers_available = false;
     }
 
     QJsonValue preset_index = configuration_entry_object.value("preset");
@@ -1278,27 +1277,25 @@ Configuration *Configurator::LoadConfiguration(const QString &path_to_configurat
 
     // Build the list of layers with their settings. If both the layers and
     // the blacklist are emtpy, then automatic fail
-    if (layer_list.length() == 0 && configuration->_excluded_layers.length() == 0) configuration->_all_layers_available = false;
 
     for (int layer_index = 0; layer_index < layer_list.length(); layer_index++) {
-        const Layer *layer_file = nullptr;
+        const Layer *layer = nullptr;
         QJsonValue layer_value = layer_objects.value(layer_list[layer_index]);
         QJsonObject layer_object = layer_value.toObject();
 
         // To match the layer we just need the name, paths are not
         // hard-matched to the configuration.
         // Find this in our lookup of layers. The standard layers are listed first
-        layer_file = FindLayerNamed(layer_list[layer_index]);
-        if (layer_file == nullptr) {  // If not found, we have a layer missing....
-            configuration->_all_layers_available = false;
+        layer = FindLayerNamed(layer_list[layer_index]);
+        if (layer == nullptr) {  // If not found, we have a layer missing....
             continue;
         }
 
-        assert(layer_file->IsValid());
+        assert(layer->IsValid());
 
         // Make a copy add it to this layer
         Layer *layer_copy = new Layer();
-        layer_file->CopyLayer(layer_copy);
+        layer->CopyLayer(layer_copy);
         configuration->_layers.push_back(layer_copy);
 
         QJsonValue layerRank = layer_object.value("layer_rank");

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -172,7 +172,17 @@ Configurator &Configurator::Get() {
 }
 
 Configurator::Configurator()
-    : _has_old_loader(false), _first_run(true), _override_application_list_updated(false), _active_configuration(nullptr) {
+    : _has_old_loader(false),
+      _first_run(true),
+      _override_application_list_updated(false),
+      _active_configuration(nullptr),
+// Hack for GitHub C.I.
+#if PLATFORM_WINDOWS && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      _running_as_administrator(IsUserAnAdmin())
+#else
+      _running_as_administrator(false)
+#endif
+{
     _available_Layers.reserve(10);
 
     // Handling of versions compatibility
@@ -188,13 +198,6 @@ Configurator::Configurator()
             settings.setValue(VKCONFIG_KEY_RESTORE_GEOMETRY, false);
         }
     }
-
-    // Hack for GitHub C.I.
-#if PLATFORM_WINDOWS && (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-    _running_as_administrator = IsUserAnAdmin();
-#else
-    _running_as_administrator = false;
-#endif
 
 // Where is stuff
 #if PLATFORM_WINDOWS

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -1123,8 +1123,12 @@ void Configurator::LoadAllConfigurations() {
             // Search the list of loaded configurations
             const QString file = QString(":/resourcefiles/") + default_configurations[i].name + ".json";
 
-            Configuration *configuration = LoadConfiguration(file);
-            if (configuration != nullptr) SaveConfiguration(*configuration);
+            Configuration *configuration = nullptr;
+            configuration = configuration->Load(file);
+            if (configuration != nullptr) {
+                const bool result = configuration->Save();
+                assert(result);
+            }
         }
 
         _first_run = false;
@@ -1143,8 +1147,8 @@ void Configurator::LoadAllConfigurations() {
         QFileInfo info = configuration_files.at(i);
         if (info.absoluteFilePath().contains("applist.json")) continue;
 
-        Configuration *configuration = LoadConfiguration(info.absoluteFilePath());
-
+        Configuration *configuration = nullptr;
+        configuration = configuration->Load(info.absoluteFilePath());
         if (configuration != nullptr) {
             configuration->_file = info.fileName();  // Easier than parsing it myself ;-)
             _available_configurations.push_back(configuration);
@@ -1221,212 +1225,6 @@ const Layer *Configurator::FindLayerNamed(QString layer_name) {
     }
 
     return nullptr;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// Load from a configuration file (.json really)
-Configuration *Configurator::LoadConfiguration(const QString &path_to_configuration) {
-    // Just load the name for now, and if it's read only
-    if (path_to_configuration.isEmpty()) return nullptr;
-
-    QFile file(path_to_configuration);
-    bool result = file.open(QIODevice::ReadOnly | QIODevice::Text);
-    assert(result);
-    QString json_text = file.readAll();
-    file.close();
-
-    // Tease it apart, get the name of the profile
-    QJsonDocument json_doc;
-    QJsonParseError parse_error;
-    json_doc = QJsonDocument::fromJson(json_text.toUtf8(), &parse_error);
-
-    if (parse_error.error != QJsonParseError::NoError) return nullptr;
-
-    // Allocate a new profile container
-    Configuration *configuration = new Configuration();
-    configuration->_file = QFileInfo(path_to_configuration).fileName();
-
-    QJsonObject json_top_object = json_doc.object();
-    QStringList key = json_top_object.keys();
-
-    // The file name overrides the stored name. Otherwise
-    // we can end up with duplicate profiles
-    configuration->_name = configuration->_file.left(configuration->_file.length() - 5);
-
-    QJsonValue configuration_entry_value = json_top_object.value(key[0]);
-    QJsonObject configuration_entry_object = configuration_entry_value.toObject();
-
-    // Build the list of blacklisted layers, check each one to see if it's present,
-    // If not present, don't add it to the list
-    QJsonValue excluded_value = configuration_entry_object.value("blacklisted_layers");
-    QJsonArray excluded_array = excluded_value.toArray();
-    for (int i = 0; i < excluded_array.size(); i++) {
-        configuration->_excluded_layers << excluded_array[i].toString();
-    }
-
-    QJsonValue preset_index = configuration_entry_object.value("preset");
-    configuration->_preset = static_cast<ValidationPreset>(preset_index.toInt());
-
-    QJsonValue editorState = configuration_entry_object.value("editor_state");
-    configuration->_setting_tree_state = editorState.toVariant().toByteArray();
-
-    QJsonValue description = configuration_entry_object.value("description");
-    configuration->_description = description.toString();
-
-    QJsonValue options_value = configuration_entry_object.value("layer_options");
-
-    QJsonObject layer_objects = options_value.toObject();
-    QStringList layer_list = layer_objects.keys();
-
-    // Build the list of layers with their settings. If both the layers and
-    // the blacklist are emtpy, then automatic fail
-
-    for (int layer_index = 0; layer_index < layer_list.length(); layer_index++) {
-        const Layer *layer = nullptr;
-        QJsonValue layer_value = layer_objects.value(layer_list[layer_index]);
-        QJsonObject layer_object = layer_value.toObject();
-
-        // To match the layer we just need the name, paths are not
-        // hard-matched to the configuration.
-        // Find this in our lookup of layers. The standard layers are listed first
-        layer = FindLayerNamed(layer_list[layer_index]);
-        if (layer == nullptr) {  // If not found, we have a layer missing....
-            continue;
-        }
-
-        assert(layer->IsValid());
-
-        // Make a copy add it to this layer
-        Layer *layer_copy = new Layer(*layer);
-
-        QJsonValue layerRank = layer_object.value("layer_rank");
-        layer_copy->_rank = layerRank.toInt();
-        layer_copy->_state = LAYER_STATE_OVERRIDDEN;  // Always because it's present in the file
-
-        configuration->_layers.push_back(layer_copy);
-
-        // Load the layer
-        ::LoadSettings(layer_object, layer_copy->_layer_settings);
-    }
-
-    SortByRank(configuration->_layers);
-
-    return configuration;
-}
-
-/////////////////////////////////////////////////////////////////////////////////////
-// This saves or resaves a configuration. Bear in mind it is called everytime
-// any edit is made to a configuration at all.
-bool Configurator::SaveConfiguration(const Configuration &configuration) {
-    assert(&configuration);
-
-    // Build the json document
-    QJsonArray excluded_list;
-    for (int i = 0, n = configuration._excluded_layers.size(); i < n; i++) excluded_list.append(configuration._excluded_layers[i]);
-
-    QJsonObject layer_list;  // This list of layers
-
-    for (int layer_index = 0, layer_count = configuration._layers.size(); layer_index < layer_count; ++layer_index) {
-        const Layer &layer = *configuration._layers[layer_index];
-        assert(layer.IsValid());
-
-        QJsonObject json_settings;
-
-        // Rank goes in here with settings
-        json_settings.insert("layer_rank", layer._rank);
-
-        // Loop through the actual settings
-        for (std::size_t setting_index = 0, setting_count = layer._layer_settings.size(); setting_index < setting_count;
-             setting_index++) {
-            QJsonObject setting;
-            const LayerSetting &layer_setting = layer._layer_settings[setting_index];
-
-            setting.insert("name", layer_setting.label);
-            setting.insert("description", layer_setting.description);
-
-            switch (layer_setting.type) {
-                case SETTING_STRING:
-                case SETTING_SAVE_FILE:
-                case SETTING_LOAD_FILE:
-                case SETTING_SAVE_FOLDER:
-                case SETTING_BOOL:
-                case SETTING_BOOL_NUMERIC:
-                case SETTING_VUID_FILTER:
-                    setting.insert("type", GetSettingTypeToken(layer_setting.type));
-                    setting.insert("default", layer_setting.value);
-                    break;
-
-                case SETTING_EXCLUSIVE_LIST: {
-                    setting.insert("type", GetSettingTypeToken(layer_setting.type));
-                    setting.insert("default", layer_setting.value);
-
-                    QJsonObject options;
-                    for (int i = 0; i < layer_setting.exclusive_labels.size(); i++)
-                        options.insert(layer_setting.exclusive_values[i], layer_setting.exclusive_labels[i]);
-                    setting.insert("options", options);
-                } break;
-
-                case SETTING_INCLUSIVE_LIST: {
-                    setting.insert("type", GetSettingTypeToken(layer_setting.type));
-
-                    QJsonObject options;
-                    for (int i = 0; i < layer_setting.inclusive_labels.size(); i++)
-                        options.insert(layer_setting.inclusive_values[i], layer_setting.inclusive_labels[i]);
-                    setting.insert("options", options);
-
-                    QJsonArray defaults;
-                    if (!layer_setting.value.isEmpty()) {
-                        QStringList list = layer_setting.value.split(",");
-                        for (int i = 0; i < list.size(); i++) defaults.append(list[i]);
-                    }
-
-                    setting.insert("default", defaults);
-                } break;
-
-                // There is a string field that is actually a complicted series of number or
-                // ranges of numbers. We should at some point add this to allow more error free editing of it.
-                case SETTING_RANGE_INT:
-                default:
-                    assert(0);
-                    break;
-            }
-
-            json_settings.insert(layer_setting.name, setting);
-        }
-
-        layer_list.insert(layer._name, json_settings);
-    }
-
-    //////////////////////////////////////////////////////////
-    // Assemble the json
-    QJsonObject root;
-    QJsonObject json_configuration;
-    json_configuration.insert("blacklisted_layers", excluded_list);
-    json_configuration.insert("description", configuration._description);
-    json_configuration.insert("preset", configuration._preset);
-    json_configuration.insert("editor_state", configuration._setting_tree_state.data());
-    json_configuration.insert("layer_options", layer_list);
-    root.insert(configuration._name, json_configuration);
-    QJsonDocument doc(root);
-
-    ///////////////////////////////////////////////////////////
-    // Write it out - file name is same as name. If it's been
-    // changed, this corrects the behavior.
-    const QString path_to_configuration = path.GetFullPath(PATH_CONFIGURATION, configuration._name);
-
-    QFile jsonFile(path_to_configuration);
-    if (!jsonFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        QMessageBox alert;
-        alert.setText("Could not save configuration file!");
-        alert.setWindowTitle(configuration._name);
-        alert.setIcon(QMessageBox::Warning);
-        alert.exec();
-        return false;
-    }
-
-    jsonFile.write(doc.toJson());
-    jsonFile.close();
-    return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -99,8 +99,7 @@ struct DefaultConfiguration {
 static const DefaultConfiguration default_configurations[] = {
     {"Validation - Standard", "VK_LAYER_KHRONOS_validation", Version("1.0.0"), "Standard", ValidationPresetStandard},
     {"Validation - GPU-Assisted", "VK_LAYER_KHRONOS_validation", Version("1.1.126"), "GPU-Assisted", ValidationPresetGPUAssisted},
-    {"Validation - Shader Printf", "VK_LAYER_KHRONOS_validation", Version("1.1.126"), "Shader Printf",
-     ValidationPresetShaderPrintf},
+    {"Validation - Shader Printf", "VK_LAYER_KHRONOS_validation", Version("1.1.126"), "Debug Printf", ValidationPresetShaderPrintf},
     {"Validation - Reduced-Overhead", "VK_LAYER_KHRONOS_validation", Version("1.0.0"), "Reduced-Overhead",
      ValidationPresetReducedOverhead},
     {"Validation - Best Practices", "VK_LAYER_KHRONOS_validation", Version("1.1.126"), "Best Practices",

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -115,8 +115,8 @@ class Configurator {
     bool _has_old_loader;  // Older loader does not support per-application overrides
 
    private:
-    bool _running_as_administrator;  // Are we being "Run as Administrator"
-    bool _first_run;                 // This is used for populating the initial set of configurations
+    const bool _running_as_administrator;  // Are we being "Run as Administrator"
+    bool _first_run;                       // This is used for populating the initial set of configurations
 
     /////////////////////////////////////////////////////////////////////////
     // Just Vulkan Configurator settings
@@ -206,7 +206,6 @@ class Configurator {
     void ExportConfiguration(const QString& source_file, const QString& full_export_path);
 
     bool HasLayers() const;
-    bool IsRunningAsAdministrator() { return _running_as_administrator; }
 
     // Set this as the current override configuration
     void SetActiveConfiguration(Configuration* configuration);

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -39,6 +39,8 @@
 
 #include <vulkan/vulkan.h>
 
+#include <vector>
+
 #define DONT_SHOW_AGAIN_MESSAGE "Do not show again"
 #define APP_SHORT_NAME "vkconfig"
 
@@ -86,8 +88,8 @@ class PathFinder {
 // to reset or initialize the a full layer definition for the
 // profiles.
 struct LayerSettingsDefaults {
-    QString layer_name;                       // Name of layer
-    QVector<LayerSetting*> default_settings;  // Default settings for this layer
+    QString layer_name;                          // Name of layer
+    std::vector<LayerSetting> default_settings;  // Default settings for this layer
 };
 
 //////////////////////////////////////////////////////////

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -201,9 +201,7 @@ class Configurator {
 
     Configuration* CreateEmptyConfiguration();
     Configuration* FindConfiguration(const QString& configuration_name) const;
-    Configuration* LoadConfiguration(const QString& path_configuration);  // Load .profile descriptor
-    void LoadAllConfigurations();                                         // Load all the .profile files found
-    bool SaveConfiguration(const Configuration& configuration);           // Write .profile descriptor
+    void LoadAllConfigurations();  // Load all the .profile files found
     void ImportConfiguration(const QString& full_import_path);
     void ExportConfiguration(const QString& source_file, const QString& full_export_path);
 

--- a/vkconfig/dlgabout.h
+++ b/vkconfig/dlgabout.h
@@ -39,4 +39,8 @@ class dlgAbout : public QDialog {
 
    private:
     Ui::dlgAbout *ui;
+
+   private:
+    dlgAbout(const dlgAbout &) = delete;
+    dlgAbout &operator=(const dlgAbout &) = delete;
 };

--- a/vkconfig/dlgcreateassociation.h
+++ b/vkconfig/dlgcreateassociation.h
@@ -60,4 +60,8 @@ class dlgCreateAssociation : public QDialog {
     void editCommandLine(const QString &cmd_line);
     void editWorkingFolder(const QString &working_folder);
     void editLogFile(const QString &log_file);
+
+   private:
+    dlgCreateAssociation(const dlgCreateAssociation &) = delete;
+    dlgCreateAssociation &operator=(const dlgCreateAssociation &) = delete;
 };

--- a/vkconfig/dlgcustompaths.h
+++ b/vkconfig/dlgcustompaths.h
@@ -44,4 +44,8 @@ class dlgCustomPaths : public QDialog {
     void on_pushButtonAdd_clicked();
     void on_pushButtonRemove_clicked();
     void on_treeWidget_itemSelectionChanged();
+
+   private:
+    dlgCustomPaths(const dlgCustomPaths &) = delete;
+    dlgCustomPaths &operator=(const dlgCustomPaths &) = delete;
 };

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -481,7 +481,8 @@ void dlgProfileEditor::accept() {
 
     // Collapse the profile and remove unused layers and write
     _configuration->CollapseConfiguration();
-    if (!Configurator::Get().SaveConfiguration(*_configuration)) {
+    const bool result = _configuration->Save();
+    if (!result) {
         AddMissingLayers(_configuration);
         LoadLayerDisplay(0);
         return;

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -467,7 +467,6 @@ void dlgProfileEditor::accept() {
     }
 
     // Prepare... get fully qualified file name, and double check if overwriting
-    _configuration->_file = _configuration->_name + ".json";
     const QString save_path = Configurator::Get().path.GetFullPath(PATH_CONFIGURATION, _configuration->_name);
 
     if (QDir().exists(save_path)) {

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -181,28 +181,27 @@ void dlgProfileEditor::AddMissingLayers(Configuration *configuration) {
     Configurator &configurator = Configurator::Get();
 
     for (int layer_index = 0, layer_count = configurator._available_Layers.size(); layer_index < layer_count; layer_index++) {
-        Layer *searched_layer_file = configurator._available_Layers[layer_index];
+        Layer *searched_layer = configurator._available_Layers[layer_index];
 
         // Look for through all layers
-        Layer *found_layer_file = configuration->FindLayer(searched_layer_file->_name, searched_layer_file->_layer_path);
+        Layer *found_layer_file = configuration->FindLayer(searched_layer->_name, searched_layer->_layer_path);
         if (found_layer_file != nullptr)  // It's in the list already
             continue;
 
         // Nope, add it to the end
-        Layer *next_layer_file = new Layer();
-        searched_layer_file->CopyLayer(next_layer_file);
+        Layer *next_layer = new Layer(*searched_layer);
 
         // Add default settings to the layer...
-        configurator.LoadDefaultSettings(next_layer_file);
+        configurator.LoadDefaultSettings(next_layer);
 
-        next_layer_file->_rank = rank++;
+        next_layer->_rank = rank++;
 
         // Check the excluded list
-        const bool is_excluded = configuration->_excluded_layers.contains(next_layer_file->_name);
-        next_layer_file->_state = is_excluded ? LAYER_STATE_EXCLUDED : LAYER_STATE_APPLICATION_CONTROLLED;
+        const bool is_excluded = configuration->_excluded_layers.contains(next_layer->_name);
+        next_layer->_state = is_excluded ? LAYER_STATE_EXCLUDED : LAYER_STATE_APPLICATION_CONTROLLED;
 
-        assert(next_layer_file->IsValid());
-        configuration->_layers.push_back(next_layer_file);
+        assert(next_layer->IsValid());
+        configuration->_layers.push_back(next_layer);
     }
 }
 

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -184,8 +184,8 @@ void dlgProfileEditor::AddMissingLayers(Configuration *configuration) {
         Layer *searched_layer = configurator._available_Layers[layer_index];
 
         // Look for through all layers
-        Layer *found_layer_file = configuration->FindLayer(searched_layer->_name, searched_layer->_layer_path);
-        if (found_layer_file != nullptr)  // It's in the list already
+        Layer *found_layer = configuration->FindLayer(searched_layer->_name, searched_layer->_layer_path);
+        if (found_layer != nullptr)  // It's in the list already
             continue;
 
         // Nope, add it to the end

--- a/vkconfig/dlgprofileeditor.h
+++ b/vkconfig/dlgprofileeditor.h
@@ -70,4 +70,8 @@ class dlgProfileEditor : public QDialog {
     void on_toolButtonDown_clicked();
 
     void layerUseChanged(QTreeWidgetItem *item, int selection);
+
+   private:
+    dlgProfileEditor(const dlgProfileEditor &) = delete;
+    dlgProfileEditor &operator=(const dlgProfileEditor &) = delete;
 };

--- a/vkconfig/dlgvulkananalysis.h
+++ b/vkconfig/dlgvulkananalysis.h
@@ -47,4 +47,7 @@ class dlgVulkanAnalysis : public QDialog {
     void LoadTable(QJsonObject& json_parent, QTableWidget* table);
 
     Ui::dlgVulkanAnalysis* ui;
+
+    dlgVulkanAnalysis(const dlgVulkanAnalysis&) = delete;
+    dlgVulkanAnalysis& operator=(const dlgVulkanAnalysis&) = delete;
 };

--- a/vkconfig/dlgvulkaninfo.h
+++ b/vkconfig/dlgvulkaninfo.h
@@ -46,4 +46,7 @@ class dlgVulkanInfo : public QDialog {
 
    private:
     Ui::dlgVulkanInfo *ui;
+
+    dlgVulkanInfo(const dlgVulkanInfo &) = delete;
+    dlgVulkanInfo &operator=(const dlgVulkanInfo &) = delete;
 };

--- a/vkconfig/dlgvulkaninstallanalysis.h
+++ b/vkconfig/dlgvulkaninstallanalysis.h
@@ -42,4 +42,6 @@ class dlgVulkanInstallAnalysis : public QAbstractItemModel {
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
    private:
+    dlgVulkanInstallAnalysis(const dlgVulkanInstallAnalysis &) = delete;
+    dlgVulkanInstallAnalysis &operator=(const dlgVulkanInstallAnalysis &) = delete;
 };

--- a/vkconfig/khronossettingsadvanced.cpp
+++ b/vkconfig/khronossettingsadvanced.cpp
@@ -155,9 +155,9 @@ QString GetSettingDetails(QString qsSetting, QString &url) {
 
 ///////////////////////////////////////////////////////////////////////////////
 KhronosSettingsAdvanced::KhronosSettingsAdvanced(QTreeWidget *main_tree, QTreeWidgetItem *parent,
-                                                 QVector<LayerSetting *> &layer_settings)
-    : _enables(FindSetting(layer_settings, "enables")),
-      _disables(FindSetting(layer_settings, "disables")),
+                                                 std::vector<LayerSetting> &settings)
+    : _enables(FindSetting(settings, "enables")),
+      _disables(FindSetting(settings, "disables")),
       _main_tree_widget(main_tree),
       _main_parent(parent) {
     ///////////////////////////////////////////////////////////////

--- a/vkconfig/khronossettingsadvanced.h
+++ b/vkconfig/khronossettingsadvanced.h
@@ -35,7 +35,7 @@ class KhronosSettingsAdvanced : public QObject {
     Q_OBJECT
 
    public:
-    explicit KhronosSettingsAdvanced(QTreeWidget *main_tree, QTreeWidgetItem *parent, QVector<LayerSetting *> &layer_Setting);
+    explicit KhronosSettingsAdvanced(QTreeWidget *main_tree, QTreeWidgetItem *parent, std::vector<LayerSetting> &settings);
     ~KhronosSettingsAdvanced();
 
     bool CollectSettings();

--- a/vkconfig/khronossettingsadvanced.h
+++ b/vkconfig/khronossettingsadvanced.h
@@ -65,4 +65,8 @@ class KhronosSettingsAdvanced : public QObject {
 
    Q_SIGNALS:
     void settingChanged();
+
+   private:
+    KhronosSettingsAdvanced(const KhronosSettingsAdvanced &) = delete;
+    KhronosSettingsAdvanced &operator=(const KhronosSettingsAdvanced &) = delete;
 };

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
             // This has to go after the construction of QApplication in
             // order to use a QMessageBox and avoid some QThread warnings.
             AppSingleton singleApp("vkconfig_single_instance");
-            if (!singleApp.IsFirstApp()) {
+            if (!singleApp.IsFirstInstance()) {
                 QMessageBox alert(nullptr);
                 alert.setWindowTitle("Cannot start another instance of vkconfig");
                 alert.setIcon(QMessageBox::Critical);

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -482,7 +482,6 @@ void MainWindow::profileItemChanged(QTreeWidgetItem *item, int column) {
         // Proceed
         remove(full_path.toUtf8().constData());
         configuration_item->configuration._name = new_name;
-        configuration_item->configuration._file = new_name + QString(".json");
         const bool result = configuration_item->configuration.Save();
         assert(result);
 
@@ -888,7 +887,7 @@ void MainWindow::ExportClicked(ConfigurationListItem *item) {
     const QString full_export_path = configurator.path.SelectPath(this, PATH_EXPORT_CONFIGURATION, full_suggested_path);
     if (full_export_path.isEmpty()) return;
 
-    configurator.ExportConfiguration(item->configuration._file, full_export_path);
+    configurator.ExportConfiguration(item->configuration._name + ".json", full_export_path);
     configurator.SaveSettings();
 }
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -483,7 +483,9 @@ void MainWindow::profileItemChanged(QTreeWidgetItem *item, int column) {
         remove(full_path.toUtf8().constData());
         configuration_item->configuration._name = new_name;
         configuration_item->configuration._file = new_name + QString(".json");
-        configurator.SaveConfiguration(configuration_item->configuration);
+        const bool result = configuration_item->configuration.Save();
+        assert(result);
+
         RestoreLastItem(configuration_item->configuration._name.toUtf8().constData());
     }
 }
@@ -839,9 +841,11 @@ void MainWindow::DuplicateClicked(ConfigurationListItem *item) {
     while (configurator.FindConfiguration(new_name) != nullptr) new_name += "2";
 
     _settings_tree_manager.CleanupGUI();
-    item->configuration._name = new_name;
 
-    configurator.SaveConfiguration(item->configuration);
+    item->configuration._name = new_name;
+    const bool result = item->configuration.Save();
+    assert(result);
+
     configurator.LoadAllConfigurations();
     LoadConfigurationList();
 

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -49,6 +49,10 @@ class ConfigurationListItem : public QTreeWidgetItem {
     ConfigurationListItem(Configuration &configuration) : configuration(configuration) {}
     Configuration &configuration;
     QRadioButton *radio_button;
+
+   private:
+    ConfigurationListItem(const ConfigurationListItem &) = delete;
+    ConfigurationListItem &operator=(const ConfigurationListItem &) = delete;
 };
 
 class MainWindow : public QMainWindow {
@@ -152,4 +156,8 @@ class MainWindow : public QMainWindow {
     void standardOutputAvailable();                                 // stdout output is available
     void errorOutputAvailable();                                    // Layeroutput is available
     void processClosed(int exitCode, QProcess::ExitStatus status);  // app died
+
+   private:
+    MainWindow(const MainWindow &) = delete;
+    MainWindow &operator=(const MainWindow &) = delete;
 };

--- a/vkconfig/preferences.h
+++ b/vkconfig/preferences.h
@@ -14,10 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * The vkConfig2 program monitors and adjusts the Vulkan configuration
- * environment. These settings are wrapped in this class, which serves
- * as the "model" of the system.
- *
  * Authors:
  * - Richard S. Wright Jr. <richard@lunarg.com>
  * - Christophe Riccio <christophe@lunarg.com>

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -321,9 +321,9 @@ void SettingsTreeManager::khronosPresetChanged(int preset_index) {
     // The easiest way to do this is to create a new profile, and copy the layer over
     const QString preset_file = QString(":/resourcefiles/") + configurator.GetValidationPresetName(preset) + ".json";
 
-    Configuration *preset_configuration = nullptr;
-    preset_configuration = preset_configuration->Load(preset_file);
-    if (preset_configuration == nullptr) return;
+    Configuration *preset_configuration = new Configuration;
+    const bool result = preset_configuration->Load(preset_file);
+    assert(result);
 
     // Copy it all into the real layer and delete it
     // Find the KhronosLaer

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -136,22 +136,12 @@ void SettingsTreeManager::BuildKhronosTree() {
                                                        _validation_layer_file->_layer_settings);
 
     // Look for the Debug Action and log file settings
-    LayerSetting *debug_action = nullptr;
-    LayerSetting *log_file = nullptr;
-    for (int i = 0; i < _validation_layer_file->_layer_settings.size(); i++) {
-        if (_validation_layer_file->_layer_settings[i]->name == QString("debug_action"))
-            debug_action = _validation_layer_file->_layer_settings[i];
-
-        if (_validation_layer_file->_layer_settings[i]->name == QString("log_filename"))
-            log_file = _validation_layer_file->_layer_settings[i];
-    }
-
-    Q_ASSERT(log_file != nullptr);
-    Q_ASSERT(debug_action != nullptr);
+    LayerSetting &debug_action = FindSetting(_validation_layer_file->_layer_settings, "debug_action");
+    LayerSetting &log_file = FindSetting(_validation_layer_file->_layer_settings, "log_filename");
 
     // Set them up
     QTreeWidgetItem *debug_action_item = new QTreeWidgetItem();
-    _validation_debug_action = new EnumSettingWidget(debug_action_item, *debug_action);
+    _validation_debug_action = new EnumSettingWidget(debug_action_item, debug_action);
     _validation_tree_item->addChild(debug_action_item);
     next_line = new QTreeWidgetItem();
     debug_action_item->addChild(next_line);
@@ -159,7 +149,7 @@ void SettingsTreeManager::BuildKhronosTree() {
 
     _validation_log_file_item = new QTreeWidgetItem();
     next_line = new QTreeWidgetItem();
-    _validation_log_file_widget = new FileSystemSettingWidget(_validation_log_file_item, *log_file, SETTING_SAVE_FILE);
+    _validation_log_file_widget = new FileSystemSettingWidget(_validation_log_file_item, log_file, SETTING_SAVE_FILE);
     connect(_validation_log_file_widget, SIGNAL(itemChanged()), this, SLOT(profileEdited()));
     debug_action_item->addChild(_validation_log_file_item);
     _validation_log_file_item->addChild(next_line);
@@ -173,14 +163,14 @@ void SettingsTreeManager::BuildKhronosTree() {
         _validation_log_file_widget->setDisabled(true);
     }
 
-    QVector<LayerSetting *> &settings = _validation_layer_file->_layer_settings;
+    std::vector<LayerSetting> &settings = _validation_layer_file->_layer_settings;
 
     // This is looking for the report flags
-    for (int setting_index = 0, settings_count = settings.size(); setting_index < settings_count; setting_index++) {
-        LayerSetting &layer_setting = *settings[setting_index];
+    for (std::size_t setting_index = 0, settings_count = settings.size(); setting_index < settings_count; setting_index++) {
+        LayerSetting &layer_setting = settings[setting_index];
 
         // Multi-enum - report flags only
-        if (!(layer_setting.type == SETTING_INCLUSIVE_LIST && layer_setting.name == QString("report_flags"))) {
+        if (!(layer_setting.type == SETTING_INCLUSIVE_LIST && layer_setting.name == "report_flags")) {
             continue;
         }
 
@@ -201,8 +191,8 @@ void SettingsTreeManager::BuildKhronosTree() {
     }
 
     // VUID message filtering
-    for (int setting_index = 0, settings_count = settings.size(); setting_index < settings_count; setting_index++) {
-        LayerSetting &layer_setting = *settings[setting_index];
+    for (std::size_t setting_index = 0, settings_count = settings.size(); setting_index < settings_count; setting_index++) {
+        LayerSetting &layer_setting = settings[setting_index];
 
         if (layer_setting.type != SETTING_VUID_FILTER) {
             continue;
@@ -254,8 +244,8 @@ void SettingsTreeManager::khronosDebugChanged(int index) {
 }
 
 void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Layer *layer) {
-    for (int layer_settings_index = 0, n = layer->_layer_settings.size(); layer_settings_index < n; layer_settings_index++) {
-        LayerSetting &setting = *layer->_layer_settings[layer_settings_index];
+    for (std::size_t setting_index = 0, n = layer->_layer_settings.size(); setting_index < n; setting_index++) {
+        LayerSetting &setting = layer->_layer_settings[setting_index];
 
         QTreeWidgetItem *setting_item = new QTreeWidgetItem();
 
@@ -307,8 +297,8 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Layer *layer
             } break;
 
             default: {
-                setting_item->setText(0, layer->_layer_settings[layer_settings_index]->label);
-                setting_item->setToolTip(0, layer->_layer_settings[layer_settings_index]->description);
+                setting_item->setText(0, setting.label);
+                setting_item->setToolTip(0, setting.description);
                 parent->addChild(setting_item);
                 assert(0);  // Unknown setting
             } break;
@@ -346,9 +336,9 @@ void SettingsTreeManager::khronosPresetChanged(int preset_index) {
 
     // Reset just specific layer settings
     for (int i = 0; i < _configuration->_layers[validation_layer_index]->_layer_settings.size(); i++) {
-        if (_validation_layer_file->_layer_settings[i]->name == QString("disables") ||
-            _validation_layer_file->_layer_settings[i]->name == QString("enables"))
-            _validation_layer_file->_layer_settings[i]->value = preset_configuration->_layers[0]->_layer_settings[i]->value;
+        if (_validation_layer_file->_layer_settings[i].name == "disables" ||
+            _validation_layer_file->_layer_settings[i].name == "enables")
+            _validation_layer_file->_layer_settings[i].value = preset_configuration->_layers[0]->_layer_settings[i].value;
     }
 
     delete preset_configuration;  // Delete the pattern

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -169,8 +169,11 @@ void SettingsTreeManager::BuildKhronosTree() {
     for (std::size_t setting_index = 0, settings_count = settings.size(); setting_index < settings_count; setting_index++) {
         LayerSetting &layer_setting = settings[setting_index];
 
+        const bool is_report_flag = layer_setting.name == "report_flags";
+        const bool is_debug_action = layer_setting.name == "debug_action";
+
         // Multi-enum - report flags only
-        if (!(layer_setting.type == SETTING_INCLUSIVE_LIST && layer_setting.name == "report_flags")) {
+        if (!(layer_setting.type == SETTING_INCLUSIVE_LIST && is_report_flag || (is_debug_action && VKCONFIG_BUILD > 1002))) {
             continue;
         }
 

--- a/vkconfig/settingstreemanager.h
+++ b/vkconfig/settingstreemanager.h
@@ -75,4 +75,8 @@ class SettingsTreeManager : QObject {
                                            // Reset layer defaults for the profile, and then call BuildKhronosTree again
     void khronosPresetEdited();            // The user has changed something from a preset, and we are now a custom setting
     void profileEdited();                  // The profile has been edited and should be saved
+
+   private:
+    SettingsTreeManager(const SettingsTreeManager &) = delete;
+    SettingsTreeManager &operator=(const SettingsTreeManager &) = delete;
 };

--- a/vkconfig/widget_bool_setting.h
+++ b/vkconfig/widget_bool_setting.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #pragma once
@@ -48,4 +48,8 @@ class BoolSettingWidget : public QCheckBox {
     QString GetToken(bool state, SettingType type) const;
     const QString _true_token;
     const QString _false_token;
+
+   private:
+    BoolSettingWidget(const BoolSettingWidget&) = delete;
+    BoolSettingWidget& operator=(const BoolSettingWidget&) = delete;
 };

--- a/vkconfig/widget_enum_setting.h
+++ b/vkconfig/widget_enum_setting.h
@@ -41,4 +41,8 @@ class EnumSettingWidget : public QComboBox {
 
    Q_SIGNALS:
     void itemChanged();
+
+   private:
+    EnumSettingWidget(const EnumSettingWidget&) = delete;
+    EnumSettingWidget& operator=(const EnumSettingWidget&) = delete;
 };

--- a/vkconfig/widget_filesystem_setting.h
+++ b/vkconfig/widget_filesystem_setting.h
@@ -53,4 +53,8 @@ class FileSystemSettingWidget : public QWidget {
     enum Mode { MODE_OPEN_FILE, MODE_SAVE_FILE, MODE_SAVE_FOLDER };
     const Mode _mode;
     Mode GetMode(SettingType type) const;
+
+   private:
+    FileSystemSettingWidget(const FileSystemSettingWidget &) = delete;
+    FileSystemSettingWidget &operator=(const FileSystemSettingWidget &) = delete;
 };

--- a/vkconfig/widget_multi_enum_setting.h
+++ b/vkconfig/widget_multi_enum_setting.h
@@ -42,4 +42,8 @@ class MultiEnumSettingWidget : public QCheckBox {
 
    Q_SIGNALS:
     void itemChanged();
+
+   private:
+    MultiEnumSettingWidget(const MultiEnumSettingWidget&) = delete;
+    MultiEnumSettingWidget& operator=(const MultiEnumSettingWidget&) = delete;
 };

--- a/vkconfig/widget_mute_message.h
+++ b/vkconfig/widget_mute_message.h
@@ -48,4 +48,8 @@ class MuteMessageWidget : public QWidget {
    Q_SIGNALS:
     void itemChanged();
     void itemRemoved(const QString &item);
+
+   private:
+    MuteMessageWidget(const MuteMessageWidget &) = delete;
+    MuteMessageWidget &operator=(const MuteMessageWidget &) = delete;
 };

--- a/vkconfig/widget_string_setting.h
+++ b/vkconfig/widget_string_setting.h
@@ -41,4 +41,8 @@ class StringSettingWidget : public QLineEdit {
 
    Q_SIGNALS:
     void itemChanged();
+
+   private:
+    StringSettingWidget(const StringSettingWidget&) = delete;
+    StringSettingWidget& operator=(const StringSettingWidget&) = delete;
 };

--- a/vkconfig/widget_tree_friendly_combobox.h
+++ b/vkconfig/widget_tree_friendly_combobox.h
@@ -38,4 +38,8 @@ class TreeFriendlyComboBoxWidget : public QComboBox {
 
    Q_SIGNALS:
     void selectionMade(QTreeWidgetItem *tree_item, int index);
+
+   private:
+    TreeFriendlyComboBoxWidget(const TreeFriendlyComboBoxWidget &) = delete;
+    TreeFriendlyComboBoxWidget &operator=(const TreeFriendlyComboBoxWidget &) = delete;
 };

--- a/vkconfig/widget_vuid_search.h
+++ b/vkconfig/widget_vuid_search.h
@@ -54,4 +54,8 @@ class VUIDSearchWidget : public QWidget {
    Q_SIGNALS:
     void itemSelected(const QString &textSelected);
     void itemChanged();
+
+   private:
+    VUIDSearchWidget(const VUIDSearchWidget &) = delete;
+    VUIDSearchWidget &operator=(const VUIDSearchWidget &) = delete;
 };

--- a/vkconfig_core/command_line.h
+++ b/vkconfig_core/command_line.h
@@ -33,5 +33,8 @@ class CommandLine {
     const Mode& mode;
 
    private:
+    CommandLine(const CommandLine&) = delete;
+    CommandLine& operator=(const CommandLine&) = delete;
+
     Mode _mode;
 };

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #include "../vkconfig_core/layer.h"
@@ -60,10 +60,7 @@ void AddString(QString& delimitedString, QString value) {
 
 Layer::Layer() : _state(LAYER_STATE_APPLICATION_CONTROLLED), _rank(0) {}
 
-Layer::~Layer() {
-    qDeleteAll(_layer_settings.begin(), _layer_settings.end());
-    _layer_settings.clear();
-}
+Layer::~Layer() { _layer_settings.clear(); }
 
 // Todo: Load the layer with Vulkan API
 bool Layer::IsValid() const {
@@ -149,90 +146,37 @@ bool Layer::ReadLayerFile(QString full_path_to_file, LayerType layer_type) {
     return IsValid();  // Not all JSON file are layer JSON valid
 }
 
-////////////////////////////////////////////////////////////////////////////
-void Layer::LoadSettingsFromJson(QJsonObject& json_layer_settings, QVector<LayerSetting*>& settings) {
-    // Okay, how many settings do we have?
-    QStringList settings_names = json_layer_settings.keys();
+bool Layer::operator==(const Layer& layer) const {
+    if (_file_format_version != layer._file_format_version)
+        return false;
+    else if (_name != layer._name)
+        return false;
+    else if (_type != layer._type)
+        return false;
+    else if (_library_path != layer._library_path)
+        return false;
+    else if (_api_version != layer._api_version)
+        return false;
+    else if (_implementation_version != layer._implementation_version)
+        return false;
+    else if (_description != layer._description)
+        return false;
+    else if (_layer_path != layer._layer_path)
+        return false;
+    else if (_layer_type != layer._layer_type)
+        return false;
+    else if (_state != layer._state)
+        return false;
+    else if (_rank != layer._rank)
+        return false;
 
-    for (int setting_index = 0, setting_count = settings_names.size(); setting_index < setting_count; setting_index++) {
-        // The layer rank may or may not be here, but it is not a
-        // user setting.
-        if (settings_names[setting_index] == QString("layer_rank")) continue;
+    for (std::size_t i = 0, n = _layer_settings.size(); i < n; ++i)
+        if (_layer_settings[i] != layer._layer_settings[i]) return false;
 
-        LayerSetting* setting = new LayerSetting;
-        setting->name = settings_names[setting_index];
-
-        QJsonValue json_value = json_layer_settings.value(settings_names[setting_index]);
-        QJsonObject json_object = json_value.toObject();
-
-        // The easy stuff...
-        QJsonValue value = json_object.value("description");
-        setting->description = value.toString();
-
-        value = json_object.value("name");
-        setting->label = value.toString();
-
-        // This is either a single value, or a comma delimted set of strings
-        // selected from a nonexclusive list
-        value = json_object.value("default");
-        if (value.isArray()) {
-            QJsonArray array = value.toArray();
-            for (int a = 0; a < array.size(); a++) {
-                setting->value += array[a].toString();
-                if (a != array.size() - 1) setting->value += ",";
-            }
-
-        } else
-            setting->value = value.toString();
-
-        ///////////////////////////////////////////////////////////////////////
-        // Everything from here down revolves around the data type
-        // Data types and values start getting a little more involved.
-        value = json_object.value("type");
-
-        setting->type = GetSettingType(value.toString().toUtf8().constData());
-
-        switch (setting->type) {
-            case SETTING_EXCLUSIVE_LIST: {
-                // Now we have a list of options, both the enum for the settings file, and the prompts
-                value = json_object.value("options");
-                QJsonObject object = value.toObject();
-                QStringList keys, values;
-                keys = object.keys();
-                for (int v = 0; v < keys.size(); v++) {
-                    if (!PLATFORM_WINDOWS && keys[v] == "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT") continue;
-                    setting->exclusive_values << keys[v];
-                    setting->exclusive_labels << object.value(keys[v]).toString();
-                }
-            } break;
-            case SETTING_INCLUSIVE_LIST: {
-                // Now we have a list of options, both the enum for the settings file, and the prompts
-                value = json_object.value("options");
-                QJsonObject object = value.toObject();
-                QStringList keys, values;
-                keys = object.keys();
-                for (int v = 0; v < keys.size(); v++) {
-                    if (!PLATFORM_WINDOWS && keys[v] == "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT") continue;
-                    setting->inclusive_values << keys[v];
-                    setting->inclusive_labels << object.value(keys[v]).toString();
-                }
-            } break;
-            case SETTING_SAVE_FILE:
-            case SETTING_LOAD_FILE:
-            case SETTING_SAVE_FOLDER:
-            case SETTING_BOOL:
-            case SETTING_BOOL_NUMERIC:
-            case SETTING_VUID_FILTER:
-            case SETTING_STRING:
-                break;
-            default:
-                assert(0);
-                break;
-        }
-
-        settings.push_back(setting);
-    }
+    return true;
 }
+
+bool Layer::operator!=(const Layer& layer) const { return !(*this == layer); }
 
 void SortByRank(QVector<Layer*>& layers) {
     if (layers.size() < 2)  // Nothing to sort

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -233,3 +233,16 @@ void Layer::LoadSettingsFromJson(QJsonObject& json_layer_settings, QVector<Layer
         settings.push_back(setting);
     }
 }
+
+void SortByRank(QVector<Layer*>& layers) {
+    if (layers.size() < 2)  // Nothing to sort
+        return;
+
+    for (int i = 0, m = layers.size() - 1; i < m; i++) {
+        for (int j = i + 1, n = layers.size(); j < n; j++) {
+            if (layers[i]->_rank > layers[j]->_rank) {
+                std::swap(layers[i], layers[j]);
+            }
+        }
+    }
+}

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -74,7 +74,7 @@ bool Layer::IsValid() const {
 /// \return true on success, false on failure.
 /// Reports errors via a message box. This might be a bad idea?
 /// //////////////////////////////////////////////////////////////////////////
-bool Layer::ReadLayerFile(QString full_path_to_file, LayerType layer_type) {
+bool Layer::Load(QString full_path_to_file, LayerType layer_type) {
     _layer_type = layer_type;  // Set layer type, no way to know this from the json file
 
     // Open the file, should be text. Read it into a

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -104,3 +104,5 @@ class Layer {
     // Utility, may move outside this class....
     static void LoadSettingsFromJson(QJsonObject& layer_settings_descriptors, QVector<LayerSetting*>& layers);
 };
+
+void SortByRank(QVector<Layer*>& layers);

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -79,25 +79,8 @@ class Layer {
     LayerState _state;
     int _rank;  // When used in a configurate, what is the rank? (0 being first layer)
 
-    // No.. I do not like operator overloading. It's a bad idea.
-    // Inlined here just so I can see all the variables that need to be copied.
-    void CopyLayer(Layer* destination_layer_file) const {
-        destination_layer_file->_file_format_version = _file_format_version;
-        destination_layer_file->_name = _name;
-        destination_layer_file->_type = _type;
-        destination_layer_file->_library_path = _library_path;
-        destination_layer_file->_api_version = _api_version;
-        destination_layer_file->_implementation_version = _implementation_version;
-        destination_layer_file->_description = _description;
-        destination_layer_file->_layer_type = _layer_type;
-        destination_layer_file->_state = _state;
-        destination_layer_file->_rank = _rank;
-        destination_layer_file->_layer_path = _layer_path;
-        destination_layer_file->_layer_settings = _layer_settings;
-    }
-
     // File based layers
-    bool ReadLayerFile(QString full_path_to_file, LayerType layer_type);
+    bool Load(QString full_path_to_file, LayerType layer_type);
 };
 
 void SortByRank(QVector<Layer*>& layers);

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -19,8 +19,8 @@
  * as the "model" of the system.
  *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #pragma once
@@ -31,7 +31,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QString>
-#include <QVector>
+
+#include <vector>
 
 void RemoveString(QString& delimitedString, QString value);
 void AddString(QString& delimitedString, QString value);
@@ -54,6 +55,8 @@ class Layer {
     ~Layer();
 
     bool IsValid() const;
+    bool operator==(const Layer& layer) const;
+    bool operator!=(const Layer& layer) const;
 
    public:
     // Standard pieces of a layer
@@ -71,7 +74,7 @@ class Layer {
     // This layers settings. This will be used to build the editor
     // as well as create settings files. This CAN be empty if the
     // layer doens't have any settings.
-    QVector<LayerSetting*> _layer_settings;
+    std::vector<LayerSetting> _layer_settings;
 
     LayerState _state;
     int _rank;  // When used in a configurate, what is the rank? (0 being first layer)
@@ -90,19 +93,11 @@ class Layer {
         destination_layer_file->_state = _state;
         destination_layer_file->_rank = _rank;
         destination_layer_file->_layer_path = _layer_path;
-
-        for (int i = 0; i < _layer_settings.length(); i++) {
-            LayerSetting* setting = new LayerSetting();
-            *setting = *_layer_settings[i];
-            destination_layer_file->_layer_settings.push_back(setting);
-        }
+        destination_layer_file->_layer_settings = _layer_settings;
     }
 
     // File based layers
     bool ReadLayerFile(QString full_path_to_file, LayerType layer_type);
-
-    // Utility, may move outside this class....
-    static void LoadSettingsFromJson(QJsonObject& layer_settings_descriptors, QVector<LayerSetting*>& layers);
 };
 
 void SortByRank(QVector<Layer*>& layers);

--- a/vkconfig_core/layer_setting.cpp
+++ b/vkconfig_core/layer_setting.cpp
@@ -14,18 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * The vkConfig2 program monitors and adjusts the Vulkan configuration
- * environment. These settings are wrapped in this class, which serves
- * as the "model" of the system.
- *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #include "util.h"
+#include "platform.h"
 
 #include "layer_setting.h"
+
+#include <QJsonArray>
 
 #include <cassert>
 
@@ -59,13 +58,125 @@ const char* GetSettingTypeToken(SettingType type) {
     return table[type];
 }
 
-LayerSetting& FindSetting(QVector<LayerSetting*>& settings, const char* name) {
-    for (int i = 0, n = settings.size(); i < n; i++) {
-        if (settings[i]->name == QString(name)) {
-            return *settings[i];
+bool operator==(const LayerSetting& a, const LayerSetting& b) {
+    if (a.name != b.name)
+        return false;
+    else if (a.label != b.label)
+        return false;
+    else if (a.description != b.description)
+        return false;
+    else if (a.type != b.type)
+        return false;
+    else if (a.max_value != b.max_value)
+        return false;
+    else if (a.min_value != b.min_value)
+        return false;
+    else if (a.exclusive_values != b.exclusive_values)
+        return false;
+    else if (a.exclusive_labels != b.exclusive_labels)
+        return false;
+    else if (a.inclusive_values != b.inclusive_values)
+        return false;
+    else if (a.inclusive_labels != b.inclusive_labels)
+        return false;
+    else if (a.value != b.value)
+        return false;
+    return true;
+}
+
+bool operator!=(const LayerSetting& a, const LayerSetting& b) { return !(a == b); }
+
+LayerSetting& FindSetting(std::vector<LayerSetting>& settings, const char* name) {
+    for (std::size_t i = 0, n = settings.size(); i < n; i++) {
+        if (settings[i].name == name) {
+            return settings[i];
         }
     }
 
     assert(0);
-    return *settings[0];
+    return settings[0];
+}
+
+void LoadSettings(QJsonObject& json_layer_settings, std::vector<LayerSetting>& settings) {
+    // Okay, how many settings do we have?
+    QStringList settings_names = json_layer_settings.keys();
+
+    for (int setting_index = 0, setting_count = settings_names.size(); setting_index < setting_count; setting_index++) {
+        // The layer rank may or may not be here, but it is not a
+        // user setting.
+        if (settings_names[setting_index] == QString("layer_rank")) continue;
+
+        LayerSetting setting;
+        setting.name = settings_names[setting_index];
+
+        QJsonValue json_value = json_layer_settings.value(settings_names[setting_index]);
+        QJsonObject json_object = json_value.toObject();
+
+        // The easy stuff...
+        QJsonValue value = json_object.value("description");
+        setting.description = value.toString();
+
+        value = json_object.value("name");
+        setting.label = value.toString();
+
+        // This is either a single value, or a comma delimted set of strings
+        // selected from a nonexclusive list
+        value = json_object.value("default");
+        if (value.isArray()) {
+            QJsonArray array = value.toArray();
+            for (int a = 0; a < array.size(); a++) {
+                setting.value += array[a].toString();
+                if (a != array.size() - 1) setting.value += ",";
+            }
+
+        } else
+            setting.value = value.toString();
+
+        ///////////////////////////////////////////////////////////////////////
+        // Everything from here down revolves around the data type
+        // Data types and values start getting a little more involved.
+        value = json_object.value("type");
+
+        setting.type = GetSettingType(value.toString().toUtf8().constData());
+
+        switch (setting.type) {
+            case SETTING_EXCLUSIVE_LIST: {
+                // Now we have a list of options, both the enum for the settings file, and the prompts
+                value = json_object.value("options");
+                QJsonObject object = value.toObject();
+                QStringList keys, values;
+                keys = object.keys();
+                for (int v = 0; v < keys.size(); v++) {
+                    if (!PLATFORM_WINDOWS && keys[v] == "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT") continue;
+                    setting.exclusive_values << keys[v];
+                    setting.exclusive_labels << object.value(keys[v]).toString();
+                }
+            } break;
+            case SETTING_INCLUSIVE_LIST: {
+                // Now we have a list of options, both the enum for the settings file, and the prompts
+                value = json_object.value("options");
+                QJsonObject object = value.toObject();
+                QStringList keys, values;
+                keys = object.keys();
+                for (int v = 0; v < keys.size(); v++) {
+                    if (!PLATFORM_WINDOWS && keys[v] == "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT") continue;
+                    setting.inclusive_values << keys[v];
+                    setting.inclusive_labels << object.value(keys[v]).toString();
+                }
+            } break;
+            case SETTING_SAVE_FILE:
+            case SETTING_LOAD_FILE:
+            case SETTING_SAVE_FOLDER:
+            case SETTING_BOOL:
+            case SETTING_BOOL_NUMERIC:
+            case SETTING_VUID_FILTER:
+            case SETTING_STRING:
+                break;
+            default:
+                assert(0);
+                break;
+        }
+
+        settings.push_back(setting);
+    }
 }

--- a/vkconfig_core/layer_setting.cpp
+++ b/vkconfig_core/layer_setting.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "util.h"
+#include "version.h"
 #include "platform.h"
 
 #include "layer_setting.h"
@@ -143,6 +144,10 @@ void LoadSettings(QJsonObject& json_layer_settings, std::vector<LayerSetting>& s
 
         setting.type = GetSettingType(json_value_type.toString().toUtf8().constData());
 
+        const bool convert_debug_action_to_inclusive =
+            (VKCONFIG_BUILD > 1002 && setting.name == "Debug Action" && setting.type == SETTING_EXCLUSIVE_LIST);
+        if (convert_debug_action_to_inclusive) setting.type = SETTING_INCLUSIVE_LIST;
+
         switch (setting.type) {
             case SETTING_EXCLUSIVE_LIST:
             case SETTING_INCLUSIVE_LIST: {
@@ -154,6 +159,8 @@ void LoadSettings(QJsonObject& json_layer_settings, std::vector<LayerSetting>& s
                 const QStringList& keys = object.keys();
                 for (int v = 0; v < keys.size(); v++) {
                     if (!PLATFORM_WINDOWS && keys[v] == "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT") continue;
+
+                    if (convert_debug_action_to_inclusive && keys[v] == "VK_DBG_LAYER_ACTION_IGNORE") continue;
 
                     if (setting.type == SETTING_INCLUSIVE_LIST) {
                         setting.inclusive_values << keys[v];

--- a/vkconfig_core/layer_setting.h
+++ b/vkconfig_core/layer_setting.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #pragma once
@@ -25,7 +25,9 @@
 
 #include <QString>
 #include <QVariant>
-#include <QVector>
+#include <QJsonObject>
+
+#include <vector>
 
 enum SettingType {  // Enum value can't be changed
     SETTING_STRING = 0,
@@ -59,7 +61,13 @@ struct LayerSetting {
     QString value;                 // Default value as a string
 };
 
-LayerSetting& FindSetting(QVector<LayerSetting*>& settings, const char* name);
+bool operator==(const LayerSetting& a, const LayerSetting& b);
+bool operator!=(const LayerSetting& a, const LayerSetting& b);
+
+LayerSetting& FindSetting(std::vector<LayerSetting>& settings, const char* name);
 
 SettingType GetSettingType(const char* token);
 const char* GetSettingTypeToken(SettingType type);
+
+// Utility, may move outside this class....
+void LoadSettings(QJsonObject& layer_settings_descriptors, std::vector<LayerSetting>& settings);

--- a/vkconfig_core/layer_type.h
+++ b/vkconfig_core/layer_type.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  * Authors:
- * - Richard S. Wright Jr.
- * - Christophe Riccio
+ * - Richard S. Wright Jr. <richard@lunarg.com>
+ * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #pragma once

--- a/vkconfig_core/path_manager.h
+++ b/vkconfig_core/path_manager.h
@@ -79,6 +79,9 @@ class PathManager {
     void Reset();
 
    private:
+    PathManager(const PathManager&) = delete;
+    PathManager& operator=(const PathManager&) = delete;
+
     QString SelectPathImpl(QWidget* parent, Path path, const QString& suggested_path);
 
     std::array<std::string, PATH_COUNT> paths;

--- a/vkconfig_core/test/test_path_manager.cpp
+++ b/vkconfig_core/test/test_path_manager.cpp
@@ -26,13 +26,11 @@
 
 #include <gtest/gtest.h>
 
-static PathManager CreatePathManager(const QString& path_value) {
-    PathManager paths;
+static void Init(PathManager& paths, const QString& path_value) {
     for (int i = 0, n = PATH_COUNT; i < n; ++i) {
         const Path path = static_cast<Path>(i);
         paths.SetPath(path, path_value);
     }
-    return paths;
 }
 
 static QString InitPath(const char* tail) {
@@ -43,14 +41,16 @@ static QString InitPath(const char* tail) {
 
 TEST(test_path_manager, init_first) {
     const QString path_value = InitPath("init_first");
-    const PathManager& paths = CreatePathManager(path_value);
+    PathManager paths;
+    Init(paths, path_value);
 
     EXPECT_STREQ(path_value.toUtf8().constData(), paths.GetPath(PATH_FIRST));
 }
 
 TEST(test_path_manager, init_last) {
     const QString path_value = InitPath("init_last");
-    const PathManager& paths = CreatePathManager(path_value);
+    PathManager paths;
+    Init(paths, path_value);
 
     EXPECT_STREQ(path_value.toUtf8().constData(), paths.GetPath(PATH_LAST));
 }


### PR DESCRIPTION
- Layer configurations are saved with a version, all versions can be read properly
- Discard layer configurations created with a newer version of vkconfig. (no forward compatibility)
- Asserts to check configuration file validity
- Some code clean up, LunarG coding conventions
- Prevent copy error with non copyable classes