### PR TITLE
C.I.: Only build with CMake XOR QMake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,6 +39,13 @@ for:
       - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
       # Multithreaded NMake
       - set CL=/MP
+    build_script:
+      - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
+
+      - echo Build Vulkan Configurator with Qt build system
+      - cd ../vkconfig
+      - qmake vkconfig.pro
+      - nmake /NOLOGO /S # silent messages
 
   -
     matrix:
@@ -139,11 +146,6 @@ build:
 
 build_script:
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
-
-  - echo Build Vulkan Configurator with Qt build system
-  - cd ../vkconfig
-  - qmake vkconfig.pro
-  - nmake /NOLOGO /S # silent messages
 
   - echo Build Vulkan Configurator, layers and VIA with cmake
   - cd ../build


### PR DESCRIPTION
- Using QMake when building with VS2015 to test the QtCreator project only
- Using CMake when building with VS2017 and VS2019 project only
- Overall reduce build time.

With multiple threads CMake XOR NMake (this PR):
Image: Visual Studio 2015; Configuration: Debug; Platform: Win32: 4 min 29 sec
Image: Visual Studio 2017; Configuration: Release; Platform: x64: 8 min 29 sec
Image: Visual Studio 2019; Configuration: Debug; Platform: x64: 8 min 27 sec

With multiple threads CMake and NMake:
Image: Visual Studio 2015; Configuration: Debug; Platform: Win32: 7 min 39 sec
Image: Visual Studio 2017; Configuration: Release; Platform: x64: 8 min 53 sec
Image: Visual Studio 2019; Configuration: Debug; Platform: x64: 9 min 40 sec

With CMake and NMake on all compiler versions:
Image: Visual Studio 2015; Configuration: Debug; Platform: Win32: 9 min 25 sec
Image: Visual Studio 2017; Configuration: Release; Platform: x64: 10 min 8 sec
Image: Visual Studio 2019; Configuration: Debug; Platform: x64: 9 min 47 sec

With Visual Studio build 2017 prior to any of my appveyor changes:
Configuration: Release; Platform: x64: 9 min 30 sec
Configuration: Debug; Platform: Win32: 6 min 24 sec

Change-Id: Idf9ba110fedc446438b3e64d39338697cc56ce89