### PR TITLE
C.I.: Improve build platform coverage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,78 +11,140 @@ version: "{build}"
 # Free accounts have a max of 1, but ask anyway.
 max_jobs: 4
 
-os:
-  - Visual Studio 2017
+platform:
+  - Win32
+  - x64
 
-environment:
-  PYTHON_PATH: "C:/Python35"
-  PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
-  CMAKE_URL: "http://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
+configuration:
+  - Debug
+  - Release
+
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
+  - Visual Studio 2019
+
+for:
+  -
+    matrix:
+      only:
+        - configuration: Debug
+          platform: Win32
+          image: Visual Studio 2015
+
+    environment:
+      PYTHON: C:\Python35
+      QTDIR: C:\Qt\5.9.9\msvc2015
+      PLATFORM_ARGUMENT: --32
+      CONFIGURATION_ARGUMENT: --debug
+    init:
+      # For building vkconfig with qmake
+      - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
+
+  -
+    matrix:
+      only:
+        - configuration: Release
+          platform: x64
+          image: Visual Studio 2017
+    environment:
+      PYTHON: C:\Python35
+      QTDIR: C:\Qt\5.9.9\msvc2017_64
+      PLATFORM_ARGUMENT: --64
+      CONFIGURATION_ARGUMENT: --release
+    init:
+      # For building vkconfig with qmake
+      - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+  -
+    matrix:
+      only:
+        - configuration: Debug
+          platform: x64
+          image: Visual Studio 2019
+    environment:
+      PYTHON: C:\Python35
+      QTDIR: C:\Qt\5.15.1\msvc2019_64
+      PLATFORM_ARGUMENT: --64
+      CONFIGURATION_ARGUMENT: --debug
+    init:
+      # For building vkconfig with qmake
+      - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+matrix:
+  exclude:
+    - configuration: Release
+      platform: Win32
+      image: Visual Studio 2015
+    - configuration: Release
+      platform: x64
+      image: Visual Studio 2015
+    - configuration: Debug
+      platform: x64
+      image: Visual Studio 2015
+    - configuration: Release
+      platform: Win32
+      image: Visual Studio 2017
+    - configuration: Debug
+      platform: Win32
+      image: Visual Studio 2017
+    - configuration: Debug
+      platform: x64
+      image: Visual Studio 2017
+    - configuration: Release
+      platform: Win32
+      image: Visual Studio 2019
+    - configuration: Debug
+      platform: Win32
+      image: Visual Studio 2019
+    - configuration: Release
+      platform: x64
+      image: Visual Studio 2019
 
 branches:
   only:
     - master
 
 install:
-  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
-  - 7z x cmake.zip -oC:\cmake > nul
-  - set path=C:\cmake\bin;%path%
-  - cmake --version
-  - if %PLATFORM% == x64 (set QTDIR=C:\Qt\5.9.9\msvc2017_64)
-  - if %PLATFORM% == Win32 (set QTDIR=C:\Qt\5.9.9\msvc2017)
-  - set PATH=%PATH%;%QTDIR%\bin
-  - choco install windows-sdk-10-version-1809-all
+  # Python
+  - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+
+  # Qt
+  - echo Qt path %QTDIR%\bin
+  - set PATH=%QTDIR%\bin;%PATH%
 
 before_build:
