### PR TITLE
[WIP] vkconfig: Improve setting tree UI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ for:
 
     environment:
       PYTHON: C:\Python35
-      QTDIR: C:\Qt\5.9.9\msvc2015
+      QTDIR: C:\Qt\5.11\msvc2015
       PLATFORM_ARGUMENT: --32
       CONFIGURATION_ARGUMENT: --debug
     init:
@@ -55,7 +55,7 @@ for:
           image: Visual Studio 2017
     environment:
       PYTHON: C:\Python35
-      QTDIR: C:\Qt\5.9.9\msvc2017_64
+      QTDIR: C:\Qt\5.11\msvc2015_64
       PLATFORM_ARGUMENT: --64
       CONFIGURATION_ARGUMENT: --release
     init:
@@ -72,7 +72,7 @@ for:
           image: Visual Studio 2019
     environment:
       PYTHON: C:\Python35
-      QTDIR: C:\Qt\5.13\msvc2017_64
+      QTDIR: C:\Qt\5.15\msvc2017_64
       PLATFORM_ARGUMENT: --64
       CONFIGURATION_ARGUMENT: --debug
     init:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,7 +55,7 @@ for:
           image: Visual Studio 2017
     environment:
       PYTHON: C:\Python35
-      QTDIR: C:\Qt\5.11\msvc2015_64
+      QTDIR: C:\Qt\5.13\msvc2017_64
       PLATFORM_ARGUMENT: --64
       CONFIGURATION_ARGUMENT: --release
     init:
@@ -72,7 +72,7 @@ for:
           image: Visual Studio 2019
     environment:
       PYTHON: C:\Python35
-      QTDIR: C:\Qt\5.15\msvc2017_64
+      QTDIR: C:\Qt\5.15\msvc2019_64
       PLATFORM_ARGUMENT: --64
       CONFIGURATION_ARGUMENT: --debug
     init:

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -22,7 +22,8 @@
 
 ## [Vulkan Configurator 2.2.1 for Vulkan SDK Next](https://github.com/LunarG/VulkanTools/tree/master) - April 2021
 
-
+### Fixes:
+- Fix configuration setting tree states being not cross-platforms
 
 ## [Vulkan Configurator 2.2.0 for Vulkan SDK 1.2.170.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.170.0) - February 2021
 

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -478,7 +478,7 @@
             <set>QAbstractItemView::NoEditTriggers</set>
            </property>
            <property name="alternatingRowColors">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="sortingEnabled">
             <bool>false</bool>
@@ -733,7 +733,7 @@
    <property name="text">
     <string>Vulkan GPU Info Reports</string>
    </property>
-  </action>     
+  </action>
  </widget>
  <resources>
   <include location="resources.qrc"/>

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -379,6 +379,7 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 QTreeWidgetItem *place_holder = new QTreeWidgetItem();
                 place_holder->setSizeHint(0, QSize(0, 28));
                 setting_item->addChild(place_holder);
+                setting_item->setSizeHint(0, QSize(0, 28));
                 _settings_tree->setItemWidget(place_holder, 0, widget);
                 _compound_widgets.push_back(place_holder);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
@@ -388,13 +389,8 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 const SettingMetaEnum &setting_meta_src = static_cast<const SettingMetaEnum &>(setting_meta);
                 SettingDataEnum &setting_data_src = static_cast<SettingDataEnum &>(setting_data);
 
-                QTreeWidgetItem *place_holder = new QTreeWidgetItem();
-                setting_item->setText(0, setting_meta.label.c_str());
-                setting_item->setToolTip(0, setting_meta.description.c_str());
-                setting_item->addChild(place_holder);
-
                 WidgetSettingEnum *enum_widget = new WidgetSettingEnum(setting_item, setting_meta_src, setting_data_src);
-                _settings_tree->setItemWidget(place_holder, 0, enum_widget);
+                _settings_tree->setItemWidget(setting_item, 0, enum_widget);
                 connect(enum_widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
@@ -416,7 +412,7 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 }
             } break;
 
