### PR TITLE
Fix gui update issue on macOS

### DIFF
--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -307,6 +307,7 @@ void dlgProfileEditor::on_pushButtonResetLayers_clicked() {
         TreeFriendlyComboBoxWidget *widget = dynamic_cast<TreeFriendlyComboBoxWidget *>(ui->layerTree->itemWidget(layer_item, 1));
         assert(widget);
         widget->setCurrentIndex(layer_item->layer_state);
+        ui->layerTree->repaint();  // Force update for macOS
     }
 }
 


### PR DESCRIPTION
Change-Id: I4ae82837c694f27f47edd15fab057ae57b07863d

Minor refresh issue that was only observed on macOS (others may exist).
Calling repaint() for force the update of the parent tree widget forced the update to occur (previously, resizing the window would do it). This is likely a Qt bug, but the repaint() work around causes no harm on Windows or Linux.