-  - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
-  - echo.
-  - echo Starting build for %APPVEYOR_REPO_NAME%
-  - echo Update external sources
-  - if %PLATFORM% == Win32 (if %CONFIGURATION% == Debug (update_external_sources.bat --32 --debug))
-  - if %PLATFORM% == Win32 (if %CONFIGURATION% == Release (update_external_sources.bat --32 --release))
-  - if %PLATFORM% == x64 (if %CONFIGURATION% == Debug (update_external_sources.bat --64 --debug))
-  - if %PLATFORM% == x64 (if %CONFIGURATION% == Release (update_external_sources.bat --64 --release))
-  # Determine the appropriate CMake generator for the current version of Visual Studio
-  - echo Determining VS version
-  - python .\scripts\determine_vs_version.py > vsversion.tmp
-  - set /p VS_VERSION=< vsversion.tmp
-  - echo Detected Visual Studio Version as %VS_VERSION%
-  - del /Q /F vsversion.tmp
-  - if %PLATFORM% == Win32 (set GENERATOR="Visual Studio %VS_VERSION%")
-  - if %PLATFORM% == x64 (set GENERATOR="Visual Studio %VS_VERSION% Win64")
-  ## Build VulkanTools deps
-  - python scripts/update_deps.py --config=%CONFIGURATION% --arch=%PLATFORM%
-  # Generate build files using CMake for the build step.
-  - echo Generating CMake files for %GENERATOR%
-  - cd %APPVEYOR_BUILD_FOLDER%
+  - echo %IMAGE%
+  - cmake --version
+  - python --version
+  - qmake --version
+  - git --version
+
+  # Update external
+  - echo Update external sources %PLATFORM_ARGUMENT% %CONFIGURATION_ARGUMENT%
+  - update_external_sources.bat %PLATFORM_ARGUMENT% %CONFIGURATION_ARGUMENT%
+
+  - echo Build VulkanTools deps %CONFIGURATION% %PLATFORM%
+  - python scripts/update_deps.py --config %CONFIGURATION% --arch %PLATFORM%
   - mkdir build
   - cd build
-  - cmake -G %GENERATOR% -C../helper.cmake ..
-  - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
-
-platform:
-  - Win32
-  - x64
-
-configuration:
-  - Release
-  - Debug
-
-# Build only x64 Release and Win32(x86) Debug to reduce build time.
-# This should still provide adequate 32-bit vs 64-bit and
-# Release vs Debug coverage.
-matrix:
-  exclude:
-    - configuration: Release
-      platform: Win32
-    - configuration: Debug
-      platform: x64
+  - cmake -A %PLATFORM% -C ../helper.cmake ..
 
 build:
-  parallel: true                  # enable MSBuild parallel builds
-  project: build/VULKAN_TOOLS.sln # path to Visual Studio solution or project
-  verbosity: quiet                # quiet|minimal|normal|detailed
+  parallel: true
+  verbosity: quiet
+
+build_script:
+  - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
+
+  - echo Build Vulkan Configurator with Qt build system
+  - cd ../vkconfig
+  - qmake vkconfig.pro
+  - nmake /NOLOGO /S
+
+  - echo Build Vulkan Configurator, layers and VIA with cmake
+  - cd ../build
+  - cmake --build . --config %CONFIGURATION% -- /m /v:minimal
 
 test_script:
   ctest -j 16 --output-on-failure -C %CONFIGURATION%
-

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -16,6 +16,11 @@
 ### Features:
 - Add command line arguments to manage layers override #1213
 