-            case SETTING_INT_RANGE: {
+            case SETTING_INT_RANGES: {
                 const SettingMetaIntRange &setting_meta_src = static_cast<const SettingMetaIntRange &>(setting_meta);
                 SettingDataIntRange &setting_data_src = static_cast<SettingDataIntRange &>(setting_data);
 

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -153,11 +153,6 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
             CountExcludedLayers(configuration->parameters, configurator.layers.available_layers);
 
         if (excluded_layer_count > 0) {
-            // A space to separate the section
-            QTreeWidgetItem *blank_item = new QTreeWidgetItem();
-            blank_item->setDisabled(true);
-            _settings_tree->addTopLevelItem(blank_item);
-
             // The last item is just the excluded layers
             QTreeWidgetItem *excluded_layers = new QTreeWidgetItem();
             excluded_layers->setText(0, "Excluded Layers:");

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -90,12 +90,8 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
                 layer_text += std::string(" (") + GetToken(layer->status) + ")";
             }
 
-            QFont font = _settings_tree->font();
-            font.setBold(true);
-
             QTreeWidgetItem *layer_item = new QTreeWidgetItem();
             layer_item->setText(0, layer_text.c_str());
-            layer_item->setFont(0, font);
             layer_item->setExpanded(!parameter.collapsed);
             if (layer != nullptr) layer_item->setToolTip(0, layer->description.c_str());
             _settings_tree->addTopLevelItem(layer_item);

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -92,6 +92,7 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
 
             QTreeWidgetItem *layer_item = new QTreeWidgetItem();
             layer_item->setText(0, layer_text.c_str());
+            layer_item->setFont(0, font);
             layer_item->setExpanded(!parameter.collapsed);
             if (layer != nullptr) layer_item->setToolTip(0, layer->description.c_str());
             _settings_tree->addTopLevelItem(layer_item);
@@ -127,8 +128,8 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
         // The last item is just the excluded layers
         QTreeWidgetItem *excluded_layers = new QTreeWidgetItem();
         excluded_layers->setText(0, "Excluded Layers:");
+        excluded_layers->setFont(0, font);
         excluded_layers->setExpanded(true);
-        _settings_tree->addTopLevelItem(excluded_layers);
 
         for (std::size_t i = 0, n = configuration->parameters.size(); i < n; ++i) {
             Parameter &parameter = configuration->parameters[i];
@@ -149,10 +150,11 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
         }
 
         // None excluded layer were found
-        if (excluded_layers->childCount() == 0) {
-            QTreeWidgetItem *child = new QTreeWidgetItem();
-            child->setText(0, "None");
-            excluded_layers->addChild(child);
+        if (excluded_layers->childCount() != 0) {
+            _settings_tree->addTopLevelItem(excluded_layers);
+        } else {
+            delete excluded_layers;
+            excluded_layers = nullptr;
         }
     }
 

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -355,7 +355,7 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 const SettingMetaBool &setting_meta_src = static_cast<const SettingMetaBool &>(setting_meta);
                 SettingDataBool &setting_data_src = static_cast<SettingDataBool &>(setting_data);
 
-                WidgetSettingBool *widget = new WidgetSettingBool(setting_meta_src, setting_data_src);
+                WidgetSettingBool *widget = new WidgetSettingBool(setting_item, setting_meta_src, setting_data_src);
                 _settings_tree->setItemWidget(setting_item, 0, widget);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -283,11 +283,9 @@ void SettingsTreeManager::BuildValidationTree(QTreeWidgetItem *parent, Parameter
             static_cast<SettingDataInt &>(parameter.settings.Create(setting_meta.key, setting_meta.type));
 
         QTreeWidgetItem *setting_item = new QTreeWidgetItem();
-        WidgetSettingInt *widget = new WidgetSettingInt(setting_item, setting_meta, setting_data);
         parent->addChild(setting_item);
-        QTreeWidgetItem *place_holder = new QTreeWidgetItem();
-        setting_item->addChild(place_holder);
-        _settings_tree->setItemWidget(place_holder, 0, widget);
+        WidgetSettingInt *widget = new WidgetSettingInt(setting_item, setting_meta, setting_data);
+        _settings_tree->setItemWidget(setting_item, 0, widget);
         connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
     }
 
@@ -359,7 +357,6 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
 
                 WidgetSettingBool *widget = new WidgetSettingBool(setting_meta_src, setting_data_src);
                 _settings_tree->setItemWidget(setting_item, 0, widget);
-                widget->setFont(_settings_tree->font());
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
@@ -368,9 +365,7 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 SettingDataInt &setting_data_src = static_cast<SettingDataInt &>(setting_data);
 
                 WidgetSettingInt *widget = new WidgetSettingInt(setting_item, setting_meta_src, setting_data_src);
-                QTreeWidgetItem *place_holder = new QTreeWidgetItem();
-                setting_item->addChild(place_holder);
-                _settings_tree->setItemWidget(place_holder, 0, widget);
+                _settings_tree->setItemWidget(setting_item, 0, widget);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -420,8 +420,8 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
             } break;
 
             case SETTING_INT_RANGES: {
-                const SettingMetaIntRange &meta = static_cast<const SettingMetaIntRange &>(setting_meta);
-                SettingDataIntRange *data = setting_datas.Get<SettingDataIntRange>(setting_meta.key.c_str());
+                const SettingMetaIntRanges &meta = static_cast<const SettingMetaIntRanges &>(setting_meta);
+                SettingDataIntRanges *data = setting_datas.Get<SettingDataIntRanges>(setting_meta.key.c_str());
                 assert(data != nullptr);
 
                 WidgetSettingIntRange *widget = new WidgetSettingIntRange(_settings_tree, parent, meta, *data);

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -421,9 +421,7 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 SettingDataIntRange &setting_data_src = static_cast<SettingDataIntRange &>(setting_data);
 
                 WidgetSettingIntRange *widget = new WidgetSettingIntRange(setting_item, setting_meta_src, setting_data_src);
-                QTreeWidgetItem *place_holder = new QTreeWidgetItem();
-                setting_item->addChild(place_holder);
-                _settings_tree->setItemWidget(place_holder, 0, widget);
+                _settings_tree->setItemWidget(setting_item, 0, widget);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -175,9 +175,6 @@ void SettingsTreeManager::CleanupGUI() {
         _validation_areas = nullptr;
     }
 
-    for (std::size_t i = 0; i < _compound_widgets.size(); i++) _settings_tree->setItemWidget(_compound_widgets[i], 1, nullptr);
-
-    _compound_widgets.clear();
     _presets_comboboxes.clear();
 
     _settings_tree->clear();
@@ -242,10 +239,9 @@ void SettingsTreeManager::BuildValidationTree(QTreeWidgetItem *parent, Parameter
             _validation_debug_action = widget;
             _validation_log_file_item = new QTreeWidgetItem();
             child->addChild(_validation_log_file_item);
-            _validation_log_file_widget = new WidgetSettingFilesystem(_validation_log_file_item, *log_file_meta, *log_file_data);
+            _validation_log_file_widget = new WidgetSettingFilesystem(_settings_tree, child, *log_file_meta, *log_file_data);
             _validation_log_file_item->setSizeHint(0, QSize(0, 28));
             _settings_tree->setItemWidget(_validation_log_file_item, 0, _validation_log_file_widget);
-            _compound_widgets.push_back(child);
 
             connect(_validation_log_file_widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             connect(_validation_debug_action, SIGNAL(stateChanged(int)), this, SLOT(khronosDebugChanged(int)));
@@ -282,10 +278,7 @@ void SettingsTreeManager::BuildValidationTree(QTreeWidgetItem *parent, Parameter
         SettingDataInt &setting_data =
             static_cast<SettingDataInt &>(parameter.settings.Create(setting_meta.key, setting_meta.type));
 
-        QTreeWidgetItem *setting_item = new QTreeWidgetItem();
-        parent->addChild(setting_item);
-        WidgetSettingInt *widget = new WidgetSettingInt(setting_item, setting_meta, setting_data);
-        _settings_tree->setItemWidget(setting_item, 0, widget);
+        WidgetSettingInt *widget = new WidgetSettingInt(_settings_tree, parent, setting_meta, setting_data);
         connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
     }
 
@@ -305,15 +298,24 @@ void SettingsTreeManager::BuildValidationTree(QTreeWidgetItem *parent, Parameter
         QTreeWidgetItem *next_line = new QTreeWidgetItem();
         next_line->setSizeHint(0, QSize(0, 28));
         mute_message_item->addChild(next_line);
+<<<<<<< HEAD
         _settings_tree->setItemWidget(next_line, 0, widget_search);
         _compound_widgets.push_back(next_line);
+=======
+        _settings_tree->setItemWidget(next_line, 0, vuid_search_widget);
+>>>>>>> d9f2fbda7... vkconfig: compact filesystem UI
 
         QTreeWidgetItem *list_item = new QTreeWidgetItem();
         mute_message_item->addChild(list_item);
         list_item->setSizeHint(0, QSize(0, 200));
+<<<<<<< HEAD
         WidgetSettingList *widget_list = new WidgetSettingList(setting_meta, setting_data);
         _compound_widgets.push_back(list_item);
         _settings_tree->setItemWidget(list_item, 0, widget_list);
+=======
+        WidgetSettingVUIDFilter *mute_message_widget = new WidgetSettingVUIDFilter(setting_meta, setting_data);
+        _settings_tree->setItemWidget(list_item, 0, mute_message_widget);
+>>>>>>> d9f2fbda7... vkconfig: compact filesystem UI
 
         connect(widget_search, SIGNAL(itemSelected(const QString &)), widget_list, SLOT(addItem(const QString &)));
         connect(widget_search, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
@@ -341,69 +343,68 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
 
     for (std::size_t setting_index = 0, n = layer_setting_metas.Size(); setting_index < n; ++setting_index) {
         const SettingMeta &setting_meta = layer_setting_metas[setting_index];
+
         if (!IsPlatformSupported(setting_meta.platform_flags)) continue;
 
         SettingData &setting_data = *parameter.settings.Get(setting_meta.key.c_str());
         assert(&setting_data);
 
-        QTreeWidgetItem *setting_item = new QTreeWidgetItem();
-        parent->addChild(setting_item);
-
         switch (setting_meta.type) {
             case SETTING_BOOL:
             case SETTING_BOOL_NUMERIC_DEPRECATED: {
-                const SettingMetaBool &setting_meta_src = static_cast<const SettingMetaBool &>(setting_meta);
-                SettingDataBool &setting_data_src = static_cast<SettingDataBool &>(setting_data);
+                const SettingMetaBool &meta = static_cast<const SettingMetaBool &>(setting_meta);
+                SettingDataBool &data = static_cast<SettingDataBool &>(setting_data);
 
-                WidgetSettingBool *widget = new WidgetSettingBool(setting_item, setting_meta_src, setting_data_src);
-                _settings_tree->setItemWidget(setting_item, 0, widget);
+                WidgetSettingBool *widget = new WidgetSettingBool(_settings_tree, parent, meta, data);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
             case SETTING_INT: {
-                const SettingMetaInt &setting_meta_src = static_cast<const SettingMetaInt &>(setting_meta);
-                SettingDataInt &setting_data_src = static_cast<SettingDataInt &>(setting_data);
+                const SettingMetaInt &meta = static_cast<const SettingMetaInt &>(setting_meta);
+                SettingDataInt &data = static_cast<SettingDataInt &>(setting_data);
 
-                WidgetSettingInt *widget = new WidgetSettingInt(setting_item, setting_meta_src, setting_data_src);
-                _settings_tree->setItemWidget(setting_item, 0, widget);
+                WidgetSettingInt *widget = new WidgetSettingInt(_settings_tree, parent, meta, data);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
             case SETTING_SAVE_FILE:
             case SETTING_LOAD_FILE:
             case SETTING_SAVE_FOLDER: {
-                const SettingMetaFilesystem &setting_meta_src = static_cast<const SettingMetaFilesystem &>(setting_meta);
-                SettingDataString &setting_data_src = static_cast<SettingDataString &>(setting_data);
+                // QTreeWidgetItem *setting_item = new QTreeWidgetItem();
+                // parent->addChild(setting_item);
 
-                WidgetSettingFilesystem *widget = new WidgetSettingFilesystem(setting_item, setting_meta_src, setting_data_src);
-                QTreeWidgetItem *place_holder = new QTreeWidgetItem();
-                place_holder->setSizeHint(0, QSize(0, 28));
-                setting_item->addChild(place_holder);
-                setting_item->setSizeHint(0, QSize(0, 28));
-                _settings_tree->setItemWidget(place_holder, 0, widget);
-                _compound_widgets.push_back(place_holder);
+                const SettingMetaFilesystem &meta = static_cast<const SettingMetaFilesystem &>(setting_meta);
+                SettingDataString &data = static_cast<SettingDataString &>(setting_data);
+
+                WidgetSettingFilesystem *widget = new WidgetSettingFilesystem(_settings_tree, parent, meta, data);
+                // QTreeWidgetItem *place_holder = new QTreeWidgetItem();
+                // place_holder->setSizeHint(0, QSize(0, 28));
+                // setting_item->addChild(place_holder);
+                // setting_item->setSizeHint(0, QSize(0, 28));
+                //_settings_tree->setItemWidget(setting_item, 0, widget);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
             case SETTING_ENUM: {
-                const SettingMetaEnum &setting_meta_src = static_cast<const SettingMetaEnum &>(setting_meta);
-                SettingDataEnum &setting_data_src = static_cast<SettingDataEnum &>(setting_data);
+                const SettingMetaEnum &meta = static_cast<const SettingMetaEnum &>(setting_meta);
+                SettingDataEnum &data = static_cast<SettingDataEnum &>(setting_data);
 
-                WidgetSettingEnum *enum_widget = new WidgetSettingEnum(setting_item, setting_meta_src, setting_data_src);
-                _settings_tree->setItemWidget(setting_item, 0, enum_widget);
+                WidgetSettingEnum *enum_widget = new WidgetSettingEnum(_settings_tree, parent, meta, data);
                 connect(enum_widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
             case SETTING_FLAGS: {
-                const SettingMetaFlags &setting_meta_src = static_cast<const SettingMetaFlags &>(setting_meta);
-                SettingDataFlags &setting_data_src = static_cast<SettingDataFlags &>(setting_data);
+                QTreeWidgetItem *setting_item = new QTreeWidgetItem();
+                parent->addChild(setting_item);
+
+                const SettingMetaFlags &meta = static_cast<const SettingMetaFlags &>(setting_meta);
+                SettingDataFlags &data = static_cast<SettingDataFlags &>(setting_data);
 
                 setting_item->setText(0, setting_meta.label.c_str());
                 setting_item->setToolTip(0, setting_meta.description.c_str());
 
-                for (std::size_t i = 0, n = setting_meta_src.enum_values.size(); i < n; ++i) {
-                    WidgetSettingFlag *widget =
-                        new WidgetSettingFlag(setting_meta_src, setting_data_src, setting_meta_src.enum_values[i].key.c_str());
+                for (std::size_t i = 0, n = meta.enum_values.size(); i < n; ++i) {
+                    WidgetSettingFlag *widget = new WidgetSettingFlag(meta, data, meta.enum_values[i].key.c_str());
                     QTreeWidgetItem *place_holder = new QTreeWidgetItem();
                     setting_item->addChild(place_holder);
                     _settings_tree->setItemWidget(place_holder, 0, widget);
@@ -413,19 +414,21 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
             } break;
 
             case SETTING_INT_RANGES: {
-                const SettingMetaIntRange &setting_meta_src = static_cast<const SettingMetaIntRange &>(setting_meta);
-                SettingDataIntRange &setting_data_src = static_cast<SettingDataIntRange &>(setting_data);
+                const SettingMetaIntRange &meta = static_cast<const SettingMetaIntRange &>(setting_meta);
+                SettingDataIntRange &data = static_cast<SettingDataIntRange &>(setting_data);
 
-                WidgetSettingIntRange *widget = new WidgetSettingIntRange(setting_item, setting_meta_src, setting_data_src);
-                _settings_tree->setItemWidget(setting_item, 0, widget);
+                WidgetSettingIntRange *widget = new WidgetSettingIntRange(_settings_tree, parent, meta, data);
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
             case SETTING_STRING: {
-                const SettingMetaString &setting_meta_src = static_cast<const SettingMetaString &>(setting_meta);
-                SettingDataString &setting_data_src = static_cast<SettingDataString &>(setting_data);
+                QTreeWidgetItem *setting_item = new QTreeWidgetItem();
+                parent->addChild(setting_item);
 
-                WidgetSettingString *widget = new WidgetSettingString(setting_item, setting_meta_src, setting_data_src);
+                const SettingMetaString &meta = static_cast<const SettingMetaString &>(setting_meta);
+                SettingDataString &data = static_cast<SettingDataString &>(setting_data);
+
+                WidgetSettingString *widget = new WidgetSettingString(setting_item, meta, data);
                 QTreeWidgetItem *place_holder = new QTreeWidgetItem();
                 setting_item->addChild(place_holder);
                 _settings_tree->setItemWidget(place_holder, 0, widget);
@@ -464,7 +467,6 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
             } break;
 
             default: {
-                setting_item->setText(0, "Unknown setting");
                 assert(0);  // Unknown setting
             } break;
         }

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -437,65 +437,34 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
             } break;
 
-<<<<<<< HEAD
             case SETTING_LIST: {
-                const SettingMetaList &setting_meta_src = static_cast<const SettingMetaList &>(setting_meta);
-                SettingDataList &setting_data =
-                    static_cast<SettingDataList &>(parameter.settings.Create(setting_meta_src.key, setting_meta_src.type));
-=======
-            case SETTING_VUID_FILTER: {
-                const SettingMetaVUIDFilter &meta = static_cast<const SettingMetaVUIDFilter &>(setting_meta);
-                SettingDataVUIDFilter *data = setting_datas.Get<SettingDataVUIDFilter>(setting_meta.key.c_str());
+                const SettingMetaList &meta = static_cast<const SettingMetaList &>(setting_meta);
+                SettingDataList *data = setting_datas.Get<SettingDataList>(setting_meta.key.c_str());
                 assert(data != nullptr);
->>>>>>> 0e9bac529... vkconfig: less verbose conversions
 
                 QTreeWidgetItem *mute_message_item = new QTreeWidgetItem;
                 mute_message_item->setText(0, setting_meta.label.c_str());
                 mute_message_item->setToolTip(0, setting_meta.description.c_str());
-<<<<<<< HEAD
                 parent->addChild(mute_message_item);
 
-                WidgetSettingSearch *widget_search = new WidgetSettingSearch(setting_meta_src.list, setting_data.value);
-=======
-                mute_message_item->setExpanded(true);
-                parent->addChild(mute_message_item);
-
-                WidgetSettingVUIDSearch *vuid_search_widget = new WidgetSettingVUIDSearch(meta.list, data->value);
->>>>>>> 0e9bac529... vkconfig: less verbose conversions
+                WidgetSettingSearch *widget_search = new WidgetSettingSearch(meta.list, data->value);
 
                 QTreeWidgetItem *next_line = new QTreeWidgetItem();
                 next_line->setSizeHint(0, QSize(0, 28));
                 mute_message_item->addChild(next_line);
-<<<<<<< HEAD
                 _settings_tree->setItemWidget(next_line, 0, widget_search);
-                _compound_widgets.push_back(next_line);
-=======
-                _settings_tree->setItemWidget(next_line, 0, vuid_search_widget);
->>>>>>> 0e9bac529... vkconfig: less verbose conversions
 
                 QTreeWidgetItem *list_item = new QTreeWidgetItem();
                 mute_message_item->addChild(list_item);
                 list_item->setSizeHint(0, QSize(0, 200));
-<<<<<<< HEAD
-                WidgetSettingList *widget_list = new WidgetSettingList(setting_meta_src, setting_data);
-                _compound_widgets.push_back(list_item);
+
+                WidgetSettingList *widget_list = new WidgetSettingList(meta, *data);
                 _settings_tree->setItemWidget(list_item, 0, widget_list);
 
                 connect(widget_search, SIGNAL(itemSelected(const QString &)), widget_list, SLOT(addItem(const QString &)));
                 connect(widget_search, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
                 connect(widget_list, SIGNAL(itemRemoved(const QString &)), widget_search, SLOT(addToSearchList(const QString &)));
                 connect(widget_list, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()), Qt::QueuedConnection);
-=======
-                WidgetSettingVUIDFilter *mute_message_widget = new WidgetSettingVUIDFilter(meta, *data);
-                _settings_tree->setItemWidget(list_item, 0, mute_message_widget);
-
-                connect(vuid_search_widget, SIGNAL(itemSelected(const QString &)), mute_message_widget,
-                        SLOT(addItem(const QString &)));
-                connect(vuid_search_widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
-                connect(mute_message_widget, SIGNAL(itemRemoved(const QString &)), vuid_search_widget,
-                        SLOT(addToSearchList(const QString &)));
-                connect(mute_message_widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()), Qt::QueuedConnection);
->>>>>>> 0e9bac529... vkconfig: less verbose conversions
             } break;
 
             default: {

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -82,7 +82,9 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
         if (overridden_layer_count > 1) {
             QTreeWidgetItem *item = new QTreeWidgetItem();
             item->setText(0, "Vulkan Applications");
+            item->setTextAlignment(0, Qt::AlignCenter);
             item->setFont(0, font_section);
+            item->setDisabled(true);
             _settings_tree->addTopLevelItem(item);
         }
 
@@ -141,7 +143,9 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
         if (overridden_layer_count > 1) {
             QTreeWidgetItem *item = new QTreeWidgetItem();
             item->setText(0, "Vulkan Drivers");
+            item->setTextAlignment(0, Qt::AlignCenter);
             item->setFont(0, font_section);
+            item->setDisabled(true);
             _settings_tree->addTopLevelItem(item);
         }
 

--- a/vkconfig/settings_tree.h
+++ b/vkconfig/settings_tree.h
@@ -60,8 +60,6 @@ class SettingsTreeManager : QObject {
     void BuildGenericTree(QTreeWidgetItem *parent, Parameter &parameter);
 
     QTreeWidget *_settings_tree;
-    std::vector<QTreeWidgetItem *> _compound_widgets;  // These have special cleanup requirements
-
     std::vector<WidgetPreset *> _presets_comboboxes;
 
     QTreeWidgetItem *_validation_log_file_item;

--- a/vkconfig/settings_tree.h
+++ b/vkconfig/settings_tree.h
@@ -36,6 +36,7 @@
 
 class SettingsTreeManager : QObject {
     Q_OBJECT
+
    public:
     SettingsTreeManager();
 

--- a/vkconfig/settings_tree.h
+++ b/vkconfig/settings_tree.h
@@ -47,11 +47,11 @@ class SettingsTreeManager : QObject {
     int SetTreeState(QByteArray &byte_array, int index, QTreeWidgetItem *top_item);
 
    public Q_SLOTS:
-    void khronosDebugChanged(int index);
+    void OnDebugLogMessageChanged(int index);
     void OnPresetChanged(int index);  // Okay, is this a custom guy HERE, or do we move it out
                                       // It really forces a reload of the entire branch of this tree
                                       // Reset layer defaults for the profile, and then call BuildKhronosTree again
-    void OnSettingChanged();          // The profile has been edited and should be saved
+    void OnSettingChanged();          // The configuration has been edited and should be saved
 
    private:
     SettingsTreeManager(const SettingsTreeManager &) = delete;
@@ -63,7 +63,6 @@ class SettingsTreeManager : QObject {
     QTreeWidget *_settings_tree;
     std::vector<WidgetPreset *> _presets_comboboxes;
 
-    QTreeWidgetItem *_validation_log_file_item;
     WidgetSettingFilesystem *_validation_log_file_widget;
     WidgetSettingFlag *_validation_debug_action;
     SettingsValidationAreas *_validation_areas;

--- a/vkconfig/settings_validation_areas.cpp
+++ b/vkconfig/settings_validation_areas.cpp
@@ -552,10 +552,7 @@ QTreeWidgetItem *SettingsValidationAreas::CreateSettingWidgetInt(QTreeWidgetItem
     if (setting_data && setting_meta) {
         assert(setting_meta->type == SETTING_INT);
 
-        child = new QTreeWidgetItem();
-        _debug_printf_buffer_size_value = new WidgetSettingInt(child, *setting_meta, *setting_data);
-        parent->addChild(child);
-        _main_tree_widget->setItemWidget(child, 0, _debug_printf_buffer_size_value);
+        _debug_printf_buffer_size_value = new WidgetSettingInt(_main_tree_widget, parent, *setting_meta, *setting_data);
     }
 
     return child;

--- a/vkconfig/settings_validation_areas.cpp
+++ b/vkconfig/settings_validation_areas.cpp
@@ -555,9 +555,7 @@ QTreeWidgetItem *SettingsValidationAreas::CreateSettingWidgetInt(QTreeWidgetItem
         child = new QTreeWidgetItem();
         _debug_printf_buffer_size_value = new WidgetSettingInt(child, *setting_meta, *setting_data);
         parent->addChild(child);
-        QTreeWidgetItem *place_holder = new QTreeWidgetItem();
-        child->addChild(place_holder);
-        _main_tree_widget->setItemWidget(place_holder, 0, _debug_printf_buffer_size_value);
+        _main_tree_widget->setItemWidget(child, 0, _debug_printf_buffer_size_value);
     }
 
     return child;

--- a/vkconfig/settings_validation_areas.h
+++ b/vkconfig/settings_validation_areas.h
@@ -24,6 +24,7 @@
 #include "../vkconfig_core/layer.h"
 
 #include "widget_setting_int.h"
+#include "widget_setting_bool.h"
 
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
@@ -52,13 +53,12 @@ class SettingsValidationAreas : public QObject {
     QTreeWidgetItem *_gpu_assisted_box;
     QRadioButton *_gpu_assisted_radio;
     QTreeWidgetItem *_gpu_assisted_reserve_box;
-    QTreeWidgetItem *_gpu_assisted_oob_box;
+    WidgetSettingBool *_gpu_assisted_oob_box;
     QTreeWidgetItem *_debug_printf_box;
     QRadioButton *_debug_printf_radio;
-    QTreeWidgetItem *_debug_printf_to_stdout;
-    QTreeWidgetItem *_debug_printf_verbose;
-    QTreeWidgetItem *_debug_printf_buffer_size;
-    WidgetSettingInt *_debug_printf_buffer_size_value;
+    WidgetSettingBool *_debug_printf_to_stdout;
+    WidgetSettingBool *_debug_printf_verbose;
+    WidgetSettingInt *_debug_printf_buffer_size;
 
     QTreeWidgetItem *_best_practices_box;
     QTreeWidgetItem *_best_practices_arm_box;
@@ -68,7 +68,7 @@ class SettingsValidationAreas : public QObject {
     void itemClicked(QTreeWidgetItem *item, int column);
     void gpuToggled(bool toggle);
     void printfToggled(bool toggle);
-    void printfBufferSizeEdited(const QString &new_value);
+    void OnSettingChanged();
 
    Q_SIGNALS:
     void settingChanged();
@@ -79,14 +79,6 @@ class SettingsValidationAreas : public QObject {
 
     bool HasEnable(const char *token) const;
     bool HasDisable(const char *token) const;
-
-    QTreeWidgetItem *CreateSettingWidgetBool(QTreeWidgetItem *parent, const char *key);
-    QTreeWidgetItem *CreateSettingWidgetInt(QTreeWidgetItem *parent, const char *key);
-
-    void StoreBoolSetting(QTreeWidgetItem *setting_data, const char *key);
-    void StoreIntSetting(QTreeWidgetItem *setting_data, const char *key);
-
-    void EnableSettingWidget(QTreeWidgetItem *setting_data, bool enable);
 
     const Version version;
     const SettingMetaSet &settings_meta;

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -53,6 +53,7 @@ SOURCES += \
     vulkan.cpp \
     alert.cpp \
     widget_preset.cpp \
+    widget_setting.cpp \
     widget_setting_bool.cpp \
     widget_setting_enum.cpp \
     widget_setting_filesystem.cpp \
@@ -109,6 +110,7 @@ HEADERS += \
     vulkan.h \
     alert.h \
     widget_preset.h \
+    widget_setting.h \
     widget_setting_bool.h \
     widget_setting_enum.h \
     widget_setting_filesystem.h \

--- a/vkconfig/widget_setting.cpp
+++ b/vkconfig/widget_setting.cpp
@@ -18,33 +18,13 @@
  * - Christophe Riccio <christophe@lunarg.com>
  */
 
-#pragma once
-
 #include "widget_setting.h"
 
-#include <QResizeEvent>
-#include <QLineEdit>
+WidgetSetting::WidgetSetting(QTreeWidgetItem* item, const SettingMeta& setting_meta) {
+    assert(item);
+    assert(&setting_meta);
 
-class WidgetSettingIntRange : public WidgetSetting {
-    Q_OBJECT
-
-   public:
-    WidgetSettingIntRange(QTreeWidgetItem* item, const SettingMetaIntRange& setting_meta, SettingDataIntRange& setting_data);
-
-   public Q_SLOTS:
-    void itemEdited(const QString& value);
-    void FieldEditedCheck();
-
-   Q_SIGNALS:
-    void itemChanged();
-
-   private:
-    virtual void resizeEvent(QResizeEvent* event) override;
-
-    void Resize();
-
-    const SettingMetaIntRange& setting_meta;
-    SettingDataIntRange& setting_data;
-    QLineEdit* field;
-    QSize resize;
-};
+    item->setText(0, setting_meta.label.c_str());
+    item->setToolTip(0, setting_meta.description.c_str());
+    item->setSizeHint(0, QSize(0, 24));
+}

--- a/vkconfig/widget_setting.cpp
+++ b/vkconfig/widget_setting.cpp
@@ -35,3 +35,13 @@ WidgetSetting::WidgetSetting(QTreeWidget* tree, QTreeWidgetItem* parent, const S
 
     tree->setItemWidget(this->item, 0, this);
 }
+
+void EnableItem(QTreeWidgetItem* item, bool enable) {
+    if (item == nullptr) return;
+
+    if (enable) {
+        item->setFlags(item->flags() | Qt::ItemIsEnabled);
+    } else {
+        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+    }
+}

--- a/vkconfig/widget_setting.cpp
+++ b/vkconfig/widget_setting.cpp
@@ -20,11 +20,18 @@
 
 #include "widget_setting.h"
 
-WidgetSetting::WidgetSetting(QTreeWidgetItem* item, const SettingMeta& setting_meta) {
-    assert(item);
+WidgetSetting::WidgetSetting(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMeta& setting_meta)
+    : tree(tree), item(new QTreeWidgetItem()) {
+    assert(tree);
+    assert(parent);
     assert(&setting_meta);
 
-    item->setText(0, setting_meta.label.c_str());
-    item->setToolTip(0, setting_meta.description.c_str());
-    item->setSizeHint(0, QSize(0, 24));
+    this->item->setText(0, setting_meta.label.c_str());
+    this->item->setToolTip(0, setting_meta.description.c_str());
+    this->item->setSizeHint(0, QSize(0, 24));
+    this->item->setFont(0, tree->font());
+
+    parent->addChild(this->item);
+
+    tree->setItemWidget(this->item, 0, this);
 }

--- a/vkconfig/widget_setting.h
+++ b/vkconfig/widget_setting.h
@@ -20,31 +20,17 @@
 
 #pragma once
 
-#include "widget_setting.h"
+#include "../vkconfig_core/setting_meta.h"
+#include "../vkconfig_core/setting_data.h"
 
-#include <QResizeEvent>
-#include <QLineEdit>
+#include <QTreeWidgetItem>
+#include <QWidget>
 
-class WidgetSettingIntRange : public WidgetSetting {
-    Q_OBJECT
-
+class WidgetSetting : public QWidget {
    public:
-    WidgetSettingIntRange(QTreeWidgetItem* item, const SettingMetaIntRange& setting_meta, SettingDataIntRange& setting_data);
-
-   public Q_SLOTS:
-    void itemEdited(const QString& value);
-    void FieldEditedCheck();
-
-   Q_SIGNALS:
-    void itemChanged();
+    explicit WidgetSetting(QTreeWidgetItem* item, const SettingMeta& setting_meta);
 
    private:
-    virtual void resizeEvent(QResizeEvent* event) override;
-
-    void Resize();
-
-    const SettingMetaIntRange& setting_meta;
-    SettingDataIntRange& setting_data;
-    QLineEdit* field;
-    QSize resize;
+    WidgetSetting(const WidgetSetting&) = delete;
+    WidgetSetting& operator=(const WidgetSetting&) = delete;
 };

--- a/vkconfig/widget_setting.h
+++ b/vkconfig/widget_setting.h
@@ -28,7 +28,11 @@
 
 class WidgetSetting : public QWidget {
    public:
-    explicit WidgetSetting(QTreeWidgetItem* item, const SettingMeta& setting_meta);
+    explicit WidgetSetting(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMeta& setting_meta);
+
+   protected:
+    QTreeWidget* tree;
+    QTreeWidgetItem* item;
 
    private:
     WidgetSetting(const WidgetSetting&) = delete;

--- a/vkconfig/widget_setting.h
+++ b/vkconfig/widget_setting.h
@@ -30,6 +30,10 @@ class WidgetSetting : public QWidget {
    public:
     explicit WidgetSetting(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMeta& setting_meta);
 
+    QTreeWidgetItem* GetItem() const { return this->item; }
+
+    virtual void Enable(bool enable) = 0;
+
    protected:
     QTreeWidget* tree;
     QTreeWidgetItem* item;
@@ -38,3 +42,5 @@ class WidgetSetting : public QWidget {
     WidgetSetting(const WidgetSetting&) = delete;
     WidgetSetting& operator=(const WidgetSetting&) = delete;
 };
+
+void EnableItem(QTreeWidgetItem* item, bool enable);

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -21,17 +21,11 @@
 
 #include "widget_setting_bool.h"
 
-#include <QCheckBox>
-
 #include <cassert>
 
 WidgetSettingBool::WidgetSettingBool(QTreeWidgetItem* item, const SettingMetaBool& setting_meta, SettingDataBool& setting_data)
-    : setting_meta(setting_meta), setting_data(setting_data) {
-    assert(&setting_meta);
+    : WidgetSetting(item, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
     assert(&setting_data);
-
-    item->setText(0, setting_meta.label.c_str());
-    item->setToolTip(0, setting_meta.description.c_str());
 
     this->field = new QCheckBox(this);
     this->field->setChecked(setting_data.value);

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -25,30 +25,30 @@
 
 #include <cassert>
 
-WidgetSettingBool::WidgetSettingBool(const SettingMetaBool& setting_meta, SettingDataBool& setting_data)
+WidgetSettingBool::WidgetSettingBool(QTreeWidgetItem* item, const SettingMetaBool& setting_meta, SettingDataBool& setting_data)
     : setting_meta(setting_meta), setting_data(setting_data) {
     assert(&setting_meta);
     assert(&setting_data);
 
-    this->setText(setting_meta.label.c_str());
-    this->setToolTip(setting_meta.description.c_str());
+    item->setText(0, setting_meta.label.c_str());
+    item->setToolTip(0, setting_meta.description.c_str());
 
-    QCheckBox* checkbox = new QCheckBox(this);
-    checkbox->setChecked(setting_data.value);
-    this->setBuddy(checkbox);
+    this->field = new QCheckBox(this);
+    this->field->setChecked(setting_data.value);
+    this->field->show();
 
-    this->connect(checkbox, SIGNAL(clicked()), this, SLOT(itemToggled()));
+    this->connect(this->field, SIGNAL(clicked()), this, SLOT(itemToggled()));
 }
 
 void WidgetSettingBool::resizeEvent(QResizeEvent* event) {
-    const QSize parent_size = event->size();
+    if (this->field == nullptr) return;
 
-    const QRect button_rect = QRect(parent_size.width() - 16, 0, 16, parent_size.height());
-    static_cast<QCheckBox*>(this->buddy())->setGeometry(button_rect);
+    const QRect button_rect = QRect(event->size().width() - 16, 0, 16, event->size().height());
+    this->field->setGeometry(button_rect);
 }
 
 void WidgetSettingBool::itemToggled() {
-    this->setting_data.value = static_cast<QCheckBox*>(this->buddy())->isChecked();
+    this->setting_data.value = this->field->isChecked();
 
     emit itemChanged();
 }

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -23,11 +23,14 @@
 
 #include <cassert>
 
-WidgetSettingBool::WidgetSettingBool(QTreeWidgetItem* item, const SettingMetaBool& setting_meta, SettingDataBool& setting_data)
-    : WidgetSetting(item, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
+WidgetSettingBool::WidgetSettingBool(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaBool& setting_meta,
+                                     SettingDataBool& setting_data)
+    : WidgetSetting(tree, parent, setting_meta),
+      setting_meta(setting_meta),
+      setting_data(setting_data),
+      field(new QCheckBox(this)) {
     assert(&setting_data);
 
-    this->field = new QCheckBox(this);
     this->field->setChecked(setting_data.value);
     this->field->show();
 
@@ -35,8 +38,6 @@ WidgetSettingBool::WidgetSettingBool(QTreeWidgetItem* item, const SettingMetaBoo
 }
 
 void WidgetSettingBool::resizeEvent(QResizeEvent* event) {
-    if (this->field == nullptr) return;
-
     const QRect button_rect = QRect(event->size().width() - 16, 0, 16, event->size().height());
     this->field->setGeometry(button_rect);
 }

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -37,6 +37,11 @@ WidgetSettingBool::WidgetSettingBool(QTreeWidget* tree, QTreeWidgetItem* parent,
     this->connect(this->field, SIGNAL(clicked()), this, SLOT(itemToggled()));
 }
 
+void WidgetSettingBool::Enable(bool enable) {
+    ::EnableItem(this->item, enable);
+    this->field->setEnabled(enable);
+}
+
 void WidgetSettingBool::resizeEvent(QResizeEvent* event) {
     const QRect button_rect = QRect(event->size().width() - 16, 0, 16, event->size().height());
     this->field->setGeometry(button_rect);

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -21,6 +21,8 @@
 
 #include "widget_setting_bool.h"
 
+#include <QCheckBox>
+
 #include <cassert>
 
 WidgetSettingBool::WidgetSettingBool(const SettingMetaBool& setting_meta, SettingDataBool& setting_data)
@@ -28,14 +30,25 @@ WidgetSettingBool::WidgetSettingBool(const SettingMetaBool& setting_meta, Settin
     assert(&setting_meta);
     assert(&setting_data);
 
-    setText(setting_meta.label.c_str());
-    setToolTip(setting_meta.description.c_str());
-    setChecked(setting_data.value);
-    connect(this, SIGNAL(clicked()), this, SLOT(itemToggled()));
+    this->setText(setting_meta.label.c_str());
+    this->setToolTip(setting_meta.description.c_str());
+
+    QCheckBox* checkbox = new QCheckBox(this);
+    checkbox->setChecked(setting_data.value);
+    this->setBuddy(checkbox);
+
+    this->connect(checkbox, SIGNAL(clicked()), this, SLOT(itemToggled()));
+}
+
+void WidgetSettingBool::resizeEvent(QResizeEvent* event) {
+    const QSize parent_size = event->size();
+
+    const QRect button_rect = QRect(parent_size.width() - 16, 0, 16, parent_size.height());
+    static_cast<QCheckBox*>(this->buddy())->setGeometry(button_rect);
 }
 
 void WidgetSettingBool::itemToggled() {
-    setting_data.value = isChecked();
+    this->setting_data.value = static_cast<QCheckBox*>(this->buddy())->isChecked();
 
     emit itemChanged();
 }

--- a/vkconfig/widget_setting_bool.h
+++ b/vkconfig/widget_setting_bool.h
@@ -21,14 +21,12 @@
 
 #pragma once
 
-#include "../vkconfig_core/setting_meta.h"
-#include "../vkconfig_core/setting_data.h"
+#include "widget_setting.h"
 
-#include <QTreeWidgetItem>
 #include <QResizeEvent>
 #include <QCheckBox>
 
-class WidgetSettingBool : public QWidget {
+class WidgetSettingBool : public WidgetSetting {
     Q_OBJECT
 
    public:
@@ -41,9 +39,6 @@ class WidgetSettingBool : public QWidget {
     void itemChanged();
 
    private:
-    WidgetSettingBool(const WidgetSettingBool&) = delete;
-    WidgetSettingBool& operator=(const WidgetSettingBool&) = delete;
-
     virtual void resizeEvent(QResizeEvent* event) override;
 
     const SettingMetaBool& setting_meta;

--- a/vkconfig/widget_setting_bool.h
+++ b/vkconfig/widget_setting_bool.h
@@ -30,7 +30,8 @@ class WidgetSettingBool : public WidgetSetting {
     Q_OBJECT
 
    public:
-    explicit WidgetSettingBool(QTreeWidgetItem* item, const SettingMetaBool& setting_meta, SettingDataBool& setting_data);
+    explicit WidgetSettingBool(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaBool& setting_meta,
+                               SettingDataBool& setting_data);
 
    public Q_SLOTS:
     void itemToggled();

--- a/vkconfig/widget_setting_bool.h
+++ b/vkconfig/widget_setting_bool.h
@@ -24,14 +24,15 @@
 #include "../vkconfig_core/setting_meta.h"
 #include "../vkconfig_core/setting_data.h"
 
-#include <QLabel>
+#include <QTreeWidgetItem>
 #include <QResizeEvent>
+#include <QCheckBox>
 
-class WidgetSettingBool : public QLabel {
+class WidgetSettingBool : public QWidget {
     Q_OBJECT
 
    public:
-    explicit WidgetSettingBool(const SettingMetaBool& setting_meta, SettingDataBool& setting_data);
+    explicit WidgetSettingBool(QTreeWidgetItem* item, const SettingMetaBool& setting_meta, SettingDataBool& setting_data);
 
    public Q_SLOTS:
     void itemToggled();
@@ -47,4 +48,5 @@ class WidgetSettingBool : public QLabel {
 
     const SettingMetaBool& setting_meta;
     SettingDataBool& setting_data;
+    QCheckBox* field;
 };

--- a/vkconfig/widget_setting_bool.h
+++ b/vkconfig/widget_setting_bool.h
@@ -33,6 +33,8 @@ class WidgetSettingBool : public WidgetSetting {
     explicit WidgetSettingBool(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaBool& setting_meta,
                                SettingDataBool& setting_data);
 
+    void Enable(bool enable) override;
+
    public Q_SLOTS:
     void itemToggled();
 

--- a/vkconfig/widget_setting_bool.h
+++ b/vkconfig/widget_setting_bool.h
@@ -24,13 +24,10 @@
 #include "../vkconfig_core/setting_meta.h"
 #include "../vkconfig_core/setting_data.h"
 
-#include <QObject>
-#include <QWidget>
-#include <QCheckBox>
+#include <QLabel>
+#include <QResizeEvent>
 
-#include <string>
-
-class WidgetSettingBool : public QCheckBox {
+class WidgetSettingBool : public QLabel {
     Q_OBJECT
 
    public:
@@ -45,6 +42,8 @@ class WidgetSettingBool : public QCheckBox {
    private:
     WidgetSettingBool(const WidgetSettingBool&) = delete;
     WidgetSettingBool& operator=(const WidgetSettingBool&) = delete;
+
+    virtual void resizeEvent(QResizeEvent* event) override;
 
     const SettingMetaBool& setting_meta;
     SettingDataBool& setting_data;

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -25,11 +25,13 @@
 
 static const int MIN_FIELD_WIDTH = 48;
 
-WidgetSettingEnum::WidgetSettingEnum(QTreeWidgetItem* item, const SettingMetaEnum& setting_meta, SettingDataEnum& setting_data)
-    : WidgetSetting(item, setting_meta), setting_meta(setting_meta), setting_data(setting_data), field(nullptr) {
+WidgetSettingEnum::WidgetSettingEnum(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaEnum& setting_meta,
+                                     SettingDataEnum& setting_data)
+    : WidgetSetting(tree, parent, setting_meta),
+      setting_meta(setting_meta),
+      setting_data(setting_data),
+      field(new QComboBox(this)) {
     assert(&setting_data);
-
-    this->field = new QComboBox(this);
 
     int selection = 0;
     for (std::size_t i = 0, n = setting_meta.enum_values.size(); i < n; ++i) {
@@ -46,8 +48,6 @@ WidgetSettingEnum::WidgetSettingEnum(QTreeWidgetItem* item, const SettingMetaEnu
 }
 
 void WidgetSettingEnum::resizeEvent(QResizeEvent* event) {
-    if (this->field == nullptr) return;
-
     int width = MIN_FIELD_WIDTH;
 
     const QFontMetrics fm = this->field->fontMetrics();

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -47,6 +47,11 @@ WidgetSettingEnum::WidgetSettingEnum(QTreeWidget* tree, QTreeWidgetItem* parent,
     this->connect(this->field, SIGNAL(currentIndexChanged(int)), this, SLOT(indexChanged(int)));
 }
 
+void WidgetSettingEnum::Enable(bool enable) {
+    ::EnableItem(this->item, enable);
+    this->field->setEnabled(enable);
+}
+
 void WidgetSettingEnum::resizeEvent(QResizeEvent* event) {
     int width = MIN_FIELD_WIDTH;
 

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -39,9 +39,8 @@ WidgetSettingEnum::WidgetSettingEnum(QTreeWidgetItem* item, const SettingMetaEnu
         }
     }
 
-    setCurrentIndex(selection);
-
-    connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(indexChanged(int)));
+    this->setCurrentIndex(selection);
+    this->connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(indexChanged(int)));
 }
 
 void WidgetSettingEnum::indexChanged(int index) {

--- a/vkconfig/widget_setting_enum.h
+++ b/vkconfig/widget_setting_enum.h
@@ -30,7 +30,8 @@ class WidgetSettingEnum : public WidgetSetting {
     Q_OBJECT
 
    public:
-    explicit WidgetSettingEnum(QTreeWidgetItem* item, const SettingMetaEnum& setting_meta, SettingDataEnum& setting_data);
+    explicit WidgetSettingEnum(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaEnum& setting_meta,
+                               SettingDataEnum& setting_data);
 
    public Q_SLOTS:
     void indexChanged(int index);

--- a/vkconfig/widget_setting_enum.h
+++ b/vkconfig/widget_setting_enum.h
@@ -33,6 +33,8 @@ class WidgetSettingEnum : public WidgetSetting {
     explicit WidgetSettingEnum(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaEnum& setting_meta,
                                SettingDataEnum& setting_data);
 
+    void Enable(bool enable) override;
+
    public Q_SLOTS:
     void indexChanged(int index);
 

--- a/vkconfig/widget_setting_enum.h
+++ b/vkconfig/widget_setting_enum.h
@@ -21,15 +21,12 @@
 
 #pragma once
 
-#include "../vkconfig_core/setting_data.h"
-#include "../vkconfig_core/setting_meta.h"
+#include "widget_setting.h"
 
-#include <QObject>
-#include <QWidget>
+#include <QResizeEvent>
 #include <QComboBox>
-#include <QTreeWidgetItem>
 
-class WidgetSettingEnum : public QComboBox {
+class WidgetSettingEnum : public WidgetSetting {
     Q_OBJECT
 
    public:
@@ -42,9 +39,9 @@ class WidgetSettingEnum : public QComboBox {
     void itemChanged();
 
    private:
-    WidgetSettingEnum(const WidgetSettingEnum&) = delete;
-    WidgetSettingEnum& operator=(const WidgetSettingEnum&) = delete;
+    virtual void resizeEvent(QResizeEvent* event) override;
 
     const SettingMetaEnum& setting_meta;
     SettingDataEnum& setting_data;
+    QComboBox* field;
 };

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  *
  * Authors:
- * - Lenny Komow  <lenny@lunarg.com>
  * - Richard S. Wright Jr. <richard@lunarg.com>
  * - Christophe Riccio <christophe@lunarg.com>
  */
@@ -45,18 +44,18 @@ WidgetSettingFilesystem::WidgetSettingFilesystem(QTreeWidget* tree, QTreeWidgetI
 
     this->child_item->setSizeHint(0, QSize(0, 24));
     this->item->addChild(this->child_item);
-    this->item->setExpanded(this->setting_data.expanded);
+    this->item->setExpanded(!this->setting_data.collapsed);
 
     this->button->setText("...");
     this->button->show();
 
     this->title_field->setText(ReplaceBuiltInVariable(setting_data.value).c_str());
     this->title_field->setToolTip(this->title_field->text());
-    this->setting_data.expanded ? this->title_field->hide() : this->title_field->show();
+    this->setting_data.collapsed ? this->title_field->show() : this->title_field->hide();
     this->tree->setItemWidget(this->item, 0, this);
 
     this->child_field->setText(ReplaceBuiltInVariable(setting_data.value).c_str());
-    this->child_field->setToolTip(this->title_field->text());
+    this->child_field->setToolTip(this->child_field->text());
     this->child_field->show();
     this->tree->setItemWidget(this->child_item, 0, this->child_field);
 
@@ -117,7 +116,7 @@ void WidgetSettingFilesystem::OnTextEdited(const QString& value) {
 void WidgetSettingFilesystem::OnItemExpanded(QTreeWidgetItem* expanded_item) {
     if (this->item != expanded_item) return;
 
-    this->setting_data.expanded = true;
+    this->setting_data.collapsed = false;
     this->title_field->hide();
     return;
 }
@@ -125,7 +124,7 @@ void WidgetSettingFilesystem::OnItemExpanded(QTreeWidgetItem* expanded_item) {
 void WidgetSettingFilesystem::OnItemCollapsed(QTreeWidgetItem* expanded_item) {
     if (this->item != expanded_item) return;
 
-    this->setting_data.expanded = false;
+    this->setting_data.collapsed = true;
     this->title_field->show();
     return;
 }

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -26,6 +26,8 @@
 
 #include <cassert>
 
+#include <QFileDialog>
+
 WidgetSettingFilesystem::WidgetSettingFilesystem(QTreeWidgetItem* item, const SettingMetaFilesystem& setting_meta,
                                                  SettingDataString& setting_data)
     : QWidget(nullptr), setting_meta(setting_meta), setting_data(setting_data), _line_edit(nullptr), _push_button(nullptr) {
@@ -54,10 +56,10 @@ void WidgetSettingFilesystem::resizeEvent(QResizeEvent* event) {
     const QSize parent_size = event->size();
 
     // Button takes up the last 32 pixels
-    const QRect edit_rect = QRect(0, 0, parent_size.width() - 32, parent_size.height());
+    const QRect edit_rect = QRect(0, 0, parent_size.width() - 24, parent_size.height());
     this->_line_edit->setGeometry(edit_rect);
 
-    const QRect button_rect = QRect(parent_size.width() - 32, 0, 32, parent_size.height());
+    const QRect button_rect = QRect(parent_size.width() - 24, 0, 24, parent_size.height());
     this->_push_button->setGeometry(button_rect);
 }
 

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -40,6 +40,7 @@ WidgetSettingFilesystem::WidgetSettingFilesystem(QTreeWidgetItem* item, const Se
 
     this->_line_edit = new QLineEdit(this);
     this->_line_edit->setText(ReplaceBuiltInVariable(setting_data.value).c_str());
+    this->_line_edit->setToolTip(this->_line_edit->text());
     this->_line_edit->show();
 
     this->_push_button = new QPushButton(this);

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -66,6 +66,14 @@ WidgetSettingFilesystem::WidgetSettingFilesystem(QTreeWidget* tree, QTreeWidgetI
     this->connect(this->item->treeWidget(), SIGNAL(itemCollapsed(QTreeWidgetItem*)), this, SLOT(OnItemCollapsed(QTreeWidgetItem*)));
 }
 
+void WidgetSettingFilesystem::Enable(bool enable) {
+    ::EnableItem(this->item, enable);
+    ::EnableItem(this->child_item, enable);
+    this->button->setEnabled(enable);
+    this->title_field->setEnabled(enable);
+    this->child_field->setEnabled(enable);
+}
+
 void WidgetSettingFilesystem::resizeEvent(QResizeEvent* event) {
     const QSize parent_size = event->size();
 

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -28,58 +28,72 @@
 
 #include <QFileDialog>
 
-WidgetSettingFilesystem::WidgetSettingFilesystem(QTreeWidgetItem* item, const SettingMetaFilesystem& setting_meta,
-                                                 SettingDataString& setting_data)
-    : QWidget(nullptr), setting_meta(setting_meta), setting_data(setting_data), _line_edit(nullptr), _push_button(nullptr) {
-    assert(item);
-    assert(&setting_meta);
+static const int MIN_FIELD_WIDTH = 64;
+static const int MIN_BUTTON_SIZE = 24;
+static const int ITEM_OFFSET = 48;
+
+WidgetSettingFilesystem::WidgetSettingFilesystem(QTreeWidget* tree, QTreeWidgetItem* parent,
+                                                 const SettingMetaFilesystem& setting_meta, SettingDataString& setting_data)
+    : WidgetSetting(tree, parent, setting_meta),
+      setting_meta(setting_meta),
+      setting_data(setting_data),
+      button(new QPushButton(this)),
+      title_field(new QLineEdit(this)),
+      child_field(new QLineEdit(this)),
+      child_item(new QTreeWidgetItem()) {
     assert(&setting_data);
 
-    item->setText(0, setting_meta.label.c_str());
-    item->setToolTip(0, setting_meta.description.c_str());
+    this->child_item->setSizeHint(0, QSize(0, 24));
+    this->item->addChild(this->child_item);
+    this->item->setExpanded(this->setting_data.expanded);
 
-    this->_line_edit = new QLineEdit(this);
-    this->_line_edit->setText(ReplaceBuiltInVariable(setting_data.value).c_str());
-    this->_line_edit->setToolTip(this->_line_edit->text());
-    this->_line_edit->show();
+    this->button->setText("...");
+    this->button->show();
 
-    this->_push_button = new QPushButton(this);
-    this->_push_button->setText("...");
-    this->_push_button->show();
+    this->title_field->setText(ReplaceBuiltInVariable(setting_data.value).c_str());
+    this->title_field->setToolTip(this->title_field->text());
+    this->setting_data.expanded ? this->title_field->hide() : this->title_field->show();
+    this->tree->setItemWidget(this->item, 0, this);
 
-    connect(this->_push_button, SIGNAL(clicked()), this, SLOT(browseButtonClicked()));
-    connect(this->_line_edit, SIGNAL(textEdited(const QString&)), this, SLOT(textFieldChanged(const QString&)));
+    this->child_field->setText(ReplaceBuiltInVariable(setting_data.value).c_str());
+    this->child_field->setToolTip(this->title_field->text());
+    this->child_field->show();
+    this->tree->setItemWidget(this->child_item, 0, this->child_field);
+
+    this->connect(this->button, SIGNAL(clicked()), this, SLOT(OnButtonClicked()));
+    this->connect(this->title_field, SIGNAL(textEdited(const QString&)), this, SLOT(OnTextEdited(const QString&)));
+    this->connect(this->child_field, SIGNAL(textEdited(const QString&)), this, SLOT(OnTextEdited(const QString&)));
+    this->connect(this->item->treeWidget(), SIGNAL(itemExpanded(QTreeWidgetItem*)), this, SLOT(OnItemExpanded(QTreeWidgetItem*)));
+    this->connect(this->item->treeWidget(), SIGNAL(itemCollapsed(QTreeWidgetItem*)), this, SLOT(OnItemCollapsed(QTreeWidgetItem*)));
 }
 
 void WidgetSettingFilesystem::resizeEvent(QResizeEvent* event) {
-    if (this->_line_edit == nullptr) return;
-
     const QSize parent_size = event->size();
 
-    // Button takes up the last 32 pixels
-    const QRect edit_rect = QRect(0, 0, parent_size.width() - 24, parent_size.height());
-    this->_line_edit->setGeometry(edit_rect);
+    const QFontMetrics fm = this->title_field->fontMetrics();
+    const int width = std::max(fm.horizontalAdvance(this->title_field->text() + "00") + ITEM_OFFSET, MIN_FIELD_WIDTH);
 
-    const QRect button_rect = QRect(parent_size.width() - 24, 0, 24, parent_size.height());
-    this->_push_button->setGeometry(button_rect);
+    const QRect edit_rect = QRect(width, 0, parent_size.width() - MIN_BUTTON_SIZE - width, parent_size.height());
+    this->title_field->setGeometry(edit_rect);
+
+    const QRect button_rect = QRect(parent_size.width() - MIN_BUTTON_SIZE, 0, MIN_BUTTON_SIZE, parent_size.height());
+    this->button->setGeometry(button_rect);
 }
 
-void WidgetSettingFilesystem::browseButtonClicked() {
+void WidgetSettingFilesystem::OnButtonClicked() {
     std::string file;
+    const char* filter = this->setting_meta.filter.c_str();
+    const char* path = this->setting_data.value.c_str();
 
     switch (this->setting_meta.type) {
         case SETTING_LOAD_FILE:
-            file = QFileDialog::getOpenFileName(this->_push_button, "Select file", this->_line_edit->text(),
-                                                this->setting_meta.filter.c_str())
-                       .toStdString();
+            file = QFileDialog::getOpenFileName(this->button, "Select file", path, filter).toStdString();
             break;
         case SETTING_SAVE_FILE:
-            file = QFileDialog::getSaveFileName(this->_push_button, "Select File", this->_line_edit->text(),
-                                                this->setting_meta.filter.c_str())
-                       .toStdString();
+            file = QFileDialog::getSaveFileName(this->button, "Select File", path, filter).toStdString();
             break;
         case SETTING_SAVE_FOLDER:
-            file = QFileDialog::getExistingDirectory(this->_push_button, "Select Folder", this->_line_edit->text()).toStdString();
+            file = QFileDialog::getExistingDirectory(this->button, "Select Folder", path).toStdString();
             break;
         default:
             assert(0);
@@ -88,13 +102,30 @@ void WidgetSettingFilesystem::browseButtonClicked() {
 
     if (!file.empty()) {
         file = ConvertNativeSeparators(file);
-        _line_edit->setText(file.c_str());
+        this->title_field->setText(file.c_str());
+        this->child_field->setText(file.c_str());
         this->setting_data.value = file;
         emit itemChanged();
     }
 }
 
-void WidgetSettingFilesystem::textFieldChanged(const QString& new_text) {
-    this->setting_data.value = new_text.toStdString();
+void WidgetSettingFilesystem::OnTextEdited(const QString& value) {
+    this->setting_data.value = value.toStdString();
     emit itemChanged();
+}
+
+void WidgetSettingFilesystem::OnItemExpanded(QTreeWidgetItem* expanded_item) {
+    if (this->item != expanded_item) return;
+
+    this->setting_data.expanded = true;
+    this->title_field->hide();
+    return;
+}
+
+void WidgetSettingFilesystem::OnItemCollapsed(QTreeWidgetItem* expanded_item) {
+    if (this->item != expanded_item) return;
+
+    this->setting_data.expanded = false;
+    this->title_field->show();
+    return;
 }

--- a/vkconfig/widget_setting_filesystem.h
+++ b/vkconfig/widget_setting_filesystem.h
@@ -34,6 +34,8 @@ class WidgetSettingFilesystem : public WidgetSetting {
     explicit WidgetSettingFilesystem(QTreeWidget *tree, QTreeWidgetItem *parent, const SettingMetaFilesystem &setting_meta,
                                      SettingDataString &setting_data);
 
+    void Enable(bool enable) override;
+
    public Q_SLOTS:
     void OnButtonClicked();
     void OnTextEdited(const QString &value);

--- a/vkconfig/widget_setting_filesystem.h
+++ b/vkconfig/widget_setting_filesystem.h
@@ -48,10 +48,13 @@ class WidgetSettingFilesystem : public WidgetSetting {
    private:
     virtual void resizeEvent(QResizeEvent *event) override;
 
+    void Resize();
+
     const SettingMetaFilesystem &setting_meta;
     SettingDataString &setting_data;
     QPushButton *button;
     QLineEdit *title_field;
     QLineEdit *child_field;
     QTreeWidgetItem *child_item;
+    QSize resize;
 };

--- a/vkconfig/widget_setting_filesystem.h
+++ b/vkconfig/widget_setting_filesystem.h
@@ -23,12 +23,10 @@
 
 #include "../vkconfig_core/layer.h"
 
-#include <QWidget>
 #include <QTreeWidgetItem>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QResizeEvent>
-#include <QFileDialog>
 
 class WidgetSettingFilesystem : public QWidget {
     Q_OBJECT

--- a/vkconfig/widget_setting_filesystem.h
+++ b/vkconfig/widget_setting_filesystem.h
@@ -44,9 +44,6 @@ class WidgetSettingFilesystem : public WidgetSetting {
     void itemChanged();
 
    private:
-    WidgetSettingFilesystem(const WidgetSettingFilesystem &) = delete;
-    WidgetSettingFilesystem &operator=(const WidgetSettingFilesystem &) = delete;
-
     virtual void resizeEvent(QResizeEvent *event) override;
 
     const SettingMetaFilesystem &setting_meta;

--- a/vkconfig/widget_setting_filesystem.h
+++ b/vkconfig/widget_setting_filesystem.h
@@ -21,23 +21,24 @@
 
 #pragma once
 
-#include "../vkconfig_core/layer.h"
+#include "widget_setting.h"
 
-#include <QTreeWidgetItem>
+#include <QResizeEvent>
 #include <QLineEdit>
 #include <QPushButton>
-#include <QResizeEvent>
 
-class WidgetSettingFilesystem : public QWidget {
+class WidgetSettingFilesystem : public WidgetSetting {
     Q_OBJECT
 
    public:
-    explicit WidgetSettingFilesystem(QTreeWidgetItem *item, const SettingMetaFilesystem &setting_meta,
+    explicit WidgetSettingFilesystem(QTreeWidget *tree, QTreeWidgetItem *parent, const SettingMetaFilesystem &setting_meta,
                                      SettingDataString &setting_data);
 
    public Q_SLOTS:
-    void browseButtonClicked();
-    void textFieldChanged(const QString &newText);
+    void OnButtonClicked();
+    void OnTextEdited(const QString &value);
+    void OnItemExpanded(QTreeWidgetItem *expanded_item);
+    void OnItemCollapsed(QTreeWidgetItem *expanded_item);
 
    Q_SIGNALS:
     void itemChanged();
@@ -50,6 +51,8 @@ class WidgetSettingFilesystem : public QWidget {
 
     const SettingMetaFilesystem &setting_meta;
     SettingDataString &setting_data;
-    QLineEdit *_line_edit;
-    QPushButton *_push_button;
+    QPushButton *button;
+    QLineEdit *title_field;
+    QLineEdit *child_field;
+    QTreeWidgetItem *child_item;
 };

--- a/vkconfig/widget_setting_int.cpp
+++ b/vkconfig/widget_setting_int.cpp
@@ -30,21 +30,22 @@
 
 static const int MIN_FIELD_WIDTH = 48;
 
-WidgetSettingInt::WidgetSettingInt(QTreeWidgetItem* item, const SettingMetaInt& setting_meta, SettingDataInt& setting_data)
-    : WidgetSetting(item, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
+WidgetSettingInt::WidgetSettingInt(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaInt& setting_meta,
+                                   SettingDataInt& setting_data)
+    : WidgetSetting(tree, parent, setting_meta),
+      setting_meta(setting_meta),
+      setting_data(setting_data),
+      field(new QLineEdit(this)) {
     assert(&setting_data);
 
-    this->field = new QLineEdit(this);
     this->field->setText(format("%d", setting_data.value).c_str());
     this->field->setAlignment(Qt::AlignRight);
     this->field->show();
 
-    connect(this->field, SIGNAL(textEdited(const QString&)), this, SLOT(itemEdited(const QString&)));
+    this->connect(this->field, SIGNAL(textEdited(const QString&)), this, SLOT(itemEdited(const QString&)));
 }
 
 void WidgetSettingInt::FieldEditedCheck() {
-    if (this->field == nullptr) return;
-
     if (setting_data.value < setting_meta.min_value || setting_data.value > setting_meta.max_value) {
         const std::string text =
             format("'%s' is out of range. Use a value in the [%d-%d].", this->field->text().toStdString().c_str(),
@@ -74,9 +75,6 @@ void WidgetSettingInt::Resize() {
 
 void WidgetSettingInt::resizeEvent(QResizeEvent* event) {
     this->resize = event->size();
-
-    if (this->field == nullptr) return;
-
     this->Resize();
 }
 

--- a/vkconfig/widget_setting_int.cpp
+++ b/vkconfig/widget_setting_int.cpp
@@ -31,13 +31,8 @@
 static const int MIN_FIELD_WIDTH = 48;
 
 WidgetSettingInt::WidgetSettingInt(QTreeWidgetItem* item, const SettingMetaInt& setting_meta, SettingDataInt& setting_data)
-    : setting_meta(setting_meta), setting_data(setting_data) {
-    assert(item);
-    assert(&setting_meta);
+    : WidgetSetting(item, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
     assert(&setting_data);
-
-    item->setText(0, setting_meta.label.c_str());
-    item->setToolTip(0, setting_meta.description.c_str());
 
     this->field = new QLineEdit(this);
     this->field->setText(format("%d", setting_data.value).c_str());

--- a/vkconfig/widget_setting_int.cpp
+++ b/vkconfig/widget_setting_int.cpp
@@ -45,6 +45,11 @@ WidgetSettingInt::WidgetSettingInt(QTreeWidget* tree, QTreeWidgetItem* parent, c
     this->connect(this->field, SIGNAL(textEdited(const QString&)), this, SLOT(itemEdited(const QString&)));
 }
 
+void WidgetSettingInt::Enable(bool enable) {
+    ::EnableItem(this->item, enable);
+    this->field->setEnabled(enable);
+}
+
 void WidgetSettingInt::FieldEditedCheck() {
     if (setting_data.value < setting_meta.min_value || setting_data.value > setting_meta.max_value) {
         const std::string text =

--- a/vkconfig/widget_setting_int.cpp
+++ b/vkconfig/widget_setting_int.cpp
@@ -28,6 +28,8 @@
 
 #include <cassert>
 
+static const int MIN_FIELD_WIDTH = 48;
+
 WidgetSettingInt::WidgetSettingInt(QTreeWidgetItem* item, const SettingMetaInt& setting_meta, SettingDataInt& setting_data)
     : setting_meta(setting_meta), setting_data(setting_data) {
     assert(item);
@@ -69,7 +71,7 @@ void WidgetSettingInt::FieldEditedCheck() {
 
 void WidgetSettingInt::Resize() {
     const QFontMetrics fm = this->field->fontMetrics();
-    const int width = std::max(fm.horizontalAdvance(this->field->text()) + fm.horizontalAdvance("00"), 48);
+    const int width = std::max(fm.horizontalAdvance(this->field->text()) + fm.horizontalAdvance("00"), MIN_FIELD_WIDTH);
 
     const QRect button_rect = QRect(this->resize.width() - width, 0, width, this->resize.height());
     this->field->setGeometry(button_rect);

--- a/vkconfig/widget_setting_int.h
+++ b/vkconfig/widget_setting_int.h
@@ -34,7 +34,8 @@ class WidgetSettingInt : public QWidget {
     WidgetSettingInt(QTreeWidgetItem* item, const SettingMetaInt& setting_meta, SettingDataInt& setting_data);
 
    public Q_SLOTS:
-    void itemEdited(const QString& newString);
+    void itemEdited(const QString& value);
+    void FieldEditedCheck();
 
    Q_SIGNALS:
     void itemChanged();
@@ -45,7 +46,10 @@ class WidgetSettingInt : public QWidget {
 
     virtual void resizeEvent(QResizeEvent* event) override;
 
+    void Resize();
+
     const SettingMetaInt& setting_meta;
     SettingDataInt& setting_data;
     QLineEdit* field;
+    QSize resize;
 };

--- a/vkconfig/widget_setting_int.h
+++ b/vkconfig/widget_setting_int.h
@@ -20,14 +20,12 @@
 
 #pragma once
 
-#include "../vkconfig_core/setting_data.h"
-#include "../vkconfig_core/setting_meta.h"
+#include "widget_setting.h"
 
-#include <QTreeWidgetItem>
 #include <QResizeEvent>
 #include <QLineEdit>
 
-class WidgetSettingInt : public QWidget {
+class WidgetSettingInt : public WidgetSetting {
     Q_OBJECT
 
    public:
@@ -41,9 +39,6 @@ class WidgetSettingInt : public QWidget {
     void itemChanged();
 
    private:
-    WidgetSettingInt(const WidgetSettingInt&) = delete;
-    WidgetSettingInt& operator=(const WidgetSettingInt&) = delete;
-
     virtual void resizeEvent(QResizeEvent* event) override;
 
     void Resize();

--- a/vkconfig/widget_setting_int.h
+++ b/vkconfig/widget_setting_int.h
@@ -31,6 +31,8 @@ class WidgetSettingInt : public WidgetSetting {
    public:
     WidgetSettingInt(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaInt& setting_meta, SettingDataInt& setting_data);
 
+    void Enable(bool enable) override;
+
    public Q_SLOTS:
     void itemEdited(const QString& value);
     void FieldEditedCheck();

--- a/vkconfig/widget_setting_int.h
+++ b/vkconfig/widget_setting_int.h
@@ -23,11 +23,11 @@
 #include "../vkconfig_core/setting_data.h"
 #include "../vkconfig_core/setting_meta.h"
 
-#include <QString>
 #include <QTreeWidgetItem>
 #include <QLineEdit>
+#include <QResizeEvent>
 
-class WidgetSettingInt : public QLineEdit {
+class WidgetSettingInt : public QWidget {
     Q_OBJECT
 
    public:
@@ -43,6 +43,9 @@ class WidgetSettingInt : public QLineEdit {
     WidgetSettingInt(const WidgetSettingInt&) = delete;
     WidgetSettingInt& operator=(const WidgetSettingInt&) = delete;
 
+    virtual void resizeEvent(QResizeEvent* event) override;
+
     const SettingMetaInt& setting_meta;
     SettingDataInt& setting_data;
+    QLineEdit* field;
 };

--- a/vkconfig/widget_setting_int.h
+++ b/vkconfig/widget_setting_int.h
@@ -29,7 +29,7 @@ class WidgetSettingInt : public WidgetSetting {
     Q_OBJECT
 
    public:
-    WidgetSettingInt(QTreeWidgetItem* item, const SettingMetaInt& setting_meta, SettingDataInt& setting_data);
+    WidgetSettingInt(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaInt& setting_meta, SettingDataInt& setting_data);
 
    public Q_SLOTS:
     void itemEdited(const QString& value);

--- a/vkconfig/widget_setting_int.h
+++ b/vkconfig/widget_setting_int.h
@@ -24,8 +24,8 @@
 #include "../vkconfig_core/setting_meta.h"
 
 #include <QTreeWidgetItem>
-#include <QLineEdit>
 #include <QResizeEvent>
+#include <QLineEdit>
 
 class WidgetSettingInt : public QWidget {
     Q_OBJECT

--- a/vkconfig/widget_setting_int_range.cpp
+++ b/vkconfig/widget_setting_int_range.cpp
@@ -30,9 +30,9 @@
 
 static const int MIN_FIELD_WIDTH = 48;
 
-WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidgetItem* item, const SettingMetaIntRange& setting_meta,
+WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRange& setting_meta,
                                              SettingDataIntRange& setting_data)
-    : WidgetSetting(item, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
+    : WidgetSetting(tree, parent, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
     assert(&setting_data);
 
     this->field = new QLineEdit(this);

--- a/vkconfig/widget_setting_int_range.cpp
+++ b/vkconfig/widget_setting_int_range.cpp
@@ -32,13 +32,8 @@ static const int MIN_FIELD_WIDTH = 48;
 
 WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidgetItem* item, const SettingMetaIntRange& setting_meta,
                                              SettingDataIntRange& setting_data)
-    : setting_meta(setting_meta), setting_data(setting_data) {
-    assert(item);
-    assert(&setting_meta);
+    : WidgetSetting(item, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
     assert(&setting_data);
-
-    item->setText(0, setting_meta.label.c_str());
-    item->setToolTip(0, setting_meta.description.c_str());
 
     this->field = new QLineEdit(this);
     this->field->setText(setting_data.value.c_str());

--- a/vkconfig/widget_setting_int_range.cpp
+++ b/vkconfig/widget_setting_int_range.cpp
@@ -30,8 +30,8 @@
 
 static const int MIN_FIELD_WIDTH = 48;
 
-WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRange& setting_meta,
-                                             SettingDataIntRange& setting_data)
+WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRanges& setting_meta,
+                                             SettingDataIntRanges& setting_data)
     : WidgetSetting(tree, parent, setting_meta),
       setting_meta(setting_meta),
       setting_data(setting_data),

--- a/vkconfig/widget_setting_int_range.cpp
+++ b/vkconfig/widget_setting_int_range.cpp
@@ -30,8 +30,8 @@
 
 static const int MIN_FIELD_WIDTH = 48;
 
-WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRanges& setting_meta,
-                                             SettingDataIntRanges& setting_data)
+WidgetSettingIntRanges::WidgetSettingIntRanges(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRanges& setting_meta,
+                                               SettingDataIntRanges& setting_data)
     : WidgetSetting(tree, parent, setting_meta),
       setting_meta(setting_meta),
       setting_data(setting_data),
@@ -45,7 +45,12 @@ WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem*
     connect(this->field, SIGNAL(textEdited(const QString&)), this, SLOT(itemEdited(const QString&)));
 }
 
-void WidgetSettingIntRange::FieldEditedCheck() {
+void WidgetSettingIntRanges::Enable(bool enable) {
+    ::EnableItem(this->item, enable);
+    this->field->setEnabled(enable);
+}
+
+void WidgetSettingIntRanges::FieldEditedCheck() {
     if (this->field == nullptr) return;
 
     if (!IsUIntRanges(setting_data.value)) {
@@ -66,7 +71,7 @@ void WidgetSettingIntRange::FieldEditedCheck() {
     }
 }
 
-void WidgetSettingIntRange::Resize() {
+void WidgetSettingIntRanges::Resize() {
     const QFontMetrics fm = this->field->fontMetrics();
     const int width = std::max(fm.horizontalAdvance(this->field->text()) + fm.horizontalAdvance("00"), MIN_FIELD_WIDTH);
 
@@ -74,12 +79,12 @@ void WidgetSettingIntRange::Resize() {
     this->field->setGeometry(button_rect);
 }
 
-void WidgetSettingIntRange::resizeEvent(QResizeEvent* event) {
+void WidgetSettingIntRanges::resizeEvent(QResizeEvent* event) {
     this->resize = event->size();
     this->Resize();
 }
 
-void WidgetSettingIntRange::itemEdited(const QString& numbers) {
+void WidgetSettingIntRanges::itemEdited(const QString& numbers) {
     this->setting_data.value = numbers.toStdString();
     QTimer::singleShot(1000, [this]() { FieldEditedCheck(); });
 

--- a/vkconfig/widget_setting_int_range.cpp
+++ b/vkconfig/widget_setting_int_range.cpp
@@ -28,6 +28,8 @@
 
 #include <cassert>
 
+static const int MIN_FIELD_WIDTH = 48;
+
 WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidgetItem* item, const SettingMetaIntRange& setting_meta,
                                              SettingDataIntRange& setting_data)
     : setting_meta(setting_meta), setting_data(setting_data) {
@@ -69,7 +71,7 @@ void WidgetSettingIntRange::FieldEditedCheck() {
 
 void WidgetSettingIntRange::Resize() {
     const QFontMetrics fm = this->field->fontMetrics();
-    const int width = std::max(fm.horizontalAdvance(this->field->text()) + fm.horizontalAdvance("00"), 48);
+    const int width = std::max(fm.horizontalAdvance(this->field->text()) + fm.horizontalAdvance("00"), MIN_FIELD_WIDTH);
 
     const QRect button_rect = QRect(this->resize.width() - width, 0, width, this->resize.height());
     this->field->setGeometry(button_rect);

--- a/vkconfig/widget_setting_int_range.cpp
+++ b/vkconfig/widget_setting_int_range.cpp
@@ -32,10 +32,12 @@ static const int MIN_FIELD_WIDTH = 48;
 
 WidgetSettingIntRange::WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRange& setting_meta,
                                              SettingDataIntRange& setting_data)
-    : WidgetSetting(tree, parent, setting_meta), setting_meta(setting_meta), setting_data(setting_data) {
+    : WidgetSetting(tree, parent, setting_meta),
+      setting_meta(setting_meta),
+      setting_data(setting_data),
+      field(new QLineEdit(this)) {
     assert(&setting_data);
 
-    this->field = new QLineEdit(this);
     this->field->setText(setting_data.value.c_str());
     this->field->setAlignment(Qt::AlignRight);
     this->field->show();
@@ -74,9 +76,6 @@ void WidgetSettingIntRange::Resize() {
 
 void WidgetSettingIntRange::resizeEvent(QResizeEvent* event) {
     this->resize = event->size();
-
-    if (this->field == nullptr) return;
-
     this->Resize();
 }
 

--- a/vkconfig/widget_setting_int_range.h
+++ b/vkconfig/widget_setting_int_range.h
@@ -29,7 +29,8 @@ class WidgetSettingIntRange : public WidgetSetting {
     Q_OBJECT
 
    public:
-    WidgetSettingIntRange(QTreeWidgetItem* item, const SettingMetaIntRange& setting_meta, SettingDataIntRange& setting_data);
+    WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRange& setting_meta,
+                          SettingDataIntRange& setting_data);
 
    public Q_SLOTS:
     void itemEdited(const QString& value);

--- a/vkconfig/widget_setting_int_range.h
+++ b/vkconfig/widget_setting_int_range.h
@@ -26,15 +26,17 @@
 #include <QString>
 #include <QTreeWidgetItem>
 #include <QLineEdit>
+#include <QResizeEvent>
 
-class WidgetSettingIntRange : public QLineEdit {
+class WidgetSettingIntRange : public QWidget {
     Q_OBJECT
 
    public:
     WidgetSettingIntRange(QTreeWidgetItem* item, const SettingMetaIntRange& setting_meta, SettingDataIntRange& setting_data);
 
    public Q_SLOTS:
-    void itemEdited(const QString& newString);
+    void itemEdited(const QString& value);
+    void FieldEditedCheck();
 
    Q_SIGNALS:
     void itemChanged();
@@ -43,6 +45,12 @@ class WidgetSettingIntRange : public QLineEdit {
     WidgetSettingIntRange(const WidgetSettingIntRange&) = delete;
     WidgetSettingIntRange& operator=(const WidgetSettingIntRange&) = delete;
 
+    virtual void resizeEvent(QResizeEvent* event) override;
+
+    void Resize();
+
     const SettingMetaIntRange& setting_meta;
     SettingDataIntRange& setting_data;
+    QLineEdit* field;
+    QSize resize;
 };

--- a/vkconfig/widget_setting_int_range.h
+++ b/vkconfig/widget_setting_int_range.h
@@ -29,8 +29,8 @@ class WidgetSettingIntRange : public WidgetSetting {
     Q_OBJECT
 
    public:
-    WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRange& setting_meta,
-                          SettingDataIntRange& setting_data);
+    WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRanges& setting_meta,
+                          SettingDataIntRanges& setting_data);
 
    public Q_SLOTS:
     void itemEdited(const QString& value);
@@ -44,8 +44,8 @@ class WidgetSettingIntRange : public WidgetSetting {
 
     void Resize();
 
-    const SettingMetaIntRange& setting_meta;
-    SettingDataIntRange& setting_data;
+    const SettingMetaIntRanges& setting_meta;
+    SettingDataIntRanges& setting_data;
     QLineEdit* field;
     QSize resize;
 };

--- a/vkconfig/widget_setting_int_range.h
+++ b/vkconfig/widget_setting_int_range.h
@@ -25,12 +25,14 @@
 #include <QResizeEvent>
 #include <QLineEdit>
 
-class WidgetSettingIntRange : public WidgetSetting {
+class WidgetSettingIntRanges : public WidgetSetting {
     Q_OBJECT
 
    public:
-    WidgetSettingIntRange(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRanges& setting_meta,
-                          SettingDataIntRanges& setting_data);
+    WidgetSettingIntRanges(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaIntRanges& setting_meta,
+                           SettingDataIntRanges& setting_data);
+
+    void Enable(bool enable) override;
 
    public Q_SLOTS:
     void itemEdited(const QString& value);

--- a/vkconfig/widget_setting_search.cpp
+++ b/vkconfig/widget_setting_search.cpp
@@ -23,6 +23,8 @@
 
 #include "widget_setting_search.h"
 
+static const int MIN_BUTTON_SIZE = 24;
+
 WidgetSettingSearch::WidgetSettingSearch(const std::vector<std::string> &layer_vuids,
                                          const std::vector<std::string> &selected_vuids)
     : QWidget(nullptr), layer_vuids(layer_vuids) {
@@ -36,13 +38,12 @@ WidgetSettingSearch::WidgetSettingSearch(const std::vector<std::string> &layer_v
 
     _user_box = new QLineEdit(this);
     _user_box->setFocusPolicy(Qt::StrongFocus);
-
-    _add_button = new QPushButton(this);
-    _add_button->setText("Add");
-
     _user_box->show();
     _user_box->setText("");
     _user_box->installEventFilter(this);
+
+    _add_button = new QPushButton(this);
+    _add_button->setText("+");
 
     _search_vuid = nullptr;  // Safe to delete a pointer
     ResetCompleter();
@@ -51,7 +52,7 @@ WidgetSettingSearch::WidgetSettingSearch(const std::vector<std::string> &layer_v
 }
 
 void WidgetSettingSearch::resizeEvent(QResizeEvent *event) {
-    const int button_size = 52;
+    const int button_size = MIN_BUTTON_SIZE;
     QSize parentSize = event->size();
     _user_box->setGeometry(0, 0, parentSize.width() - 2 - button_size, parentSize.height());
     _add_button->setGeometry(parentSize.width() - button_size, 0, button_size, parentSize.height());

--- a/vkconfig/widget_setting_string.cpp
+++ b/vkconfig/widget_setting_string.cpp
@@ -36,7 +36,7 @@ WidgetSettingString::WidgetSettingString(QTreeWidgetItem* item, const SettingMet
     connect(this, SIGNAL(textEdited(const QString&)), this, SLOT(itemEdited(const QString&)));
 }
 
-void WidgetSettingString::itemEdited(const QString& new_string) {
-    this->setting_data.value = new_string.toStdString();
+void WidgetSettingString::itemEdited(const QString& value) {
+    this->setting_data.value = value.toStdString();
     emit itemChanged();
 }

--- a/vkconfig/widget_setting_string.cpp
+++ b/vkconfig/widget_setting_string.cpp
@@ -56,6 +56,13 @@ WidgetSettingString::WidgetSettingString(QTreeWidget* tree, QTreeWidgetItem* par
     this->connect(this->item->treeWidget(), SIGNAL(itemCollapsed(QTreeWidgetItem*)), this, SLOT(OnItemCollapsed(QTreeWidgetItem*)));
 }
 
+void WidgetSettingString::Enable(bool enable) {
+    ::EnableItem(this->item, enable);
+    ::EnableItem(this->child_item, enable);
+    this->title_field->setEnabled(enable);
+    this->child_field->setEnabled(enable);
+}
+
 void WidgetSettingString::Resize() {
     const QFontMetrics fm = this->title_field->fontMetrics();
     const int width = std::max(fm.horizontalAdvance(this->item->text(0) + "00") + ITEM_OFFSET, MIN_FIELD_WIDTH);

--- a/vkconfig/widget_setting_string.h
+++ b/vkconfig/widget_setting_string.h
@@ -33,6 +33,8 @@ class WidgetSettingString : public WidgetSetting {
     WidgetSettingString(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaString& setting_meta,
                         SettingDataString& setting_data);
 
+    void Enable(bool enable) override;
+
    public Q_SLOTS:
     void OnTextEdited(const QString& value);
     void OnItemExpanded(QTreeWidgetItem* expanded_item);

--- a/vkconfig/widget_setting_string.h
+++ b/vkconfig/widget_setting_string.h
@@ -21,29 +21,35 @@
 
 #pragma once
 
-#include "../vkconfig_core/setting_data.h"
-#include "../vkconfig_core/setting_meta.h"
+#include "widget_setting.h"
 
-#include <QString>
-#include <QTreeWidgetItem>
+#include <QResizeEvent>
 #include <QLineEdit>
 
-class WidgetSettingString : public QLineEdit {
+class WidgetSettingString : public WidgetSetting {
     Q_OBJECT
 
    public:
-    WidgetSettingString(QTreeWidgetItem* item, const SettingMetaString& setting_meta, SettingDataString& setting_data);
+    WidgetSettingString(QTreeWidget* tree, QTreeWidgetItem* parent, const SettingMetaString& setting_meta,
+                        SettingDataString& setting_data);
 
    public Q_SLOTS:
-    void itemEdited(const QString& newString);
+    void OnTextEdited(const QString& value);
+    void OnItemExpanded(QTreeWidgetItem* expanded_item);
+    void OnItemCollapsed(QTreeWidgetItem* expanded_item);
 
    Q_SIGNALS:
     void itemChanged();
 
    private:
-    WidgetSettingString(const WidgetSettingString&) = delete;
-    WidgetSettingString& operator=(const WidgetSettingString&) = delete;
+    virtual void resizeEvent(QResizeEvent* event) override;
+
+    void Resize();
 
     const SettingMetaString& setting_meta;
     SettingDataString& setting_data;
+    QLineEdit* title_field;
+    QLineEdit* child_field;
+    QTreeWidgetItem* child_item;
+    QSize resize;
 };

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -74,8 +74,6 @@ bool Configuration::Load2_0(const std::vector<Layer>& available_layers, const QJ
         assert(result == 0);
     }
 
-    setting_tree_state = configuration_entry_object.value("editor_state").toVariant().toByteArray();
-
     description = ReadString(configuration_entry_object, "description").c_str();
 
     const QJsonValue& json_platform_value = configuration_entry_object.value("platforms");
@@ -134,7 +132,6 @@ bool Configuration::Load2_1(const std::vector<Layer>& available_layers, const QJ
 
     // Required configuration values
     key = ReadString(json_configuration_object, "name").c_str();
-    setting_tree_state = json_configuration_object.value("editor_state").toVariant().toByteArray();
     description = ReadString(json_configuration_object, "description").c_str();
 
     // Optional configuration values
@@ -179,7 +176,6 @@ bool Configuration::Load2_2(const std::vector<Layer>& available_layers, const QJ
 
     // Required configuration values
     key = ReadString(json_configuration_object, "name").c_str();
-    setting_tree_state = json_configuration_object.value("editor_state").toVariant().toByteArray();
     description = ReadString(json_configuration_object, "description").c_str();
 
     // Optional configuration values
@@ -201,6 +197,11 @@ bool Configuration::Load2_2(const std::vector<Layer>& available_layers, const QJ
         const QJsonValue& json_platform_value = json_layer_object.value("platforms");
         if (json_platform_value != QJsonValue::Undefined) {
             parameter.platform_flags = GetPlatformFlags(ReadStringArray(json_layer_object, "platforms"));
+        }
+
+        const QJsonValue& json_collapsed_value = json_layer_object.value("collapsed");
+        if (json_collapsed_value != QJsonValue::Undefined) {
+            parameter.collapsed = ReadBoolValue(json_layer_object, "collapsed");
         }
 
         SettingDataSet settings;
@@ -377,7 +378,6 @@ bool Configuration::Save(const std::vector<Layer>& available_layers, const std::
     json_configuration.insert("name", key.c_str());
     json_configuration.insert("description", description.c_str());
     SaveStringArray(json_configuration, "platforms", GetPlatformTokens(platform_flags));
-    json_configuration.insert("editor_state", setting_tree_state.data());
     json_configuration.insert("layers", json_layers);
     root.insert("configuration", json_configuration);
 

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -132,6 +132,7 @@ bool Configuration::Load2_1(const std::vector<Layer>& available_layers, const QJ
 
     // Required configuration values
     key = ReadString(json_configuration_object, "name").c_str();
+    setting_tree_state = json_configuration_object.value("editor_state").toVariant().toByteArray();
     description = ReadString(json_configuration_object, "description").c_str();
 
     // Optional configuration values
@@ -176,6 +177,7 @@ bool Configuration::Load2_2(const std::vector<Layer>& available_layers, const QJ
 
     // Required configuration values
     key = ReadString(json_configuration_object, "name").c_str();
+    setting_tree_state = json_configuration_object.value("editor_state").toVariant().toByteArray();
     description = ReadString(json_configuration_object, "description").c_str();
 
     // Optional configuration values
@@ -379,6 +381,7 @@ bool Configuration::Save(const std::vector<Layer>& available_layers, const std::
     json_configuration.insert("name", key.c_str());
     json_configuration.insert("description", description.c_str());
     SaveStringArray(json_configuration, "platforms", GetPlatformTokens(platform_flags));
+    json_configuration.insert("editor_state", setting_tree_state.data());
     json_configuration.insert("layers", json_layers);
     root.insert("configuration", json_configuration);
 

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -235,9 +235,7 @@ bool Configuration::Load2_2(const std::vector<Layer>& available_layers, const QJ
                     break;
                 }
                 case SETTING_INT_RANGE: {
-                    const QJsonObject& json_range_object = ReadObject(json_setting_object, "value");
-                    static_cast<SettingDataIntRange&>(setting_data).min_value = ReadIntValue(json_range_object, "min");
-                    static_cast<SettingDataIntRange&>(setting_data).max_value = ReadIntValue(json_range_object, "max");
+                    static_cast<SettingDataIntRange&>(setting_data).value = ReadStringValue(json_setting_object, "value");
                     break;
                 }
                 case SETTING_BOOL_NUMERIC_DEPRECATED:
@@ -336,19 +334,13 @@ bool Configuration::Save(const std::vector<Layer>& available_layers, const std::
                 case SETTING_SAVE_FILE:
                 case SETTING_SAVE_FOLDER:
                 case SETTING_ENUM:
+                case SETTING_INT_RANGE:
                 case SETTING_STRING: {
                     json_setting.insert("value", static_cast<const SettingDataString&>(setting_data).value.c_str());
                     break;
                 }
                 case SETTING_INT: {
                     json_setting.insert("value", static_cast<const SettingDataInt&>(setting_data).value);
-                    break;
-                }
-                case SETTING_INT_RANGE: {
-                    QJsonObject json_range_object;
-                    json_range_object.insert("min", static_cast<const SettingDataIntRange&>(setting_data).min_value);
-                    json_range_object.insert("max", static_cast<const SettingDataIntRange&>(setting_data).max_value);
-                    json_setting.insert("value", json_range_object);
                     break;
                 }
                 case SETTING_BOOL_NUMERIC_DEPRECATED:

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -321,6 +321,7 @@ bool Configuration::Save(const std::vector<Layer>& available_layers, const std::
         json_layer.insert("rank", parameter.overridden_rank);
         json_layer.insert("state", GetToken(parameter.state));
         SaveStringArray(json_layer, "platforms", GetPlatformTokens(parameter.platform_flags));
+        json_layer.insert("collapsed", parameter.collapsed);
 
         QJsonArray json_settings;
         for (std::size_t j = 0, m = parameter.settings.Size(); j < m; ++j) {

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -238,7 +238,7 @@ bool Configuration::Load2_2(const std::vector<Layer>& available_layers, const QJ
                     break;
                 }
                 case SETTING_INT_RANGES: {
-                    static_cast<SettingDataIntRange&>(setting_data).value = ReadStringValue(json_setting_object, "value");
+                    static_cast<SettingDataIntRanges&>(setting_data).value = ReadStringValue(json_setting_object, "value");
                     break;
                 }
                 case SETTING_BOOL_NUMERIC_DEPRECATED:

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -234,7 +234,7 @@ bool Configuration::Load2_2(const std::vector<Layer>& available_layers, const QJ
                     static_cast<SettingDataInt&>(setting_data).value = ReadIntValue(json_setting_object, "value");
                     break;
                 }
-                case SETTING_INT_RANGE: {
+                case SETTING_INT_RANGES: {
                     static_cast<SettingDataIntRange&>(setting_data).value = ReadStringValue(json_setting_object, "value");
                     break;
                 }
@@ -334,7 +334,7 @@ bool Configuration::Save(const std::vector<Layer>& available_layers, const std::
                 case SETTING_SAVE_FILE:
                 case SETTING_SAVE_FOLDER:
                 case SETTING_ENUM:
-                case SETTING_INT_RANGE:
+                case SETTING_INT_RANGES:
                 case SETTING_STRING: {
                     json_setting.insert("value", static_cast<const SettingDataString&>(setting_data).value.c_str());
                     break;

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -43,8 +43,7 @@ class Configuration {
 
     std::string key;  // User readable display of the configuration name (may contain spaces)
     int platform_flags;
-    std::string description;        // A friendly description of what this profile does
-    QByteArray setting_tree_state;  // Recall editor tree state
+    std::string description;  // A friendly description of what this profile does
 
     std::vector<Parameter> parameters;
 

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -43,7 +43,8 @@ class Configuration {
 
     std::string key;  // User readable display of the configuration name (may contain spaces)
     int platform_flags;
-    std::string description;  // A friendly description of what this profile does
+    std::string description;        // A friendly description of what this profile does
+    QByteArray setting_tree_state;  // Recall editor tree state
 
     std::vector<Parameter> parameters;
 

--- a/vkconfig_core/json.cpp
+++ b/vkconfig_core/json.cpp
@@ -85,6 +85,7 @@ int ReadIntValue(const QJsonObject& json_object, const char* key) {
     const QJsonValue& json_value = json_object.value(key);
     assert(json_value != QJsonValue::Undefined);
     assert(!json_value.isArray());
+    assert(!json_value.isString());
     return json_value.toInt();
 }
 

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -187,7 +187,7 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                     SettingMetaInt& setting_meta_int = static_cast<SettingMetaInt&>(setting_meta);
                     setting_meta_int.default_value = ReadIntValue(json_setting, "default");
                     if (json_setting.value("range") != QJsonValue::Undefined) {
-                        QJsonObject json_setting_range = ReadObject(json_setting, "range");
+                        const QJsonObject& json_setting_range = ReadObject(json_setting, "range");
                         if (json_setting_range.value("min") != QJsonValue::Undefined) {
                             setting_meta_int.min_value = ReadIntValue(json_setting_range, "min");
                         }

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -374,8 +374,8 @@ void InitSettingDefaultValue(SettingData& setting_data, const SettingMeta& setti
             break;
         }
         case SETTING_INT_RANGES: {
-            const SettingMetaIntRange& meta_object = static_cast<const SettingMetaIntRange&>(setting_meta);
-            static_cast<SettingDataIntRange&>(setting_data).value = meta_object.default_value;
+            const SettingMetaIntRanges& meta_object = static_cast<const SettingMetaIntRanges&>(setting_meta);
+            static_cast<SettingDataIntRanges&>(setting_data).value = meta_object.default_value;
             break;
         }
         case SETTING_LIST: {

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -177,33 +177,40 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
             SettingMeta& setting_meta = settings.Create(key, type);
 
             switch (type) {
-                case SETTING_SAVE_FOLDER:
                 case SETTING_INT_RANGES:
                 case SETTING_STRING: {
-                    static_cast<SettingMetaString&>(setting_meta).default_value = ReadStringValue(json_setting, "default");
+                    SettingMetaString& meta = static_cast<SettingMetaString&>(setting_meta);
+                    meta.default_value = ReadStringValue(json_setting, "default");
+                    if (json_setting.value("collapsed") != QJsonValue::Undefined) {
+                        meta.collapsed = ReadBoolValue(json_setting, "collapsed");
+                    }
                     break;
                 }
                 case SETTING_INT: {
-                    SettingMetaInt& setting_meta_int = static_cast<SettingMetaInt&>(setting_meta);
-                    setting_meta_int.default_value = ReadIntValue(json_setting, "default");
+                    SettingMetaInt& meta = static_cast<SettingMetaInt&>(setting_meta);
+                    meta.default_value = ReadIntValue(json_setting, "default");
                     if (json_setting.value("range") != QJsonValue::Undefined) {
                         const QJsonObject& json_setting_range = ReadObject(json_setting, "range");
                         if (json_setting_range.value("min") != QJsonValue::Undefined) {
-                            setting_meta_int.min_value = ReadIntValue(json_setting_range, "min");
+                            meta.min_value = ReadIntValue(json_setting_range, "min");
                         }
                         if (json_setting_range.value("max") != QJsonValue::Undefined) {
-                            setting_meta_int.max_value = ReadIntValue(json_setting_range, "max");
+                            meta.max_value = ReadIntValue(json_setting_range, "max");
                         }
                     }
                     break;
                 }
+                case SETTING_SAVE_FOLDER:
                 case SETTING_SAVE_FILE:
                 case SETTING_LOAD_FILE: {
-                    SettingMetaFilesystem& setting_meta_filesystem = static_cast<SettingMetaFilesystem&>(setting_meta);
+                    SettingMetaFilesystem& meta = static_cast<SettingMetaFilesystem&>(setting_meta);
                     if (json_setting.value("filter") != QJsonValue::Undefined) {
-                        setting_meta_filesystem.filter = ReadStringValue(json_setting, "filter");
+                        meta.filter = ReadStringValue(json_setting, "filter");
                     }
-                    setting_meta_filesystem.default_value = ReadStringValue(json_setting, "default");
+                    if (json_setting.value("collapsed") != QJsonValue::Undefined) {
+                        meta.collapsed = ReadBoolValue(json_setting, "collapsed");
+                    }
+                    meta.default_value = ReadStringValue(json_setting, "default");
                     break;
                 }
                 case SETTING_BOOL_NUMERIC_DEPRECATED:
@@ -213,7 +220,7 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                 }
                 case SETTING_FLAGS:
                 case SETTING_ENUM: {
-                    SettingMetaEnumeration& setting_meta_enumeration = static_cast<SettingMetaEnumeration&>(setting_meta);
+                    SettingMetaEnumeration& meta = static_cast<SettingMetaEnumeration&>(setting_meta);
                     const QJsonArray& json_array_flags = ReadArray(json_setting, "flags");
                     for (int i = 0, n = json_array_flags.size(); i < n; ++i) {
                         const QJsonObject& json_object = json_array_flags[i].toObject();
@@ -222,7 +229,10 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                         setting_enum_value.key = ReadStringValue(json_object, "key");
                         LoadMetaHeader(setting_enum_value, json_object);
 
-                        setting_meta_enumeration.enum_values.push_back(setting_enum_value);
+                        meta.enum_values.push_back(setting_enum_value);
+                    }
+                    if (json_setting.value("collapsed") != QJsonValue::Undefined) {
+                        meta.collapsed = ReadBoolValue(json_setting, "collapsed");
                     }
                     if (type == SETTING_FLAGS) {
                         static_cast<SettingMetaFlags&>(setting_meta).default_value = ReadStringArray(json_setting, "default");
@@ -232,8 +242,12 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                     break;
                 }
                 case SETTING_LIST: {
-                    static_cast<SettingMetaList&>(setting_meta).list = ReadStringArray(json_setting, "list");
-                    static_cast<SettingMetaList&>(setting_meta).default_value = ReadStringArray(json_setting, "default");
+                    SettingMetaList& meta = static_cast<SettingMetaList&>(setting_meta);
+                    meta.list = ReadStringArray(json_setting, "list");
+                    meta.default_value = ReadStringArray(json_setting, "default");
+                    if (json_setting.value("collapsed") != QJsonValue::Undefined) {
+                        meta.collapsed = ReadBoolValue(json_setting, "collapsed");
+                    }
                     break;
                 }
                 default: {

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -178,18 +178,23 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
 
             switch (type) {
                 case SETTING_SAVE_FOLDER:
+                case SETTING_INT_RANGE:
                 case SETTING_STRING: {
                     static_cast<SettingMetaString&>(setting_meta).default_value = ReadStringValue(json_setting, "default");
                     break;
                 }
                 case SETTING_INT: {
-                    static_cast<SettingMetaInt&>(setting_meta).default_value = ReadIntValue(json_setting, "default");
-                    break;
-                }
-                case SETTING_INT_RANGE: {
-                    const QJsonObject& json_range_object = ReadObject(json_setting, "default");
-                    static_cast<SettingMetaIntRange&>(setting_meta).default_min_value = ReadIntValue(json_range_object, "min");
-                    static_cast<SettingMetaIntRange&>(setting_meta).default_max_value = ReadIntValue(json_range_object, "max");
+                    SettingMetaInt& setting_meta_int = static_cast<SettingMetaInt&>(setting_meta);
+                    setting_meta_int.default_value = ReadIntValue(json_setting, "default");
+                    if (json_setting.value("range") != QJsonValue::Undefined) {
+                        QJsonObject json_setting_range = ReadObject(json_setting, "range");
+                        if (json_setting_range.value("min") != QJsonValue::Undefined) {
+                            setting_meta_int.min_value = ReadIntValue(json_setting_range, "min");
+                        }
+                        if (json_setting_range.value("max") != QJsonValue::Undefined) {
+                            setting_meta_int.max_value = ReadIntValue(json_setting_range, "max");
+                        }
+                    }
                     break;
                 }
                 case SETTING_SAVE_FILE:
@@ -270,18 +275,13 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                     case SETTING_SAVE_FILE:
                     case SETTING_SAVE_FOLDER:
                     case SETTING_ENUM:
+                    case SETTING_INT_RANGE:
                     case SETTING_STRING: {
                         static_cast<SettingDataString&>(setting_data).value = ReadStringValue(json_setting_object, "value");
                         break;
                     }
                     case SETTING_INT: {
                         static_cast<SettingDataInt&>(setting_data).value = ReadIntValue(json_setting_object, "value");
-                        break;
-                    }
-                    case SETTING_INT_RANGE: {
-                        const QJsonObject& json_range_object = ReadObject(json_setting_object, "value");
-                        static_cast<SettingDataIntRange&>(setting_data).min_value = ReadIntValue(json_range_object, "min");
-                        static_cast<SettingDataIntRange&>(setting_data).max_value = ReadIntValue(json_range_object, "max");
                         break;
                     }
                     case SETTING_BOOL_NUMERIC_DEPRECATED:
@@ -361,8 +361,7 @@ void InitSettingDefaultValue(SettingData& setting_data, const SettingMeta& setti
         }
         case SETTING_INT_RANGE: {
             const SettingMetaIntRange& meta_object = static_cast<const SettingMetaIntRange&>(setting_meta);
-            static_cast<SettingDataIntRange&>(setting_data).min_value = meta_object.default_min_value;
-            static_cast<SettingDataIntRange&>(setting_data).max_value = meta_object.default_max_value;
+            static_cast<SettingDataIntRange&>(setting_data).value = meta_object.default_value;
             break;
         }
         case SETTING_LIST: {

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -178,7 +178,7 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
 
             switch (type) {
                 case SETTING_SAVE_FOLDER:
-                case SETTING_INT_RANGE:
+                case SETTING_INT_RANGES:
                 case SETTING_STRING: {
                     static_cast<SettingMetaString&>(setting_meta).default_value = ReadStringValue(json_setting, "default");
                     break;
@@ -275,7 +275,7 @@ bool Layer::Load(const std::string& full_path_to_file, LayerType layer_type) {
                     case SETTING_SAVE_FILE:
                     case SETTING_SAVE_FOLDER:
                     case SETTING_ENUM:
-                    case SETTING_INT_RANGE:
+                    case SETTING_INT_RANGES:
                     case SETTING_STRING: {
                         static_cast<SettingDataString&>(setting_data).value = ReadStringValue(json_setting_object, "value");
                         break;
@@ -359,7 +359,7 @@ void InitSettingDefaultValue(SettingData& setting_data, const SettingMeta& setti
             static_cast<SettingDataFlags&>(setting_data).value = meta_object.default_value;
             break;
         }
-        case SETTING_INT_RANGE: {
+        case SETTING_INT_RANGES: {
             const SettingMetaIntRange& meta_object = static_cast<const SettingMetaIntRange&>(setting_meta);
             static_cast<SettingDataIntRange&>(setting_data).value = meta_object.default_value;
             break;

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
@@ -145,7 +145,7 @@
                 "env": "VK_APIDUMP_OUTPUT_RANGE",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "INT_RANGES",
+                "type": "STRING",
                 "default": "0-0"
             }            
         ]

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
@@ -85,7 +85,11 @@
                 "label": "Indent Size",
                 "description": "Specifies the number of spaces that a tab is equal to",
                 "type": "INT",
-                "default": 4
+                "default": 4,
+                "range": {
+                    "min": 1,
+                    "max": 16
+                }
             },
             {
                 "key": "show_types",
@@ -99,14 +103,20 @@
                 "label": "Name Size",
                 "description": "The number of characters the name of a variable should consume, assuming more are not required",
                 "type": "INT",
-                "default": 32
+                "default": 32,
+                "range": {
+                    "min": 1
+                }
             },
             {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
                 "type": "INT",
-                "default": 0
+                "default": 0,
+                "range": {
+                    "min": 0
+                }
             },
             {
                 "key": "use_spaces",
@@ -135,7 +145,7 @@
                 "env": "VK_APIDUMP_OUTPUT_RANGE",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "STRING",
+                "type": "INT_RANGE",
                 "default": "0-0"
             }            
         ]

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
@@ -70,7 +70,7 @@
                 "description": "Specifies the file to dump to when output files are enabled",
                 "type": "SAVE_FILE",
                 "filter": "*.txt",
-                "default": "vk_apidump.txt"
+                "default": "stdout"
             },
             {
                 "key": "flush",
@@ -145,7 +145,7 @@
                 "env": "VK_APIDUMP_OUTPUT_RANGE",
                 "label": "Output Range",
                 "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "INT_RANGE",
+                "type": "INT_RANGES",
                 "default": "0-0"
             }            
         ]

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
@@ -14,7 +14,16 @@
                         ]
             }
         ],
-        "settings" : [
+        "settings": [
+            {
+                "key": "output_range",
+                "env": "VK_APIDUMP_OUTPUT_RANGE",
+                "label": "Output Range",
+                "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
+                "type": "STRING",
+                "default": "0-0",
+                "collapsed" : true
+            },
             {
                 "key": "output_format",
                 "env": "VK_APIDUMP_OUTPUT_FORMAT",
@@ -41,22 +50,6 @@
                 "default": "text"
             },
             {
-                "key": "detailed",
-                "env": "VK_APIDUMP_DETAILED",
-                "label": "Detailed Output",
-                "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
-                "type": "BOOL",
-                "default": true
-            },
-            {
-                "key": "no_addr",
-                "env": "VK_APIDUMP_NO_ADDR",
-                "label": "Hide Addresses",
-                "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
-                "type": "BOOL",
-                "default": false
-            },
-            {
                 "key": "file",
                 "label": "Output to File",
                 "description": "Setting this to true indicates that output should be written to file instead of stdout",
@@ -70,7 +63,8 @@
                 "description": "Specifies the file to dump to when output files are enabled",
                 "type": "SAVE_FILE",
                 "filter": "*.txt",
-                "default": "stdout"
+                "default": "stdout",
+                "collapsed": true
             },
             {
                 "key": "flush",
@@ -92,9 +86,9 @@
                 }
             },
             {
-                "key": "show_types",
-                "label": "Show Types",
-                "description": "Setting this to true causes types to be dumped in addition to values",
+                "key": "use_spaces",
+                "label": "Use Spaces",
+                "description": "Setting this to true causes all tab characters to be replaced with spaces",
                 "type": "BOOL",
                 "default": true
             },
@@ -109,6 +103,13 @@
                 }
             },
             {
+                "key": "show_types",
+                "label": "Show Types",
+                "description": "Setting this to true causes types to be dumped in addition to values",
+                "type": "BOOL",
+                "default": true
+            },
+            {
                 "key": "type_size",
                 "label": "Type Size",
                 "description": "The number of characters the name of a type should consume, assuming more are not required",
@@ -119,11 +120,20 @@
                 }
             },
             {
-                "key": "use_spaces",
-                "label": "Use Spaces",
-                "description": "Setting this to true causes all tab characters to be replaced with spaces",
+                "key": "detailed",
+                "env": "VK_APIDUMP_DETAILED",
+                "label": "Detailed Output",
+                "description": "Setting this to true causes parameter details to be dumped in addition to API calls",
                 "type": "BOOL",
                 "default": true
+            },
+            {
+                "key": "no_addr",
+                "env": "VK_APIDUMP_NO_ADDR",
+                "label": "Hide Addresses",
+                "description": "Setting this to true causes \"address\" to be dumped in place of hex addresses",
+                "type": "BOOL",
+                "default": false
             },
             {
                 "key": "show_timestamp",
@@ -139,15 +149,7 @@
                 "description": "Setting this to true causes the shader binary code in pCode to be also written to output",
                 "type": "BOOL",
                 "default": false
-            },
-            {
-                "key": "output_range",
-                "env": "VK_APIDUMP_OUTPUT_RANGE",
-                "label": "Output Range",
-                "description": "Comma separated list of frames to output or a range of frames with a start, count, and optional interval separated by a dash. A count of 0 will output every frame after the start of the range. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "STRING",
-                "default": "0-0"
-            }            
+            }
         ]
     }
 }

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -149,7 +149,7 @@
                 "env": "GFXRECON_CAPTURE_FRAMES",
                 "label": "Capture Specific Frames",
                 "description": "Specify one or more comma-separated frame ranges to capture. Each range will be written to its own file. A frame range can be specified as a single value, to specify a single frame to capture, or as two hyphenated values, to specify the first and last frame to capture. Frame ranges should be specified in ascending order and cannot overlap. Note that frame numbering is 1-based (i.e. the first frame is frame 1). Example: 200,301-305 will create two capture files, one containing a single frame and one containing five frames. Default is: Empty string (all frames are captured).",
-                "type": "STRING",
+                "type": "INT_RANGES",
                 "default": ""
             },
             {

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -149,7 +149,7 @@
                 "env": "GFXRECON_CAPTURE_FRAMES",
                 "label": "Capture Specific Frames",
                 "description": "Specify one or more comma-separated frame ranges to capture. Each range will be written to its own file. A frame range can be specified as a single value, to specify a single frame to capture, or as two hyphenated values, to specify the first and last frame to capture. Frame ranges should be specified in ascending order and cannot overlap. Note that frame numbering is 1-based (i.e. the first frame is frame 1). Example: 200,301-305 will create two capture files, one containing a single frame and one containing five frames. Default is: Empty string (all frames are captured).",
-                "type": "INT_RANGES",
+                "type": "STRING",
                 "default": ""
             },
             {

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_screenshot.json
@@ -20,7 +20,7 @@
                 "env": "VK_SCREENSHOT_FRAMES",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "STRING",
+                "type": "INT_RANGES",
                 "default": ""
             },
             {

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_screenshot.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_screenshot.json
@@ -20,7 +20,7 @@
                 "env": "VK_SCREENSHOT_FRAMES",
                 "label": "Frames",
                 "description": "Comma separated list of frames to output as screen shots or a range of frames with a start, count, and optional interval separated by a dash. Setting the variable to \"all\" will output every frame. Example: \"5-8-2\" will output frame 5, continue until frame 13, dumping every other frame. Example: \"3,8-2\" will output frames 3, 8, and 9.",
-                "type": "INT_RANGES",
+                "type": "STRING",
                 "default": ""
             },
             {

--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -189,7 +189,7 @@ bool WriteSettingsOverride(const Environment& environment, const std::vector<Lay
                     break;
                 }
                 case SETTING_INT_RANGES: {
-                    stream << static_cast<const SettingDataIntRange&>(setting_data).value.c_str();
+                    stream << static_cast<const SettingDataIntRanges&>(setting_data).value.c_str();
                     break;
                 }
                 case SETTING_BOOL_NUMERIC_DEPRECATED: {

--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -188,7 +188,7 @@ bool WriteSettingsOverride(const Environment& environment, const std::vector<Lay
                     stream << static_cast<const SettingDataInt&>(setting_data).value;
                     break;
                 }
-                case SETTING_INT_RANGE: {
+                case SETTING_INT_RANGES: {
                     stream << static_cast<const SettingDataIntRange&>(setting_data).value.c_str();
                     break;
                 }

--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -189,8 +189,7 @@ bool WriteSettingsOverride(const Environment& environment, const std::vector<Lay
                     break;
                 }
                 case SETTING_INT_RANGE: {
-                    const SettingDataIntRange& setting_object = static_cast<const SettingDataIntRange&>(setting_data);
-                    stream << format("%d-%d", setting_object.min_value, setting_object.max_value).c_str();
+                    stream << static_cast<const SettingDataIntRange&>(setting_data).value.c_str();
                     break;
                 }
                 case SETTING_BOOL_NUMERIC_DEPRECATED: {

--- a/vkconfig_core/parameter.cpp
+++ b/vkconfig_core/parameter.cpp
@@ -130,3 +130,36 @@ bool HasMissingLayer(const std::vector<Parameter>& parameters, const std::vector
     }
     return false;
 }
+
+std::size_t CountOverriddenLayers(const std::vector<Parameter>& parameters) {
+    std::size_t count = 0;
+
+    for (std::size_t i = 0, n = parameters.size(); i < n; ++i) {
+        const Parameter& parameter = parameters[i];
+        if (!IsPlatformSupported(parameter.platform_flags)) continue;
+
+        if (parameter.state != LAYER_STATE_OVERRIDDEN) continue;
+
+        ++count;
+    }
+
+    return count;
+}
+
+std::size_t CountExcludedLayers(const std::vector<Parameter>& parameters, const std::vector<Layer>& layers) {
+    std::size_t count = 0;
+
+    for (std::size_t i = 0, n = parameters.size(); i < n; ++i) {
+        const Parameter& parameter = parameters[i];
+        if (!IsPlatformSupported(parameter.platform_flags)) continue;
+
+        if (parameter.state != LAYER_STATE_EXCLUDED) continue;
+
+        const Layer* layer = FindByKey(layers, parameter.key.c_str());
+        if (layer == nullptr) continue;  // Do not display missing excluded layers
+
+        ++count;
+    }
+
+    return count;
+}

--- a/vkconfig_core/parameter.h
+++ b/vkconfig_core/parameter.h
@@ -38,9 +38,9 @@ enum ParameterRank {
 struct Parameter {
     static const int NO_RANK = -1;
 
-    Parameter() : state(LAYER_STATE_APPLICATION_CONTROLLED), platform_flags(PLATFORM_ALL_BIT), overridden_rank(NO_RANK) {}
     Parameter(const std::string& key, const LayerState state)
         : key(key), state(state), platform_flags(PLATFORM_ALL_BIT), overridden_rank(NO_RANK), collapsed(false) {}
+    Parameter() : Parameter("", LAYER_STATE_APPLICATION_CONTROLLED) {}
 
     bool ApplyPresetSettings(const LayerPreset& preset);
 
@@ -57,3 +57,6 @@ void OrderParameter(std::vector<Parameter>& parameters, const std::vector<Layer>
 void FilterParameters(std::vector<Parameter>& parameters, const LayerState state);
 
 bool HasMissingLayer(const std::vector<Parameter>& parameters, const std::vector<Layer>& layers);
+
+std::size_t CountOverriddenLayers(const std::vector<Parameter>& parameters);
+std::size_t CountExcludedLayers(const std::vector<Parameter>& parameters, const std::vector<Layer>& layers);

--- a/vkconfig_core/parameter.h
+++ b/vkconfig_core/parameter.h
@@ -40,7 +40,7 @@ struct Parameter {
 
     Parameter() : state(LAYER_STATE_APPLICATION_CONTROLLED), platform_flags(PLATFORM_ALL_BIT), overridden_rank(NO_RANK) {}
     Parameter(const std::string& key, const LayerState state)
-        : key(key), state(state), platform_flags(PLATFORM_ALL_BIT), overridden_rank(NO_RANK) {}
+        : key(key), state(state), platform_flags(PLATFORM_ALL_BIT), overridden_rank(NO_RANK), collapsed(false) {}
 
     bool ApplyPresetSettings(const LayerPreset& preset);
 
@@ -49,6 +49,7 @@ struct Parameter {
     int platform_flags;
     SettingDataSet settings;
     int overridden_rank;
+    bool collapsed;
 };
 
 ParameterRank GetParameterOrdering(const std::vector<Layer>& available_layers, const Parameter& parameter);

--- a/vkconfig_core/setting_data.cpp
+++ b/vkconfig_core/setting_data.cpp
@@ -76,22 +76,6 @@ SettingData& SettingDataString::Assign(const SettingData& other) {
     return *this;
 }
 
-bool SettingDataIntRange::Equal(const SettingData& other) const {
-    if (!SettingData::Equal(other)) return false;
-
-    const SettingDataIntRange& data = static_cast<const SettingDataIntRange&>(other);
-
-    return this->min_value == data.min_value && this->max_value == data.max_value;
-}
-
-SettingData& SettingDataIntRange::Assign(const SettingData& other) {
-    assert(this->type == other.type);
-
-    this->min_value = static_cast<const SettingDataIntRange&>(other).min_value;
-    this->max_value = static_cast<const SettingDataIntRange&>(other).max_value;
-    return *this;
-}
-
 bool SettingDataVector::Equal(const SettingData& other) const {
     if (!SettingData::Equal(other)) return false;
 

--- a/vkconfig_core/setting_data.h
+++ b/vkconfig_core/setting_data.h
@@ -108,16 +108,9 @@ struct SettingDataFolderSave : public SettingDataString {
     virtual ~SettingDataFolderSave() {}
 };
 
-struct SettingDataIntRange : public SettingData {
-    SettingDataIntRange(const std::string& key) : SettingData(key, SETTING_INT_RANGE), min_value(0), max_value(0) {}
+struct SettingDataIntRange : public SettingDataString {
+    SettingDataIntRange(const std::string& key) : SettingDataString(key, SETTING_INT_RANGE) {}
     virtual ~SettingDataIntRange() {}
-
-    int min_value;
-    int max_value;
-
-   protected:
-    virtual bool Equal(const SettingData& other) const;
-    virtual SettingData& Assign(const SettingData& other);
 };
 
 struct SettingDataVector : public SettingData {

--- a/vkconfig_core/setting_data.h
+++ b/vkconfig_core/setting_data.h
@@ -80,10 +80,10 @@ struct SettingDataString : public SettingData {
     virtual ~SettingDataString() {}
 
     std::string value;
-    bool expanded;
+    bool collapsed;
 
    protected:
-    SettingDataString(const std::string& key, const SettingType type) : SettingData(key, type) {}
+    SettingDataString(const std::string& key, const SettingType type) : SettingData(key, type), collapsed(false) {}
 
     virtual bool Equal(const SettingData& other) const;
     virtual SettingData& Assign(const SettingData& other);
@@ -116,9 +116,10 @@ struct SettingDataIntRange : public SettingDataString {
 
 struct SettingDataVector : public SettingData {
     std::vector<std::string> value;
+    bool collapsed;
 
    protected:
-    SettingDataVector(const std::string& key, const SettingType type) : SettingData(key, type) {}
+    SettingDataVector(const std::string& key, const SettingType type) : SettingData(key, type), collapsed(false) {}
     virtual ~SettingDataVector() {}
 
     virtual bool Equal(const SettingData& other) const;

--- a/vkconfig_core/setting_data.h
+++ b/vkconfig_core/setting_data.h
@@ -109,9 +109,9 @@ struct SettingDataFolderSave : public SettingDataString {
     virtual ~SettingDataFolderSave() {}
 };
 
-struct SettingDataIntRange : public SettingDataString {
-    SettingDataIntRange(const std::string& key) : SettingDataString(key, SETTING_INT_RANGES) {}
-    virtual ~SettingDataIntRange() {}
+struct SettingDataIntRanges : public SettingDataString {
+    SettingDataIntRanges(const std::string& key) : SettingDataString(key, SETTING_INT_RANGES) {}
+    virtual ~SettingDataIntRanges() {}
 };
 
 struct SettingDataVector : public SettingData {

--- a/vkconfig_core/setting_data.h
+++ b/vkconfig_core/setting_data.h
@@ -109,7 +109,7 @@ struct SettingDataFolderSave : public SettingDataString {
 };
 
 struct SettingDataIntRange : public SettingDataString {
-    SettingDataIntRange(const std::string& key) : SettingDataString(key, SETTING_INT_RANGE) {}
+    SettingDataIntRange(const std::string& key) : SettingDataString(key, SETTING_INT_RANGES) {}
     virtual ~SettingDataIntRange() {}
 };
 

--- a/vkconfig_core/setting_data.h
+++ b/vkconfig_core/setting_data.h
@@ -80,6 +80,7 @@ struct SettingDataString : public SettingData {
     virtual ~SettingDataString() {}
 
     std::string value;
+    bool expanded;
 
    protected:
     SettingDataString(const std::string& key, const SettingType type) : SettingData(key, type) {}

--- a/vkconfig_core/setting_meta.cpp
+++ b/vkconfig_core/setting_meta.cpp
@@ -60,14 +60,6 @@ bool SettingMetaBool::Equal(const SettingMeta& other) const {
     return this->default_value == static_cast<const SettingMetaBool&>(other).default_value;
 }
 
-bool SettingMetaIntRange::Equal(const SettingMeta& other) const {
-    if (!SettingMeta::Equal(other)) return false;
-
-    const SettingMetaIntRange& meta = static_cast<const SettingMetaIntRange&>(other);
-
-    return this->default_min_value == meta.default_min_value && this->default_max_value == meta.default_max_value;
-}
-
 bool SettingMetaFilesystem::Equal(const SettingMeta& other) const {
     if (!SettingMeta::Equal(other)) return false;
 

--- a/vkconfig_core/setting_meta.h
+++ b/vkconfig_core/setting_meta.h
@@ -89,9 +89,9 @@ struct SettingMetaBoolNumeric : public SettingMeta {
     bool default_value;
 };
 
-struct SettingMetaIntRange : public SettingMetaString {
-    SettingMetaIntRange(const std::string& key) : SettingMetaString(key, SETTING_INT_RANGES) {}
-    virtual ~SettingMetaIntRange() {}
+struct SettingMetaIntRanges : public SettingMetaString {
+    SettingMetaIntRanges(const std::string& key) : SettingMetaString(key, SETTING_INT_RANGES) {}
+    virtual ~SettingMetaIntRanges() {}
 };
 
 struct SettingMetaFilesystem : public SettingMeta {

--- a/vkconfig_core/setting_meta.h
+++ b/vkconfig_core/setting_meta.h
@@ -48,9 +48,10 @@ struct SettingMetaString : public SettingMeta {
     virtual ~SettingMetaString() {}
 
     std::string default_value;
+    bool collapsed;
 
    protected:
-    SettingMetaString(const std::string& key, const SettingType& setting_type) : SettingMeta(key, setting_type) {}
+    SettingMetaString(const std::string& key, const SettingType& setting_type) : SettingMeta(key, setting_type), collapsed(false) {}
 
     virtual bool Equal(const SettingMeta& other) const;
 };
@@ -94,11 +95,13 @@ struct SettingMetaIntRange : public SettingMetaString {
 };
 
 struct SettingMetaFilesystem : public SettingMeta {
-    SettingMetaFilesystem(const std::string& key, const SettingType& setting_type) : SettingMeta(key, setting_type) {}
+    SettingMetaFilesystem(const std::string& key, const SettingType& setting_type)
+        : SettingMeta(key, setting_type), collapsed(false) {}
     virtual ~SettingMetaFilesystem() {}
 
     std::string default_value;
     std::string filter;
+    bool collapsed;
 
    protected:
     virtual bool Equal(const SettingMeta& other) const;
@@ -127,10 +130,12 @@ bool operator==(const SettingEnumValue& a, const SettingEnumValue& b);
 inline bool operator!=(const SettingEnumValue& a, const SettingEnumValue& b) { return !(a == b); }
 
 struct SettingMetaEnumeration : public SettingMeta {
-    SettingMetaEnumeration(const std::string& key, const SettingType& setting_type) : SettingMeta(key, setting_type) {}
+    SettingMetaEnumeration(const std::string& key, const SettingType& setting_type)
+        : SettingMeta(key, setting_type), collapsed(false) {}
     virtual ~SettingMetaEnumeration() {}
 
     std::vector<SettingEnumValue> enum_values;
+    bool collapsed;
 
    protected:
     virtual bool Equal(const SettingMeta& other) const;
@@ -157,11 +162,12 @@ struct SettingMetaFlags : public SettingMetaEnumeration {
 };
 
 struct SettingMetaList : public SettingMeta {
-    SettingMetaList(const std::string& key) : SettingMeta(key, SETTING_LIST) {}
+    SettingMetaList(const std::string& key) : SettingMeta(key, SETTING_LIST), collapsed(false) {}
     virtual ~SettingMetaList() {}
 
     std::vector<std::string> list;
     std::vector<std::string> default_value;
+    bool collapsed;
 
    protected:
     virtual bool Equal(const SettingMeta& other) const;

--- a/vkconfig_core/setting_meta.h
+++ b/vkconfig_core/setting_meta.h
@@ -89,7 +89,7 @@ struct SettingMetaBoolNumeric : public SettingMeta {
 };
 
 struct SettingMetaIntRange : public SettingMetaString {
-    SettingMetaIntRange(const std::string& key) : SettingMetaString(key, SETTING_INT_RANGE) {}
+    SettingMetaIntRange(const std::string& key) : SettingMetaString(key, SETTING_INT_RANGES) {}
     virtual ~SettingMetaIntRange() {}
 };
 

--- a/vkconfig_core/setting_meta.h
+++ b/vkconfig_core/setting_meta.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <limits>
 
 struct SettingMeta : public Header {
     SettingMeta(const std::string& key, const SettingType type);
@@ -43,20 +44,28 @@ struct SettingMeta : public Header {
 };
 
 struct SettingMetaString : public SettingMeta {
-    SettingMetaString(const std::string& key) : SettingMeta(key, SETTING_STRING) {}
+    SettingMetaString(const std::string& key) : SettingMetaString(key, SETTING_STRING) {}
     virtual ~SettingMetaString() {}
 
     std::string default_value;
 
    protected:
+    SettingMetaString(const std::string& key, const SettingType& setting_type) : SettingMeta(key, setting_type) {}
+
     virtual bool Equal(const SettingMeta& other) const;
 };
 
 struct SettingMetaInt : public SettingMeta {
-    SettingMetaInt(const std::string& key) : SettingMeta(key, SETTING_INT), default_value(0) {}
+    SettingMetaInt(const std::string& key)
+        : SettingMeta(key, SETTING_INT),
+          default_value(0),
+          min_value(std::numeric_limits<int>::min()),
+          max_value(std::numeric_limits<int>::max()) {}
     virtual ~SettingMetaInt() {}
 
     int default_value;
+    int min_value;
+    int max_value;
 
    protected:
     virtual bool Equal(const SettingMeta& other) const;
@@ -79,15 +88,9 @@ struct SettingMetaBoolNumeric : public SettingMeta {
     bool default_value;
 };
 
-struct SettingMetaIntRange : public SettingMeta {
-    SettingMetaIntRange(const std::string& key) : SettingMeta(key, SETTING_INT_RANGE), default_min_value(0), default_max_value(0) {}
+struct SettingMetaIntRange : public SettingMetaString {
+    SettingMetaIntRange(const std::string& key) : SettingMetaString(key, SETTING_INT_RANGE) {}
     virtual ~SettingMetaIntRange() {}
-
-    int default_min_value;
-    int default_max_value;
-
-   protected:
-    virtual bool Equal(const SettingMeta& other) const;
 };
 
 struct SettingMetaFilesystem : public SettingMeta {

--- a/vkconfig_core/setting_set.cpp
+++ b/vkconfig_core/setting_set.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<SettingData> SettingSet<SettingData>::AllocSetting(const std::st
         case SETTING_FLAGS:
             return std::shared_ptr<SettingData>(new SettingDataFlags(key));
         case SETTING_INT_RANGES:
-            return std::shared_ptr<SettingData>(new SettingDataIntRange(key));
+            return std::shared_ptr<SettingData>(new SettingDataIntRanges(key));
         case SETTING_LIST:
             return std::shared_ptr<SettingData>(new SettingDataList(key));
         default:
@@ -79,7 +79,7 @@ std::shared_ptr<SettingMeta> SettingSet<SettingMeta>::AllocSetting(const std::st
         case SETTING_FLAGS:
             return std::shared_ptr<SettingMeta>(new SettingMetaFlags(key));
         case SETTING_INT_RANGES:
-            return std::shared_ptr<SettingMeta>(new SettingMetaIntRange(key));
+            return std::shared_ptr<SettingMeta>(new SettingMetaIntRanges(key));
         case SETTING_LIST:
             return std::shared_ptr<SettingMeta>(new SettingMetaList(key));
         default:

--- a/vkconfig_core/setting_set.cpp
+++ b/vkconfig_core/setting_set.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<SettingData> SettingSet<SettingData>::AllocSetting(const std::st
             return std::shared_ptr<SettingData>(new SettingDataEnum(key));
         case SETTING_FLAGS:
             return std::shared_ptr<SettingData>(new SettingDataFlags(key));
-        case SETTING_INT_RANGE:
+        case SETTING_INT_RANGES:
             return std::shared_ptr<SettingData>(new SettingDataIntRange(key));
         case SETTING_LIST:
             return std::shared_ptr<SettingData>(new SettingDataList(key));
@@ -78,7 +78,7 @@ std::shared_ptr<SettingMeta> SettingSet<SettingMeta>::AllocSetting(const std::st
             return std::shared_ptr<SettingMeta>(new SettingMetaEnum(key));
         case SETTING_FLAGS:
             return std::shared_ptr<SettingMeta>(new SettingMetaFlags(key));
-        case SETTING_INT_RANGE:
+        case SETTING_INT_RANGES:
             return std::shared_ptr<SettingMeta>(new SettingMetaIntRange(key));
         case SETTING_LIST:
             return std::shared_ptr<SettingMeta>(new SettingMetaList(key));

--- a/vkconfig_core/setting_type.cpp
+++ b/vkconfig_core/setting_type.cpp
@@ -48,7 +48,7 @@ const char* GetSettingToken(SettingType type) {
         "BOOL_NUMERIC",  // SETTING_BOOL_NUMERIC_DEPRECATED
         "ENUM",          // SETTING_ENUM
         "FLAGS",         // SETTING_FLAGS
-        "INT_RANGE",     // SETTING_RANGE_INT
+        "INT_RANGES",    // SETTING_INT_RANGES
         "LIST"           // SETTING_LIST
     };
     static_assert(countof(table) == SETTING_COUNT, "The tranlation table size doesn't match the enum number of elements");

--- a/vkconfig_core/setting_type.h
+++ b/vkconfig_core/setting_type.h
@@ -32,7 +32,7 @@ enum SettingType {  // Enum value can't be changed
     SETTING_BOOL_NUMERIC_DEPRECATED,  // Deprecated
     SETTING_ENUM,
     SETTING_FLAGS,
-    SETTING_INT_RANGE,
+    SETTING_INT_RANGES,
     SETTING_LIST,
 
     SETTING_FIRST = SETTING_STRING,

--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -9,7 +9,11 @@ function(vkConfigTest NAME)
 	set(TEST_FILE ./${NAME}.cpp)
     set(TEST_NAME vkconfig_${NAME})
 
-    add_executable(${TEST_NAME} ${TEST_FILE} resources.qrc)
+    file(GLOB FILES_JSON ./*.json)
+    file(GLOB FILES_TEXT ./*0.txt)
+    source_group("Test Files" FILES ${FILES_JSON} ${FILES_TEXT})
+
+    add_executable(${TEST_NAME} ${TEST_FILE} ${FILES_JSON} ${FILES_TEXT} resources.qrc)
     target_link_libraries(${TEST_NAME} vkconfig_core gtest gtest_main Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
     if(WIN32)
         target_link_libraries(${TEST_NAME} Cfgmgr32)

--- a/vkconfig_core/test/Configuration 2.2.0.json
+++ b/vkconfig_core/test/Configuration 2.2.0.json
@@ -86,11 +86,8 @@
                     },
                     {
                         "key": "int_range_with_optional",
-                        "type": "INT_RANGE",
-                        "value": {
-                            "min": 79,
-                            "max": 82
-                        }
+                        "type": "INT_RANGES",
+                        "value": "79-82"
                     },
                     {
                         "key": "list_with_optional",

--- a/vkconfig_core/test/Configuration 2.2.1.json
+++ b/vkconfig_core/test/Configuration 2.2.1.json
@@ -86,11 +86,8 @@
                     },
                     {
                         "key": "int_range_with_optional",
-                        "type": "INT_RANGE",
-                        "value": {
-                            "min": 79,
-                            "max": 82
-                        }
+                        "type": "INT_RANGES",
+                        "value": "79-82"
                     },
                     {
                         "key": "list_with_optional",

--- a/vkconfig_core/test/Layer 1.4.0 - setting types.json
+++ b/vkconfig_core/test/Layer 1.4.0 - setting types.json
@@ -226,11 +226,15 @@
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#int",
                 "status": "BETA",
                 "platforms": [ "WINDOWS", "LINUX" ],
+                "range": {
+                    "min": 75,
+                    "max": 82
+                },
                 "default": 76
             },
             {
                 "key": "int_range_with_optional",
-                "type": "INT_RANGE",
+                "type": "INT_RANGES",
                 "label": "Integer Range",
                 "description": "Integer Range Description",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#int_range",

--- a/vkconfig_core/test/Layer 1.4.0 - setting types.json
+++ b/vkconfig_core/test/Layer 1.4.0 - setting types.json
@@ -236,10 +236,7 @@
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#int_range",
                 "status": "BETA",
                 "platforms": [ "WINDOWS", "LINUX" ],
-                "default": {
-                    "min": 76,
-                    "max": 82
-                }
+                "default": "76-82"
             },
             {
                 "key": "list_with_optional",

--- a/vkconfig_core/test/test_configuration.cpp
+++ b/vkconfig_core/test/test_configuration.cpp
@@ -33,8 +33,6 @@ static bool operator==(const Configuration& a, const Configuration& b) {
         return false;
     else if (a.description != b.description)
         return false;
-    else if (a.setting_tree_state != b.setting_tree_state)
-        return false;
     else if (a.parameters != b.parameters)
         return false;
     return true;

--- a/vkconfig_core/test/test_configuration_built_in.cpp
+++ b/vkconfig_core/test/test_configuration_built_in.cpp
@@ -34,8 +34,6 @@ static bool operator==(const Configuration& a, const Configuration& b) {
         return false;
     else if (a.description != b.description)
         return false;
-    else if (a.setting_tree_state != b.setting_tree_state)
-        return false;
     else if (a.parameters != b.parameters)
         return false;
     return true;

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -471,6 +471,8 @@ TEST(test_layer, load_1_4_0_setting_int_with_optional) {
     EXPECT_STREQ("Integer", setting_meta->label.c_str());
     EXPECT_STREQ("Integer Description", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#int", setting_meta->url.c_str());
+    EXPECT_EQ(75, setting_meta->min_value);
+    EXPECT_EQ(82, setting_meta->max_value);
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
 

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -485,7 +485,7 @@ TEST(test_layer, load_1_4_0_setting_int_range_with_optional) {
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
-    SettingMetaIntRange* setting_meta = dynamic_cast<SettingMetaIntRange*>(layer.settings.Get("int_range_with_optional"));
+    SettingMetaIntRanges* setting_meta = dynamic_cast<SettingMetaIntRanges*>(layer.settings.Get("int_range_with_optional"));
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("int_range_with_optional", setting_meta->key.c_str());

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -487,15 +487,14 @@ TEST(test_layer, load_1_4_0_setting_int_range_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("int_range_with_optional", setting_meta->key.c_str());
-    EXPECT_EQ(SETTING_INT_RANGE, setting_meta->type);
+    EXPECT_EQ(SETTING_INT_RANGES, setting_meta->type);
     EXPECT_STREQ("Integer Range", setting_meta->label.c_str());
     EXPECT_STREQ("Integer Range Description", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#int_range", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
 
-    EXPECT_EQ(76, setting_meta->default_min_value);
-    EXPECT_EQ(82, setting_meta->default_max_value);
+    EXPECT_STREQ("76-82", setting_meta->default_value.c_str());
 }
 
 TEST(test_layer, load_1_4_0_setting_list_with_optional) {

--- a/vkconfig_core/test/test_setting_data.cpp
+++ b/vkconfig_core/test/test_setting_data.cpp
@@ -61,9 +61,9 @@ TEST(test_setting_data, equal_int) {
 }
 
 TEST(test_setting_data, equal_int_range) {
-    SettingDataIntRange data0("data");
+    SettingDataIntRanges data0("data");
     data0.value = "6-7";
-    SettingDataIntRange data1("data");
+    SettingDataIntRanges data1("data");
     data1.value = "6-7";
 
     EXPECT_EQ(data0, data1);
@@ -75,7 +75,7 @@ TEST(test_setting_data, equal_int_range) {
     EXPECT_EQ(*ptr0, data1);
     EXPECT_EQ(data0, *ptr1);
 
-    SettingDataIntRange dataX("dataX");
+    SettingDataIntRanges dataX("dataX");
     dataX.value = "6-7";
 
     EXPECT_NE(data0, dataX);
@@ -85,7 +85,7 @@ TEST(test_setting_data, equal_int_range) {
     EXPECT_NE(*ptr0, dataX);
     EXPECT_NE(data0, *ptrX);
 
-    SettingDataIntRange dataY("data");
+    SettingDataIntRanges dataY("data");
     dataY.value = "5-7";
 
     EXPECT_NE(data0, dataY);

--- a/vkconfig_core/test/test_setting_data.cpp
+++ b/vkconfig_core/test/test_setting_data.cpp
@@ -62,11 +62,9 @@ TEST(test_setting_data, equal_int) {
 
 TEST(test_setting_data, equal_int_range) {
     SettingDataIntRange data0("data");
-    data0.min_value = 6;
-    data0.max_value = 7;
+    data0.value = "6-7";
     SettingDataIntRange data1("data");
-    data1.min_value = 6;
-    data1.max_value = 7;
+    data1.value = "6-7";
 
     EXPECT_EQ(data0, data1);
 
@@ -78,8 +76,7 @@ TEST(test_setting_data, equal_int_range) {
     EXPECT_EQ(data0, *ptr1);
 
     SettingDataIntRange dataX("dataX");
-    dataX.min_value = 6;
-    dataX.max_value = 7;
+    dataX.value = "6-7";
 
     EXPECT_NE(data0, dataX);
 
@@ -89,8 +86,7 @@ TEST(test_setting_data, equal_int_range) {
     EXPECT_NE(data0, *ptrX);
 
     SettingDataIntRange dataY("data");
-    dataY.min_value = 5;
-    dataY.max_value = 7;
+    dataY.value = "5-7";
 
     EXPECT_NE(data0, dataY);
 

--- a/vkconfig_core/test/test_setting_meta.cpp
+++ b/vkconfig_core/test/test_setting_meta.cpp
@@ -61,9 +61,9 @@ TEST(test_setting_meta, equal_int) {
 }
 
 TEST(test_setting_meta, equal_int_range) {
-    SettingMetaIntRange data0("data");
+    SettingMetaIntRanges data0("data");
     data0.default_value = "6-7";
-    SettingMetaIntRange data1("data");
+    SettingMetaIntRanges data1("data");
     data1.default_value = "6-7";
 
     EXPECT_EQ(data0, data1);
@@ -75,7 +75,7 @@ TEST(test_setting_meta, equal_int_range) {
     EXPECT_EQ(*ptr0, data1);
     EXPECT_EQ(data0, *ptr1);
 
-    SettingMetaIntRange dataX("dataX");
+    SettingMetaIntRanges dataX("dataX");
     dataX.default_value = "6-7";
 
     EXPECT_NE(data0, dataX);
@@ -85,7 +85,7 @@ TEST(test_setting_meta, equal_int_range) {
     EXPECT_NE(*ptr0, dataX);
     EXPECT_NE(data0, *ptrX);
 
-    SettingMetaIntRange dataY("data");
+    SettingMetaIntRanges dataY("data");
     dataY.default_value = "5-7";
 
     EXPECT_NE(data0, dataY);

--- a/vkconfig_core/test/test_setting_meta.cpp
+++ b/vkconfig_core/test/test_setting_meta.cpp
@@ -62,11 +62,9 @@ TEST(test_setting_meta, equal_int) {
 
 TEST(test_setting_meta, equal_int_range) {
     SettingMetaIntRange data0("data");
-    data0.default_min_value = 6;
-    data0.default_max_value = 7;
+    data0.default_value = "6-7";
     SettingMetaIntRange data1("data");
-    data1.default_min_value = 6;
-    data1.default_max_value = 7;
+    data1.default_value = "6-7";
 
     EXPECT_EQ(data0, data1);
 
@@ -78,8 +76,7 @@ TEST(test_setting_meta, equal_int_range) {
     EXPECT_EQ(data0, *ptr1);
 
     SettingMetaIntRange dataX("dataX");
-    dataX.default_min_value = 6;
-    dataX.default_max_value = 7;
+    dataX.default_value = "6-7";
 
     EXPECT_NE(data0, dataX);
 
@@ -89,8 +86,7 @@ TEST(test_setting_meta, equal_int_range) {
     EXPECT_NE(data0, *ptrX);
 
     SettingMetaIntRange dataY("data");
-    dataY.default_min_value = 5;
-    dataY.default_max_value = 7;
+    dataY.default_value = "5-7";
 
     EXPECT_NE(data0, dataY);
 

--- a/vkconfig_core/test/test_util.cpp
+++ b/vkconfig_core/test/test_util.cpp
@@ -185,3 +185,25 @@ TEST(test_util, to_upper_case) {
     EXPECT_STREQ("STRING76", ToUpperCase("StrinG76").c_str());
     EXPECT_STREQ("STR ING", ToUpperCase("Str inG").c_str());
 }
+
+TEST(test_util, is_number) {
+    EXPECT_EQ(true, IsNumber("0123456789"));
+    EXPECT_EQ(false, IsNumber("01234c56789"));
+    EXPECT_EQ(false, IsNumber("$%#&@()-_[]{}"));
+}
+
+TEST(test_util, is_uint_ranges) {
+    EXPECT_EQ(true, IsUIntRanges("0-2,6,7"));
+    EXPECT_EQ(true, IsUIntRanges("0-2,6-7"));
+    EXPECT_EQ(true, IsUIntRanges("0,2,6,7"));
+
+    EXPECT_EQ(false, IsUIntRanges("1,"));
+    EXPECT_EQ(false, IsUIntRanges("-1"));
+    EXPECT_EQ(false, IsUIntRanges("1-"));
+    EXPECT_EQ(false, IsUIntRanges("1--4"));
+    EXPECT_EQ(false, IsUIntRanges("1,,4"));
+    EXPECT_EQ(false, IsUIntRanges("1,-4"));
+    EXPECT_EQ(false, IsUIntRanges(",-76"));
+    EXPECT_EQ(false, IsUIntRanges("76,-"));
+    EXPECT_EQ(false, IsUIntRanges("76,-82"));
+}

--- a/vkconfig_core/util.cpp
+++ b/vkconfig_core/util.cpp
@@ -61,6 +61,23 @@ bool IsNumber(const std::string& s) {
     return true;
 }
 
+bool IsUIntRanges(const std::string& s) {
+    if (s.find("--") != std::string::npos) return false;
+    if (s.find(",,") != std::string::npos) return false;
+    if (s.find("-,") != std::string::npos) return false;
+    if (s.find(",-") != std::string::npos) return false;
+
+    for (std::size_t i = 0, n = s.length(); i < n; ++i) {
+        if (std::isdigit(s[i])) continue;
+
+        if (i > 0 && (i < n - 1) && (s[i] == '-' || s[i] == ',')) continue;
+
+        return false;
+    }
+
+    return true;
+}
+
 void RemoveString(std::vector<std::string>& list, const std::string& value) {
     std::vector<std::string> new_list;
     new_list.reserve(list.size());

--- a/vkconfig_core/util.h
+++ b/vkconfig_core/util.h
@@ -57,6 +57,8 @@ std::string format(const char* message, ...);
 
 bool IsNumber(const std::string& s);
 
+bool IsUIntRanges(const std::string& s);
+
 template <typename T>
 T* FindByKey(std::vector<T>& container, const char* key) {
     assert(key != nullptr);


### PR DESCRIPTION
- Improve setting tree layout, more compact, more visible.
- Check integer UI input validity.

Todo:
- Check WidgetSettingFilesystem UI user inputs
- Refactor enum and flags widgets
- Add meta (default value) and data (actual) states for collapsed or expanded
- Add per layer collapsed and expanded configuration states
- Add units for ints and int ranges setting types

Before:
![image](https://user-images.githubusercontent.com/62888873/109721693-f847a100-7bab-11eb-94cf-9f257a7e1354.png)

After:
![image](https://user-images.githubusercontent.com/62888873/110137034-ae8bd000-7dd0-11eb-86d0-72627b0c9744.png)

