### PR TITLE
vkconfig: Fixed macOS regression for vkcube search

### DIFF
--- a/vkconfig_core/environment.cpp
+++ b/vkconfig_core/environment.cpp
@@ -319,6 +319,25 @@ static QString GetDefaultExecutablePath(const QString& executable_name) {
 #error "Unknown platform"
 #endif
 
+#if PLATFORM_MACOS
+    // Using the standard install loation on macOS
+    {
+        const QString search_path = "/Applications/" + executable_name;
+        QFileInfo file_info(search_path);
+        if (file_info.exists())  // Couldn't find vkcube
+            return file_info.filePath();
+    }
+
+    // Using relative path to vkconfig in case SDK is not "installed"
+    {
+        const QString search_path = QString("..") + DEFAULT_PATH + executable_name;
+        QFileInfo file_info(search_path);
+        if (file_info.exists())                   // Couldn't find vkcube
+            return file_info.absoluteFilePath();  // This cannot be file path like the others
+    }
+    // Allow fall through to below. Really, only the VULKAN_SDK is likely to catch anything
+#endif
+
     // Using relative path to vkconfig
     {
         const QString search_path = QString("../bin") + DEFAULT_PATH + executable_name;

--- a/vkconfig_core/environment.cpp
+++ b/vkconfig_core/environment.cpp
@@ -319,24 +319,24 @@ static QString GetDefaultExecutablePath(const QString& executable_name) {
 #error "Unknown platform"
 #endif
 
-if(PLATFORM_MACOS) {
-    // Using the standard install loation on macOS
-    {
-        const QString search_path = "/Applications/" + executable_name;
-        QFileInfo file_info(search_path);
-        if (file_info.exists())  // Couldn't find vkcube
-            return file_info.filePath();
-    }
+    if (PLATFORM_MACOS) {
+        // Using the standard install loation on macOS
+        {
+            const QString search_path = "/Applications/" + executable_name;
+            QFileInfo file_info(search_path);
+            if (file_info.exists())  // Couldn't find vkcube
+                return file_info.filePath();
+        }
 
-    // Using relative path to vkconfig in case SDK is not "installed"
-    {
-        const QString search_path = QString("..") + DEFAULT_PATH + executable_name;
-        QFileInfo file_info(search_path);
-        if (file_info.exists())                   // Couldn't find vkcube
-            return file_info.absoluteFilePath();  // This cannot be file path like the others
+        // Using relative path to vkconfig in case SDK is not "installed"
+        {
+            const QString search_path = QString("..") + DEFAULT_PATH + executable_name;
+            QFileInfo file_info(search_path);
+            if (file_info.exists())                   // Couldn't find vkcube
+                return file_info.absoluteFilePath();  // This cannot be file path like the others
+        }
+        // Allow fall through to below. Really, only the VULKAN_SDK is likely to catch anything
     }
-    // Allow fall through to below. Really, only the VULKAN_SDK is likely to catch anything
-}
 
     // Using relative path to vkconfig
     {

--- a/vkconfig_core/environment.cpp
+++ b/vkconfig_core/environment.cpp
@@ -319,7 +319,7 @@ static QString GetDefaultExecutablePath(const QString& executable_name) {
 #error "Unknown platform"
 #endif
 
-#if PLATFORM_MACOS
+if(PLATFORM_MACOS) {
     // Using the standard install loation on macOS
     {
         const QString search_path = "/Applications/" + executable_name;
@@ -336,7 +336,7 @@ static QString GetDefaultExecutablePath(const QString& executable_name) {
             return file_info.absoluteFilePath();  // This cannot be file path like the others
     }
     // Allow fall through to below. Really, only the VULKAN_SDK is likely to catch anything
-#endif
+}
 
     // Using relative path to vkconfig
     {


### PR DESCRIPTION
Change-Id: I3d5e1944600bfcc0cc09aa7b0e7a248d4a1afdf9
Fixed regressions for not being able to find vkcube on initial startup, and proper paths for the launcher feature.