+### Improvements:
+- Test with VS2015, VS2017 and VS2019
+- Test with Qt 5.9 and Qt 5.15 including QMake build
+- Test manually using a [use cases based template](https://docs.google.com/document/d/1z0WqfMp2IBko1fvDICkjDE_3JKnf8SrU5APQTqKRR-U/edit)
+
 ### Fixes:
 - Fix manual layers ordering #1214
 - Fix layers override update when changing layers management options #1225

--- a/vkconfig/main_layers.cpp
+++ b/vkconfig/main_layers.cpp
@@ -64,6 +64,8 @@ static int RunLayersOverride(const CommandLine& command_line) {
 }
 
 static int RunLayersSurrender(const CommandLine& command_line) {
+    (void)command_line;
+
     PathManager paths;
     Environment environment(paths);
     environment.Reset(Environment::DEFAULT);
@@ -88,6 +90,8 @@ static int RunLayersSurrender(const CommandLine& command_line) {
 }
 
 static int RunLayersList(const CommandLine& command_line) {
+    (void)command_line;
+
     PathManager paths;
     Environment environment(paths);
     environment.Reset(Environment::DEFAULT);
@@ -106,6 +110,8 @@ static int RunLayersList(const CommandLine& command_line) {
 }
 
 static int RunLayersVerbose(const CommandLine& command_line) {
+    (void)command_line;
+
     PathManager paths;
     Environment environment(paths);
     environment.Reset(Environment::DEFAULT);

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -328,8 +328,9 @@ void MainWindow::on_check_box_apply_list_clicked() {
     Configurator &configurator = Configurator::Get();
 
     // Handle old loader case
-    if (!configurator.SupportApplicationList(false)) {
-        const std::string version = GetVulkanLoaderVersion().str();
+    Version loader_version;
+    if (!configurator.SupportApplicationList(&loader_version)) {
+        const std::string version = loader_version.str();
         const std::string message =
             format("The detected Vulkan loader version is %s but version 1.2.141 or newer is required", version.c_str());
         ui->check_box_apply_list->setToolTip(message.c_str());
@@ -1075,7 +1076,6 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             QTreeWidgetItem *configuration_item = ui->configuration_tree->itemAt(right_click->pos());
             ConfigurationListItem *item = dynamic_cast<ConfigurationListItem *>(configuration_item);
 
-            Configurator &configurator = Configurator::Get();
             const Environment &environment = Configurator::Get().environment;
             const QString &active_contiguration_name = environment.Get(ACTIVE_CONFIGURATION);
 

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -6,7 +6,7 @@ CONFIG += c++11
 CONFIG += sdk_no_version_check
 
 INCLUDEPATH += $$(VULKAN_SDK)/include
-
+INCLUDEPATH += ../Vulkan-Headers/include
 
 # The following define makes your compiler emit warnings if you use
 # any Qt feature that has been marked deprecated (the exact warnings

--- a/vkconfig_core/environment.cpp
+++ b/vkconfig_core/environment.cpp
@@ -283,31 +283,31 @@ bool Environment::LoadApplications() {
         data = file.readAll();
         file.close();
 
-        const QJsonDocument& json_doc = QJsonDocument::fromJson(data.toLocal8Bit());
-        assert(json_doc.isObject());
-        assert(!json_doc.isEmpty());
-
-        // Get the list of apps
-        const QJsonObject& json_doc_object = json_doc.object();
-        const QStringList& app_keys = json_doc_object.keys();
-
         applications.clear();
 
-        for (int i = 0, n = app_keys.length(); i < n; i++) {
-            const QJsonValue& app_value = json_doc_object.value(app_keys[i]);
-            const QJsonObject& app_object = app_value.toObject();
+        const QJsonDocument& json_doc = QJsonDocument::fromJson(data.toLocal8Bit());
+        assert(json_doc.isObject());
+        if (!json_doc.isEmpty()) {
+            // Get the list of apps
+            const QJsonObject& json_doc_object = json_doc.object();
+            const QStringList& app_keys = json_doc_object.keys();
 
-            Application application;
-            application.executable_path = app_object.value("app_path").toString();
-            application.working_folder = app_object.value("app_folder").toString();
-            application.override_layers = !app_object.value("exclude_override").toBool();
-            application.log_file = app_object.value("log_file").toString();
+            for (int i = 0, n = app_keys.length(); i < n; i++) {
+                const QJsonValue& app_value = json_doc_object.value(app_keys[i]);
+                const QJsonObject& app_object = app_value.toObject();
 
-            // Arguments are in an array to make room for adding more in a future version
-            const QJsonArray& args = app_object.value("command_lines").toArray();
-            application.arguments = args[0].toString();
+                Application application;
+                application.executable_path = app_object.value("app_path").toString();
+                application.working_folder = app_object.value("app_folder").toString();
+                application.override_layers = !app_object.value("exclude_override").toBool();
+                application.log_file = app_object.value("log_file").toString();
 
-            applications.push_back(application);
+                // Arguments are in an array to make room for adding more in a future version
+                const QJsonArray& args = app_object.value("command_lines").toArray();
+                application.arguments = args[0].toString();
+
+                applications.push_back(application);
+            }
         }
 
         UpdateDefaultApplications(first_run || applications.empty());


### PR DESCRIPTION
- Build with VS2015, VS2017 and VS2019
- Build with Qt 5.9 and Qt 5.15
- Build Vulkan Configurator with QMake
- Failing tests build doesn't result in green run anymore...
- Fix build warnings
- Fix Vulkan Configurator empty application list case

Change-Id: Icc0fae3614b3acb82d2fb73b2f67595f855e4aff