### PR TITLE
vkconfig: Fix configuration renaming #1144

### DIFF
--- a/vkconfig/alert.cpp
+++ b/vkconfig/alert.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#include "alert.h"
+
+#include <QMessageBox>
+
+void Alert::ConfigurationRenamingFailed() {
+    QMessageBox alert;
+    alert.setWindowTitle("Renaming of the layers configuration failed...");
+    alert.setText("There is already a configuration with the same name.");
+    alert.setInformativeText("Use a different name for the configuration.");
+    alert.setStandardButtons(QMessageBox::Ok);
+    alert.setDefaultButton(QMessageBox::Ok);
+    alert.setIcon(QMessageBox::Warning);
+    alert.exec();
+}
+
+void Alert::ConfigurationNameEmpty() {
+    QMessageBox alert;
+    alert.setWindowTitle("Renaming of the layers configuration failed...");
+    alert.setText("The configuration name is empty.");
+    alert.setInformativeText("The configuration name is required.");
+    alert.setStandardButtons(QMessageBox::Ok);
+    alert.setDefaultButton(QMessageBox::Ok);
+    alert.setIcon(QMessageBox::Warning);
+    alert.exec();
+}

--- a/vkconfig/alert.h
+++ b/vkconfig/alert.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#pragma once
+
+struct Alert {
+    static void ConfigurationRenamingFailed();
+    static void ConfigurationNameEmpty();
+};

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "configurator.h"
+#include "alert.h"
 
 #include "dlgprofileeditor.h"
 #include "ui_dlgprofileeditor.h"
@@ -401,12 +402,13 @@ void dlgProfileEditor::layerUseChanged(QTreeWidgetItem *item, int selection) {
 void dlgProfileEditor::accept() {
     // Hard Fail: Name must not be blank
     if (ui->lineEditName->text().isEmpty()) {
-        QMessageBox alert;
-        alert.setWindowTitle("The configuration name is empty...");
-        alert.setText("The configuration name is required.");
-        alert.setStandardButtons(QMessageBox::Ok);
-        alert.setIcon(QMessageBox::Warning);
-        alert.exec();
+        Alert::ConfigurationNameEmpty();
+        return;
+    }
+
+    Configurator &configurator = Configurator::Get();
+    if (configuration._name != ui->lineEditName->text() && configurator.FindConfiguration(ui->lineEditName->text())) {
+        Alert::ConfigurationRenamingFailed();
         return;
     }
 
@@ -439,7 +441,7 @@ void dlgProfileEditor::accept() {
         if (saved_parameter) parameter.settings = saved_parameter->settings;
 
         // Second, get default layer settings
-        const LayerSettingsDefaults *defaults = Configurator::Get().FindLayerSettings(layer_item->layer_name);
+        const LayerSettingsDefaults *defaults = configurator.FindLayerSettings(layer_item->layer_name);
         if (defaults && saved_parameter == nullptr) parameter.settings = defaults->default_settings;
 
         parameters.push_back(parameter);

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -35,6 +35,7 @@ SOURCES += \
     ..\vkconfig_core\layer_type.cpp \
     ..\vkconfig_core\path_manager.cpp \
     vulkan.cpp \
+    alert.cpp \
     widget_bool_setting.cpp \
     widget_enum_setting.cpp \
     widget_multi_enum_setting.cpp \
@@ -68,6 +69,7 @@ HEADERS += \
     ..\vkconfig_core\layer_type.h \
     ..\vkconfig_core\path_manager.h \
     vulkan.h \
+    alert.h \
     widget_bool_setting.h \
     widget_enum_setting.h \
     widget_multi_enum_setting.h \


### PR DESCRIPTION
- Fix issue #1144 
- Fix configuration setting area not updated correctly when failing to rename a configuration
- Fix configuration renaming on main window with an empty name assert 
- Factorize the same message box at a single code location

Change-Id: Icb210fde1e04372e28c48cd12a87e26de15cbc2c