### PR TITLE
devsim: Update Devsim supported version error

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -1697,8 +1697,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
 
     const VkApplicationInfo *app_info = pCreateInfo->pApplicationInfo;
     const uint32_t requested_version = (app_info && app_info->apiVersion) ? app_info->apiVersion : VK_API_VERSION_1_0;
-    if (requested_version != VK_API_VERSION_1_0) {
-        DebugPrintf("%s currently supports only VK_API_VERSION_1_0\n", kOurLayerName);
+    if (requested_version > VK_API_VERSION_1_1) {
+        DebugPrintf("%s currently only supports VK_API_VERSION_1_1 and lower.\n", kOurLayerName);
     }
 
     std::lock_guard<std::mutex> lock(global_lock);


### PR DESCRIPTION
Updated the error Devsim throws when an application is trying to use an
API version greater than what Devsim supports to include Vulkan v1.1 as
a support Vulkan API version.