### PR TITLE
devsim: Fix manifest JSON file

### DIFF
--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -13,10 +13,6 @@
                  "spec_version": "1",
                  "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
                         ]
-            },
-            {
-                 "name": "VK_KHR_portability_subset",
-                 "spec_version": "1"
             }
         ]
 


### PR DESCRIPTION
Small change to the VK_LAYER_LUNARG_device_simulation manifest JSON file
to fix behaviour with VkConfig.

With the addition of the portability emulation feature, the
layer sometimes implements the VK_KHR_portability_subset extension and
sometimes doesn't.  Because of this, we want more control over how the
layer reports the implementation of VK_KHR_portability_subset.

This requires removal of the extension entry in the layer manifest JSON
file.

Change-Id: Iebb2f68317bc4d73ccba940d224506c8b492d664