### PR TITLE
vkconfig: Fix no setting when switch between exclude and override #1150

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -568,8 +568,8 @@ void Configurator::BuildCustomLayerTree(QTreeWidget *tree_widget) {
 ///////////////////////////////////////////////////////////////////////////////
 /// Find the settings for this named layer. If none found, return nullptr
 const LayerSettingsDefaults *Configurator::FindLayerSettings(const QString &layer_name) const {
-    for (int i = 0; i < _default_layers_settings.size(); i++)
-        if (layer_name == _default_layers_settings[i]->layer_name) return _default_layers_settings[i];
+    for (std::size_t i = 0, n = _default_layers_settings.size(); i < n; ++i)
+        if (layer_name == _default_layers_settings[i].layer_name) return &_default_layers_settings[i];
 
     return nullptr;
 }
@@ -685,17 +685,17 @@ void Configurator::LoadDefaultLayerSettings() {
     // of settings.
     QStringList layers_with_settings = layers_options_object.keys();
     for (int i = 0; i < layers_with_settings.size(); i++) {  // For each setting
-        LayerSettingsDefaults *settings_defaults = new LayerSettingsDefaults();
-        settings_defaults->layer_name = layers_with_settings[i];
+        LayerSettingsDefaults settings_defaults;
+        settings_defaults.layer_name = layers_with_settings[i];
 
         // Save the name of the layer, and by default none are read only
-        settings_defaults->layer_name = layers_with_settings[i];
+        settings_defaults.layer_name = layers_with_settings[i];
 
         // Get the object for just this layer
         QJsonValue layerValue = layers_options_object.value(layers_with_settings[i]);
         QJsonObject layerObject = layerValue.toObject();
 
-        ::LoadSettings(layerObject, settings_defaults->default_settings);
+        ::LoadSettings(layerObject, settings_defaults.default_settings);
 
         // Add to my list of layer settings
         _default_layers_settings.push_back(settings_defaults);

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -115,7 +115,7 @@ class Configurator {
     // A readonly list of layer names with the associated settings
     // and their default values. This is for reference by individual profile
     // objects.
-    QVector<LayerSettingsDefaults*> _default_layers_settings;
+    std::vector<LayerSettingsDefaults> _default_layers_settings;
     void LoadDefaultLayerSettings();
     const LayerSettingsDefaults* FindLayerSettings(const QString& layer_name) const;
 

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -442,7 +442,12 @@ void dlgProfileEditor::accept() {
 
         // Second, get default layer settings
         const LayerSettingsDefaults *defaults = configurator.FindLayerSettings(layer_item->layer_name);
-        if (defaults && saved_parameter == nullptr) parameter.settings = defaults->default_settings;
+        if (defaults && (parameter.settings.empty() || saved_parameter == nullptr)) {
+            parameter.settings = defaults->default_settings;
+            if (parameter.name == "VK_LAYER_KHRONOS_validation") {
+                configuration._preset = ValidationPresetStandard;
+            }
+        }
 
         parameters.push_back(parameter);
     }

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -159,12 +159,16 @@ bool Configuration::Load(const QString& full_path) {
 
         // const QJsonValue& layer_rank = layer_object.value("layer_rank");
 
-        Parameter parameter;
-        parameter.name = layers[layer_index];
-        parameter.state = LAYER_STATE_OVERRIDDEN;
-        LoadSettings(layer_object, parameter.settings);
-
-        parameters.push_back(parameter);
+        Parameter* parameter = FindParameter(layers[layer_index]);
+        if (parameter) {
+            LoadSettings(layer_object, parameter->settings);
+        } else {
+            Parameter parameter;
+            parameter.name = layers[layer_index];
+            parameter.state = LAYER_STATE_OVERRIDDEN;
+            LoadSettings(layer_object, parameter.settings);
+            parameters.push_back(parameter);
+        }
     }
 
     return true;
@@ -189,7 +193,7 @@ bool Configuration::Save(const QString& full_path) const {
 
     for (std::size_t i = 0, n = parameters.size(); i < n; ++i) {
         const Parameter& parameter = parameters[i];
-        if (parameters[i].state != LAYER_STATE_OVERRIDDEN) {
+        if (parameters[i].state == LAYER_STATE_APPLICATION_CONTROLLED) {
             continue;
         }
 


### PR DESCRIPTION
- The settings are stored when switching to excluding the layer
- The settings are restored to the user selection when switching from exclude
to override
- When creating a new configuration with the validation layer the preset shows
'Standard' instead of 'User Defined'
- Fix a memory leak of default settings

Now fixed:
![no_settings_fixed](https://user-images.githubusercontent.com/62888873/93231374-f9f5e780-f778-11ea-8ff1-2917b3b4b88a.gif)

Previously broken (and they were no way to restore the settings hence the P0):
![no_settings](https://user-images.githubusercontent.com/62888873/93231451-08dc9a00-f779-11ea-843b-d42ea2d6f0bc.gif)

Change-Id: I429ba4f4b47917b5284ba69998425cd63a18a93f