### PR TITLE
vkconfig: Add support for VK_KHR_portability_subset to devsim

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -794,7 +794,14 @@ void Configurator::LoadDefaultLayerSettings() {
         const QJsonValue &layer_value = layers_options_object.value(layers_with_settings[i]);
         const QJsonObject &layer_object = layer_value.toObject();
 
-        ::LoadSettings(layer_object, settings_defaults.settings);
+        Parameter parameter;
+        parameter.name = settings_defaults.layer_name;
+        parameter.state = LAYER_STATE_APPLICATION_CONTROLLED;
+        parameter.settings = settings_defaults.settings;
+
+        ::LoadSettings(layer_object, parameter);
+
+        settings_defaults.settings = parameter.settings;
 
         // Add to my list of layer settings
         _default_layers_settings.push_back(settings_defaults);

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -192,8 +192,8 @@ Configurator::Configurator()
 bool Configurator::Init() {
     // Load simple app settings, the additional search paths, and the
     // override app list.
-    LoadDefaultLayerSettings();  // findAllInstalledLayers uses the results of this.
     LoadAllInstalledLayers();
+    LoadDefaultLayerSettings();
 
     // If no layers are found, give the user another chance to add some custom paths
     if (_available_Layers.empty()) {
@@ -673,6 +673,8 @@ void Configurator::LoadAllConfigurations() {
 // the defaults. These are all stored in layer_info.json
 // 4/8/2020
 void Configurator::LoadDefaultLayerSettings() {
+    assert(!_available_Layers.isEmpty());  // layers should be loaded before default settings
+
     // Load the main object into the json document
     QFile file(":/resourcefiles/layer_info.json");
     file.open(QFile::ReadOnly);
@@ -702,11 +704,13 @@ void Configurator::LoadDefaultLayerSettings() {
         // Save the name of the layer, and by default none are read only
         settings_defaults.layer_name = layers_with_settings[i];
 
-        // Get the object for just this layer
-        QJsonValue layerValue = layers_options_object.value(layers_with_settings[i]);
-        QJsonObject layerObject = layerValue.toObject();
+        Layer *layer = FindLayerNamed(settings_defaults.layer_name);
 
-        ::LoadSettings(layerObject, settings_defaults.settings);
+        // Get the object for just this layer
+        const QJsonValue &layer_value = layers_options_object.value(layers_with_settings[i]);
+        const QJsonObject &layer_object = layer_value.toObject();
+
+        ::LoadSettings(layer_object, settings_defaults.settings);
 
         // Add to my list of layer settings
         _default_layers_settings.push_back(settings_defaults);

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -43,6 +43,8 @@
 
 #define DONT_SHOW_AGAIN_MESSAGE "Do not show again"
 
+void SortLayers(std::vector<Parameter>& parameters);
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Going back and forth between the Windows registry and looking for files
 /// in specific folders is just a mess. This class consolidates all that into

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -458,7 +458,7 @@ void dlgProfileEditor::accept() {
         parameters.push_back(layer_item->parameter);
     }
 
-    Sort(parameters);
+    SortLayers(parameters);
 
     configuration._name = ui->lineEditName->text();
     configuration._description = ui->lineEditDescription->text();

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -252,6 +252,22 @@ void dlgProfileEditor::LoadLayerDisplay() {
     ui->layerTree->clear();
 
     Configurator &configurator = Configurator::Get();
+    QVector<Layer *> &available_layers = Configurator::Get()._available_Layers;
+
+    for (int i = 0, n = available_layers.size(); i < n; ++i) {
+        const Layer &layer = *available_layers[i];
+
+        if (layer._layer_type != LAYER_TYPE_IMPLICIT) continue;
+
+        // The layer is overridden
+        if (configuration.FindParameter(layer._name)) continue;
+
+        Parameter parameter;
+        parameter.name = layer._name;
+        parameter.state = LAYER_STATE_APPLICATION_CONTROLLED;
+
+        AddLayerItem(parameter);
+    }
 
     // Loop through the layers. They are expected to be in order
     for (std::size_t i = 0, n = configuration.parameters.size(); i < n; ++i) {
@@ -261,9 +277,10 @@ void dlgProfileEditor::LoadLayerDisplay() {
         AddLayerItem(parameter);
     }
 
-    QVector<Layer *> &available_layers = Configurator::Get()._available_Layers;
     for (int i = 0, n = available_layers.size(); i < n; ++i) {
         const Layer &layer = *available_layers[i];
+
+        if (layer._layer_type == LAYER_TYPE_IMPLICIT) continue;
 
         // The layer is already in the layer tree
         if (configuration.FindParameter(layer._name)) continue;

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -314,14 +314,12 @@ void dlgProfileEditor::resizeEvent(QResizeEvent *event) {
 /// This button clears the display. Basically, we delete the profile and
 /// start over.
 void dlgProfileEditor::on_pushButtonResetLayers_clicked() {
+    configuration._preset = ValidationPresetNone;
+
     for (int i = 0, n = ui->layerTree->topLevelItemCount(); i < n; ++i) {
         TreeWidgetItemParameter *layer_item = dynamic_cast<TreeWidgetItemParameter *>(ui->layerTree->topLevelItem(i));
         assert(layer_item);
         layer_item->parameter.state = LAYER_STATE_APPLICATION_CONTROLLED;
-
-        if (layer_item->parameter.name == "VK_LAYER_KHRONOS_validation") {
-            configuration._preset = GetValidationPreset(configuration._name);
-        }
 
         const LayerSettingsDefaults *defaults = Configurator::Get().FindLayerSettings(layer_item->parameter.name);
         if (defaults) layer_item->parameter.settings = defaults->settings;

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -458,6 +458,8 @@ void dlgProfileEditor::accept() {
         parameters.push_back(layer_item->parameter);
     }
 
+    Sort(parameters);
+
     configuration._name = ui->lineEditName->text();
     configuration._description = ui->lineEditDescription->text();
     configuration.parameters = parameters;

--- a/vkconfig/dlgprofileeditor.cpp
+++ b/vkconfig/dlgprofileeditor.cpp
@@ -292,10 +292,6 @@ void dlgProfileEditor::LoadLayerDisplay() {
         const LayerSettingsDefaults *defaults = configurator.FindLayerSettings(layer._name);
         if (defaults) parameter.settings = defaults->settings;
 
-        if (layer._name == "VK_LAYER_KHRONOS_validation") {
-            configuration._preset = GetValidationPreset(ui->lineEditName->text());
-        }
-
         AddLayerItem(parameter);
     }
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -130,7 +130,7 @@ MainWindow::MainWindow(QWidget *parent)
     // insufficinet.
     ui->logBrowser->document()->setMaximumBlockCount(2048);
     ui->logBrowser->append("Vulkan Development Status:");
-    // ui->logBrowser->append(GenerateVulkanStatus());
+    ui->logBrowser->append(GenerateVulkanStatus());
     ui->profileTree->scrollToItem(ui->profileTree->topLevelItem(0), QAbstractItemView::PositionAtTop);
 
     if (current_configuration) {
@@ -440,7 +440,7 @@ void MainWindow::toolsResetToDefault(bool checked) {
 
     ui->logBrowser->clear();
     ui->logBrowser->append("Vulkan Development Status:");
-    // ui->logBrowser->append(GenerateVulkanStatus());
+    ui->logBrowser->append(GenerateVulkanStatus());
 
     UpdateUI();
 }

--- a/vkconfig/resourcefiles/layer_info.json
+++ b/vkconfig/resourcefiles/layer_info.json
@@ -221,7 +221,7 @@
         },
         "VK_LAYER_LUNARG_device_simulation": {
             "filename": {
-                "name": "Filename",
+                "name": "Devsim JSON configuration file",
                 "description": "Name of one or more configuration file(s) to load.",
                 "type": "load_file",
                 "default": ""
@@ -233,14 +233,10 @@
                 "default": "0"
             },
             "emulate_portability": {
-                "name": "Emulation mode",
-                "description": "",
-                "type": "enum",
-                "options": {
-                    "": "Vulkan 1.0",
-                    "VK_DEVSIM_EMULATE_PORTABILITY_SUBSET_EXTENSION": "Vulkan Portability"
-                },
-                "default": ""
+                "name": "Emulate VK_KHR_portability_subset",
+                "description": "Emulate that VK_KHR_portability_subset extension is supported by the device.",
+                "type": "bool_numeric",
+                "default": "0"
             },
             "exit_on_error": {
                 "name": "Exit On Error",

--- a/vkconfig/resourcefiles/layer_info.json
+++ b/vkconfig/resourcefiles/layer_info.json
@@ -232,6 +232,16 @@
                 "type": "bool_numeric",
                 "default": "0"
             },
+            "emulate_portability": {
+                "name": "Emulation mode",
+                "description": "",
+                "type": "enum",
+                "options": {
+                    "": "Vulkan 1.0",
+                    "VK_DEVSIM_EMULATE_PORTABILITY_SUBSET_EXTENSION": "Vulkan Portability"
+                },
+                "default": ""
+            },
             "exit_on_error": {
                 "name": "Exit On Error",
                 "description": "Enables exit-on-error.",

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -89,7 +89,7 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree, Configuration *conf
             }
 
             // Generic is the only one left
-            BuildGenericTree(item, parameter.settings);
+            BuildGenericTree(item, parameter);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -277,7 +277,9 @@ void SettingsTreeManager::khronosDebugChanged(int index) {
     profileEdited();
 }
 
-void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, std::vector<LayerSetting> &settings) {
+void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &parameter) {
+    std::vector<LayerSetting> &settings = parameter.settings;
+
     for (std::size_t setting_index = 0, n = settings.size(); setting_index < n; setting_index++) {
         LayerSetting &setting = settings[setting_index];
 
@@ -287,6 +289,14 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, std::vector<
             case SETTING_BOOL:          // True false?
             case SETTING_BOOL_NUMERIC:  // True false? (with numeric output instead of text)
             {
+                // Don't display "emulate_portability" setting if the layer doesn't support it
+                if (setting.name == "emulate_portability" && parameter.name == "VK_LAYER_LUNARG_device_simulation") {
+                    Layer *layer = Configurator::Get().FindLayerNamed("VK_LAYER_LUNARG_device_simulation");
+                    if (layer) {
+                        if (Version(layer->_implementation_version) <= Version("1.3.0")) break;
+                    }
+                }
+
                 BoolSettingWidget *widget = new BoolSettingWidget(setting, setting.type);
                 parent->addChild(setting_item);
                 _configuration_settings_tree->setItemWidget(setting_item, 0, widget);

--- a/vkconfig/settingstreemanager.h
+++ b/vkconfig/settingstreemanager.h
@@ -55,7 +55,7 @@ class SettingsTreeManager : QObject {
     QVector<QTreeWidgetItem *> _compound_widgets;  // These have special cleanup requirements
 
     void BuildKhronosTree(std::vector<LayerSetting> &settings);
-    void BuildGenericTree(QTreeWidgetItem *parent, std::vector<LayerSetting> &settings);
+    void BuildGenericTree(QTreeWidgetItem *parent, Parameter &parameter);
 
     QVector<QTreeWidgetItem *> _layer_items;  // These parallel the profiles layers
 

--- a/vkconfig/vulkan.cpp
+++ b/vkconfig/vulkan.cpp
@@ -68,6 +68,8 @@ Version GetVulkanLoaderVersion() {
 QString GenerateVulkanStatus() {
     QString log;
 
+    return log;  // bug https://github.com/LunarG/VulkanTools/issues/1172
+
     // Check Vulkan SDK path
     QString search_path = qgetenv("VULKAN_SDK");
     QFileInfo local(search_path);
@@ -106,6 +108,7 @@ QString GenerateVulkanStatus() {
     QLibrary library(VULKAN_LIBRARY);
     PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties =
         (PFN_vkEnumerateInstanceLayerProperties)library.resolve("vkEnumerateInstanceLayerProperties");
+    assert(vkEnumerateInstanceLayerProperties);
 
     std::uint32_t instance_layer_count = 0;
     VkResult err = vkEnumerateInstanceLayerProperties(&instance_layer_count, NULL);
@@ -146,6 +149,7 @@ QString GenerateVulkanStatus() {
 
     VkInstance inst;
     PFN_vkCreateInstance vkCreateInstance = (PFN_vkCreateInstance)library.resolve("vkCreateInstance");
+    assert(vkCreateInstance);
     err = vkCreateInstance(&inst_info, NULL, &inst);
     if (err == VK_ERROR_INCOMPATIBLE_DRIVER) {
         QMessageBox alert(NULL);

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -158,12 +158,12 @@ bool Configuration::Load(const QString& full_path) {
 
         Parameter* parameter = FindParameter(layers[layer_index]);
         if (parameter) {
-            LoadSettings(layer_object, parameter->settings);
+            LoadSettings(layer_object, *parameter);
         } else {
             Parameter parameter;
             parameter.name = layers[layer_index];
             parameter.state = LAYER_STATE_OVERRIDDEN;
-            LoadSettings(layer_object, parameter.settings);
+            LoadSettings(layer_object, parameter);
             parameters.push_back(parameter);
         }
     }
@@ -198,7 +198,7 @@ bool Configuration::Save(const QString& full_path) const {
         // Rank goes in here with settings
         json_settings.insert("layer_rank", static_cast<int>(i));
 
-        const bool result = SaveSettings(parameter.settings, json_settings);
+        const bool result = SaveSettings(parameter, json_settings);
         assert(result);
 
         overridden_list.insert(parameter.name, json_settings);
@@ -235,23 +235,3 @@ bool Configuration::Save(const QString& full_path) const {
 }
 
 bool Configuration::IsEmpty() const { return parameters.empty(); }
-
-bool operator==(const std::vector<Parameter>& a, const std::vector<Parameter>& b) {
-    if (a.size() != b.size()) return false;
-
-    for (std::size_t i = 0, n = a.size(); i < n; ++i) {
-        if (a[i].name != b[i].name) return false;
-
-        if (a[i].state != b[i].state) return false;
-
-        if (a[i].settings.size() != b[i].settings.size()) return false;
-
-        for (std::size_t j = 0, o = a[i].settings.size(); j < o; ++j) {
-            if (a[i].settings[j] != b[i].settings[j]) return false;
-        }
-    }
-
-    return true;
-}
-
-bool operator!=(const std::vector<Parameter>& a, const std::vector<Parameter>& b) { return !(a == b); }

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -33,16 +33,6 @@
 
 #include <cassert>
 
-void Sort(std::vector<Parameter>& parameters) {
-    std::vector<Parameter> sorted_parameters;
-
-    for (std::size_t i = 0, n = parameters.size(); i < n; ++i) {
-        if (parameters[i].state == LAYER_STATE_EXCLUDED) sorted_parameters.push_back(parameters[i]);
-    }
-
-    std::swap(parameters, sorted_parameters);
-}
-
 Configuration::Configuration() : _name("New Configuration"), _preset(ValidationPresetNone) {}
 
 ///////////////////////////////////////////////////////////
@@ -159,9 +149,6 @@ bool Configuration::Load(const QString& full_path) {
         alert.setDefaultButton(QMessageBox::Yes);
         if (alert.exec() == QMessageBox::No) exit(-1);
     }
-
-    // Build the list of layers with their settings. If both the layers and
-    // the blacklist are emtpy, then automatic fail
 
     for (int layer_index = 0; layer_index < layers.length(); layer_index++) {
         const QJsonValue& layer_value = layer_objects.value(layers[layer_index]);

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -33,6 +33,16 @@
 
 #include <cassert>
 
+void Sort(std::vector<Parameter>& parameters) {
+    std::vector<Parameter> sorted_parameters;
+
+    for (std::size_t i = 0, n = parameters.size(); i < n; ++i) {
+        if (parameters[i].state == LAYER_STATE_EXCLUDED) sorted_parameters.push_back(parameters[i]);
+    }
+
+    std::swap(parameters, sorted_parameters);
+}
+
 Configuration::Configuration() : _name("New Configuration"), _preset(ValidationPresetNone) {}
 
 ///////////////////////////////////////////////////////////

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -45,17 +45,6 @@ enum ValidationPreset {
 
 enum { ValidationPresetCount = ValidationPresetLast - ValidationPresetFirst + 1 };
 
-struct Parameter {
-    Parameter() : state(LAYER_STATE_APPLICATION_CONTROLLED) {}
-
-    QString name;
-    LayerState state;
-    std::vector<LayerSetting> settings;
-};
-
-// Order of layers matters and we handle this internally
-void SortLayers(std::vector<Parameter>& parameters);
-
 class Configuration {
    public:
     Configuration();
@@ -75,6 +64,3 @@ class Configuration {
 
     bool IsEmpty() const;
 };
-
-bool operator==(const std::vector<Parameter>& a, const std::vector<Parameter>& b);
-bool operator!=(const std::vector<Parameter>& a, const std::vector<Parameter>& b);

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -53,6 +53,9 @@ struct Parameter {
     std::vector<LayerSetting> settings;
 };
 
+// Order of layers matters and we handle this internally
+void Sort(std::vector<Parameter>& parameters);
+
 class Configuration {
    public:
     Configuration();

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -54,7 +54,7 @@ struct Parameter {
 };
 
 // Order of layers matters and we handle this internally
-void Sort(std::vector<Parameter>& parameters);
+void SortLayers(std::vector<Parameter>& parameters);
 
 class Configuration {
    public:

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -38,18 +38,6 @@
 void RemoveString(QString& delimitedString, QString value);
 void AddString(QString& delimitedString, QString value);
 
-// The value of this enum can't be changed
-enum LayerState {
-    LAYER_STATE_APPLICATION_CONTROLLED = 0,  // The Vulkan application configured this layer at will
-    LAYER_STATE_OVERRIDDEN = 1,              // Force on/override this layer and configure it regarless of the Vulkan application
-    LAYER_STATE_EXCLUDED = 2,                // Force off/exclude this layer regarless of the Vulkan application
-
-    LAYER_STATE_FIRST = LAYER_STATE_APPLICATION_CONTROLLED,
-    LAYER_STATE_LAST = LAYER_STATE_EXCLUDED
-};
-
-enum { LAYER_STATE_COUNT = LAYER_STATE_LAST - LAYER_STATE_FIRST + 1 };
-
 class Layer {
    public:
     Layer();

--- a/vkconfig_core/layer_setting.cpp
+++ b/vkconfig_core/layer_setting.cpp
@@ -98,10 +98,10 @@ LayerSetting& FindSetting(std::vector<LayerSetting>& settings, const char* name)
     return settings[0];
 }
 
-bool LoadSettings(const QJsonObject& json_layer_settings, std::vector<LayerSetting>& settings) {
+bool LoadSettings(const QJsonObject& json_layer_settings, Parameter& parameter) {
     const QStringList& settings_names = json_layer_settings.keys();
 
-    for (int setting_index = 0, setting_count = settings_names.size(); setting_index < setting_count; setting_index++) {
+    for (int setting_index = 0, setting_count = settings_names.size(); setting_index < setting_count; ++setting_index) {
         // The layer rank may or may not be here, but it is not a
         // user setting.
         if (settings_names[setting_index] == "layer_rank") continue;
@@ -194,19 +194,19 @@ bool LoadSettings(const QJsonObject& json_layer_settings, std::vector<LayerSetti
                 break;
         }
 
-        settings.push_back(setting);
+        parameter.settings.push_back(setting);
     }
 
     return true;
 }
 
-bool SaveSettings(const std::vector<LayerSetting>& settings, QJsonObject& json_settings) {
+bool SaveSettings(const Parameter& parameter, QJsonObject& json_settings) {
     assert(&json_settings);
 
     // Loop through the actual settings
-    for (std::size_t setting_index = 0, setting_count = settings.size(); setting_index < setting_count; setting_index++) {
+    for (std::size_t setting_index = 0, setting_count = parameter.settings.size(); setting_index < setting_count; ++setting_index) {
         QJsonObject json_setting;
-        const LayerSetting& setting = settings[setting_index];
+        const LayerSetting& setting = parameter.settings[setting_index];
 
         json_setting.insert("name", setting.label);
         json_setting.insert("description", setting.description);
@@ -263,3 +263,23 @@ bool SaveSettings(const std::vector<LayerSetting>& settings, QJsonObject& json_s
 
     return true;
 }
+
+bool operator==(const std::vector<Parameter>& a, const std::vector<Parameter>& b) {
+    if (a.size() != b.size()) return false;
+
+    for (std::size_t i = 0, n = a.size(); i < n; ++i) {
+        if (a[i].name != b[i].name) return false;
+
+        if (a[i].state != b[i].state) return false;
+
+        if (a[i].settings.size() != b[i].settings.size()) return false;
+
+        for (std::size_t j = 0, o = a[i].settings.size(); j < o; ++j) {
+            if (a[i].settings[j] != b[i].settings[j]) return false;
+        }
+    }
+
+    return true;
+}
+
+bool operator!=(const std::vector<Parameter>& a, const std::vector<Parameter>& b) { return !(a == b); }

--- a/vkconfig_core/layer_setting.h
+++ b/vkconfig_core/layer_setting.h
@@ -47,6 +47,18 @@ enum SettingType {  // Enum value can't be changed
 
 enum { SETTING_COUNT = SETTING_LAST - SETTING_FIRST + 1 };
 
+// The value of this enum can't be changed
+enum LayerState {
+    LAYER_STATE_APPLICATION_CONTROLLED = 0,  // The Vulkan application configured this layer at will
+    LAYER_STATE_OVERRIDDEN = 1,              // Force on/override this layer and configure it regarless of the Vulkan application
+    LAYER_STATE_EXCLUDED = 2,                // Force off/exclude this layer regarless of the Vulkan application
+
+    LAYER_STATE_FIRST = LAYER_STATE_APPLICATION_CONTROLLED,
+    LAYER_STATE_LAST = LAYER_STATE_EXCLUDED
+};
+
+enum { LAYER_STATE_COUNT = LAYER_STATE_LAST - LAYER_STATE_FIRST + 1 };
+
 struct LayerSetting {
     QString name;                  // Name of the setting the layer looks for (programatic variable name)
     QString label;                 // Short name to prompt end user
@@ -69,5 +81,19 @@ LayerSetting& FindSetting(std::vector<LayerSetting>& settings, const char* name)
 SettingType GetSettingType(const char* token);
 const char* GetSettingTypeToken(SettingType type);
 
-bool LoadSettings(const QJsonObject& layer_settings_descriptors, std::vector<LayerSetting>& settings);
-bool SaveSettings(const std::vector<LayerSetting>& settings, QJsonObject& layer_settings_descriptors);
+struct Parameter {
+    Parameter() : state(LAYER_STATE_APPLICATION_CONTROLLED) {}
+
+    QString name;
+    LayerState state;
+    std::vector<LayerSetting> settings;
+};
+
+bool LoadSettings(const QJsonObject& layer_settings_descriptors, Parameter& parameter);
+bool SaveSettings(const Parameter& parameter, QJsonObject& layer_settings_descriptors);
+
+// Order of layers matters and we handle this internally
+void SortLayers(std::vector<Parameter>& parameters);
+
+bool operator==(const std::vector<Parameter>& a, const std::vector<Parameter>& b);
+bool operator!=(const std::vector<Parameter>& a, const std::vector<Parameter>& b);


### PR DESCRIPTION
- Add a setting to be able to enable VK_KHR_portability_subset emulation with devsim
- Sort the layers in a matter that reflect the layer properties. devsim layer will always be ordered last, close to the device.
- This PR resolved at least partially #1160

TODO:
- Check the version of devsim layer before displaying VK_KHR_portability_subset emulation setting.

