### PR TITLE
vkconfig: Improve the management of tool home directories

### DIFF
--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -137,6 +137,7 @@ class Configurator {
     void ImportConfiguration(const QString& full_import_path);
     void ExportConfiguration(const QString& source_file, const QString& full_export_path);
     bool HasMissingLayers(const Configuration& configuration) const;
+    void ResetDefaultsConfigurations();
 
     bool HasLayers() const;
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -404,38 +404,14 @@ void MainWindow::toolsResetToDefault(bool checked) {
     alert.setDefaultButton(QMessageBox::Yes);
     if (alert.exec() == QMessageBox::No) return;
 
-    Configurator &configurator = Configurator::Get();
-
-    // Clear the current profile as we may be about to remove it.
-    configurator.SetActiveConfiguration(nullptr);
-
-    configurator.environment.Reset(Environment::DEFAULT);
-
-    // Delete all the *.json files in the storage folder
-    QDir dir(configurator.path.GetPath(PATH_CONFIGURATION));
-    dir.setFilter(QDir::Files | QDir::NoSymLinks);
-    dir.setNameFilters(QStringList() << "*.json");
-    QFileInfoList configuration_files = dir.entryInfoList();
-
-    // Loop through all the profiles found and remove them
-    for (int i = 0; i < configuration_files.size(); i++) {
-        QFileInfo info = configuration_files.at(i);
-        if (info.absoluteFilePath().contains("applist.json")) continue;
-        remove(info.filePath().toUtf8().constData());
-    }
-
-    // Now we need to kind of restart everything
     _settings_tree_manager.CleanupGUI();
-    configurator.LoadAllConfigurations();
 
-    // Find the "Validation - Standard" configuration and make it current if we are active
-    Configuration *active_configuration = configurator.FindConfiguration(configurator.environment.Get(ACTIVE_CONFIGURATION));
-    if (configurator.environment.UseOverride()) {
-        configurator.SetActiveConfiguration(active_configuration);
-    }
+    Configurator &configurator = Configurator::Get();
+    configurator.ResetDefaultsConfigurations();
 
     LoadConfigurationList();
 
+    Configuration *active_configuration = configurator.FindConfiguration(configurator.environment.Get(ACTIVE_CONFIGURATION));
     if (active_configuration) _settings_tree_manager.CreateGUI(ui->layerSettingsTree, active_configuration);
 
     ui->logBrowser->clear();

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -223,7 +223,7 @@ bool Configuration::Save(const QString& full_path) const {
     QFile json_file(full_path);
     if (!json_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QMessageBox alert;
-        alert.setText("Could not save configuration file!");
+        alert.setText("Could not save the configuration file!");
         alert.setWindowTitle(_name);
         alert.setIcon(QMessageBox::Warning);
         alert.exec();

--- a/vkconfig_core/path_manager.h
+++ b/vkconfig_core/path_manager.h
@@ -60,6 +60,8 @@ class PathManager {
     bool Load();
     bool Save();
 
+    void CheckDefaultDirectories() const;
+
     const char* GetPath(Path path) const;
 
     // The path value should not have the filename


### PR DESCRIPTION
- When no configuration could be found on start up, the tool ask the user if the user want to restore the default configuration
- When the Vulkan Configurator home directories are deleted, the directories are recreated and all the user/current configurations restored on Vulkan Configurator exist 

Change-Id: Ia1cb480821f9b37986b7469ff9581800a742619b