### PR TITLE
apidump: Use VkInstance instead of NULL in GIPA

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -808,6 +808,12 @@ class ApiDumpInstance {
 
     std::unordered_map<uint64_t, std::string> object_name_map;
 
+    void set_vk_instance(VkPhysicalDevice phys_dev, VkInstance instance) { vk_instance_map.insert({phys_dev, instance}); }
+    VkInstance get_vk_instance(VkPhysicalDevice phys_dev) const {
+        if (vk_instance_map.count(phys_dev) == 0) return VK_NULL_HANDLE;
+        return vk_instance_map.at(phys_dev);
+    }
+
    private:
     static ApiDumpInstance current_instance;
 
@@ -831,6 +837,10 @@ class ApiDumpInstance {
     bool first_func_call_on_frame = false;
 
     std::chrono::system_clock::time_point program_start;
+
+    // Store the VkInstance handle so we don't use null in the call to
+    // vkGetInstanceProcAddr(instance_handle, "vkCreateDevice");
+    std::unordered_map<VkPhysicalDevice, VkInstance> vk_instance_map;
 };
 
 // Utility to output an address.

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -307,7 +307,8 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     assert(chain_info->u.pLayerInfo != 0);
     PFN_vkGetInstanceProcAddr fpGetInstanceProcAddr = chain_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
     PFN_vkGetDeviceProcAddr fpGetDeviceProcAddr = chain_info->u.pLayerInfo->pfnNextGetDeviceProcAddr;
-    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice) fpGetInstanceProcAddr(NULL, "vkCreateDevice");
+    VkInstance vk_instance = ApiDumpInstance::current().get_vk_instance(physicalDevice);
+    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice) fpGetInstanceProcAddr(vk_instance, "vkCreateDevice");
     if(fpCreateDevice == NULL) {{
         return VK_ERROR_INITIALIZATION_FAILED;
     }}
@@ -403,6 +404,13 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
     {funcReturn} result = instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
     {funcStateTrackingCode}
+    @if('{funcName}' == 'vkEnumeratePhysicalDevices')
+    if (pPhysicalDeviceCount != nullptr && pPhysicalDevices != nullptr) {{
+        for (uint32_t i = 0; i < *pPhysicalDeviceCount; i++) {{
+            ApiDumpInstance::current().set_vk_instance(pPhysicalDevices[i], instance);
+        }}
+    }}
+    @end if
     dump_body_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
     return result;
 }}


### PR DESCRIPTION
The call to vkGetInstanceProcAddr to get vkCreateDevice used NULL for the
VkInstance handle. This is forbidden by the spec but was allowed on
various implementations. This commmit fixes it by keeping track of the
physical device and instance handles.

Fixes #1233 

Change-Id: Ib247c71913f1512f919349523a2058907616ee23