### PR TITLE
vkconfig: Fix layers override update when changing layers management options

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -16,6 +16,9 @@
 ### Features:
 - Add command line arguments to manage layers override #1213
 
+### Fixes:
+- Fix layers override update when changing layers management options #1225
+
 ## [Vulkan Configurator 2.0.2 for Vulkan SDK 1.2.154.0](https://github.com/LunarG/VulkanTools/releases/tag/sdk-1.2.154.0) - 2020-10-05
 
 ### Features:

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -121,10 +121,6 @@ Configurator &Configurator::Get() {
 
 Configurator::Configurator() : environment(path), layers(environment) {}
 
-///////////////////////////////////////////////////////////////////////////////////
-/// A good rule of C++ is to not put things in the constructor that can fail, or
-/// that might require recursion. This initializes
-///
 bool Configurator::Init() {
     // Load simple app settings, the additional search paths, and the
     // override app list.
@@ -177,11 +173,7 @@ bool Configurator::Init() {
         }
     }
 
-    // This will reset or clear the current profile if the files have been
-    // manually manipulated
-    SetActiveConfiguration(_active_configuration);
-
-    if (_active_configuration != available_configurations.end()) {
+    if (HasActiveConfiguration()) {
         if (HasMissingParameter(_active_configuration->parameters, layers.available_layers)) {
             QSettings settings;
             if (settings.value("VKCONFIG_WARN_MISSING_LAYERS_IGNORE").toBool() == false) {
@@ -214,8 +206,9 @@ Configurator::~Configurator() {
         available_configurations[i].Save(path.GetFullPath(PATH_CONFIGURATION, available_configurations[i].name));
     }
 
-    layers.Clear();
-    available_configurations.clear();
+    if (!environment.UsePersistentOverrideMode()) {
+        SurrenderLayers(environment);
+    }
 }
 
 bool Configurator::HasLayers() const { return !layers.Empty(); }
@@ -350,16 +343,7 @@ void Configurator::LoadAllConfigurations() {
         }
     }
 
-    // Cache the active configuration
-    const QString &active_configuration_name = environment.Get(ACTIVE_CONFIGURATION);
-    if (!active_configuration_name.isEmpty()) {
-        _active_configuration = Find(available_configurations, active_configuration_name);
-        if (_active_configuration == available_configurations.end()) {
-            environment.Set(ACTIVE_CONFIGURATION, "");  // The configuration no longer exist
-        }
-    } else {
-        _active_configuration = available_configurations.end();
-    }
+    RefreshConfiguration();
 }
 
 void Configurator::LoadDefaultLayerSettings() {
@@ -412,6 +396,23 @@ void Configurator::LoadDefaultLayerSettings() {
     }
 }
 
+void Configurator::RemoveConfiguration(const QString &configuration_name) {
+    assert(!configuration_name.isEmpty());
+
+    // Not the active configuration
+    if (GetActiveConfiguration()->name == configuration_name) {
+        SetActiveConfiguration(available_configurations.end());
+    }
+
+    // Delete the configuration file
+    const QString full_path(path.GetFullPath(PATH_CONFIGURATION, configuration_name));
+    const bool result = std::remove(full_path.toUtf8().constData()) == 0;
+    assert(result);
+
+    // Reload to remove the configuration in the UI
+    LoadAllConfigurations();
+}
+
 void Configurator::SetActiveConfiguration(const QString &configuration_name) {
     assert(!configuration_name.isEmpty());
 
@@ -421,9 +422,6 @@ void Configurator::SetActiveConfiguration(const QString &configuration_name) {
     SetActiveConfiguration(configuration);
 }
 
-// Set this as the current override profile. The profile definition passed in
-// is used to construct the override and settings files.
-// Passing in nullptr IS valid, and will clear the current profile
 void Configurator::SetActiveConfiguration(std::vector<Configuration>::iterator active_configuration) {
     _active_configuration = active_configuration;
 
@@ -433,19 +431,31 @@ void Configurator::SetActiveConfiguration(std::vector<Configuration>::iterator a
         environment.Set(ACTIVE_CONFIGURATION, _active_configuration->name);
         surrender = _active_configuration->IsEmpty();
     } else {
-        environment.Set(ACTIVE_CONFIGURATION, "");
+        _active_configuration = available_configurations.end();
         surrender = true;
     }
 
     if (surrender) {
+        assert(_active_configuration == available_configurations.end());
         SurrenderLayers(environment);
     } else {
+        assert(_active_configuration != available_configurations.end());
         OverrideLayers(environment, layers.available_layers, *active_configuration);
     }
 }
 
 void Configurator::RefreshConfiguration() {
-    if (_active_configuration != available_configurations.end()) SetActiveConfiguration(_active_configuration);
+    const QString active_configuration_name = environment.Get(ACTIVE_CONFIGURATION);
+
+    if (!active_configuration_name.isEmpty() && environment.UseOverride()) {
+        auto active_configuration = Find(available_configurations, active_configuration_name);
+        if (active_configuration == available_configurations.end()) {
+            environment.Set(ACTIVE_CONFIGURATION, "");
+        }
+        SetActiveConfiguration(active_configuration);
+    } else {
+        SetActiveConfiguration(available_configurations.end());
+    }
 }
 
 bool Configurator::HasActiveConfiguration() const {
@@ -534,10 +544,4 @@ void Configurator::ResetDefaultsConfigurations() {
 
     // Now we need to kind of restart everything
     LoadAllConfigurations();
-
-    // Find the "Validation - Standard" configuration and make it current if we are active
-    auto active_configuration = Find(available_configurations, environment.Get(ACTIVE_CONFIGURATION));
-    if (environment.UseOverride()) {
-        SetActiveConfiguration(active_configuration);
-    }
 }

--- a/vkconfig/configurator.h
+++ b/vkconfig/configurator.h
@@ -91,6 +91,7 @@ class Configurator {
     void SetActiveConfiguration(std::vector<Configuration>::iterator active_configuration);
     void SetActiveConfiguration(const QString& configuration_name);
     void RefreshConfiguration();
+    void RemoveConfiguration(const QString& configuration_name);
     bool HasActiveConfiguration() const;
 
    private:

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -115,11 +115,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->splitter_2->restoreState(environment.Get(LAYOUT_MAIN_SPLITTER2));
     ui->splitter_3->restoreState(environment.Get(LAYOUT_MAIN_SPLITTER3));
 
-    // We need to resetup the new profile for consistency sake.
-    auto active_configuration = Find(configurator.available_configurations, environment.Get(ACTIVE_CONFIGURATION));
-    if (environment.UseOverride()) {
-        configurator.SetActiveConfiguration(active_configuration);
-    }
+    configurator.RefreshConfiguration();
 
     LoadConfigurationList();
 
@@ -132,7 +128,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->log_browser->append(GenerateVulkanStatus());
     ui->configuration_tree->scrollToItem(ui->configuration_tree->topLevelItem(0), QAbstractItemView::PositionAtTop);
 
-    if (active_configuration != configurator.available_configurations.end()) {
+    if (configurator.HasActiveConfiguration()) {
         _settings_tree_manager.CreateGUI(ui->settings_tree);
     }
 
@@ -328,13 +324,7 @@ void MainWindow::on_radio_override_clicked() {
     Configurator &configurator = Configurator::Get();
 
     configurator.environment.SetMode(OVERRIDE_MODE_ACTIVE, true);
-
-    // This just doesn't work. Make a function to look for the radio button checked.
-    ConfigurationListItem *item = GetCheckedItem();
-    auto configuration = item == nullptr ? configurator.available_configurations.end()
-                                         : Find(configurator.available_configurations, item->configuration_name);
-
-    configurator.SetActiveConfiguration(configuration);
+    configurator.RefreshConfiguration();
 
     UpdateUI();
 }
@@ -344,7 +334,7 @@ void MainWindow::on_radio_fully_clicked() {
     Configurator &configurator = Configurator::Get();
 
     configurator.environment.SetMode(OVERRIDE_MODE_ACTIVE, false);
-    configurator.SetActiveConfiguration(configurator.available_configurations.end());
+    configurator.RefreshConfiguration();
 
     UpdateUI();
 }
@@ -402,15 +392,11 @@ void MainWindow::toolsResetToDefault(bool checked) {
     Configurator &configurator = Configurator::Get();
     configurator.ResetDefaultsConfigurations();
 
-    // Find the "Validation - Standard" configuration and make it current if we are active
-    auto active_configuration = Find(configurator.available_configurations, configurator.environment.Get(ACTIVE_CONFIGURATION));
-    if (configurator.environment.UseOverride()) {
-        configurator.SetActiveConfiguration(active_configuration);
-    }
+    configurator.RefreshConfiguration();
 
     LoadConfigurationList();
 
-    if (active_configuration != configurator.available_configurations.end()) {
+    if (configurator.HasActiveConfiguration()) {
         _settings_tree_manager.CreateGUI(ui->settings_tree);
     }
 
@@ -435,7 +421,8 @@ void MainWindow::OnConfigurationItemClicked(bool checked) {
     ui->configuration_tree->setCurrentItem(item);
 
     Configurator &configurator = Configurator::Get();
-    configurator.SetActiveConfiguration(Find(configurator.available_configurations, item->configuration_name));
+    configurator.environment.Set(ACTIVE_CONFIGURATION, item->configuration_name);
+    configurator.RefreshConfiguration();
 }
 
 /// An item has been changed. Check for edit of the items name (configuration name)
@@ -504,8 +491,7 @@ void MainWindow::OnConfigurationTreeChanged(QTreeWidgetItem *current, QTreeWidge
     if (configuration_item == nullptr) return;
 
     configuration_item->radio_button->setChecked(true);
-    auto configuration = Find(Configurator::Get().available_configurations, configuration_item->configuration_name);
-    Configurator::Get().SetActiveConfiguration(configuration);
+    Configurator::Get().SetActiveConfiguration(configuration_item->configuration_name);
 
     _settings_tree_manager.CreateGUI(ui->settings_tree);
 
@@ -571,13 +557,6 @@ void MainWindow::closeEvent(QCloseEvent *event) {
     }
 
     _settings_tree_manager.CleanupGUI();
-    if (!configurator.environment.UsePersistentOverrideMode()) {
-        auto active_configuration = configurator.GetActiveConfiguration();
-        const QString active_configuration_name =
-            active_configuration == configurator.available_configurations.end() ? "" : active_configuration->name;
-        configurator.SetActiveConfiguration(configurator.available_configurations.end());
-        configurator.environment.Set(ACTIVE_CONFIGURATION, active_configuration_name);
-    }
 
     configurator.environment.Set(LAYOUT_MAIN_GEOMETRY, saveGeometry());
     configurator.environment.Set(LAYOUT_MAIN_WINDOW_STATE, saveState());
@@ -763,17 +742,8 @@ void MainWindow::RemoveClicked(ConfigurationListItem *item) {
 
     SaveLastItem();
     _settings_tree_manager.CleanupGUI();
-    // What if this is the active profile? We will go boom boom soon...
-    Configurator &configurator = Configurator::Get();
-    if (configurator.GetActiveConfiguration()->name == &item->configuration_name) {
-        configurator.SetActiveConfiguration(configurator.available_configurations.end());
-    }
 
-    // Delete the configuration file
-    const QString full_path(configurator.path.GetFullPath(PATH_CONFIGURATION, item->configuration_name));
-    remove(full_path.toUtf8().constData());
-
-    configurator.LoadAllConfigurations();
+    Configurator::Get().RemoveConfiguration(item->configuration_name);
     LoadConfigurationList();
     RestoreLastItem();
 }
@@ -878,10 +848,9 @@ void MainWindow::OnConfigurationTreeClicked(QTreeWidgetItem *item, int column) {
     configurator.environment.Notify(NOTIFICATION_RESTART);
 
     ConfigurationListItem *configuration_item = dynamic_cast<ConfigurationListItem *>(item);
-    auto configuration = item == nullptr ? configurator.available_configurations.end()
-                                         : Find(configurator.available_configurations, configuration_item->configuration_name);
-
-    configurator.SetActiveConfiguration(configuration);
+    if (configuration_item != nullptr) {
+        configurator.SetActiveConfiguration(configuration_item->configuration_name);
+    }
     SaveLastItem();
 
     UpdateUI();

--- a/vkconfig/settingstreemanager.cpp
+++ b/vkconfig/settingstreemanager.cpp
@@ -478,6 +478,7 @@ void SettingsTreeManager::CleanupGUI() {
     Configurator &configurator = Configurator::Get();
 
     std::vector<Configuration>::iterator configuration = configurator.GetActiveConfiguration();
+    if (configuration == configurator.available_configurations.end()) return;
 
     // Get the state of the last tree, and save it!
     configuration->_setting_tree_state.clear();


### PR DESCRIPTION
- Fix assert when a configuration doesn't exist anymore but is active
- Factorize configuration refresh
- Remove layers override instantly when using fully app control
- Immediately override and surrender layers when changing layers management option

Change-Id: Iadbc962b918f0807c07d0c455bf21696046438c1