### PR TITLE
Fix for recent macOS regressions

### DIFF
--- a/vkconfig/dlgcreateassociation.cpp
+++ b/vkconfig/dlgcreateassociation.cpp
@@ -308,6 +308,9 @@ void dlgCreateAssociation::GetExecutableFromAppBundle(QString &app_path) {
             // Complete the partial path
             path += QString("MacOS/");
             path += QString(cExeName);
+
+            // Return original if not found, but root if found
+            app_path = path;
             delete[] cExeName;
             break;
         }

--- a/vkconfig/dlgvulkananalysis.cpp
+++ b/vkconfig/dlgvulkananalysis.cpp
@@ -22,6 +22,8 @@
 #include "dlgvulkananalysis.h"
 #include "ui_dlgvulkananalysis.h"
 
+#include "../vkconfig_core/platform.h"
+
 #include <stdlib.h>
 #include <QProcess>
 #include <QDir>

--- a/vkconfig_core/path_manager.cpp
+++ b/vkconfig_core/path_manager.cpp
@@ -306,13 +306,7 @@ QString PathManager::SelectPathImpl(QWidget* parent, Path path, const QString& s
                 return "";
 
             SetPath(path, QFileInfo(selected_path).absolutePath());
-#if PLATFORM_WINDOWS
-            return GetFullPath(path, QFileInfo(selected_path).baseName());
-#else
-            // On Linux, we have no extension to trim off. On macOS, we may or may not have a
-            // .app extension. If the later, it must be preserved at this point.
-            return GetFullPath(path, QFileInfo(selected_path).absoluteFilePath());
-#endif
+            return GetFullPath(path, QFileInfo(selected_path).fileName());
         }
         case PATH_WORKING_DIR: {
             const QString selected_path = QFileDialog::getExistingDirectory(parent, "Set Working Folder To...", suggested_path);

--- a/vkconfig_core/path_manager.cpp
+++ b/vkconfig_core/path_manager.cpp
@@ -306,7 +306,13 @@ QString PathManager::SelectPathImpl(QWidget* parent, Path path, const QString& s
                 return "";
 
             SetPath(path, QFileInfo(selected_path).absolutePath());
+#if PLATFORM_WINDOWS
             return GetFullPath(path, QFileInfo(selected_path).baseName());
+#else
+            // On Linux, we have no extension to trim off. On macOS, we may or may not have a
+            // .app extension. If the later, it must be preserved at this point.
+            return GetFullPath(path, QFileInfo(selected_path).absoluteFilePath());
+#endif
         }
         case PATH_WORKING_DIR: {
             const QString selected_path = QFileDialog::getExistingDirectory(parent, "Set Working Folder To...", suggested_path);


### PR DESCRIPTION
Change-Id: I513681dbd3752af3b066dba90c66a744e896950c
Mostly pertaining to restoring the correct handling of the unique nature of .app program bundles.