### PR TITLE
vkconfig: Use types for settings in layers and configs files

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 # Release notes
 
-## [Vulkan Configurator 2.1.1 for Vulkan SDK 1.2.X.0](https://github.com/LunarG/VulkanTools/tree/master) - February 2021
+## [Vulkan Configurator 2.2.0 for Vulkan SDK 1.2.X.0](https://github.com/LunarG/VulkanTools/tree/master) - February 2021
 
 ### Features:
 - Add *Synchronization* default configuration #1304

--- a/vkconfig/resourcefiles/configurations/API dump.json
+++ b/vkconfig/resourcefiles/configurations/API dump.json
@@ -1,103 +1,78 @@
- {
-    "API dump": {
-        "blacklisted_layers": [
+{
+    "file_format_version": "2.2.0",
+    "configuration": {
+        "name": "API dump",
+        "platforms": [
+            "WINDOWS",
+            "LINUX",
+            "MACOS"
         ],
         "description": "A Simple API dump configuration",
-        "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
-        "layer_options": {
-            "VK_LAYER_LUNARG_api_dump": {
-                "detailed": {
-                    "default": "TRUE",
-                    "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                    "name": "Detailed Output",
-                    "type": "bool"
-                },
-                "file": {
-                    "default": "FALSE",
-                    "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                    "name": "Output to File",
-                    "type": "bool"
-                },
-                "flush": {
-                    "default": "TRUE",
-                    "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                    "name": "Flush",
-                    "type": "bool"
-                },
-                "indent_size": {
-                    "default": "4",
-                    "description": "Specifies the number of spaces that a tab is equal to",
-                    "name": "Indent Size",
-                    "type": "string"
-                },
-                "layer_rank": 0,
-                "log_filename": {
-                    "default": "stdout",
-                    "description": "Specifies the file to dump to when output files are enabled",
-                    "name": "Log Filename",
-                    "type": "save_file"
-                },
-                "name_size": {
-                    "default": "32",
-                    "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                    "name": "Name Size",
-                    "type": "string"
-                },
-                "no_addr": {
-                    "default": "FALSE",
-                    "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                    "name": "Hide Addresses",
-                    "type": "bool"
-                },
-                "output_format": {
-                    "default": "",
-                    "name": "Output Format",
-                    "description": "Specifies the format used for output; can be Text (default -- outputs plain text), Html, or Json",
-                    "type": "enum",
-                    "options": {
-                        "Text": "Text",
-                        "Html": "Html",
-                        "Json": "Json"
+        "editor_state": "011111111111111111111111",
+        "layers": [
+            {
+                "name": "VK_LAYER_LUNARG_api_dump",
+                "rank": 0,
+                "settings": [
+                    {
+                        "key": "output_format",
+                        "value": "Text"
                     },
-                    "default": "Text"
-                },
-                "output_range": {
-                    "default": "0-0",
-                    "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                    "name": "Output Range",
-                    "type": "string"
-                },
-                "show_shader": {
-                    "default": "TRUE",
-                    "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                    "name": "Show Shader",
-                    "type": "bool"
-                },
-                "show_timestamp": {
-                    "default": "TRUE",
-                    "description": "Show the timestamp of function calls since start in microseconds",
-                    "name": "Show Timestamp",
-                    "type": "bool"
-                },
-                "show_types": {
-                    "default": "TRUE",
-                    "description": "Setting this to true causes types to be dumped in addition to values",
-                    "name": "Show Types",
-                    "type": "bool"
-                },
-                "type_size": {
-                    "default": "0",
-                    "description": "The number of characters the name of a type should consume, assuming more are not required",
-                    "name": "Type Size",
-                    "type": "string"
-                },
-                "use_spaces": {
-                    "default": "TRUE",
-                    "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                    "name": "Use Spaces",
-                    "type": "bool"
-                }
+                    {
+                        "key": "detailed",
+                        "value": true
+                    },
+                    {
+                        "key": "no_addr",
+                        "value": false
+                    },
+                    {
+                        "key": "file",
+                        "value": false
+                    },
+                    {
+                        "key": "log_filename",
+                        "value": "stdout"
+                    },
+                    {
+                        "key": "flush",
+                        "value": true
+                    },
+                    {
+                        "key": "indent_size",
+                        "value": 4
+                    },
+                    {
+                        "key": "show_types",
+                        "value": true
+                    },
+                    {
+                        "key": "name_size",
+                        "value": 32
+                    },
+                    {
+                        "key": "type_size",
+                        "value": 0
+                    },
+                    {
+                        "key": "use_spaces",
+                        "value": true
+                    },
+                    {
+                        "key": "show_timestamp",
+                        "value": true
+                    },
+                    {
+                        "key": "show_shader",
+                        "value": true
+                    },
+                    {
+                        "key": "output_range",
+                        "value": "0-0"
+                    }
+                ],
+                "state": "OVERRIDDEN"
             }
-        }
+        ]
     }
 }

--- a/vkconfig/resourcefiles/configurations/Frame Capture.json
+++ b/vkconfig/resourcefiles/configurations/Frame Capture.json
@@ -1,157 +1,97 @@
 {
-    "Frame Capture": {
-        "blacklisted_layers": [
+    "file_format_version": "2.2.0",
+    "configuration": {
+        "name": "Frame Capture",
+        "platforms": [
+            "WINDOWS",
+            "LINUX"
         ],
         "description": "Capture a range of frames",
-        "platforms": [ "WINDOWS", "LINUX" ],
-        "editor_state": "011111111111111111111111111",
-        "layer_options": {
-            "VK_LAYER_LUNARG_gfxreconstruct": {
-                "capture_compression_type": {
-                    "default": "LZ4",
-                    "description": "Compression format to use with the capture file. Valid values are: LZ4, ZLIB, ZSTD, and NONE. Default is: LZ4",
-                    "name": "Compression Format",
-                    "options": {
-                        "LZ4": "LZ4",
-                        "NONE": "NONE",
-                        "ZLIB": "ZLIB",
-                        "ZSTD": "ZSTD"
+        "editor_state": "0111111111111111111111111110111",
+        "layers": [
+            {
+                "name": "VK_LAYER_LUNARG_gfxreconstruct",
+                "rank": 0,
+                "settings": [
+                    {
+                        "key": "capture_trigger",
+                        "value": "F5"
                     },
-                    "type": "enum"
-                },
-                "capture_file": {
-                    "default": "${LOCAL}/gfxrecon_capture.gfxr",
-                    "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
-                    "name": "Capture File Name",
-                    "type": "save_file"
-                },
-                "capture_file_flush": {
-                    "default": "TRUE",
-                    "description": "Flush output stream after each packet is written to the capture file. Default is: false.",
-                    "name": "Capture File Flush After Write",
-                    "type": "bool"
-                },
-                "capture_file_timestamp": {
-                    "default": "TRUE",
-                    "description": "Add a timestamp (yyyymmddThhmmss) postfix to the capture file name.",
-                    "name": "Capture File Name with Timestamp",
-                    "type": "bool"
-                },
-                "capture_frames": {
-                    "default": "",
-                    "description": "Specify one or more comma-separated frame ranges to capture. Each range will be written to its own file. A frame range can be specified as a single value, to specify a single frame to capture, or as two hyphenated values, to specify the first and last frame to capture. Frame ranges should be specified in ascending order and cannot overlap. Note that frame numbering is 1-based (i.e. the first frame is frame 1). Example: 200,301-305 will create two capture files, one containing a single frame and one containing five frames. Default is: Empty string (all frames are captured).",
-                    "name": "Capture Specific Frames",
-                    "type": "string"
-                },
-                "capture_trigger": {
-                    "default": "F5",
-                    "description": "Specify a hotkey (any one of F1-F12, TAB, CONTROL) that will be used to start/stop capture. Example: F3 will set the capture trigger to F3 hotkey. One capture file will be generated for each pair of start/stop hotkey presses. Default is: Empty string (hotkey capture trigger is disabled).",
-                    "name": "Hotkey Capture Trigger",
-                    "options": {
-                        "": "None",
-                        "CONTROL": "CONTROL",
-                        "F1": "F1",
-                        "F10": "F10",
-                        "F11": "F11",
-                        "F12": "F12",
-                        "F2": "F2",
-                        "F3": "F3",
-                        "F4": "F4",
-                        "F5": "F5",
-                        "F6": "F6",
-                        "F7": "F7",
-                        "F8": "F8",
-                        "F9": "F9",
-                        "TAB": "TAB"
+                    {
+                        "key": "capture_frames",
+                        "value": ""
                     },
-                    "type": "enum"
-                },
-                "layer_rank": 0,
-                "log_break_on_error": {
-                    "default": "FALSE",
-                    "description": "Trigger a debug break when logging an error.",
-                    "name": "Trigger Debug Break on Error",
-                    "type": "bool"
-                },
-                "log_file": {
-                    "default": "",
-                    "description": "When set, log messages will be written to a file at the specified path. Default is: Empty string (file logging disabled).",
-                    "name": "Log File",
-                    "type": "save_file"
-                },
-                "log_file_create_new": {
-                    "default": "FALSE",
-                    "description": "Specifies that log file initialization should overwrite an existing file when true, or append to an existing file when false.",
-                    "name": "Log File Overwrite",
-                    "type": "bool"
-                },
-                "log_file_flush_after_write": {
-                    "default": "FALSE",
-                    "description": "Flush the log file to disk after each write when true.",
-                    "name": "Log File Flush After Write",
-                    "type": "bool"
-                },
-                "log_file_keep_open": {
-                    "default": "FALSE",
-                    "description": "Keep the log file open between log messages when true, or close and reopen the log file for each message when false.",
-                    "name": "Log File Keep Open",
-                    "type": "bool"
-                },
-                "log_level": {
-                    "default": "debug",
-                    "description": "Specify the highest level message to log. Options are: debug, info, warning, error, and fatal. The specified level and all levels listed after it will be enabled for logging. For example, choosing the warning level will also enable the error and fatal levels.",
-                    "name": "Log Level",
-                    "options": {
-                        "debug": "debug, info, warning, error",
-                        "error": "error, fatal",
-                        "fatal": "fatal",
-                        "info": "info, warning, error, fatal",
-                        "warning": "warning, error, fatal"
+                    {
+                        "key": "capture_file",
+                        "value": "${LOCAL}/gfxrecon_capture.gfxr"
                     },
-                    "type": "enum"
-                },
-                "log_output_to_console": {
-                    "default": "FALSE",
-                    "description": "Log messages will be written to stdout.",
-                    "name": "Log Output to Console / stdout",
-                    "type": "bool"
-                },
-                "log_output_to_os_debug_string": {
-                    "default": "FALSE",
-                    "description": "Windows only option. Log messages will be written to the Debug Console with OutputDebugStringA",
-                    "name": "Log Output to Debug Console",
-                    "type": "bool"
-                },
-                "memory_tracking_mode": {
-                    "default": "page_guard",
-                    "description": "Specifies the memory tracking mode to use for detecting modifications to mapped Vulkan memory objects. Available options are: page_guard, assisted, and unassisted.",
-                    "name": "Memory Tracking Mode",
-                    "options": {
-                        "assisted": "assisted",
-                        "page_guard": "page_guard",
-                        "unassisted": "unassisted"
+                    {
+                        "key": "capture_file_timestamp",
+                        "value": true
                     },
-                    "type": "enum"
-                },
-                "page_guard_copy_on_map": {
-                    "default": "TRUE",
-                    "description": "When the page_guard memory tracking mode is enabled, copies the content of the mapped memory to the shadow memory immediately after the memory is mapped.",
-                    "name": "Page Guard Copy on Map",
-                    "type": "bool"
-                },
-                "page_guard_external_memory": {
-                    "default": "FALSE",
-                    "description": "When the page_guard memory tracking mode is enabled, use the VK_EXT_external_memory_host extension to eliminate the need for shadow memory allocations. For each memory allocation from a host visible memory type, the capture layer will create an allocation from system memory, which it can monitor for write access, and provide that allocation to vkAllocateMemory as external memory. Only available on Windows.",
-                    "name": "Page Guard External Memory",
-                    "type": "bool"
-                },
-                "page_guard_separate_read": {
-                    "default": "TRUE",
-                    "description": "When the page_guard memory tracking mode is enabled, copies the content of pages accessed for read from mapped memory to shadow memory on each read. Can overwrite unprocessed shadow memory content when an application is reading from and writing to the same page.",
-                    "name": "Page Guard Separate Read Tracking",
-                    "type": "bool"
-                }
+                    {
+                        "key": "capture_file_flush",
+                        "value": true
+                    },
+                    {
+                        "key": "capture_compression_type",
+                        "value": "LZ4"
+                    },
+                    {
+                        "key": "log_output_to_console",
+                        "value": false
+                    },
+                    {
+                        "key": "log_break_on_error",
+                        "value": false
+                    },
+                    {
+                        "key": "log_output_to_os_debug_string",
+                        "value": false
+                    },
+                    {
+                        "key": "log_file",
+                        "value": ""
+                    },
+                    {
+                        "key": "log_detailed",
+                        "value": false
+                    },
+                    {
+                        "key": "log_file_flush_after_write",
+                        "value": false
+                    },
+                    {
+                        "key": "log_file_keep_open",
+                        "value": false
+                    },
+                    {
+                        "key": "log_file_create_new",
+                        "value": false
+                    },
+                    {
+                        "key": "log_level",
+                        "value": "debug"
+                    },
+                    {
+                        "key": "memory_tracking_mode",
+                        "value": "page_guard"
+                    },
+                    {
+                        "key": "page_guard_copy_on_map",
+                        "value": true
+                    },
+                    {
+                        "key": "page_guard_separate_read",
+                        "value": true
+                    },
+                    {
+                        "key": "page_guard_external_memory",
+                        "value": false
+                    }
+                ],
+                "state": "OVERRIDDEN"
             }
-        }
+        ]
     }
 }

--- a/vkconfig/resourcefiles/configurations/Portability.json
+++ b/vkconfig/resourcefiles/configurations/Portability.json
@@ -1,5 +1,12 @@
 {
+    "file_format_version": "2.2.0",
     "configuration": {
+        "name": "Portability",
+        "platforms": [
+            "WINDOWS",
+            "LINUX",
+            "MACOS"
+        ],
         "description": "Check the Vulkan application is portable to Apple platforms",
         "editor_state": "0110011111111111111111100101111011111000111111111111",
         "layers": [
@@ -45,7 +52,7 @@
                     },
                     {
                         "key": "duplicate_message_limit",
-                        "value": "10"
+                        "value": 10
                     },
                     {
                         "key": "enables",
@@ -72,15 +79,15 @@
                 "settings": [
                     {
                         "key": "debug_enable",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "emulate_portability",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "exit_on_error",
-                        "value": "0"
+                        "value": false
                     },
                     {
                         "key": "filename",
@@ -89,13 +96,6 @@
                 ],
                 "state": "OVERRIDDEN"
             }
-        ],
-        "name": "Portability",
-        "platforms": [
-            "WINDOWS",
-            "LINUX",
-            "MACOS"
         ]
-    },
-    "file_format_version": "2.1.0"
+    }
 }

--- a/vkconfig/resourcefiles/configurations/Synchronization.json
+++ b/vkconfig/resourcefiles/configurations/Synchronization.json
@@ -1,5 +1,12 @@
 {
+    "file_format_version": "2.2.0",
     "configuration": {
+        "name": "Synchronization",
+        "platforms": [
+            "WINDOWS",
+            "LINUX",
+            "MACOS"
+        ],
         "description": "Identify resource access conflicts due to missing or incorrect synchronization operations between actions reading or writing the same regions of memory.",
         "editor_state": "011100111111111111111111010111111111100111011111",
         "layers": [
@@ -9,7 +16,7 @@
                 "settings": [
                     {
                         "key": "force_enable",
-                        "value": "FALSE"
+                        "value": false
                     }
                 ],
                 "state": "OVERRIDDEN"
@@ -32,7 +39,7 @@
                     },
                     {
                         "key": "duplicate_message_limit",
-                        "value": "10"
+                        "value": 10
                     },
                     {
                         "key": "message_id_filter",
@@ -48,30 +55,23 @@
                     },
                     {
                         "key": "gpuav_buffer_oob",
-                        "value": "FALSE"
+                        "value": false
                     },
                     {
                         "key": "printf_to_stdout",
-                        "value": "TRUE"
+                        "value": true
                     },
                     {
                         "key": "printf_verbose",
-                        "value": "FALSE"
+                        "value": false
                     },
                     {
                         "key": "printf_buffer_size",
-                        "value": "1024"
+                        "value": 1024
                     }
                 ],
                 "state": "OVERRIDDEN"
             }
-        ],
-        "name": "Synchronization",
-        "platforms": [
-            "WINDOWS",
-            "LINUX",
-            "MACOS"
         ]
-    },
-    "file_format_version": "2.1.0"
+    }
 }

--- a/vkconfig/resourcefiles/configurations/Validation.json
+++ b/vkconfig/resourcefiles/configurations/Validation.json
@@ -1,93 +1,66 @@
 {
-    "Validation": {
-        "blacklisted_layers": [
+    "file_format_version": "2.2.0",
+    "configuration": {
+        "name": "Validation",
+        "platforms": [
+            "WINDOWS",
+            "LINUX",
+            "MACOS"
         ],
         "description": "This configuration is a good default validation setting and should serve most needs most of the time.",
-        "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
-        "editor_state": "011001111111111111111111010111111111100111",
-        "layer_options": {
-            "VK_LAYER_KHRONOS_validation": {
-                "debug_action": {
-                    "default": "VK_DBG_LAYER_ACTION_LOG_MSG",
-                    "description": "This indicates what action is to be taken when a layer wants to report information",
-                    "name": "Debug Action",
-                    "options": {
-                        "VK_DBG_LAYER_ACTION_BREAK": "Break",
-                        "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
-                        "VK_DBG_LAYER_ACTION_IGNORE": "Ignore",
-                        "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
-                        "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT": "Debug Output"
+        "editor_state": "0110011111111111111111110101111111111001110111",
+        "layers": [
+            {
+                "name": "VK_LAYER_KHRONOS_validation",
+                "rank": 0,
+                "settings": [
+                    {
+                        "key": "debug_action",
+                        "value": "VK_DBG_LAYER_ACTION_LOG_MSG"
                     },
-                    "type": "enum"
-                },
-                "disables": {
-                    "default": [
-                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT"
-                    ],
-                    "description": "Setting an option here will disable areas of validation",
-                    "name": "Disables",
-                    "options": {
-                        "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE": "Command Buffer State",
-                        "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET": "Idle Descritor Set",
-                        "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION": "Image Layout Validation",
-                        "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE": "Object in Use",
-                        "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE": "Push Constant Range",
-                        "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION": "Query Validation",
-                        "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless Parameter",
-                        "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT": "Core Validation",
-                        "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT": "Object Lifetime",
-                        "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT": "Disable Shaders",
-                        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread Safety",
-                        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT": "Handle Wrapping"
+                    {
+                        "key": "report_flags",
+                        "value": "error,perf,info,warn"
                     },
-                    "type": "multi_enum"
-                },
-                "enables": {
-                    "default": [
-                    ],
-                    "description": "Setting an option here will enable specialized areas of validation",
-                    "name": "Enables",
-                    "options": {
-                        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM": "ARM specific",
-                        "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT": "Best Practices",
-                        "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug Printf",
-                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted",
-                        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use"
+                    {
+                        "key": "log_filename",
+                        "value": "stdout"
                     },
-                    "type": "multi_enum"
-                },
-                "layer_rank": 0,
-                "log_filename": {
-                    "default": "stdout",
-                    "description": "Specifies the output filename, use stdout to rely on the standard output instead.",
-                    "name": "Log Filename",
-                    "type": "save_file"
-                },
-                "message_id_filter": {
-                    "default": "",
-                    "description": "VUID's to ignore",
-                    "name": "Message Filter",
-                    "type": "vuid_exclude"
-                },
-                "report_flags": {
-                    "default": [
-                        "error",
-                        "perf",
-                        "info",
-                        "warn"
-                    ],
-                    "description": "The message severity the layer should report back",
-                    "name": "Message Severity",
-                    "options": {
-                        "debug": "Debug",
-                        "error": "Error",
-                        "info": "Info",
-                        "perf": "Perf",
-                        "warn": "Warn"
+                    {
+                        "key": "duplicate_message_limit",
+                        "value": 10
                     },
-                    "type": "multi_enum"
-                }
+                    {
+                        "key": "message_id_filter",
+                        "value": ""
+                    },
+                    {
+                        "key": "disables",
+                        "value": "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT"
+                    },
+                    {
+                        "key": "enables",
+                        "value": ""
+                    },
+                    {
+                        "key": "gpuav_buffer_oob",
+                        "value": false
+                    },
+                    {
+                        "key": "printf_to_stdout",
+                        "value": true
+                    },
+                    {
+                        "key": "printf_verbose",
+                        "value": false
+                    },
+                    {
+                        "key": "printf_buffer_size",
+                        "value": 1024
+                    }
+                ],
+                "state": "OVERRIDDEN"
             }
-        }
+        ]
     }
 }

--- a/vkconfig/resourcefiles/layers_130/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_130/VK_LAYER_KHRONOS_validation.json
@@ -148,7 +148,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "ENUM",
+                "type": "FLAGS",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",

--- a/vkconfig/resourcefiles/layers_130/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_130/VK_LAYER_KHRONOS_validation.json
@@ -148,7 +148,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
@@ -161,7 +161,7 @@
                 "key": "report_flags",
                 "label": "Message Severity",
                 "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "info": "Info",
                     "warn": "Warn",
@@ -179,14 +179,14 @@
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the output filename",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "stdout"
             },
             {
                 "key": "disables",
                 "label": "Disables",
                 "description": "Setting an option here will disable areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety",
                     "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter",
@@ -207,7 +207,7 @@
                 "key": "enables",
                 "label": "Enables",
                 "description": "Setting an option here will enable specialized areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
                     "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use",

--- a/vkconfig/resourcefiles/layers_130/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig/resourcefiles/layers_130/VK_LAYER_LUNARG_api_dump.json
@@ -1,6 +1,6 @@
 {
     "file_format_version" : "1.4.0",
-    "layer" : {
+    "layer": {
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_api_dump.dll",
@@ -9,13 +9,14 @@
         "description": "LunarG API dump layer",
         "device_extensions": [
             {
-                 "name": "VK_EXT_tooling_info",
-                 "spec_version": "1",
-                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
-                        ]
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
             }
         ],
-        "settings" : [
+        "settings": [
             {
                 "key": "output_format",
                 "label": "Output Format",
@@ -32,93 +33,93 @@
                 "key": "detailed",
                 "label": "Detailed Output",
                 "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "no_addr",
                 "label": "Hide Addresses",
                 "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the file to dump to when output files are enabled",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "vk_apidump.txt"
             },
             {
                 "key": "flush",
                 "label": "Log Flush After Write",
                 "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "indent_size",
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
-                "type": "string",
-                "default": "4"
+                "type": "INT",
+                "default": 4
             },
             {
                 "key": "show_types",
                 "label": "Show Types",
                 "description": "Setting this to true causes types to be dumped in addition to values",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "name_size",
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                "type": "string",
-                "default": "32"
+                "type": "INT",
+                "default": 32
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
-                "type": "string",
-                "default": "0"
+                "type": "INT",
+                "default": 0
             },
             {
                 "key": "use_spaces",
                 "label": "Use Spaces",
                 "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "show_timestamp",
                 "label": "Show Timestamp",
                 "description": "Show the timestamp of function calls since start in microseconds",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_shader",
                 "label": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "output_range",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": "0-0"
-            }            
+            }
         ]
     }
 }

--- a/vkconfig/resourcefiles/layers_130/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig/resourcefiles/layers_130/VK_LAYER_LUNARG_device_simulation.json
@@ -21,22 +21,22 @@
                 "key": "filename",
                 "label": "Devsim JSON configuration file",
                 "description": "Path of a devsim configuration file to load.",
-                "type": "load_file",
+                "type": "LOAD_FILE",
                 "default": ""
             },
             {
                 "key": "debug_enable",
                 "label": "Debug Enable",
                 "description": "Enables debug message output.",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "exit_on_error",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "bool_numeric",
-                "default": "0"
+                "type": "BOOL_NUMERIC",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_130/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig/resourcefiles/layers_130/VK_LAYER_LUNARG_screenshot.json
@@ -20,21 +20,21 @@
                 "key": "frames",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": ""
             },
             {
                 "key": "dir",
                 "label": "Directory",
                 "description": "This can be set to specify the directory in which to create the screenshot files.",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": ""
             },
             {
                 "key": "format",
                 "label": "Format",
                 "description": "This can be set to a color space for the output.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "UNORM": "UNORM",
                     "SNORM": "SNORM",

--- a/vkconfig/resourcefiles/layers_135/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_135/VK_LAYER_KHRONOS_validation.json
@@ -148,7 +148,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "ENUM",
+                "type": "FLAGS",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",

--- a/vkconfig/resourcefiles/layers_135/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_135/VK_LAYER_KHRONOS_validation.json
@@ -148,7 +148,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
@@ -161,7 +161,7 @@
                 "key": "report_flags",
                 "label": "Message Severity",
                 "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "info": "Info",
                     "warn": "Warn",
@@ -179,14 +179,14 @@
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the output filename",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "stdout"
             },
             {
                 "key": "disables",
                 "label": "Disables",
                 "description": "Setting an option here will disable areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety",
                     "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter",
@@ -207,7 +207,7 @@
                 "key": "enables",
                 "label": "Enables",
                 "description": "Setting an option here will enable specialized areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",
                     "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT": "Reserve a descriptorSet binding slot for internal use",

--- a/vkconfig/resourcefiles/layers_135/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig/resourcefiles/layers_135/VK_LAYER_LUNARG_api_dump.json
@@ -1,6 +1,6 @@
 {
     "file_format_version" : "1.4.0",
-    "layer" : {
+    "layer": {
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_api_dump.dll",
@@ -9,13 +9,14 @@
         "description": "LunarG API dump layer",
         "device_extensions": [
             {
-                 "name": "VK_EXT_tooling_info",
-                 "spec_version": "1",
-                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
-                        ]
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
             }
         ],
-        "settings" : [
+        "settings": [
             {
                 "key": "output_format",
                 "label": "Output Format",
@@ -32,93 +33,93 @@
                 "key": "detailed",
                 "label": "Detailed Output",
                 "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "no_addr",
                 "label": "Hide Addresses",
                 "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the file to dump to when output files are enabled",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "vk_apidump.txt"
             },
             {
                 "key": "flush",
                 "label": "Log Flush After Write",
                 "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "indent_size",
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
-                "type": "string",
-                "default": "4"
+                "type": "INT",
+                "default": 4
             },
             {
                 "key": "show_types",
                 "label": "Show Types",
                 "description": "Setting this to true causes types to be dumped in addition to values",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "name_size",
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                "type": "string",
-                "default": "32"
+                "type": "INT",
+                "default": 32
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
-                "type": "string",
-                "default": "0"
+                "type": "INT",
+                "default": 0
             },
             {
                 "key": "use_spaces",
                 "label": "Use Spaces",
                 "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "show_timestamp",
                 "label": "Show Timestamp",
                 "description": "Show the timestamp of function calls since start in microseconds",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_shader",
                 "label": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "output_range",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": "0-0"
-            }            
+            }
         ]
     }
 }

--- a/vkconfig/resourcefiles/layers_135/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig/resourcefiles/layers_135/VK_LAYER_LUNARG_device_simulation.json
@@ -21,22 +21,22 @@
                 "key": "filename",
                 "label": "Devsim JSON configuration file",
                 "description": "Path of a devsim configuration file to load.",
-                "type": "load_file",
+                "type": "LOAD_FILE",
                 "default": ""
             },
             {
                 "key": "debug_enable",
                 "label": "Debug Enable",
                 "description": "Enables debug message output.",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "exit_on_error",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "bool_numeric",
-                "default": "0"
+                "type": "BOOL_NUMERIC",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_135/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig/resourcefiles/layers_135/VK_LAYER_LUNARG_screenshot.json
@@ -20,21 +20,21 @@
                 "key": "frames",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": ""
             },
             {
                 "key": "dir",
                 "label": "Directory",
                 "description": "This can be set to specify the directory in which to create the screenshot files.",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": ""
             },
             {
                 "key": "format",
                 "label": "Format",
                 "description": "This can be set to a color space for the output.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "UNORM": "UNORM",
                     "SNORM": "SNORM",

--- a/vkconfig/resourcefiles/layers_141/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_141/VK_LAYER_KHRONOS_validation.json
@@ -172,7 +172,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
@@ -185,7 +185,7 @@
                 "key": "report_flags",
                 "label": "Message Severity",
                 "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "info": "Info",
                     "warn": "Warn",
@@ -203,14 +203,14 @@
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the output filename",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "stdout"
             },
             {
                 "key": "message_id_filter",
                 "label": "Mute Message VUIDs",
                 "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
-                "type": "vuid_exclude",
+                "type": "VUID_EXCLUDE",
                 "options": [
                     "VUID-VkAabbPositionsKHR-minX-03546",
                     "VUID-VkAabbPositionsKHR-minY-03547",
@@ -6678,7 +6678,7 @@
                 "key": "disables",
                 "label": "Disables",
                 "description": "Setting an option here will disable areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety",
                     "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter",
@@ -6699,7 +6699,7 @@
                 "key": "enables",
                 "label": "Enables",
                 "description": "Setting an option here will enable specialized areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
                     "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",

--- a/vkconfig/resourcefiles/layers_141/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_141/VK_LAYER_KHRONOS_validation.json
@@ -172,7 +172,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "ENUM",
+                "type": "FLAGS",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",

--- a/vkconfig/resourcefiles/layers_141/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig/resourcefiles/layers_141/VK_LAYER_LUNARG_api_dump.json
@@ -1,6 +1,6 @@
 {
     "file_format_version" : "1.4.0",
-    "layer" : {
+    "layer": {
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_api_dump.dll",
@@ -9,13 +9,14 @@
         "description": "LunarG API dump layer",
         "device_extensions": [
             {
-                 "name": "VK_EXT_tooling_info",
-                 "spec_version": "1",
-                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
-                        ]
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
             }
         ],
-        "settings" : [
+        "settings": [
             {
                 "key": "output_format",
                 "label": "Output Format",
@@ -32,93 +33,93 @@
                 "key": "detailed",
                 "label": "Detailed Output",
                 "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "no_addr",
                 "label": "Hide Addresses",
                 "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the file to dump to when output files are enabled",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "vk_apidump.txt"
             },
             {
                 "key": "flush",
                 "label": "Log Flush After Write",
                 "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "indent_size",
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
-                "type": "string",
-                "default": "4"
+                "type": "INT",
+                "default": 4
             },
             {
                 "key": "show_types",
                 "label": "Show Types",
                 "description": "Setting this to true causes types to be dumped in addition to values",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "name_size",
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                "type": "string",
-                "default": "32"
+                "type": "INT",
+                "default": 32
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
-                "type": "string",
-                "default": "0"
+                "type": "INT",
+                "default": 0
             },
             {
                 "key": "use_spaces",
                 "label": "Use Spaces",
                 "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "show_timestamp",
                 "label": "Show Timestamp",
                 "description": "Show the timestamp of function calls since start in microseconds",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_shader",
                 "label": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "output_range",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": "0-0"
-            }            
+            }
         ]
     }
 }

--- a/vkconfig/resourcefiles/layers_141/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig/resourcefiles/layers_141/VK_LAYER_LUNARG_device_simulation.json
@@ -21,22 +21,22 @@
                 "key": "filename",
                 "label": "Devsim JSON configuration file",
                 "description": "Path of a devsim configuration file to load.",
-                "type": "load_file",
+                "type": "LOAD_FILE",
                 "default": ""
             },
             {
                 "key": "debug_enable",
                 "label": "Debug Enable",
                 "description": "Enables debug message output.",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "exit_on_error",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "bool_numeric",
-                "default": "0"
+                "type": "BOOL_NUMERIC",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_141/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig/resourcefiles/layers_141/VK_LAYER_LUNARG_screenshot.json
@@ -20,21 +20,21 @@
                 "key": "frames",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": ""
             },
             {
                 "key": "dir",
                 "label": "Directory",
                 "description": "This can be set to specify the directory in which to create the screenshot files.",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": ""
             },
             {
                 "key": "format",
                 "label": "Format",
                 "description": "This can be set to a color space for the output.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "UNORM": "UNORM",
                     "SNORM": "SNORM",

--- a/vkconfig/resourcefiles/layers_148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_148/VK_LAYER_KHRONOS_validation.json
@@ -172,7 +172,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
@@ -185,7 +185,7 @@
                 "key": "report_flags",
                 "label": "Message Severity",
                 "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "info": "Info",
                     "warn": "Warn",
@@ -203,21 +203,21 @@
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the output filename",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "stdout"
             },
             {
                 "key": "duplicate_message_limit",
                 "label": "Duplicated Messages Limit",
                 "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
-                "type": "string",
-                "default": "10"
+                "type": "INT",
+                "default": 10
             },
             {
                 "key": "message_id_filter",
                 "label": "Mute Message VUIDs",
                 "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
-                "type": "vuid_exclude",
+                "type": "VUID_EXCLUDE",
                 "options": [
                     "VUID-VkAabbPositionsKHR-minX-03546",
                     "VUID-VkAabbPositionsKHR-minY-03547",
@@ -6685,7 +6685,7 @@
                 "key": "disables",
                 "label": "Disables",
                 "description": "Setting an option here will disable areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety",
                     "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter",
@@ -6706,7 +6706,7 @@
                 "key": "enables",
                 "label": "Enables",
                 "description": "Setting an option here will enable specialized areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",
                     "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT": "GPU-Assisted Validation",

--- a/vkconfig/resourcefiles/layers_148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_148/VK_LAYER_KHRONOS_validation.json
@@ -172,7 +172,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "ENUM",
+                "type": "FLAGS",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",

--- a/vkconfig/resourcefiles/layers_148/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig/resourcefiles/layers_148/VK_LAYER_LUNARG_api_dump.json
@@ -1,6 +1,6 @@
 {
     "file_format_version" : "1.4.0",
-    "layer" : {
+    "layer": {
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_api_dump.dll",
@@ -9,13 +9,14 @@
         "description": "LunarG API dump layer",
         "device_extensions": [
             {
-                 "name": "VK_EXT_tooling_info",
-                 "spec_version": "1",
-                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
-                        ]
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
             }
         ],
-        "settings" : [
+        "settings": [
             {
                 "key": "output_format",
                 "label": "Output Format",
@@ -32,93 +33,93 @@
                 "key": "detailed",
                 "label": "Detailed Output",
                 "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "no_addr",
                 "label": "Hide Addresses",
                 "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the file to dump to when output files are enabled",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "vk_apidump.txt"
             },
             {
                 "key": "flush",
                 "label": "Log Flush After Write",
                 "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "indent_size",
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
-                "type": "string",
-                "default": "4"
+                "type": "INT",
+                "default": 4
             },
             {
                 "key": "show_types",
                 "label": "Show Types",
                 "description": "Setting this to true causes types to be dumped in addition to values",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "name_size",
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                "type": "string",
-                "default": "32"
+                "type": "INT",
+                "default": 32
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
-                "type": "string",
-                "default": "0"
+                "type": "INT",
+                "default": 0
             },
             {
                 "key": "use_spaces",
                 "label": "Use Spaces",
                 "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "show_timestamp",
                 "label": "Show Timestamp",
                 "description": "Show the timestamp of function calls since start in microseconds",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_shader",
                 "label": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "output_range",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": "0-0"
-            }            
+            }
         ]
     }
 }

--- a/vkconfig/resourcefiles/layers_148/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig/resourcefiles/layers_148/VK_LAYER_LUNARG_device_simulation.json
@@ -21,22 +21,22 @@
                 "key": "filename",
                 "label": "Devsim JSON configuration file",
                 "description": "Path of a devsim configuration file to load.",
-                "type": "load_file",
+                "type": "LOAD_FILE",
                 "default": ""
             },
             {
                 "key": "debug_enable",
                 "label": "Debug Enable",
                 "description": "Enables debug message output.",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "exit_on_error",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "bool_numeric",
-                "default": "0"
+                "type": "BOOL_NUMERIC",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_148/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig/resourcefiles/layers_148/VK_LAYER_LUNARG_screenshot.json
@@ -20,21 +20,21 @@
                 "key": "frames",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": ""
             },
             {
                 "key": "dir",
                 "label": "Directory",
                 "description": "This can be set to specify the directory in which to create the screenshot files.",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": ""
             },
             {
                 "key": "format",
                 "label": "Format",
                 "description": "This can be set to a color space for the output.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "UNORM": "UNORM",
                     "SNORM": "SNORM",

--- a/vkconfig/resourcefiles/layers_154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_154/VK_LAYER_KHRONOS_validation.json
@@ -195,7 +195,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "ENUM",
+                "type": "FLAGS",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",

--- a/vkconfig/resourcefiles/layers_154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_154/VK_LAYER_KHRONOS_validation.json
@@ -195,7 +195,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
@@ -208,7 +208,7 @@
                 "key": "report_flags",
                 "label": "Message Severity",
                 "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "info": "Info",
                     "warn": "Warn",
@@ -226,21 +226,21 @@
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the output filename",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "stdout"
             },
             {
                 "key": "duplicate_message_limit",
                 "label": "Duplicated Messages Limit",
                 "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
-                "type": "string",
-                "default": "10"
+                "type": "INT",
+                "default": 10
             },
             {
                 "key": "message_id_filter",
                 "label": "Mute Message VUIDs",
                 "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
-                "type": "vuid_exclude",
+                "type": "VUID_EXCLUDE",
                 "options": [
                     "VUID-VkAabbPositionsKHR-minX-03546",
                     "VUID-VkAabbPositionsKHR-minY-03547",
@@ -6708,7 +6708,7 @@
                 "key": "disables",
                 "label": "Disables",
                 "description": "Setting an option here will disable areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread safety",
                     "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless parameter",
@@ -6729,7 +6729,7 @@
                 "key": "enables",
                 "label": "Enables",
                 "description": "Setting an option here will enable specialized areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT": "Synchronization (ALPHA)",
                     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug printf",

--- a/vkconfig/resourcefiles/layers_154/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig/resourcefiles/layers_154/VK_LAYER_LUNARG_api_dump.json
@@ -1,6 +1,6 @@
 {
     "file_format_version" : "1.4.0",
-    "layer" : {
+    "layer": {
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_api_dump.dll",
@@ -9,13 +9,14 @@
         "description": "LunarG API dump layer",
         "device_extensions": [
             {
-                 "name": "VK_EXT_tooling_info",
-                 "spec_version": "1",
-                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
-                        ]
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
             }
         ],
-        "settings" : [
+        "settings": [
             {
                 "key": "output_format",
                 "label": "Output Format",
@@ -32,93 +33,93 @@
                 "key": "detailed",
                 "label": "Detailed Output",
                 "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "no_addr",
                 "label": "Hide Addresses",
                 "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the file to dump to when output files are enabled",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "vk_apidump.txt"
             },
             {
                 "key": "flush",
                 "label": "Log Flush After Write",
                 "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "indent_size",
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
-                "type": "string",
-                "default": "4"
+                "type": "INT",
+                "default": 4
             },
             {
                 "key": "show_types",
                 "label": "Show Types",
                 "description": "Setting this to true causes types to be dumped in addition to values",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "name_size",
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                "type": "string",
-                "default": "32"
+                "type": "INT",
+                "default": 32
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
-                "type": "string",
-                "default": "0"
+                "type": "INT",
+                "default": 0
             },
             {
                 "key": "use_spaces",
                 "label": "Use Spaces",
                 "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "show_timestamp",
                 "label": "Show Timestamp",
                 "description": "Show the timestamp of function calls since start in microseconds",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_shader",
                 "label": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "output_range",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": "0-0"
-            }            
+            }
         ]
     }
 }

--- a/vkconfig/resourcefiles/layers_154/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig/resourcefiles/layers_154/VK_LAYER_LUNARG_device_simulation.json
@@ -28,15 +28,15 @@
                 "key": "debug_enable",
                 "label": "Debug Enable",
                 "description": "Enables debug message output.",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "exit_on_error",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "bool_numeric",
-                "default": "0"
+                "type": "BOOL_NUMERIC",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_154/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig/resourcefiles/layers_154/VK_LAYER_LUNARG_screenshot.json
@@ -20,21 +20,21 @@
                 "key": "frames",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": ""
             },
             {
                 "key": "dir",
                 "label": "Directory",
                 "description": "This can be set to specify the directory in which to create the screenshot files.",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": ""
             },
             {
                 "key": "format",
                 "label": "Format",
                 "description": "This can be set to a color space for the output.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "UNORM": "UNORM",
                     "SNORM": "SNORM",

--- a/vkconfig/resourcefiles/layers_162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_162/VK_LAYER_KHRONOS_validation.json
@@ -195,7 +195,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "ENUMRANGE",
+                "type": "FLAGS",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",

--- a/vkconfig/resourcefiles/layers_162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_162/VK_LAYER_KHRONOS_validation.json
@@ -195,7 +195,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "enum",
+                "type": "ENUMRANGE",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
@@ -208,7 +208,7 @@
                 "key": "report_flags",
                 "label": "Message Severity",
                 "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "info": "Info",
                     "warn": "Warn",
@@ -226,21 +226,21 @@
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the output filename",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "stdout"
             },
             {
                 "key": "duplicate_message_limit",
                 "label": "Duplicated Messages Limit",
                 "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
-                "type": "string",
-                "default": "10"
+                "type": "INT",
+                "default": 10
             },
             {
                 "key": "message_id_filter",
                 "label": "Mute Message VUIDs",
                 "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
-                "type": "vuid_exclude",
+                "type": "VUID_EXCLUDE",
                 "options": [
                     "VUID-VkAabbPositionsKHR-minX-03546",
                     "VUID-VkAabbPositionsKHR-minY-03547",
@@ -6708,7 +6708,7 @@
                 "key": "disables",
                 "label": "Disables",
                 "description": "Setting an option here will disable areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread Safety",
                     "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless Parameter",
@@ -6729,7 +6729,7 @@
                 "key": "enables",
                 "label": "Enables",
                 "description": "Setting an option here will enable specialized areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT": "Synchronization",
                     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug Printf",
@@ -6744,29 +6744,29 @@
                 "key": "gpuav_buffer_oob",
                 "label": "Buffer out of bounds check",
                 "description": "Enable buffer out of bounds checking",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "printf_to_stdout",
                 "label": "Printf to stdout",
                 "description": "To redirect Debug Printf messages from the debug callback to stdout",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "printf_verbose",
                 "label": "Verbose",
                 "description": "Verbosity of debug printf messages",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "printf_buffer_size",
                 "label": "Printf buffer size",
                 "description": "The size in bytes of the buffer used by debug printf",
-                "type": "string",
-                "default": "1024"
+                "type": "INT",
+                "default": 1024
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_api_dump.json
@@ -32,91 +32,91 @@
                 "key": "detailed",
                 "label": "Detailed Output",
                 "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "no_addr",
                 "label": "Hide Addresses",
                 "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the file to dump to when output files are enabled",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "vk_apidump.txt"
             },
             {
                 "key": "flush",
                 "label": "Log Flush After Write",
                 "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "indent_size",
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
-                "type": "string",
-                "default": "4"
+                "type": "INT",
+                "default": 4
             },
             {
                 "key": "show_types",
                 "label": "Show Types",
                 "description": "Setting this to true causes types to be dumped in addition to values",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "name_size",
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                "type": "string",
-                "default": "32"
+                "type": "INT",
+                "default": 32
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
-                "type": "string",
-                "default": "0"
+                "type": "INT",
+                "default": 0
             },
             {
                 "key": "use_spaces",
                 "label": "Use Spaces",
                 "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "show_timestamp",
                 "label": "Show Timestamp",
                 "description": "Show the timestamp of function calls since start in microseconds",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_shader",
                 "label": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "output_range",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": "0-0"
             }            
         ]

--- a/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_device_simulation.json
@@ -25,7 +25,7 @@
                 "settings": [
                     {
                         "key": "emulate_portability",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "filename",
@@ -41,7 +41,7 @@
                 "settings": [
                     {
                         "key": "emulate_portability",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "filename",
@@ -57,7 +57,7 @@
                 "settings": [
                     {
                         "key": "emulate_portability",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "filename",
@@ -71,7 +71,7 @@
                 "key": "filename",
                 "label": "Devsim JSON configuration file",
                 "description": "Path of a devsim configuration file to load.",
-                "type": "load_file",
+                "type": "LOAD_FILE",
                 "default": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
             },
             {
@@ -82,8 +82,8 @@
                     "WINDOWS",
                     "LINUX"
                 ],
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "emulate_portability",
@@ -93,15 +93,15 @@
                     "WINDOWS",
                     "LINUX"
                 ],
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "exit_on_error",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "bool_numeric",
-                "default": "0"
+                "type": "BOOL_NUMERIC",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -61,7 +61,7 @@
                 "key": "capture_trigger",
                 "label": "Hotkey Capture Trigger",
                 "description": "Specify a hotkey (any one of F1-F12, TAB, CONTROL) that will be used to start/stop capture. Example: F3 will set the capture trigger to F3 hotkey. One capture file will be generated for each pair of start/stop hotkey presses. Default is: Empty string (hotkey capture trigger is disabled).",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "": "None",
                     "F1": "F1",
@@ -85,29 +85,29 @@
                 "key": "capture_frames",
                 "label": "Capture Specific Frames",
                 "description": "Specify one or more comma-separated frame ranges to capture. Each range will be written to its own file. A frame range can be specified as a single value, to specify a single frame to capture, or as two hyphenated values, to specify the first and last frame to capture. Frame ranges should be specified in ascending order and cannot overlap. Note that frame numbering is 1-based (i.e. the first frame is frame 1). Example: 200,301-305 will create two capture files, one containing a single frame and one containing five frames. Default is: Empty string (all frames are captured).",
-                "type": "string",
+                "type": "STRING",
                 "default": ""
             },
             {
                 "key": "capture_file",
                 "label": "Capture File Name",
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "${LOCAL}/gfxrecon_capture.gfxr"
             },
             {
                 "key": "capture_file_timestamp",
                 "label": "Capture File Name with Timestamp",
                 "description": "Add a timestamp (yyyymmddThhmmss) postfix to the capture file name.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "capture_file_flush",
                 "label": "Capture File Flush After Write",
                 "description": "Flush output stream after each packet is written to the capture file. Default is: false.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "capture_compression_type",
@@ -126,63 +126,63 @@
                 "key": "log_output_to_console",
                 "label": "Log Output to Console / stdout",
                 "description": "Log messages will be written to stdout.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "log_break_on_error",
                 "label": "Trigger Debug Break on Error",
                 "description": "Trigger a debug break when logging an error.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_output_to_os_debug_string",
                 "label": "Log Output to Debug Console",
                 "description": "Windows only option. Log messages will be written to the Debug Console with OutputDebugStringA",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_file",
                 "label": "Log File",
                 "description": "When set, log messages will be written to a file at the specified path. Default is: Empty string (file logging disabled).",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": ""
             },
             {
                 "key": "log_detailed",
                 "label": "Log Detailed",
                 "description": "Include name and line number from the file responsible.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_file_flush_after_write",
                 "label": "Log File Flush After Write",
                 "description": "Flush the log file to disk after each write when true.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_file_keep_open",
                 "label": "Log File Keep Open",
                 "description": "Keep the log file open between log messages when true, or close and reopen the log file for each message when false.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "log_file_create_new",
                 "label": "Log File Overwrite",
                 "description": "Specifies that log file initialization should overwrite an existing file when true, or append to an existing file when false.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "log_level",
                 "label": "Log Level",
                 "description": "Specify the highest level message to log. Options are: debug, info, warning, error, and fatal. The specified level and all levels listed after it will be enabled for logging. For example, choosing the warning level will also enable the error and fatal levels.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "debug": "debug, info, warning, error",
                     "info": "info, warning, error, fatal",
@@ -196,7 +196,7 @@
                 "key": "memory_tracking_mode",
                 "label": "Memory Tracking Mode",
                 "description": "Specifies the memory tracking mode to use for detecting modifications to mapped Vulkan memory objects. Available options are: page_guard, assisted, and unassisted.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "page_guard": "page_guard",
                     "assisted": "assisted",
@@ -208,22 +208,22 @@
                 "key": "page_guard_copy_on_map",
                 "label": "Page Guard Copy on Map",
                 "description": "When the page_guard memory tracking mode is enabled, copies the content of the mapped memory to the shadow memory immediately after the memory is mapped.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "page_guard_separate_read",
                 "label": "Page Guard Separate Read Tracking",
                 "description": "When the page_guard memory tracking mode is enabled, copies the content of pages accessed for read from mapped memory to shadow memory on each read. Can overwrite unprocessed shadow memory content when an application is reading from and writing to the same page.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "page_guard_external_memory",
                 "label": "Page Guard External Memory",
                 "description": "When the page_guard memory tracking mode is enabled, use the VK_EXT_external_memory_host extension to eliminate the need for shadow memory allocations. For each memory allocation from a host visible memory type, the capture layer will create an allocation from system memory, which it can monitor for write access, and provide that allocation to vkAllocateMemory as external memory. Only available on Windows.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig/resourcefiles/layers_162/VK_LAYER_LUNARG_screenshot.json
@@ -20,21 +20,21 @@
                 "key": "frames",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "STRING",
                 "default": ""
             },
             {
                 "key": "dir",
                 "label": "Directory",
                 "description": "This can be set to specify the directory in which to create the screenshot files.",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": ""
             },
             {
                 "key": "format",
                 "label": "Format",
                 "description": "This can be set to a color space for the output.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "UNORM": "UNORM",
                     "SNORM": "SNORM",

--- a/vkconfig/resourcefiles/layers_latest/VK_LAYER_KHRONOS_synchronization2.json
+++ b/vkconfig/resourcefiles/layers_latest/VK_LAYER_KHRONOS_synchronization2.json
@@ -18,8 +18,8 @@
                 "key": "force_enable",
                 "label": "Force Enable",
                 "description": "Force the layer to be active even if the underlying driver already supports the synchonization2 extension.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_latest/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig/resourcefiles/layers_latest/VK_LAYER_KHRONOS_validation.json
@@ -195,7 +195,7 @@
                 "key": "debug_action",
                 "label": "Debug Action",
                 "description": "This indicates what action is to be taken when a layer wants to report information",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "VK_DBG_LAYER_ACTION_LOG_MSG": "Log Message",
                     "VK_DBG_LAYER_ACTION_CALLBACK": "Callback",
@@ -208,7 +208,7 @@
                 "key": "report_flags",
                 "label": "Message Severity",
                 "description": "This is a comma-delineated list of options telling the layer what types of messages it should report back",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "info": "Info",
                     "warn": "Warn",
@@ -226,21 +226,21 @@
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the output filename",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "stdout"
             },
             {
                 "key": "duplicate_message_limit",
                 "label": "Duplicated Messages Limit",
                 "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
-                "type": "string",
-                "default": "10"
+                "type": "INT",
+                "default": 10
             },
             {
                 "key": "message_id_filter",
                 "label": "Mute Message VUIDs",
                 "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
-                "type": "vuid_exclude",
+                "type": "VUID_EXCLUDE",
                 "options": [
                     "VUID-VkAabbPositionsKHR-minX-03546",
                     "VUID-VkAabbPositionsKHR-minY-03547",
@@ -6708,7 +6708,7 @@
                 "key": "disables",
                 "label": "Disables",
                 "description": "Setting an option here will disable areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT": "Thread Safety",
                     "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT": "Stateless Parameter",
@@ -6729,7 +6729,7 @@
                 "key": "enables",
                 "label": "Enables",
                 "description": "Setting an option here will enable specialized areas of validation",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT": "Synchronization",
                     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT": "Debug Printf",
@@ -6744,29 +6744,29 @@
                 "key": "gpuav_buffer_oob",
                 "label": "Buffer out of bounds check",
                 "description": "Enable buffer out of bounds checking",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "printf_to_stdout",
                 "label": "Printf to stdout",
                 "description": "To redirect Debug Printf messages from the debug callback to stdout",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "printf_verbose",
                 "label": "Verbose",
                 "description": "Verbosity of debug printf messages",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "printf_buffer_size",
                 "label": "Printf buffer size",
                 "description": "The size in bytes of the buffer used by debug printf",
-                "type": "string",
-                "default": "1024"
+                "type": "INT",
+                "default": 1024
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_api_dump.json
@@ -20,7 +20,7 @@
                 "key": "output_format",
                 "label": "Output Format",
                 "description": "Specifies the format used for output; can be Text (default -- outputs plain text), Html, or Json",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "Text": "Text",
                     "Html": "HTML",
@@ -32,91 +32,91 @@
                 "key": "detailed",
                 "label": "Detailed Output",
                 "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "no_addr",
                 "label": "Hide Addresses",
                 "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_filename",
                 "label": "Log Filename",
                 "description": "Specifies the file to dump to when output files are enabled",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "vk_apidump.txt"
             },
             {
                 "key": "flush",
                 "label": "Log Flush After Write",
                 "description": "Setting this to true causes IO to be flushed after each API call that is written",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "indent_size",
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
-                "type": "string",
-                "default": "4"
+                "type": "INT",
+                "default": 4
             },
             {
                 "key": "show_types",
                 "label": "Show Types",
                 "description": "Setting this to true causes types to be dumped in addition to values",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "name_size",
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
-                "type": "string",
-                "default": "32"
+                "type": "INT",
+                "default": 32
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
-                "type": "string",
-                "default": "0"
+                "type": "INT",
+                "default": 0
             },
             {
                 "key": "use_spaces",
                 "label": "Use Spaces",
                 "description": "Setting this to true causes all tab characters to be replaced with spaces",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "show_timestamp",
                 "label": "Show Timestamp",
                 "description": "Show the timestamp of function calls since start in microseconds",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_shader",
                 "label": "Show Shader",
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "output_range",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": "0-0"
             }            
         ]

--- a/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_device_simulation.json
@@ -25,7 +25,7 @@
                 "settings": [
                     {
                         "key": "emulate_portability",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "filename",
@@ -41,7 +41,7 @@
                 "settings": [
                     {
                         "key": "emulate_portability",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "filename",
@@ -57,7 +57,7 @@
                 "settings": [
                     {
                         "key": "emulate_portability",
-                        "value": "1"
+                        "value": true
                     },
                     {
                         "key": "filename",
@@ -71,29 +71,29 @@
                 "key": "filename",
                 "label": "Devsim JSON configuration file",
                 "description": "Path of a devsim configuration file to load.",
-                "type": "load_file",
+                "type": "LOAD_FILE",
                 "default": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
             },
             {
                 "key": "debug_enable",
                 "label": "Debug Enable",
                 "description": "Enables debug message output.",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "emulate_portability",
                 "label": "Emulate VK_KHR_portability_subset",
                 "description": "Emulate that VK_KHR_portability_subset extension is supported by the device.",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
                 "key": "exit_on_error",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "bool_numeric",
-                "default": "0"
+                "type": "BOOL_NUMERIC",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -61,7 +61,7 @@
                 "key": "capture_trigger",
                 "label": "Hotkey Capture Trigger",
                 "description": "Specify a hotkey (any one of F1-F12, TAB, CONTROL) that will be used to start/stop capture. Example: F3 will set the capture trigger to F3 hotkey. One capture file will be generated for each pair of start/stop hotkey presses. Default is: Empty string (hotkey capture trigger is disabled).",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "": "None",
                     "F1": "F1",
@@ -85,35 +85,35 @@
                 "key": "capture_frames",
                 "label": "Capture Specific Frames",
                 "description": "Specify one or more comma-separated frame ranges to capture. Each range will be written to its own file. A frame range can be specified as a single value, to specify a single frame to capture, or as two hyphenated values, to specify the first and last frame to capture. Frame ranges should be specified in ascending order and cannot overlap. Note that frame numbering is 1-based (i.e. the first frame is frame 1). Example: 200,301-305 will create two capture files, one containing a single frame and one containing five frames. Default is: Empty string (all frames are captured).",
-                "type": "string",
+                "type": "INT_RANGE",
                 "default": ""
             },
             {
                 "key": "capture_file",
                 "label": "Capture File Name",
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "${LOCAL}/gfxrecon_capture.gfxr"
             },
             {
                 "key": "capture_file_timestamp",
                 "label": "Capture File Name with Timestamp",
                 "description": "Add a timestamp (yyyymmddThhmmss) postfix to the capture file name.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "capture_file_flush",
                 "label": "Capture File Flush After Write",
                 "description": "Flush output stream after each packet is written to the capture file. Default is: false.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "capture_compression_type",
                 "label": "Compression Format",
                 "description": "Compression format to use with the capture file. Valid values are: LZ4, ZLIB, ZSTD, and NONE. Default is: LZ4",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "LZ4": "LZ4",
                     "ZLIB": "ZLIB",
@@ -126,63 +126,63 @@
                 "key": "log_output_to_console",
                 "label": "Log Output to Console / stdout",
                 "description": "Log messages will be written to stdout.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "log_break_on_error",
                 "label": "Trigger Debug Break on Error",
                 "description": "Trigger a debug break when logging an error.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_output_to_os_debug_string",
                 "label": "Log Output to Debug Console",
                 "description": "Windows only option. Log messages will be written to the Debug Console with OutputDebugStringA",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_file",
                 "label": "Log File",
                 "description": "When set, log messages will be written to a file at the specified path. Default is: Empty string (file logging disabled).",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": ""
             },
             {
                 "key": "log_detailed",
                 "label": "Log Detailed",
                 "description": "Include name and line number from the file responsible.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_file_flush_after_write",
                 "label": "Log File Flush After Write",
                 "description": "Flush the log file to disk after each write when true.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "log_file_keep_open",
                 "label": "Log File Keep Open",
                 "description": "Keep the log file open between log messages when true, or close and reopen the log file for each message when false.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "log_file_create_new",
                 "label": "Log File Overwrite",
                 "description": "Specifies that log file initialization should overwrite an existing file when true, or append to an existing file when false.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "log_level",
                 "label": "Log Level",
                 "description": "Specify the highest level message to log. Options are: debug, info, warning, error, and fatal. The specified level and all levels listed after it will be enabled for logging. For example, choosing the warning level will also enable the error and fatal levels.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "debug": "debug, info, warning, error",
                     "info": "info, warning, error, fatal",
@@ -196,7 +196,7 @@
                 "key": "memory_tracking_mode",
                 "label": "Memory Tracking Mode",
                 "description": "Specifies the memory tracking mode to use for detecting modifications to mapped Vulkan memory objects. Available options are: page_guard, assisted, and unassisted.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "page_guard": "page_guard",
                     "assisted": "assisted",
@@ -208,22 +208,22 @@
                 "key": "page_guard_copy_on_map",
                 "label": "Page Guard Copy on Map",
                 "description": "When the page_guard memory tracking mode is enabled, copies the content of the mapped memory to the shadow memory immediately after the memory is mapped.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "page_guard_separate_read",
                 "label": "Page Guard Separate Read Tracking",
                 "description": "When the page_guard memory tracking mode is enabled, copies the content of pages accessed for read from mapped memory to shadow memory on each read. Can overwrite unprocessed shadow memory content when an application is reading from and writing to the same page.",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
                 "key": "page_guard_external_memory",
                 "label": "Page Guard External Memory",
                 "description": "When the page_guard memory tracking mode is enabled, use the VK_EXT_external_memory_host extension to eliminate the need for shadow memory allocations. For each memory allocation from a host visible memory type, the capture layer will create an allocation from system memory, which it can monitor for write access, and provide that allocation to vkAllocateMemory as external memory. Only available on Windows.",
-                "type": "bool",
-                "default": "FALSE"
+                "type": "BOOL",
+                "default": false
             }
         ]
     }

--- a/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig/resourcefiles/layers_latest/VK_LAYER_LUNARG_screenshot.json
@@ -20,21 +20,21 @@
                 "key": "frames",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "string",
+                "type": "STRING",
                 "default": ""
             },
             {
                 "key": "dir",
                 "label": "Directory",
                 "description": "This can be set to specify the directory in which to create the screenshot files.",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": ""
             },
             {
                 "key": "format",
                 "label": "Format",
                 "description": "This can be set to a color space for the output.",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "UNORM": "UNORM",
                     "SNORM": "SNORM",

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -346,6 +346,14 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
+            case SETTING_INT: {  // TODO
+                StringSettingWidget *widget = new StringSettingWidget(setting_item, layer_setting_meta, *layer_setting_data);
+                QTreeWidgetItem *place_holder = new QTreeWidgetItem();
+                setting_item->addChild(place_holder);
+                _settings_tree->setItemWidget(place_holder, 0, widget);
+                connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
+            } break;
+
             case SETTING_SAVE_FILE:    // Save a file?
             case SETTING_LOAD_FILE:    // Load a file?
             case SETTING_SAVE_FOLDER:  // Save to folder?
@@ -371,6 +379,7 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 connect(enum_widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
+            case SETTING_INT_RANGE:
             case SETTING_STRING:  // Raw text field?
             {
                 StringSettingWidget *widget = new StringSettingWidget(setting_item, layer_setting_meta, *layer_setting_data);

--- a/vkconfig_core/json.cpp
+++ b/vkconfig_core/json.cpp
@@ -88,6 +88,13 @@ int ReadIntValue(const QJsonObject& json_object, const char* key) {
     return json_value.toInt();
 }
 
+bool ReadBoolValue(const QJsonObject& json_object, const char* key) {
+    const QJsonValue& json_value = json_object.value(key);
+    assert(json_value != QJsonValue::Undefined);
+    assert(json_value.isBool());
+    return json_value.toBool();
+}
+
 Version ReadVersionValue(const QJsonObject& json_object, const char* key) {
     const std::string& version_string = ReadStringValue(json_object, key);
     assert(!version_string.empty());

--- a/vkconfig_core/json.h
+++ b/vkconfig_core/json.h
@@ -43,6 +43,9 @@ std::string ReadString(const QJsonObject& json_object, const char* key);
 // Read an int value from the json_object
 int ReadIntValue(const QJsonObject& json_object, const char* key);
 
+// Read a bool value from the json_object
+bool ReadBoolValue(const QJsonObject& json_object, const char* key);
+
 // Read a Version from the json_object
 Version ReadVersionValue(const QJsonObject& json_object, const char* key);
 

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -155,7 +155,6 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
             else
                 setting.platform_flags = PLATFORM_ALL_BIT;
             setting.type = GetSettingType(ReadStringValue(json_setting, "type").c_str());
-            setting.default_value = ReadString(json_setting, "default");
 
             switch (setting.type) {
                 case SETTING_EXCLUSIVE_LIST:
@@ -173,10 +172,15 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                         setting.enum_values << key;
                         setting.enum_labels << default_value;
                     }
+
+                    setting.default_value = ReadString(json_setting, "default");
                 } break;
                 case SETTING_LOAD_FILE:
-                case SETTING_SAVE_FILE: {
-                    setting.default_value = setting.default_value.c_str();
+                case SETTING_SAVE_FILE:
+                case SETTING_SAVE_FOLDER:
+                case SETTING_INT_RANGE:
+                case SETTING_STRING: {
+                    setting.default_value = ReadString(json_setting, "default");
                 } break;
                 case SETTING_VUID_FILTER: {
                     const QJsonValue& json_value_options = json_setting.value("options");
@@ -186,14 +190,20 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                     for (int i = 0, n = json_value_array.size(); i < n; ++i) {
                         setting.enum_values.append(json_value_array[i].toString());
                     }
+                    setting.default_value = ReadString(json_setting, "default");
                 } break;
-                case SETTING_SAVE_FOLDER:
-                case SETTING_BOOL:
-                case SETTING_BOOL_NUMERIC:
-                case SETTING_STRING:
-                case SETTING_RANGE_INT:
-                case SETTING_INT:
+                case SETTING_BOOL: {
+                    setting.default_value = ReadBoolValue(json_setting, "default") ? "TRUE" : "FALSE";
                     break;
+                }
+                case SETTING_BOOL_NUMERIC: {
+                    setting.default_value = ReadBoolValue(json_setting, "default") ? "1" : "0";
+                    break;
+                }
+                case SETTING_INT: {
+                    setting.default_value = format("%d", ReadIntValue(json_setting, "default"));
+                    break;
+                }
                 default:
                     assert(0);
                     break;

--- a/vkconfig_core/layer_setting_type.cpp
+++ b/vkconfig_core/layer_setting_type.cpp
@@ -21,12 +21,10 @@
 #include "layer_setting_type.h"
 #include "util.h"
 
-#include <cstring>
-
 SettingType GetSettingType(const char* token) {
     for (int i = SETTING_FIRST; i <= SETTING_LAST; ++i) {
         const SettingType type = static_cast<SettingType>(i);
-        if (std::strcmp(token, GetSettingToken(type)) == 0) return type;
+        if (ToUpperCase(token) == GetSettingToken(type)) return type;
     }
 
     assert(0);  // Unknown token
@@ -37,17 +35,17 @@ const char* GetSettingToken(SettingType type) {
     assert(type >= SETTING_FIRST && type <= SETTING_LAST);
 
     static const char* table[] = {
-        "string",        // SETTING_STRING
-        "int",           // SETTING_INT
-        "save_file",     // SETTING_SAVE_FILE
-        "load_file",     // SETTING_LOAD_FILE
-        "save_folder",   // SETTING_SAVE_FOLDER
-        "bool",          // SETTING_BOOL
-        "bool_numeric",  // SETTING_BOOL_NUMERIC
-        "enum",          // SETTING_EXCLUSIVE_LIST
-        "multi_enum",    // SETTING_INCLUSIVE_LIST
-        "range",         // SETTING_RANGE_INT
-        "vuid_exclude"   // SETTING_VUID_FILTER
+        "STRING",        // SETTING_STRING
+        "INT",           // SETTING_INT
+        "SAVE_FILE",     // SETTING_SAVE_FILE
+        "LOAD_FILE",     // SETTING_LOAD_FILE
+        "SAVE_FOLDER",   // SETTING_SAVE_FOLDER
+        "BOOL",          // SETTING_BOOL
+        "BOOL_NUMERIC",  // SETTING_BOOL_NUMERIC
+        "ENUM",          // SETTING_EXCLUSIVE_LIST
+        "FLAGS",         // SETTING_INCLUSIVE_LIST
+        "INT_RANGE",     // SETTING_RANGE_INT
+        "VUID_EXCLUDE"   // SETTING_VUID_FILTER
     };
     static_assert(countof(table) == SETTING_COUNT, "The tranlation table size doesn't match the enum number of elements");
 

--- a/vkconfig_core/layer_setting_type.h
+++ b/vkconfig_core/layer_setting_type.h
@@ -32,7 +32,7 @@ enum SettingType {  // Enum value can't be changed
     SETTING_BOOL_NUMERIC,  // Deprecated
     SETTING_EXCLUSIVE_LIST,
     SETTING_INCLUSIVE_LIST,
-    SETTING_RANGE_INT,
+    SETTING_INT_RANGE,
     SETTING_VUID_FILTER,
 
     SETTING_FIRST = SETTING_STRING,

--- a/vkconfig_core/layer_setting_value.cpp
+++ b/vkconfig_core/layer_setting_value.cpp
@@ -74,7 +74,7 @@ bool SettingValue::Load(const char* key, const SettingType type, const QJsonObje
             setting_value.push_back(QVariant(json_value.toInt()));
             break;
         }
-        case SETTING_RANGE_INT: {
+        case SETTING_INT_RANGE: {
             assert(json_value.isArray());
             const QJsonArray& json_array = json_value.toArray();
             assert(json_array.size() == 2);
@@ -125,7 +125,7 @@ bool SettingValue::Save(const char* key, const SettingType type, QJsonObject& js
             json_object.insert(key, this->setting_value[0].toInt());
             break;
         }
-        case SETTING_RANGE_INT: {
+        case SETTING_INT_RANGE: {
             assert(this->setting_value.size() == 2);
             QJsonArray json_array;
             for (std::size_t i = 0, n = this->setting_value.size(); i < n; ++i) {

--- a/vkconfig_core/test/Layer 1.4.0 - presets.json
+++ b/vkconfig_core/test/Layer 1.4.0 - presets.json
@@ -48,7 +48,7 @@
                 "label": "String",
                 "platforms": [ "WINDOWS" ],
                 "description": "string",
-                "type": "string",
+                "type": "STRING",
                 "default": "A string"
             }
         ]

--- a/vkconfig_core/test/Layer 1.4.0 - setting platforms.json
+++ b/vkconfig_core/test/Layer 1.4.0 - setting platforms.json
@@ -22,7 +22,7 @@
                 "label": "Windows only setting",
                 "platforms": [ "WINDOWS" ],
                 "description": "windows only setting",
-                "type": "string",
+                "type": "STRING",
                 "default": "WINDOWS"
             },
             {
@@ -30,7 +30,7 @@
                 "label": "Linux only setting",
                 "platforms": [ "LINUX" ],
                 "description": "Linux only setting",
-                "type": "string",
+                "type": "STRING",
                 "default": "LINUX"
             },
             {
@@ -38,7 +38,7 @@
                 "label": "macOS only setting",
                 "platforms": [ "MACOS" ],
                 "description": "macOS only setting",
-                "type": "string",
+                "type": "STRING",
                 "default": "MACOS"
             },
             {
@@ -46,14 +46,14 @@
                 "label": "explicit cross platform setting",
                 "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
                 "description": "explicit cross platform setting",
-                "type": "string",
+                "type": "STRING",
                 "default": "ALL"
             },
             {
                 "key": "case4",
                 "label": "implicit cross platform setting",
                 "description": "implicit cross platform setting",
-                "type": "string",
+                "type": "STRING",
                 "default": "ALL"
             },
             {
@@ -61,7 +61,7 @@
                 "label": "multiple platform setting",
                 "platforms": [ "WINDOWS", "MACOS" ],
                 "description": "multiple platform setting",
-                "type": "string",
+                "type": "STRING",
                 "default": "WINDOWS and MACOS"
             }
         ]

--- a/vkconfig_core/test/Layer 1.4.0 - setting types.json
+++ b/vkconfig_core/test/Layer 1.4.0 - setting types.json
@@ -18,11 +18,11 @@
         ],
         "settings": [
             {
-                "key": "enum",
+                "key": "ENUM",
                 "label": "enum",
                 "platforms": [ "WINDOWS" ],
                 "description": "enum case",
-                "type": "enum",
+                "type": "ENUM",
                 "options": {
                     "value0": "Value 0",
                     "value1": "Value 1",
@@ -31,10 +31,10 @@
                 "default": "value1"
             },
             {
-                "key": "flags",
+                "key": "FLAGS",
                 "label": "flags",
                 "description": "flags case",
-                "type": "multi_enum",
+                "type": "FLAGS",
                 "options": {
                     "flag0": "Flag 0",
                     "flag1": "Flag 1",
@@ -43,67 +43,67 @@
                 "default": [ "flag0", "flag1" ]
             },
             {
-                "key": "string",
+                "key": "STRING",
                 "label": "String",
                 "platforms": [ "WINDOWS" ],
                 "description": "string",
-                "type": "string",
+                "type": "STRING",
                 "default": "A string"
             },
             {
-                "key": "bool",
+                "key": "BOOL",
                 "label": "bool",
                 "description": "true or false",
-                "type": "bool",
-                "default": "TRUE"
+                "type": "BOOL",
+                "default": true
             },
             {
-                "key": "bool_numeric",
+                "key": "BOOL_NUMERIC",
                 "label": "bool numeric",
                 "description": "1 or 0",
-                "type": "bool_numeric",
-                "default": "1"
+                "type": "BOOL_NUMERIC",
+                "default": true
             },
             {
-                "key": "save_file",
+                "key": "SAVE_FILE",
                 "label": "Save file",
                 "description": "Save file path",
-                "type": "save_file",
+                "type": "SAVE_FILE",
                 "default": "./test.txt"
             },
             {
-                "key": "save_folder",
+                "key": "SAVE_FOLDER",
                 "label": "Save folder",
                 "description": "Save folder path",
-                "type": "save_folder",
+                "type": "SAVE_FOLDER",
                 "default": "./test"
             },
             {
-                "key": "load_file",
+                "key": "LOAD_FILE",
                 "label": "Load file",
                 "description": "Load file path",
-                "type": "load_file",
+                "type": "LOAD_FILE",
                 "default": "./test.txt"
             },
             {
-                "key": "int",
+                "key": "INT",
                 "label": "Integer",
                 "description": "Integer",
-                "type": "int",
-                "default": "76"
+                "type": "INT",
+                "default": 76
             },
             {
-                "key": "range",
+                "key": "INT_RANGE",
                 "label": "Integer Range",
                 "description": "Range",
-                "type": "range",
+                "type": "INT_RANGE",
                 "default": "76-82"
             },
             {
-                "key": "message_id_filter",
+                "key": "VUID_EXCLUDE",
                 "label": "string list",
                 "description": "list of strings",
-                "type": "vuid_exclude",
+                "type": "VUID_EXCLUDE",
                 "options": [
                     "stringA",
                     "stringB",

--- a/vkconfig_core/test/test_json.cpp
+++ b/vkconfig_core/test/test_json.cpp
@@ -97,3 +97,17 @@ TEST(test_json, read_int_value) {
 
     EXPECT_EQ(76, ReadIntValue(json_object, "key"));
 }
+
+TEST(test_json, read_bool_value_true) {
+    QJsonObject json_object;
+    json_object.insert("key", true);
+
+    EXPECT_EQ(true, ReadBoolValue(json_object, "key"));
+}
+
+TEST(test_json, read_bool_value_false) {
+    QJsonObject json_object;
+    json_object.insert("key", false);
+
+    EXPECT_EQ(false, ReadBoolValue(json_object, "key"));
+}

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -82,17 +82,17 @@ TEST(test_layer, load_v1_4_0_layer_setting_default_value) {
 
     EXPECT_EQ(SETTING_COUNT, layer.settings.size());
 
-    EXPECT_STREQ("value1", FindByKey(layer.settings, "enum")->default_value.c_str());
-    EXPECT_STREQ("flag0,flag1", FindByKey(layer.settings, "flags")->default_value.c_str());
-    EXPECT_STREQ("A string", FindByKey(layer.settings, "string")->default_value.c_str());
-    EXPECT_STREQ("TRUE", FindByKey(layer.settings, "bool")->default_value.c_str());
-    EXPECT_STREQ("1", FindByKey(layer.settings, "bool_numeric")->default_value.c_str());
-    EXPECT_STREQ("./test.txt", FindByKey(layer.settings, "save_file")->default_value.c_str());
-    EXPECT_STREQ("./test", FindByKey(layer.settings, "save_folder")->default_value.c_str());
-    EXPECT_STREQ("./test.txt", FindByKey(layer.settings, "load_file")->default_value.c_str());
-    EXPECT_STREQ("76", FindByKey(layer.settings, "int")->default_value.c_str());
-    EXPECT_STREQ("76-82", FindByKey(layer.settings, "range")->default_value.c_str());
-    EXPECT_STREQ("stringB,stringC", FindByKey(layer.settings, "message_id_filter")->default_value.c_str());
+    EXPECT_STREQ("value1", FindByKey(layer.settings, "ENUM")->default_value.c_str());
+    EXPECT_STREQ("flag0,flag1", FindByKey(layer.settings, "FLAGS")->default_value.c_str());
+    EXPECT_STREQ("A string", FindByKey(layer.settings, "STRING")->default_value.c_str());
+    EXPECT_STREQ("TRUE", FindByKey(layer.settings, "BOOL")->default_value.c_str());
+    EXPECT_STREQ("1", FindByKey(layer.settings, "BOOL_NUMERIC")->default_value.c_str());
+    EXPECT_STREQ("./test.txt", FindByKey(layer.settings, "SAVE_FILE")->default_value.c_str());
+    EXPECT_STREQ("./test", FindByKey(layer.settings, "SAVE_FOLDER")->default_value.c_str());
+    EXPECT_STREQ("./test.txt", FindByKey(layer.settings, "LOAD_FILE")->default_value.c_str());
+    EXPECT_STREQ("76", FindByKey(layer.settings, "INT")->default_value.c_str());
+    EXPECT_STREQ("76-82", FindByKey(layer.settings, "INT_RANGE")->default_value.c_str());
+    EXPECT_STREQ("stringB,stringC", FindByKey(layer.settings, "VUID_EXCLUDE")->default_value.c_str());
 }
 
 TEST(test_layer, load_v1_4_0_layer_preset) {

--- a/vkconfig_core/test/test_layer_setting_type.cpp
+++ b/vkconfig_core/test/test_layer_setting_type.cpp
@@ -28,9 +28,9 @@ TEST(test_setting_type, is_enum_true2) { EXPECT_EQ(true, IsEnum(SETTING_INCLUSIV
 
 TEST(test_setting_type, is_enum_false) { EXPECT_EQ(false, IsEnum(SETTING_STRING)); }
 
-TEST(test_setting_type, get_setting_token) { EXPECT_STREQ("string", GetSettingToken(SETTING_STRING)); }
+TEST(test_setting_type, get_setting_token) { EXPECT_STREQ("STRING", GetSettingToken(SETTING_STRING)); }
 
-TEST(test_setting_type, get_setting_type) { EXPECT_EQ(SETTING_STRING, GetSettingType("string")); }
+TEST(test_setting_type, get_setting_type) { EXPECT_EQ(SETTING_STRING, GetSettingType("STRING")); }
 
 TEST(test_setting_type, get_setting_save_file) { EXPECT_TRUE(IsPath(SETTING_SAVE_FILE)); }
 

--- a/vkconfig_core/util.cpp
+++ b/vkconfig_core/util.cpp
@@ -30,7 +30,8 @@
 
 #include <QString>
 #include <QStringList>
-#include <QDir>
+
+#include <cctype>
 
 std::string format(const char* message, ...) {
     std::size_t const STRING_BUFFER(4096);
@@ -102,4 +103,24 @@ QStringList ConvertString(const std::vector<std::string>& strings) {
     }
 
     return string_list;
+}
+
+std::string ToLowerCase(const std::string& value) {
+    std::string result = value;
+
+    for (std::size_t i = 0, n = result.size(); i < n; ++i) {
+        result[i] = std::tolower(result[i]);
+    }
+
+    return result;
+}
+
+std::string ToUpperCase(const std::string& value) {
+    std::string result = value;
+
+    for (std::size_t i = 0, n = result.size(); i < n; ++i) {
+        result[i] = std::toupper(result[i]);
+    }
+
+    return result;
 }

--- a/vkconfig_core/util.h
+++ b/vkconfig_core/util.h
@@ -116,3 +116,7 @@ void AppendString(std::string& delimited_string, const std::string& value);
 std::vector<std::string> ConvertString(const QStringList& string_list);
 
 QStringList ConvertString(const std::vector<std::string>& strings);
+
+std::string ToLowerCase(const std::string& value);
+
+std::string ToUpperCase(const std::string& value);

--- a/vkconfig_core/version.cpp
+++ b/vkconfig_core/version.cpp
@@ -28,7 +28,7 @@
 #include <cassert>
 #include <cstring>
 
-const Version Version::VKCONFIG(2, 1, 1);
+const Version Version::VKCONFIG(2, 2, 0);
 const Version Version::VKHEADER(VK_HEADER_VERSION_COMPLETE);
 const Version Version::VERSION_NULL(0u);
 


### PR DESCRIPTION
TODO:
- Make sure Vulkan Configurator can read configuration file settings v2.1 and earlier.