### PR TITLE
vkconfig: new config naming

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,6 +59,9 @@ before_build:
   - cd build
   - cmake -G %GENERATOR% -C../helper.cmake ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
+  - cd ../vkconfig
+  - qmake
+  - nmake
 
 platform:
   - Win32

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,9 +59,6 @@ before_build:
   - cd build
   - cmake -G %GENERATOR% -C../helper.cmake ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
-  - cd ../vkconfig
-  - qmake
-  - nmake
 
 platform:
   - Win32

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -1000,6 +1000,8 @@ void Configurator::ExportConfiguration(const QString &source_file, const QString
 }
 
 bool Configurator::IsValid(const Configuration &configuration) const {
+    assert(&configuration);
+
     for (int i = 0, n = configuration._layers.size(); i < n; ++i) {
         if (!IsLayerAvailable(configuration._layers[i]->_name)) return false;
     }

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -145,6 +145,7 @@ class Configurator {
 
     // Set this as the current override configuration
     void SetActiveConfiguration(Configuration* active_configuration);
+    void SetActiveConfiguration(const QString& configuration_name);
     Configuration* GetActiveConfiguration() const { return _active_configuration; }
     void RefreshConfiguration() {
         if (_active_configuration) SetActiveConfiguration(_active_configuration);

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -329,8 +329,11 @@ void dlgProfileEditor::LoadLayerDisplay(int selection) {
 
     resizeEvent(nullptr);
     ui->layerTree->update();
-    //    int width = ui->layerTree->width() - comboWidth;
-    //    ui->layerTree->setColumnWidth(0, width);
+}
+
+QString dlgProfileEditor::GetConfigurationName() const {
+    assert(_configuration);
+    return _configuration->_name;
 }
 
 // The only way to catch the resize from the layouts

--- a/vkconfig/dlgprofileeditor.h
+++ b/vkconfig/dlgprofileeditor.h
@@ -44,6 +44,11 @@ class dlgProfileEditor : public QDialog {
     // Load all layers into the list box
     void LoadLayerDisplay(int selection = -1);
 
+    QString GetConfigurationName() const {
+        assert(_configuration);
+        return _configuration->_name;
+    }
+
    private:
     Ui::dlgProfileEditor *ui;
 

--- a/vkconfig/dlgprofileeditor.h
+++ b/vkconfig/dlgprofileeditor.h
@@ -44,10 +44,7 @@ class dlgProfileEditor : public QDialog {
     // Load all layers into the list box
     void LoadLayerDisplay(int selection = -1);
 
-    QString GetConfigurationName() const {
-        assert(_configuration);
-        return _configuration->_name;
-    }
+    QString GetConfigurationName() const;
 
    private:
     Ui::dlgProfileEditor *ui;

--- a/vkconfig/dlgprofileeditor.ui
+++ b/vkconfig/dlgprofileeditor.ui
@@ -206,7 +206,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -682,21 +682,23 @@ void MainWindow::on_pushButtonEditProfile_clicked() {
     ConfigurationListItem *item = SaveLastItem();
     if (item == nullptr) return;
 
+    Configurator &configurator = Configurator::Get();
+
     // Save current state before we go in
     _settings_tree_manager.CleanupGUI();
 
-    Configuration *configuration = Configurator::Get().GetActiveConfiguration();
+    Configuration *configuration = configurator.GetActiveConfiguration();
     assert(configuration);
 
     dlgProfileEditor dlg(this, configuration);
     dlg.exec();
 
-    Configurator &configurator = Configurator::Get();
     configurator.LoadAllConfigurations();
     configurator.SetActiveConfiguration(dlg.GetConfigurationName());
     LoadConfigurationList();
 
     RestoreLastItem();
+    _settings_tree_manager.CreateGUI(ui->layerSettingsTree, configurator.GetActiveConfiguration());
 }
 
 ///////////////////////////////////////////////////////////////
@@ -778,22 +780,20 @@ void MainWindow::EditClicked(ConfigurationListItem *item) {
     assert(item);
     assert(!item->configuration_name.isEmpty());
 
+    Configurator &configurator = Configurator::Get();
+
     SaveLastItem();
     _settings_tree_manager.CleanupGUI();
 
-    dlgProfileEditor dlg(this, Configurator::Get().FindConfiguration(item->configuration_name));
+    dlgProfileEditor dlg(this, configurator.FindConfiguration(item->configuration_name));
     dlg.exec();
 
-    Configurator &configurator = Configurator::Get();
     configurator.LoadAllConfigurations();
-    configurator.SetActiveConfiguration(item->configuration_name);
+    configurator.SetActiveConfiguration(dlg.GetConfigurationName());
     LoadConfigurationList();
 
     RestoreLastItem();
-
-    Configuration *configuration = Configurator::Get().FindConfiguration(item->configuration_name);
-    assert(configuration);
-    _settings_tree_manager.CreateGUI(ui->layerSettingsTree, configuration);
+    _settings_tree_manager.CreateGUI(ui->layerSettingsTree, configurator.GetActiveConfiguration());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -811,11 +811,9 @@ void MainWindow::NewClicked() {
         configurator.LoadAllConfigurations();
         configurator.SetActiveConfiguration(dlg.GetConfigurationName());
         LoadConfigurationList();
-        RestoreLastItem(dlg.GetConfigurationName().toUtf8().constData());
 
-        Configuration *configuration = Configurator::Get().FindConfiguration(dlg.GetConfigurationName());
-        assert(configuration);
-        _settings_tree_manager.CreateGUI(ui->layerSettingsTree, configuration);
+        RestoreLastItem(dlg.GetConfigurationName().toUtf8().constData());
+        _settings_tree_manager.CreateGUI(ui->layerSettingsTree, configurator.GetActiveConfiguration());
     }
 }
 
@@ -901,6 +899,7 @@ void MainWindow::ImportClicked(ConfigurationListItem *item) {
     if (full_import_path.isEmpty()) return;
 
     _settings_tree_manager.CleanupGUI();
+
     Configurator::Get().ImportConfiguration(full_import_path);
     LoadConfigurationList();
 }

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -170,6 +170,8 @@ void MainWindow::UpdateUI() {
         assert(!item->configuration_name.isEmpty());
 
         Configuration *configuration = configurator.FindConfiguration(item->configuration_name);
+        if (configuration == nullptr) continue;
+
         if (configurator.IsValid(*configuration)) {
             item->setText(1, item->configuration_name);
             item->radio_button->setToolTip(configuration->_description);
@@ -433,12 +435,7 @@ void MainWindow::toolsResetToDefault(bool checked) {
 
     LoadConfigurationList();
 
-    // Active or not, set it in the tree so we can see the settings.
-    for (int i = 0; i < ui->profileTree->topLevelItemCount(); i++) {
-        ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(ui->profileTree->topLevelItem(i));
-        if (item == nullptr) continue;
-        if (&item->configuration_name == active_configuration->_name) ui->profileTree->setCurrentItem(item);
-    }
+    if (active_configuration) _settings_tree_manager.CreateGUI(ui->layerSettingsTree, active_configuration);
 
     ui->logBrowser->clear();
     ui->logBrowser->append("Vulkan Development Status:");

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -46,8 +46,8 @@ QT_END_NAMESPACE
 /// with a list widget item.
 class ConfigurationListItem : public QTreeWidgetItem {
    public:
-    ConfigurationListItem(Configuration &configuration) : configuration(configuration) {}
-    Configuration &configuration;
+    ConfigurationListItem(const QString &configuration_name) : configuration_name(configuration_name) {}
+    QString configuration_name;
     QRadioButton *radio_button;
 
    private:

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -58,6 +58,8 @@ class ConfigurationListItem : public QTreeWidgetItem {
 class MainWindow : public QMainWindow {
     Q_OBJECT
 
+    Ui::MainWindow *ui;
+
    public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
@@ -85,8 +87,6 @@ class MainWindow : public QMainWindow {
    private:
     void Log(const QString &log);
 
-    Ui::MainWindow *ui;
-    ConfigurationListItem *_selected_configuration_item;
     ConfigurationListItem *GetCheckedItem();
 
     QComboBox *_launcher_apps_combo;
@@ -96,10 +96,6 @@ class MainWindow : public QMainWindow {
     QPushButton *_launcher_apps_browse_button;
     QPushButton *_launcher_working_browse_button;
     QPushButton *_launcher_log_file_browse_button;
-
-    ConfigurationListItem *SaveLastItem();
-    bool RestoreLastItem(const char *szOverride = nullptr);
-    QString _last_item;
 
     void RemoveClicked(ConfigurationListItem *item);
     void RenameClicked(ConfigurationListItem *item);

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -97,6 +97,12 @@ class MainWindow : public QMainWindow {
     QPushButton *_launcher_working_browse_button;
     QPushButton *_launcher_log_file_browse_button;
 
+    bool SelectConfigurationItem(const QString &configuration_name);
+
+    ConfigurationListItem *SaveLastItem();
+    bool RestoreLastItem(const char *szOverride = nullptr);
+    QString _last_item;
+
     void RemoveClicked(ConfigurationListItem *item);
     void RenameClicked(ConfigurationListItem *item);
     void EditClicked(ConfigurationListItem *item);

--- a/vkconfig/preferences.cpp
+++ b/vkconfig/preferences.cpp
@@ -30,6 +30,6 @@ const Preferences& Preferences::Get() {
     return instance;
 }
 
-Preferences::Preferences() : _use_separated_select_and_activate(false), _use_last_selected_application_in_launcher(false) {}
+Preferences::Preferences() : _use_last_selected_application_in_launcher(false) {}
 
 Preferences::~Preferences() {}

--- a/vkconfig/preferences.h
+++ b/vkconfig/preferences.h
@@ -25,12 +25,6 @@ class Preferences {
    public:
     static const Preferences& Get();
 
-    // When the user click on the Vulkan Layers Configurations tree,
-    // the user has to click on the ratio button is used to activate the configuration
-    // and the row is used to edit the configuration.
-    // Alternatively, selection and activation is done together wherever we click.
-    bool _use_separated_select_and_activate;
-
     // Change the current launcher application when selecting an application in the list
     // Disable by default at the feature is not ready.
     bool _use_last_selected_application_in_launcher;

--- a/vkconfig/resourcefiles/layer_info.json
+++ b/vkconfig/resourcefiles/layer_info.json
@@ -82,7 +82,7 @@
                 "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
                 "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set"
                 },
-                "default": []
+                "default": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]
             },
             "enables": {
                 "name": "Enables",

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -97,6 +97,12 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree, Configuration *conf
         }
     }
 
+    if (configuration->_excluded_layers.isEmpty() && configuration->_layers.isEmpty()) {
+        QTreeWidgetItem *item = new QTreeWidgetItem();
+        item->setText(0, "No overridden or excluded layer");
+        build_tree->addTopLevelItem(item);
+    }
+
     // Everyone is expanded.
     build_tree->resizeColumnToContents(0);
     SetTreeState(_configuration->_setting_tree_state, 0, _configuration_settings_tree->invisibleRootItem());

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -73,7 +73,7 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree, Configuration *conf
         // There are settings.
         // Okay kid, this is where it gets complicated...
         // Is this Khronos? Khronos is special...
-        if (configuration->_layers[layer_index]->_name == QString("VK_LAYER_KHRONOS_validation")) {
+        if (configuration->_layers[layer_index]->_name == "VK_LAYER_KHRONOS_validation") {
             _validation_layer_file = configuration->_layers[layer_index];
             _validation_tree_item = item;
             BuildKhronosTree();

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -112,12 +112,12 @@ void SettingsTreeManager::BuildKhronosTree() {
     _validation_presets_combo_box = new QComboBox();
     _validation_presets_combo_box->blockSignals(true);
     for (int i = ValidationPresetFirst; i <= ValidationPresetLast; ++i) {
-        QString presetName = Configurator::Get().GetValidationPresetLabel(static_cast<ValidationPreset>(i));
+        QString preset_name = Configurator::Get().GetValidationPresetLabel(static_cast<ValidationPreset>(i));
 
         // There is no preset for a user defined group of settings, so watch for blank.
-        if (presetName.isEmpty()) presetName = "User Defined";
+        if (preset_name.isEmpty()) preset_name = "User Defined";
 
-        _validation_presets_combo_box->addItem(presetName);
+        _validation_presets_combo_box->addItem(preset_name);
     }
 
     _validation_presets_combo_box->setCurrentIndex(_configuration->_preset);

--- a/vkconfig/settingstreemanager.h
+++ b/vkconfig/settingstreemanager.h
@@ -53,9 +53,9 @@ class SettingsTreeManager : QObject {
     QVector<QTreeWidgetItem *> _compound_widgets;  // These have special cleanup requirements
 
     void BuildKhronosTree();
-    void BuildGenericTree(QTreeWidgetItem *parent, Layer *layer_file);
+    void BuildGenericTree(QTreeWidgetItem *parent, Layer *layer);
 
-    QVector<QTreeWidgetItem *> _layer_items;  // These parallel the  profiles layers
+    QVector<QTreeWidgetItem *> _layer_items;  // These parallel the profiles layers
 
     QComboBox *_validation_presets_combo_box;
     Layer *_validation_layer_file;

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -25,6 +25,7 @@ linux: QMAKE_CXXFLAGS += -Wunused-variable
 
 SOURCES += \
     ..\vkconfig_core\application_singleton.cpp \
+    ..\vkconfig_core\configuration.cpp \
     ..\vkconfig_core\command_line.cpp \
     ..\vkconfig_core\environment.cpp \
     ..\vkconfig_core\util.cpp \
@@ -51,13 +52,13 @@ SOURCES += \
     khronossettingsadvanced.cpp \
     main.cpp \
     mainwindow.cpp \
-    configuration.cpp \
     preferences.cpp \
     settingstreemanager.cpp \
     configurator.cpp
 
 HEADERS += \
     ..\vkconfig_core\application_singleton.h \
+    ..\vkconfig_core\configuration.h \
     ..\vkconfig_core\command_line.h \
     ..\vkconfig_core\environment.h \
     ..\vkconfig_core\util.h \
@@ -83,7 +84,6 @@ HEADERS += \
     dlgvulkaninfo.h \
     khronossettingsadvanced.h \
     mainwindow.h \
-    configuration.h \
     preferences.h \
     settingstreemanager.h \
     configurator.h

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -32,7 +32,7 @@
 
 #include <cassert>
 
-Configuration::Configuration() : _preset(ValidationPresetNone) {}
+Configuration::Configuration() : _name("New Configuration"), _preset(ValidationPresetNone) {}
 
 Configuration::~Configuration() {
     qDeleteAll(_layers.begin(), _layers.end());
@@ -276,3 +276,5 @@ bool Configuration::Save(const QString& full_path) const {
     json_file.close();
     return true;
 }
+
+bool Configuration::IsEmpty() const { return _excluded_layers.empty() && _layers.empty(); }

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -68,4 +68,6 @@ class Configuration {
     Configuration *Duplicate();  // Copy a profile so we can mess with it
 
     void Collapse();  // Remove unused layers and settings, set blacklist
+
+    bool IsEmpty() const;
 };


### PR DESCRIPTION
- A new configuration with no layers is not an invalid configuration anymore.
- Fix naming of new configurations
- Fix naming of configurations when layers are missing
- Fix QtCreator build
