### PR TITLE
devsim: Conditionally increase query count

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -1692,10 +1692,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
 
     if (result == VK_SUCCESS && !pLayerName && emulatePortability.num > 0 &&
         !PhysicalDeviceData::HasSimulatedOrRealExtension(physicalDevice, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
-        *pCount += 1;
         if (pProperties) {
             strncpy(pProperties[(*pCount) - 1].extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE);
             pProperties[(*pCount) - 1].specVersion = VK_KHR_PORTABILITY_SUBSET_SPEC_VERSION;
+        } else {
+            *pCount += 1;
         }
     }
 


### PR DESCRIPTION
Ensure EnumerateDeviceExtensionProperties only increases the returned
query count once.

Change-Id: Ib54ae43d536fb7684fb14a50bc54d8db9e0abaad