### PR TITLE
devsim: Update to Vulkan 1.1

### DIFF
--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -5,7 +5,7 @@
         "type": "GLOBAL",
         "library_path": "@RELATIVE_LAYER_BINARY@",
         "api_version": "@VK_VERSION@",
-        "implementation_version": "1.5.1",
+        "implementation_version": "1.6.0",
         "description": "LunarG device simulation layer",
         "device_extensions": [
             {

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -16,6 +16,7 @@
  *
  * Author: Mike Weiblen <mikew@lunarg.com>
  * Author: Arda Coskunses <arda@lunarg.com>
+ * Author: Jeremy Kniager <jeremyk@lunarg.com>
  */
 
 /*
@@ -64,12 +65,12 @@ namespace {
 
 // For new features/functionality, increment the minor level and reset patch level to zero.
 // For any changes, at least increment the patch level.  See https://semver.org/
-// When updating the version, be sure to make corresponding changes to the layer manifest files at
-// layersvt/{linux,windows}/VkLayer_device_simulation*.json
+// When updating the version, be sure to make corresponding changes to the layer manifest file at
+// layersvt/VkLayer_device_simulation.json.in
 
 const uint32_t kVersionDevsimMajor = 1;
-const uint32_t kVersionDevsimMinor = 5;
-const uint32_t kVersionDevsimPatch = 1;
+const uint32_t kVersionDevsimMinor = 6;
+const uint32_t kVersionDevsimPatch = 0;
 const uint32_t kVersionDevsimImplementation = VK_MAKE_VERSION(kVersionDevsimMajor, kVersionDevsimMinor, kVersionDevsimPatch);
 
 // Properties of this layer:

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -1923,9 +1923,23 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties(VkPhysicalDevice ph
     }
 }
 
+VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2(VkPhysicalDevice physicalDevice,
+                                                              VkPhysicalDeviceMemoryProperties2KHR *pMemoryProperties) {
+    {
+        std::lock_guard<std::mutex> lock(global_lock);
+        const auto dt = instance_dispatch_table(physicalDevice);
+        dt->GetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties);
+    }
+    GetPhysicalDeviceMemoryProperties(physicalDevice, &pMemoryProperties->memoryProperties);
+    if (modifyMemoryFlags.num > 0) {
+        PhysicalDeviceData *pdd = PhysicalDeviceData::Find(physicalDevice);
+        FillPNextChain(pdd, pMemoryProperties->pNext);
+    }
+}
+
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2KHR(VkPhysicalDevice physicalDevice,
                                                                  VkPhysicalDeviceMemoryProperties2KHR *pMemoryProperties) {
-    GetPhysicalDeviceMemoryProperties(physicalDevice, &pMemoryProperties->memoryProperties);
+    GetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,
@@ -1973,6 +1987,12 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysical
     *pQueueFamilyPropertyCount = copy_count;
 }
 
+VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2(VkPhysicalDevice physicalDevice,
+                                                                   uint32_t *pQueueFamilyPropertyCount,
+                                                                   VkQueueFamilyProperties2KHR *pQueueFamilyProperties2) {
+    GetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties2);
+}
+
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
                                                              VkFormatProperties *pFormatProperties) {
     std::lock_guard<std::mutex> lock(global_lock);
@@ -1989,9 +2009,19 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(VkPhysicalDevice ph
     }
 }
 
+VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                              VkFormatProperties2KHR *pFormatProperties) {
+    {
+        std::lock_guard<std::mutex> lock(global_lock);
+        const auto dt = instance_dispatch_table(physicalDevice);
+        dt->GetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties);
+    }
+    GetPhysicalDeviceFormatProperties(physicalDevice, format, &pFormatProperties->formatProperties);
+}
+
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2KHR(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                  VkFormatProperties2KHR *pFormatProperties) {
-    GetPhysicalDeviceFormatProperties(physicalDevice, format, &pFormatProperties->formatProperties);
+    GetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t *pToolCount,
@@ -2173,10 +2203,13 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
     GET_PROC_ADDR(GetPhysicalDeviceFeatures2);
     GET_PROC_ADDR(GetPhysicalDeviceFeatures2KHR);
     GET_PROC_ADDR(GetPhysicalDeviceMemoryProperties);
+    GET_PROC_ADDR(GetPhysicalDeviceMemoryProperties2);
     GET_PROC_ADDR(GetPhysicalDeviceMemoryProperties2KHR);
     GET_PROC_ADDR(GetPhysicalDeviceQueueFamilyProperties);
+    GET_PROC_ADDR(GetPhysicalDeviceQueueFamilyProperties2);
     GET_PROC_ADDR(GetPhysicalDeviceQueueFamilyProperties2KHR);
     GET_PROC_ADDR(GetPhysicalDeviceFormatProperties);
+    GET_PROC_ADDR(GetPhysicalDeviceFormatProperties2);
     GET_PROC_ADDR(GetPhysicalDeviceFormatProperties2KHR);
     GET_PROC_ADDR(GetPhysicalDeviceToolPropertiesEXT);
 #undef GET_PROC_ADDR

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -668,6 +668,7 @@ class JsonLoader {
     enum class SchemaId {
         kUnknown = 0,
         kDevsim100,
+        kDevsim110,
         kDevsim16BitStorageKHR,
         kDevsimMaintenance2KHR,
         kDevsimMaintenance3KHR,
@@ -1015,6 +1016,25 @@ bool JsonLoader::LoadFile(const char *filename) {
             result = true;
             break;
 
+        case SchemaId::kDevsim110:
+            GetValue(root, "VkPhysicalDeviceProperties", &pdd_.physical_device_properties_);
+            GetValue(root, "VkPhysicalDeviceMaintenance3Properties", &pdd_.physical_device_maintenance_3_properties_);
+            GetValue(root, "VkPhysicalDeviceMultiviewProperties", &pdd_.physical_device_multiview_properties_);
+            GetValue(root, "VkPhysicalDevicePointClippingProperties", &pdd_.physical_device_point_clipping_properties_);
+            GetValue(root, "VkPhysicalDeviceFeatures", &pdd_.physical_device_features_);
+            GetValue(root, "VkPhysicalDevice16BitStorageFeatures", &pdd_.physical_device_16bit_storage_features_);
+            GetValue(root, "VkPhysicalDeviceMultiviewFeatures", &pdd_.physical_device_multiview_features_);
+            GetValue(root, "VkPhysicalDeviceSamplerYcbcrConversionFeatures",
+                &pdd_.physical_device_sampler_ycbcr_conversion_features_);
+            GetValue(root, "VkPhysicalDeviceVariablePointersFeatures", &pdd_.physical_device_variable_pointers_features_);
+            GetValue(root, "VkPhysicalDeviceMemoryProperties", &pdd_.physical_device_memory_properties_);
+            GetArray(root, "ArrayOfVkQueueFamilyProperties", &pdd_.arrayof_queue_family_properties_);
+            GetArray(root, "ArrayOfVkFormatProperties", &pdd_.arrayof_format_properties_);
+            GetArray(root, "ArrayOfVkLayerProperties", &pdd_.arrayof_layer_properties_);
+            GetArray(root, "ArrayOfVkExtensionProperties", &pdd_.arrayof_extension_properties_);
+            result = true;
+            break;
+
         case SchemaId::kDevsim16BitStorageKHR:
             if (!PhysicalDeviceData::HasExtension(&pdd_, VK_KHR_16BIT_STORAGE_EXTENSION_NAME)) {
                 ErrorPrintf(
@@ -1110,6 +1130,8 @@ JsonLoader::SchemaId JsonLoader::IdentifySchema(const Json::Value &value) {
     const char *schema_string = value.asCString();
     if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_1_0_0.json#") == 0) {
         schema_id = SchemaId::kDevsim100;
+    } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_1_1_0.json#") == 0) {
+        schema_id = SchemaId::kDevsim110;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json#") == 0) {
         schema_id = SchemaId::kDevsim16BitStorageKHR;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json#") == 0) {

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -96,6 +96,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | Vulkan v1.0 | https://schema.khronos.org/vulkan/devsim_1_0_0.json# |
 | VK_KHR_portability_subset | https://schema.khronos.org/vulkan/devsim_VK_KHR_portability_subset-provisional-1.json# |
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
+| VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.0 schema.
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -100,6 +100,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |
 | VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
+| VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.0 schema.
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -98,6 +98,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
+| VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.0 schema.
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -99,6 +99,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |
+| VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.0 schema.
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -97,6 +97,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_portability_subset | https://schema.khronos.org/vulkan/devsim_VK_KHR_portability_subset-provisional-1.json# |
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
+| VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.0 schema.
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -95,6 +95,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 |:----------:|:-------------:|
 | Vulkan v1.0 | https://schema.khronos.org/vulkan/devsim_1_0_0.json# |
 | VK_KHR_portability_subset | https://schema.khronos.org/vulkan/devsim_VK_KHR_portability_subset-provisional-1.json# |
+| VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.0 schema.
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -94,6 +94,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | Schema Use | Canonical URI |
 |:----------:|:-------------:|
 | Vulkan v1.0 | https://schema.khronos.org/vulkan/devsim_1_0_0.json# |
+| Vulkan v1.1 | https://schema.khronos.org/vulkan/devsim_1_1_0.json# |
 | VK_KHR_portability_subset | https://schema.khronos.org/vulkan/devsim_VK_KHR_portability_subset-provisional-1.json# |
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |


### PR DESCRIPTION
Updated Devsim to modify structs provided by extensions made core in Vulkan 1.1.
The following extensions are included:
- `VK_KHR_16bit_storage`
- `VK_KHR_get_physical_device_properties2`
- `VK_KHR_maintenance2`
- `VK_KHR_maintenance3`
- `VK_KHR_multiview`
- `VK_KHR_sampler_ycbcr_conversion`
- `VK_KHR_variable_pointers`

The following structs are now modified by the Devsim layer:
- `VkPhysicalDeviceProperties2`
- `VkPhysicalDeviceMaintenance3Properties`
- `VkPhysicalDeviceMultiviewProperties`
- `VkPhysicalDevicePointClippingProperties`
- `VkPhysicalDeviceFeatures2`
- `VkPhysicalDevice16BitStorageFeatures`
- `VkPhysicalDeviceMultiviewFeatures`
- `VkPhysicalDeviceSamplerYcbcrConversionFeatures`
- `VkPhysicalDeviceVariablePointersFeatures`
- `VkPhysicalDeviceMemoryProperties2`
- `VkQueueFamilyProperties2`

These updates require new JSON schemas to define format for new Devsim config files.
These JSON schema files and example test config files can be provided upon request.