### PR TITLE
devsim: bool layer settings can be strings

### DIFF
--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_device_simulation.json
@@ -81,7 +81,7 @@
                 "env": "VK_DEVSIM_DEBUG_ENABLE",
                 "label": "Debug Enable",
                 "description": "Enables debug message output.",
-                "type": "BOOL_NUMERIC",
+                "type": "BOOL",
                 "default": true
             },
             {
@@ -89,7 +89,11 @@
                 "env": "VK_DEVSIM_EMULATE_PORTABILITY_SUBSET_EXTENSION",
                 "label": "Emulate VK_KHR_portability_subset",
                 "description": "Emulate that VK_KHR_portability_subset extension is supported by the device.",
-                "type": "BOOL_NUMERIC",
+                "platforms": [
+                    "WINDOWS",
+                    "LINUX"
+                ],
+                "type": "BOOL",
                 "default": true
             },
             {
@@ -97,15 +101,15 @@
                 "env": "VK_DEVSIM_EXIT_ON_ERROR",
                 "label": "Exit on Error",
                 "description": "Enables exit-on-error.",
-                "type": "BOOL_NUMERIC",
+                "type": "BOOL",
                 "default": false
             },
             {
                 "key": "modify_extension_list",
                 "env": "VK_DEVSIM_MODIFY_EXTENSION_LIST",
-                "label": "Modify device entionsions list",
+                "label": "Modify Device Extension list",
                 "description": "Modify the device extensions list from the layer JSON config file.",
-                "type": "BOOL_NUMERIC",
+                "type": "BOOL",
                 "default": false
             }
         ]

--- a/vkconfig_core/setting_set.h
+++ b/vkconfig_core/setting_set.h
@@ -37,7 +37,12 @@ class SettingSet {
         {
             T* setting = this->Get(key.c_str());
             if (setting != nullptr) {
-                return *setting;
+                if (setting->type == type)
+                    return *setting;
+                else {
+                    Remove(key.c_str());
+                    return Create(key, type);
+                }
             }
         }
 
@@ -77,6 +82,16 @@ class SettingSet {
     }
 
    private:
+    void Remove(const char* key) {
+        std::vector<std::shared_ptr<T> > new_data;
+        for (std::size_t i = 0, n = data.size(); i < n; ++i) {
+            if (data[i]->key == key) continue;
+            new_data.push_back(data[i]);
+        }
+
+        std::swap(new_data, data);
+    }
+
     std::shared_ptr<T> AllocSetting(const std::string& key, SettingType type) const;
 
     std::vector<std::shared_ptr<T> > data;


### PR DESCRIPTION
Support this:
```
# VK_LAYER_LUNARG_device_simulation
lunarg_device_simulation.filename = C:\VulkanSDK\1.2.169.0\Config\VK_LAYER_LUNARG_device_simulation\macOS_gpu_family_1_portability.json
lunarg_device_simulation.debug_enable = TRUE
lunarg_device_simulation.emulate_portability = TRUE
lunarg_device_simulation.exit_on_error = FALSE
lunarg_device_simulation.modify_extension_list = FALSE
```

Keep this for compatbility:
```
# VK_LAYER_LUNARG_device_simulation
lunarg_device_simulation.filename = C:\VulkanSDK\1.2.169.0\Config\VK_LAYER_LUNARG_device_simulation\macOS_gpu_family_1_portability.json
lunarg_device_simulation.debug_enable = 1
lunarg_device_simulation.emulate_portability = 1
lunarg_device_simulation.exit_on_error = 0
lunarg_device_simulation.modify_extension_list = 0
```