### PR TITLE
devsim: Update API version check

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -1407,7 +1407,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
         dt->GetPhysicalDeviceProperties(physical_device, &pdd.physical_device_properties_);
 
         // Initialize PDD members to the actual Vulkan implementation's defaults.
-        if (get_physical_device_properties2_active || pdd.physical_device_properties_.apiVersion > VK_VERSION_1_0) {
+        if (get_physical_device_properties2_active || VK_VERSION_MINOR(requested_version) > 0) {
             VkPhysicalDeviceProperties2KHR property_chain = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR};
             VkPhysicalDeviceFeatures2KHR feature_chain = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
             VkPhysicalDeviceMemoryProperties2KHR memory_chain = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR};


### PR DESCRIPTION
Change the API version check used by the dev-sim layer to determine if vkGetPhysicalDeviceProperties2 is available from a comparison between the API version retrieved from vkGetPhysicalDeviceProperties and VK_VERSION_1_0, which is now defined as 1, to a comparison between the minor API version that the application specified through VkApplicationInfo and 0.
