### PR TITLE
vkconfig: Test generated layers and setting overrides files

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Fixes:
 - Fix export and import path being truncated when the path as '.' character
+- Fix crash when loading a JSON file as if it's a JSON layer file but it's not #1330
 
 ## [Vulkan Configurator 2.1.0 for Vulkan SDK 1.2.162.1](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.162.1) - January 2021
 

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -33,6 +33,9 @@
 - Rename "Custom Path" by "User-Defined Path"
 - Add extension filters to load and save file layer settings #1317
 
+### Fixes:
+- Fix export and import path being truncated when the path as '.' character
+
 ## [Vulkan Configurator 2.1.0 for Vulkan SDK 1.2.162.1](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.162.1) - January 2021
 
 ### Features:

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -56,7 +56,7 @@ Configurator::~Configurator() {
     configurations.SaveAllConfigurations(layers.available_layers);
 
     if (!environment.UsePersistentOverrideMode()) {
-        SurrenderLayers(environment);
+        SurrenderConfiguration(environment);
     }
 }
 

--- a/vkconfig/main_layers.cpp
+++ b/vkconfig/main_layers.cpp
@@ -45,7 +45,7 @@ static int RunLayersOverride(const CommandLine& command_line) {
     const bool use_application_list = environment.UseApplicationListOverrideMode();
     environment.SetMode(OVERRIDE_MODE_LIST, false);
 
-    const bool override_result = OverrideLayers(environment, layers.available_layers, configuration);
+    const bool override_result = OverrideConfiguration(environment, layers.available_layers, configuration);
 
     environment.SetMode(OVERRIDE_MODE_LIST, use_application_list);
 
@@ -75,8 +75,8 @@ static int RunLayersSurrender(const CommandLine& command_line) {
     Environment environment(paths);
     environment.Reset(Environment::DEFAULT);
 
-    const bool has_overridden_layers = HasOverriddenLayers(environment);
-    const bool surrender_result = SurrenderLayers(environment);
+    const bool has_overridden_layers = HasOverride(environment);
+    const bool surrender_result = SurrenderConfiguration(environment);
 
     environment.Reset(Environment::SYSTEM);  // Don't change the system settings on exit
 

--- a/vkconfig/main_signal.cpp
+++ b/vkconfig/main_signal.cpp
@@ -25,20 +25,20 @@
 
 #include <csignal>
 
-void SurrenderLayers(int signal) {
+void SurrenderConfiguration(int signal) {
     (void)signal;
 
     PathManager paths;
     Environment environment(paths);
 
-    SurrenderLayers(environment);
+    SurrenderConfiguration(environment);
 }
 
 void InitSignals() {
-    std::signal(SIGINT, SurrenderLayers);
-    std::signal(SIGTERM, SurrenderLayers);
-    std::signal(SIGSEGV, SurrenderLayers);
-    std::signal(SIGABRT, SurrenderLayers);
-    std::signal(SIGILL, SurrenderLayers);
-    std::signal(SIGFPE, SurrenderLayers);
+    std::signal(SIGINT, SurrenderConfiguration);
+    std::signal(SIGTERM, SurrenderConfiguration);
+    std::signal(SIGSEGV, SurrenderConfiguration);
+    std::signal(SIGABRT, SurrenderConfiguration);
+    std::signal(SIGILL, SurrenderConfiguration);
+    std::signal(SIGFPE, SurrenderConfiguration);
 }

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -55,7 +55,7 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
     build_tree->blockSignals(true);
     build_tree->clear();
 
-    if (!configuration->HasOverriddenLayers()) {
+    if (!configuration->HasOverride()) {
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setText(0, "No overridden or excluded layer");
         build_tree->addTopLevelItem(item);

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -458,7 +458,7 @@ void Configuration::Reset(const std::vector<Layer>& available_layers, const Path
     }
 }
 
-bool Configuration::HasOverriddenLayers() const {
+bool Configuration::HasOverride() const {
     for (std::size_t i = 0, n = this->parameters.size(); i < n; ++i) {
         if (this->parameters[i].state != LAYER_STATE_APPLICATION_CONTROLLED) return true;
     }

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -36,7 +36,7 @@ class Configuration {
     bool Load(const std::vector<Layer>& available_layers, const std::string& full_path);
     bool Save(const std::vector<Layer>& available_layers, const std::string& full_path) const;
     bool IsAvailableOnThisPlatform() const;
-    bool HasOverriddenLayers() const;
+    bool HasOverride() const;
 
     void Reset(const std::vector<Layer>& available_layers, const PathManager& path_manager);
 

--- a/vkconfig_core/configuration_manager.cpp
+++ b/vkconfig_core/configuration_manager.cpp
@@ -183,17 +183,17 @@ void ConfigurationManager::SetActiveConfiguration(const std::vector<Layer> &avai
     if (this->active_configuration != nullptr) {
         assert(!this->active_configuration->key.empty());
         environment.Set(ACTIVE_CONFIGURATION, this->active_configuration->key.c_str());
-        surrender = !this->active_configuration->HasOverriddenLayers();
+        surrender = !this->active_configuration->HasOverride();
     } else {
         this->active_configuration = nullptr;
         surrender = true;
     }
 
     if (surrender) {
-        SurrenderLayers(environment);
+        SurrenderConfiguration(environment);
     } else {
         assert(this->active_configuration != nullptr);
-        OverrideLayers(environment, available_layers, *active_configuration);
+        OverrideConfiguration(environment, available_layers, *active_configuration);
     }
 }
 
@@ -214,7 +214,7 @@ void ConfigurationManager::RefreshConfiguration(const std::vector<Layer> &availa
 bool ConfigurationManager::HasActiveConfiguration(const std::vector<Layer> &available_layers) const {
     if (this->active_configuration != nullptr)
         return !HasMissingLayer(this->active_configuration->parameters, available_layers) &&
-               this->active_configuration->HasOverriddenLayers();
+               this->active_configuration->HasOverride();
     else
         return false;
 }

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -109,8 +109,14 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
 
     // Populate key items about the layer
     const QJsonObject& json_root_object = json_document.object();
-    file_format_version = ReadVersionValue(json_root_object, "file_format_version");
+    if (json_root_object.value("file_format_version") == QJsonValue::Undefined) {
+        return false;  // Not a layer JSON file
+    }
+    if (json_root_object.value("layer") == QJsonValue::Undefined) {
+        return false;  // Not a layer JSON file
+    }
 
+    file_format_version = ReadVersionValue(json_root_object, "file_format_version");
     const QJsonObject& json_layer_object = ReadObject(json_root_object, "layer");
 
     key = ReadStringValue(json_layer_object, "name");

--- a/vkconfig_core/layer_manager.cpp
+++ b/vkconfig_core/layer_manager.cpp
@@ -96,25 +96,25 @@ void LayerManager::LoadAllInstalledLayers() {
     const std::vector<std::string> &env_user_defined_layers_paths =
         environment.GetUserDefinedLayersPaths(USER_DEFINED_LAYERS_PATHS_ENV);
     for (std::size_t i = 0, n = env_user_defined_layers_paths.size(); i < n; ++i) {
-        LoadLayersFromPath(env_user_defined_layers_paths[i], available_layers);
+        LoadLayersFromPath(env_user_defined_layers_paths[i]);
     }
 
     // SECOND: Any user-defined path from Vulkan Configurator? Search for those too
     const std::vector<std::string> &gui_user_defined_layers_paths =
         environment.GetUserDefinedLayersPaths(USER_DEFINED_LAYERS_PATHS_GUI);
     for (std::size_t i = 0, n = gui_user_defined_layers_paths.size(); i < n; ++i) {
-        LoadLayersFromPath(gui_user_defined_layers_paths[i], available_layers);
+        LoadLayersFromPath(gui_user_defined_layers_paths[i]);
     }
 
     // THIRD: Standard layer paths, in standard locations. The above has always taken precedence.
     for (std::size_t i = 0, n = countof(SEARCH_PATHS); i < n; i++) {
-        LoadLayersFromPath(SEARCH_PATHS[i], available_layers);
+        LoadLayersFromPath(SEARCH_PATHS[i]);
     }
 
     // FOURTH: Finally, see if thee is anyting in the VULKAN_SDK path that wasn't already found elsewhere
     const std::string vulkan_sdk(qgetenv("VULKAN_SDK").toStdString());
     if (!vulkan_sdk.empty()) {
-        LoadLayersFromPath(vulkan_sdk + GetPlatformString(PLATFORM_STRING_EXPLICIT_LAYERS), available_layers);
+        LoadLayersFromPath(vulkan_sdk + GetPlatformString(PLATFORM_STRING_EXPLICIT_LAYERS));
     }
 }
 
@@ -122,7 +122,7 @@ void LayerManager::LoadAllInstalledLayers() {
 /// load the default settings for each layer. This is just a master list of
 /// layers found. Do NOT load duplicate layer names. The type of layer (explicit or implicit) is
 /// determined from the path name.
-void LayerManager::LoadLayersFromPath(const std::string &path, std::vector<Layer> &layers) {
+void LayerManager::LoadLayersFromPath(const std::string &path) {
     // On Windows custom files are in the file system. On non Windows all layers are
     // searched this way
     LayerType type = LAYER_TYPE_CUSTOM;
@@ -134,7 +134,7 @@ void LayerManager::LoadLayersFromPath(const std::string &path, std::vector<Layer
     if (VKC_PLATFORM == VKC_PLATFORM_WINDOWS) {
         if (QString(path.c_str()).contains("...")) {
 #if VKC_PLATFORM == VKC_PLATFORM_WINDOWS
-            LoadRegistryLayers(path.c_str(), layers, type);
+            LoadRegistryLayers(path.c_str(), available_layers, type);
 #endif
             return;
         }
@@ -161,7 +161,7 @@ void LayerManager::LoadLayersFromPath(const std::string &path, std::vector<Layer
             if (FindByKey(available_layers, layer.key.c_str()) != nullptr) continue;
 
             // Good to go, add the layer
-            layers.push_back(layer);
+            available_layers.push_back(layer);
         }
     }
 }

--- a/vkconfig_core/layer_manager.h
+++ b/vkconfig_core/layer_manager.h
@@ -36,7 +36,7 @@ class LayerManager {
     bool Empty() const;
 
     void LoadAllInstalledLayers();
-    void LoadLayersFromPath(const std::string& path, std::vector<Layer>& layers);
+    void LoadLayersFromPath(const std::string& path);
 
     std::vector<Layer> available_layers;
 

--- a/vkconfig_core/override.h
+++ b/vkconfig_core/override.h
@@ -25,10 +25,11 @@
 #include "application.h"
 
 // Create the VkLayer_override.json and vk_layer_settings.txt files to take over Vulkan layers from Vulkan applications
-bool OverrideLayers(const Environment& environment, const std::vector<Layer>& available_layers, const Configuration& configuration);
+bool OverrideConfiguration(const Environment& environment, const std::vector<Layer>& available_layers,
+                           const Configuration& configuration);
 
 // Remove the VkLayer_override.json and vk_layer_settings.txt files to return full control of the layers to the Vulkan applications
-bool SurrenderLayers(const Environment& environment);
+bool SurrenderConfiguration(const Environment& environment);
 
 // Check whether a layers configuration is activated
-bool HasOverriddenLayers(const Environment& environment);
+bool HasOverride(const Environment& environment);

--- a/vkconfig_core/path_manager.cpp
+++ b/vkconfig_core/path_manager.cpp
@@ -272,7 +272,7 @@ std::string PathManager::SelectPathImpl(QWidget* parent, PathType path, const st
                 return "";
 
             SetPath(path, QFileInfo(selected_path.c_str()).absolutePath().toStdString());
-            return GetFullPath(path, QFileInfo(selected_path.c_str()).baseName().toStdString());
+            return selected_path;
         }
         case PATH_EXPORT_CONFIGURATION: {
             const std::string selected_path = QFileDialog::getSaveFileName(parent, "Export Layers Configuration File",
@@ -282,7 +282,7 @@ std::string PathManager::SelectPathImpl(QWidget* parent, PathType path, const st
                 return "";
 
             SetPath(path, QFileInfo(selected_path.c_str()).absolutePath().toStdString());
-            return GetFullPath(path, QFileInfo(selected_path.c_str()).baseName().toStdString());
+            return selected_path;
         }
         default:
             assert(0);

--- a/vkconfig_core/test/Configuration 2.2.0 - Layer 1.4.0.json
+++ b/vkconfig_core/test/Configuration 2.2.0 - Layer 1.4.0.json
@@ -1,0 +1,77 @@
+{
+    "file_format_version": "2.2.0",
+    "configuration": {
+        "name": "All layers",
+        "platforms": [
+            "WINDOWS",
+            "LINUX",
+            "MACOS"
+        ],
+        "description": "All layers test",
+        "editor_state": "011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+        "layers": [
+            {
+                "name": "VK_LAYER_LUNARG_test_1_4_0_setting_types",
+                "rank": 8,
+                "settings": [
+                    {
+                        "key": "ENUM",
+                        "type": "ENUM",
+                        "value": "value2"
+                    },
+                    {
+                        "key": "FLAGS",
+                        "type": "FLAGS",
+                        "value": "flag0, flag2"
+                    },
+                    {
+                        "key": "STRING",
+                        "type": "STRING",
+                        "value": "My string"
+                    },
+                    {
+                        "key": "BOOL",
+                        "type": "BOOL",
+                        "value": true
+                    },
+                    {
+                        "key": "BOOL_NUMERIC",
+                        "type": "BOOL_NUMERIC",
+                        "value": true
+                    },
+                    {
+                        "key": "SAVE_FILE",
+                        "type": "SAVE_FILE",
+                        "value": "./my_test.txt"
+                    },
+                    {
+                        "key": "SAVE_FOLDER",
+                        "type": "SAVE_FOLDER",
+                        "value": "./my_test"
+                    },
+                    {
+                        "key": "LOAD_FILE",
+                        "type": "LOAD_FILE",
+                        "value": "./my_test.txt"
+                    },
+                    {
+                        "key": "INT",
+                        "type": "INT",
+                        "value": 82
+                    },
+                    {
+                        "key": "INT_RANGE",
+                        "type": "INT_RANGE",
+                        "value": "79-82"
+                    },
+                    {
+                        "key": "VUID_EXCLUDE",
+                        "type": "VUID_EXCLUDE",
+                        "value": "stringA,stringB"
+                    }
+                ],
+                "state": "OVERRIDDEN"
+            }
+        ]
+    }
+}

--- a/vkconfig_core/test/Layer 1.3.0.json
+++ b/vkconfig_core/test/Layer 1.3.0.json
@@ -1,7 +1,7 @@
 {
     "file_format_version" : "1.3.0",
     "layer": {
-        "name": "VK_LAYER_LUNARG_test",
+        "name": "VK_LAYER_LUNARG_test_1_3_0",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_test.dll",
         "api_version": "1.2.162",

--- a/vkconfig_core/test/Layer 1.4.0 - presets.json
+++ b/vkconfig_core/test/Layer 1.4.0 - presets.json
@@ -1,7 +1,7 @@
 {
     "file_format_version" : "1.4.0",
     "layer": {
-        "name": "VK_LAYER_LUNARG_test",
+        "name": "VK_LAYER_LUNARG_test_1_4_0_presets",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_test.dll",
         "api_version": "1.2.162",

--- a/vkconfig_core/test/Layer 1.4.0 - setting platforms.json
+++ b/vkconfig_core/test/Layer 1.4.0 - setting platforms.json
@@ -1,7 +1,7 @@
 {
     "file_format_version" : "1.4.0",
     "layer": {
-        "name": "VK_LAYER_LUNARG_test",
+        "name": "VK_LAYER_LUNARG_test_1_4_0_setting_platforms",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_test.dll",
         "api_version": "1.2.162",

--- a/vkconfig_core/test/Layer 1.4.0 - setting types.json
+++ b/vkconfig_core/test/Layer 1.4.0 - setting types.json
@@ -1,7 +1,7 @@
 {
     "file_format_version" : "1.4.0",
     "layer": {
-        "name": "VK_LAYER_LUNARG_test",
+        "name": "VK_LAYER_LUNARG_test_1_4_0_setting_types",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_test.dll",
         "api_version": "1.2.162",

--- a/vkconfig_core/test/override_layers_1_4_0.json
+++ b/vkconfig_core/test/override_layers_1_4_0.json
@@ -1,0 +1,21 @@
+{
+    "file_format_version": "1.1.2",
+    "layer": {
+        "api_version": "1.2.162",
+        "blacklisted_layers": [
+        ],
+        "component_layers": [
+            "VK_LAYER_LUNARG_test_1_4_0_setting_types"
+        ],
+        "description": "LunarG Override Layer",
+        "disable_environment": {
+            "DISABLE_VK_LAYER_LUNARG_override": "1"
+        },
+        "implementation_version": "1",
+        "name": "VK_LAYER_LUNARG_override",
+        "override_paths": [
+            ":"
+        ],
+        "type": "GLOBAL"
+    }
+}

--- a/vkconfig_core/test/override_settings_1_4_0.txt
+++ b/vkconfig_core/test/override_settings_1_4_0.txt
@@ -1,0 +1,13 @@
+
+# VK_LAYER_LUNARG_test_1_4_0_setting_types
+lunarg_test_1_4_0_setting_types.ENUM = value2
+lunarg_test_1_4_0_setting_types.FLAGS = flag0, flag2
+lunarg_test_1_4_0_setting_types.STRING = My string
+lunarg_test_1_4_0_setting_types.BOOL = TRUE
+lunarg_test_1_4_0_setting_types.BOOL_NUMERIC = 1
+lunarg_test_1_4_0_setting_types.SAVE_FILE = ./my_test.txt
+lunarg_test_1_4_0_setting_types.SAVE_FOLDER = ./my_test
+lunarg_test_1_4_0_setting_types.LOAD_FILE = ./my_test.txt
+lunarg_test_1_4_0_setting_types.INT = 82
+lunarg_test_1_4_0_setting_types.INT_RANGE = 79-82
+lunarg_test_1_4_0_setting_types.VUID_EXCLUDE = stringA,stringB

--- a/vkconfig_core/test/resources.qrc
+++ b/vkconfig_core/test/resources.qrc
@@ -29,5 +29,8 @@
         <file>Layer 1.4.0 - presets.json</file>
         <file>Layer 1.4.0 - setting platforms.json</file>
         <file>Layer 1.4.0 - setting types.json</file>
+        
+        <file>override_layers_1_4_0.json</file>
+        <file>override_settings_1_4_0.txt</file>
     </qresource>
 </RCC>

--- a/vkconfig_core/test/resources.qrc
+++ b/vkconfig_core/test/resources.qrc
@@ -22,6 +22,7 @@
         <file>Configuration 2.1.0 - Portability.json</file>
         <file>Configuration 2.1.0 - Override all layers.json</file>
         
+        <file>Configuration 2.2.0 - Layer 1.4.0.json</file>
         <file>Configuration 2.2.0 - Override all layers.json</file>
     
         <file>Layer 1.3.0.json</file>

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -44,6 +44,7 @@ TEST(test_layer, load_v1_X_0_layer_header) {
     static const char* SOURCES[] = {":/Layer 1.3.0.json", ":/Layer 1.4.0 - setting platforms.json"};
 
     static const char* FILE_FORMAT_VERSIONS[] = {"1.3.0", "1.4.0"};
+    static const char* KEYS[] = {"VK_LAYER_LUNARG_test_1_3_0", "VK_LAYER_LUNARG_test_1_4_0_setting_platforms"};
 
     for (std::size_t i = 0, n = countof(SOURCES); i < n; ++i) {
         Layer layer;
@@ -52,7 +53,7 @@ TEST(test_layer, load_v1_X_0_layer_header) {
 
         EXPECT_STREQ(FILE_FORMAT_VERSIONS[i], layer.file_format_version.str().c_str());
 
-        EXPECT_STREQ("VK_LAYER_LUNARG_test", layer.key.c_str());
+        EXPECT_STREQ(KEYS[i], layer.key.c_str());
         EXPECT_STREQ("GLOBAL", layer._type.c_str());
         EXPECT_STREQ(".\\VkLayer_test.dll", layer._library_path.c_str());
         EXPECT_STREQ("1.2.162", layer._api_version.str().c_str());

--- a/vkconfig_core/test/test_layer_manager.cpp
+++ b/vkconfig_core/test/test_layer_manager.cpp
@@ -21,3 +21,16 @@
 #include "../layer_manager.h"
 
 #include <gtest/gtest.h>
+
+TEST(test_layer_manager, load_only_layer_json) {
+    PathManager paths;
+    Environment environment(paths);
+    environment.Reset(Environment::DEFAULT);
+
+    LayerManager layer_manager(environment);
+    layer_manager.LoadLayersFromPath(":/");
+
+    EXPECT_EQ(4, layer_manager.available_layers.size());
+
+    environment.Reset(Environment::SYSTEM);  // Don't change the system settings on exit
+}


### PR DESCRIPTION
- Test generated layers and setting overrides files
- Fix export and import path truncated
- Fix crash when loading a JSON file as if it's a JSON layer file but it's not