### PR TITLE
vkconfig: add default configuration for the first time

### DIFF
--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -95,6 +95,8 @@ bool Configurator::Init() {
 
     if (configurations.Empty()) {
         configurations.ResetDefaultsConfigurations(layers.available_layers);
+    } else {
+        configurations.FirstDefaultsConfigurations(layers.available_layers);
     }
 
     if (configurations.HasActiveConfiguration(layers.available_layers)) {

--- a/vkconfig_core/configuration_manager.cpp
+++ b/vkconfig_core/configuration_manager.cpp
@@ -265,3 +265,32 @@ void ConfigurationManager::ResetDefaultsConfigurations(const std::vector<Layer> 
     // Now we need to kind of restart everything
     LoadAllConfigurations(available_layers);
 }
+
+void ConfigurationManager::FirstDefaultsConfigurations(const std::vector<Layer> &available_layers) {
+    const QFileInfoList &configuration_files = GetJSONFiles(":/configurations/");
+
+    for (int i = 0, n = configuration_files.size(); i < n; ++i) {
+        if (environment.IsDefaultConfigurationInit(configuration_files[i].baseName().toStdString())) {
+            continue;
+        }
+
+        environment.InitDefaultConfiguration(configuration_files[i].baseName().toStdString());
+
+        Configuration configuration;
+        const bool result = configuration.Load(available_layers, configuration_files[i].absoluteFilePath().toStdString());
+        assert(result);
+
+        if (!configuration.IsAvailableOnThisPlatform()) {
+            continue;
+        }
+
+        if (FindByKey(available_configurations, configuration.key.c_str()) != nullptr) {
+            continue;
+        }
+
+        OrderParameter(configuration.parameters, available_layers);
+        available_configurations.push_back(configuration);
+    }
+
+    RefreshConfiguration(available_layers);
+}

--- a/vkconfig_core/configuration_manager.h
+++ b/vkconfig_core/configuration_manager.h
@@ -53,6 +53,8 @@ class ConfigurationManager {
 
     void ResetDefaultsConfigurations(const std::vector<Layer>& available_layers);
 
+    void FirstDefaultsConfigurations(const std::vector<Layer>& available_layers);
+
     bool Empty() const { return available_configurations.empty(); }
 
     std::vector<Configuration> available_configurations;

--- a/vkconfig_core/environment.cpp
+++ b/vkconfig_core/environment.cpp
@@ -265,6 +265,9 @@ bool Environment::Load() {
         layout_states[i] = settings.value(GetLayoutStateToken(static_cast<LayoutState>(i))).toByteArray();
     }
 
+    // Load default configuration already init
+    this->default_configuration_filenames = ConvertString(settings.value("default_configuration_files").toStringList());
+
     // Load custom paths
     user_defined_layers_paths[USER_DEFINED_LAYERS_PATHS_GUI] =
         ConvertString(settings.value(VKCONFIG_KEY_CUSTOM_PATHS).toStringList());
@@ -359,6 +362,9 @@ bool Environment::Save() const {
 
     // Save custom paths
     settings.setValue(VKCONFIG_KEY_CUSTOM_PATHS, ConvertString(user_defined_layers_paths[USER_DEFINED_LAYERS_PATHS_GUI]));
+
+    // Save default configuration initizalized
+    settings.setValue("default_configuration_files", ConvertString(this->default_configuration_filenames));
 
     const bool result = SaveApplications();
     assert(result);
@@ -553,6 +559,18 @@ bool Environment::RemoveCustomLayerPath(const std::string& path) {
 
     std::swap(custom_layer_paths_gui, new_custom_layer_paths_gui);
     return found;
+}
+
+bool Environment::IsDefaultConfigurationInit(const std::string& default_configuration_filename) const {
+    for (std::size_t i = 0, n = default_configuration_filenames.size(); i < n; ++i) {
+        if (default_configuration_filenames[i] == default_configuration_filename) return true;
+    }
+
+    return false;
+}
+
+void Environment::InitDefaultConfiguration(const std::string& configuration_filename) {
+    AppendString(this->default_configuration_filenames, configuration_filename);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/vkconfig_core/environment.h
+++ b/vkconfig_core/environment.h
@@ -139,6 +139,9 @@ class Environment {
         return user_defined_layers_paths[user_defined_layers_paths_id];
     }
 
+    bool IsDefaultConfigurationInit(const std::string& configuration_filename) const;
+    void InitDefaultConfiguration(const std::string& configuration_filename);
+
    private:
     Environment(const Environment&) = delete;
     Environment& operator=(const Environment&) = delete;
@@ -153,6 +156,8 @@ class Environment {
     std::vector<Application> applications;
 
     PathManager& paths_manager;
+
+    std::vector<std::string> default_configuration_filenames;
 
    public:
     const PathManager& paths;


### PR DESCRIPTION
Add new default configurations to the list (here we are interested in Synchronization configuration) if it was never added.

Change-Id: I8cc2363f89053244eff3c33fcf4c56c7922f3581