### PR TITLE
macOS fixes for cmake builds

### DIFF
--- a/vkconfig/macOS/vkconfig.cmake
+++ b/vkconfig/macOS/vkconfig.cmake
@@ -28,7 +28,7 @@ set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/macOS/Resources/LunarGIc
                             PROPERTIES
                             MACOSX_PACKAGE_LOCATION
                             "Resources")
-target_link_libraries(vkconfig Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
+target_link_libraries(vkconfig vkconfig_core Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
 target_link_libraries(vkconfig "-framework Cocoa -framework QuartzCore")
 
 get_target_property(QMAKE_EXE Qt5::qmake IMPORTED_LOCATION)

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -24,16 +24,16 @@ Release: DEFINES += QT_NO_DEBUG_OUTPUT QT_NO_WARNING_OUTPUT
 linux: QMAKE_CXXFLAGS += -Wunused-variable
 
 SOURCES += \
-    ..\vkconfig_core\application_singleton.cpp \
-    ..\vkconfig_core\configuration.cpp \
-    ..\vkconfig_core\command_line.cpp \
-    ..\vkconfig_core\environment.cpp \
-    ..\vkconfig_core\util.cpp \
-    ..\vkconfig_core\version.cpp \
-    ..\vkconfig_core\layer.cpp \
-    ..\vkconfig_core\layer_setting.cpp \
-    ..\vkconfig_core\layer_type.cpp \
-    ..\vkconfig_core\path_manager.cpp \
+    ../vkconfig_core/application_singleton.cpp \
+    ../vkconfig_core/configuration.cpp \
+    ../vkconfig_core/command_line.cpp \
+    ../vkconfig_core/environment.cpp \
+    ../vkconfig_core/util.cpp \
+    ../vkconfig_core/version.cpp \
+    ../vkconfig_core/layer.cpp \
+    ../vkconfig_core/layer_setting.cpp \
+    ../vkconfig_core/layer_type.cpp \
+    ../vkconfig_core/path_manager.cpp \
     vulkan.cpp \
     alert.cpp \
     widget_bool_setting.cpp \

--- a/vkconfig_core/CMakeLists.txt
+++ b/vkconfig_core/CMakeLists.txt
@@ -17,18 +17,17 @@ if(Qt5_FOUND)
     add_definitions(-DQT_NO_DEBUG_OUTPUT)
     add_definitions(-DQT_NO_WARNING_OUTPUT)
 
-    if(NOT APPLE)
-        add_library(vkconfig_core STATIC ${FILES_ALL})
 
-        if(WIN32)
-            add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-            target_link_libraries(vkconfig_core Cfgmgr32)
-        endif()
+    add_library(vkconfig_core STATIC ${FILES_ALL})
 
-        target_include_directories(vkconfig_core PRIVATE "${Vulkan_INCLUDE_DIR}")
-        target_link_libraries(vkconfig_core Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
-        target_compile_definitions(vkconfig_core PRIVATE ${VKCONFIG_DEFINITIONS})
-
-        add_subdirectory(test)
+    if(WIN32)
+        add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+        target_link_libraries(vkconfig_core Cfgmgr32)
     endif()
+
+    target_include_directories(vkconfig_core PRIVATE "${Vulkan_INCLUDE_DIR}")
+    target_link_libraries(vkconfig_core Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
+    target_compile_definitions(vkconfig_core PRIVATE ${VKCONFIG_DEFINITIONS})
+
+    add_subdirectory(test)
 endif()


### PR DESCRIPTION
Change-Id: I720dd07676ee57dbcc0be122e3ae10d7cbdc3d3f
This commit will be needed for macOS SDK builds.
Recent refactoring has broken macOS builds when using cmake.
In addition, the version of Qt used on macOS for SDK builds is less tolerant of forward slash/backslash issues, so it is corrected here as well.