### PR TITLE
devsim: populate PDD after CreateInstance

### DIFF
--- a/layersvt/VkLayer_device_simulation.def
+++ b/layersvt/VkLayer_device_simulation.def
@@ -1,8 +1,8 @@
 
 ;;;; Begin Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
-; Copyright (c) 2015-2017 Valve Corporation
-; Copyright (c) 2015-2017 LunarG, Inc.
+; Copyright (c) 2015-2021 Valve Corporation
+; Copyright (c) 2015-2021 LunarG, Inc.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -26,4 +26,5 @@ vkGetInstanceProcAddr
 vkCreateInstance
 vkEnumerateInstanceLayerProperties
 vkEnumerateInstanceExtensionProperties
+vkEnumeratePhysicalDevices
 vkNegotiateLoaderLayerInterfaceVersion


### PR DESCRIPTION
Ensure that PhysicalDeviceData is only populated from calls
requiring VK_KHR_get_physical_device_properties2 after vkCreateInstance
has completely finished.

NOT COMPLETE

This change "works" to get vkcube running with VVL enabled. See `HACK!!`
comments for details.