### PR TITLE
vkconfig: Surrender layers on crash

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -11,11 +11,14 @@
 
 # Release notes
 
-## [Vulkan Configurator 2.1.0 for Vulkan SDK 1.2.X.X](https://github.com/LunarG/VulkanTools/tree/master) - January 2020
+## [Vulkan Configurator 2.1.0 for Vulkan SDK 1.2.162.1](https://github.com/LunarG/VulkanTools/tree/master) - January 2020
 
 ### Features:
 - Refactor built-in configurations #1247
-- Add layer settings presets #1247
+- Add layer settings presets #1271
+
+### Improvements:
+- In case of crash or user interruption, remove the layers override #1278
 
 ## [Vulkan Configurator 2.0.3 for Vulkan SDK 1.2.162.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.162) - December 2020
 

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -20,12 +20,15 @@
 
 #include "main_gui.h"
 #include "main_layers.h"
+#include "main_signal.h"
 
 #include "../vkconfig_core/command_line.h"
 
 #include <cassert>
 
 int main(int argc, char* argv[]) {
+    InitSignals();
+
     const CommandLine command_line(argc, argv);
 
     if (command_line.error != ERROR_NONE) {

--- a/vkconfig/main_signal.cpp
+++ b/vkconfig/main_signal.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#include "../vkconfig_core/override.h"
+#include "../vkconfig_core/layer_manager.h"
+
+#include "main_signal.h"
+
+#include <csignal>
+
+void SurrenderLayers(int signal) {
+    PathManager paths;
+    Environment environment(paths);
+
+    SurrenderLayers(environment);
+}
+
+void InitSignals() {
+    std::signal(SIGINT, SurrenderLayers);
+    std::signal(SIGTERM, SurrenderLayers);
+    std::signal(SIGSEGV, SurrenderLayers);
+    std::signal(SIGABRT, SurrenderLayers);
+    std::signal(SIGILL, SurrenderLayers);
+    std::signal(SIGFPE, SurrenderLayers);
+}

--- a/vkconfig/main_signal.h
+++ b/vkconfig/main_signal.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020 Valve Corporation
+ * Copyright (c) 2020 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#pragma once
+
+void InitSignals();

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -67,6 +67,7 @@ SOURCES += \
     dialog_vulkan_info.cpp \
     main.cpp \
     main_gui.cpp \
+    main_signal.cpp \
     main_layers.cpp \
     mainwindow.cpp \
     settings_tree.cpp \
@@ -116,6 +117,7 @@ HEADERS += \
     dialog_vulkan_analysis.h \
     dialog_vulkan_info.h \
     main_gui.h \
+    main_signal.h \
     main_layers.h \
     mainwindow.h \
     settings_validation_areas.h \


### PR DESCRIPTION
- If the user interupt Vulkan Configurator (^C) or Vulkan Configurator crash
surrender the layers to avoid the layers override to remain without the user
knowning it.

PS: This is not working with Visual Studio (SHIFT F5/stop debugging)