### PR TITLE
vkconfig: Fix `printf buffer size' setting exposed a `bool`

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Fixes:
 - Fix export and import path being truncated when the path as '.' character
 - Fix crash when loading a JSON file as if it's a JSON layer file but it's not #1330
+- Fix validation layer 'printf buffer size' setting exposed as a 'bool' instead of a 'int' #1338
 
 ## [Vulkan Configurator 2.1.0 for Vulkan SDK 1.2.162.1](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.162.1) - January 2021
 

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -287,7 +287,6 @@ void SettingsTreeManager::BuildValidationTree(QTreeWidgetItem *parent, Parameter
 
         QTreeWidgetItem *setting_item = new QTreeWidgetItem();
         WidgetSettingInt *widget = new WidgetSettingInt(setting_item, setting_meta, setting_data);
-        widget->setToolTip(setting_meta.description.c_str());
         parent->addChild(setting_item);
         QTreeWidgetItem *place_holder = new QTreeWidgetItem();
         setting_item->addChild(place_holder);

--- a/vkconfig/settings_validation_areas.h
+++ b/vkconfig/settings_validation_areas.h
@@ -23,6 +23,8 @@
 
 #include "../vkconfig_core/layer.h"
 
+#include "widget_setting_int.h"
+
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QRadioButton>
@@ -54,12 +56,14 @@ class SettingsValidationAreas : public QObject {
     QTreeWidgetItem *_debug_printf_to_stdout;
     QTreeWidgetItem *_debug_printf_verbose;
     QTreeWidgetItem *_debug_printf_buffer_size;
+    WidgetSettingInt *_debug_printf_buffer_size_value;
 
    public Q_SLOTS:
     void itemChanged(QTreeWidgetItem *item, int column);
     void itemClicked(QTreeWidgetItem *item, int column);
     void gpuToggled(bool toggle);
     void printfToggled(bool toggle);
+    void printfBufferSizeEdited(const QString &new_value);
 
    Q_SIGNALS:
     void settingChanged();
@@ -71,9 +75,11 @@ class SettingsValidationAreas : public QObject {
     bool HasEnable(const char *token) const;
     bool HasDisable(const char *token) const;
 
-    QTreeWidgetItem *CreateSettingWidget(QTreeWidgetItem *parent, const char *key) const;
+    QTreeWidgetItem *CreateSettingWidgetBool(QTreeWidgetItem *parent, const char *key);
+    QTreeWidgetItem *CreateSettingWidgetInt(QTreeWidgetItem *parent, const char *key);
 
     void StoreBoolSetting(QTreeWidgetItem *setting_data, const char *key);
+    void StoreIntSetting(QTreeWidgetItem *setting_data, const char *key);
 
     void EnableSettingWidget(QTreeWidgetItem *setting_data, bool enable);
 

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -6883,7 +6883,7 @@
             },
             {
                 "key": "printf_buffer_size",
-                "label": "Printf buffer size",
+                "label": "Printf buffer size (in bytes)",
                 "description": "The size in bytes of the buffer used by debug printf",
                 "type": "INT",
                 "default": 1024

--- a/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
@@ -6883,7 +6883,7 @@
             },
             {
                 "key": "printf_buffer_size",
-                "label": "Printf buffer size",
+                "label": "Printf buffer size (in bytes)",
                 "description": "The size in bytes of the buffer used by debug printf",
                 "type": "INT",
                 "default": 1024


### PR DESCRIPTION
Validation layer `printf buffer size' setting should be exposed as a int instead of a bool in the UI #1338

![image](https://user-images.githubusercontent.com/62888873/106631902-7d27a680-657d-11eb-9667-cb2f9df8be79.png)
