### PR TITLE
vkconfig: Fix initialization of added applications on macOS

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix layers override update when changing layers management options #1225
 - Fix reset button in layers window #1227
 - Fix warning about old loader when trying to use application list #1230
+- Fix initialization of added applications on macOS #1249 
 
 ## [Vulkan Configurator 2.0.2 for Vulkan SDK 1.2.154.0](https://github.com/LunarG/VulkanTools/releases/tag/sdk-1.2.154.0) - 2020-10-05
 

--- a/vkconfig/dialog_applications.h
+++ b/vkconfig/dialog_applications.h
@@ -33,7 +33,6 @@ class ApplicationsDialog : public QDialog {
    public:
     explicit ApplicationsDialog(QWidget *parent = nullptr);
 
-    static void GetExecutableFromAppBundle(QString &path);
     int GetSelectedLaunchApplicationIndex() const { return _last_selected_application_index; }
 
    private:

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -5,9 +5,8 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets network
 CONFIG += c++11
 CONFIG += sdk_no_version_check
 
-INCLUDEPATH += $$(VULKAN_SDK)/include
-INCLUDEPATH += ../Build/Vulkan-Headers/include
 INCLUDEPATH += ../Vulkan-Headers/include
+INCLUDEPATH += ../Build/Vulkan-Headers/include
 
 # The following define makes your compiler emit warnings if you use
 # any Qt feature that has been marked deprecated (the exact warnings

--- a/vkconfig_core/environment.h
+++ b/vkconfig_core/environment.h
@@ -147,3 +147,5 @@ class Environment {
    public:
     const PathManager& paths;
 };
+
+bool ExactExecutableFromAppBundle(QString& path);


### PR DESCRIPTION
Fixed a couple of regressions, one not Mac related at all. Code to extract an executable from app bundles was not being called for the default applications vkcube and vkcubepp on setup for macOS.
Paths to these applications in the override json file had an extra forward slash after Applications in the path (as in Applications//vkcube.app)
On all platforms, the list of applications was always added to the override json file, even when "Apply only to the selected list of Vulkan applications" was unchecked.