### PR TITLE
vkconfig: add 'view' property to settings and enum values

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -28,6 +28,9 @@
 ### Improvements:
 - Add display of layer execution order in the setting tree #1390
 
+### Fixes:
+- Hide 'Callback' from validation layer 'Debug Action' debug action that is NOOP
+
 ## [Vulkan Configurator 2.2.0 for Vulkan SDK 1.2.170.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.170.0) - February 2021
 
 ### Features:

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -247,6 +247,7 @@ void SettingsTreeManager::BuildValidationTree(QTreeWidgetItem *parent, Parameter
     // Each debug action has it's own checkbox
     for (std::size_t i = 0, n = meta_debug->enum_values.size(); i < n; ++i) {
         if (!IsPlatformSupported(meta_debug->enum_values[i].platform_flags)) continue;
+        if (meta_debug->enum_values[i].view == SETTING_VIEW_HIDDEN) continue;
 
         QTreeWidgetItem *child = new QTreeWidgetItem();
         child->setSizeHint(0, QSize(0, ITEM_HEIGHT));
@@ -286,6 +287,9 @@ void SettingsTreeManager::BuildValidationTree(QTreeWidgetItem *parent, Parameter
         parent->addChild(sub_category);
 
         for (std::size_t i = 0, n = meta.enum_values.size(); i < n; ++i) {
+            if (!IsPlatformSupported(meta.enum_values[i].platform_flags)) continue;
+            if (meta.enum_values[i].view == SETTING_VIEW_HIDDEN) continue;
+
             QTreeWidgetItem *child = new QTreeWidgetItem();
             child->setSizeHint(0, QSize(0, ITEM_HEIGHT));
             WidgetSettingFlag *widget = new WidgetSettingFlag(meta, data, meta.enum_values[i].key.c_str());
@@ -357,6 +361,7 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
 
     for (std::size_t setting_index = 0, n = layer_setting_metas.Size(); setting_index < n; ++setting_index) {
         if (!IsPlatformSupported(layer_setting_metas[setting_index].platform_flags)) continue;
+        if (layer_setting_metas[setting_index].view == SETTING_VIEW_HIDDEN) continue;
 
         QTreeWidgetItem *item = new QTreeWidgetItem();
         item->setSizeHint(0, QSize(0, ITEM_HEIGHT));
@@ -416,6 +421,9 @@ void SettingsTreeManager::BuildGenericTree(QTreeWidgetItem *parent, Parameter &p
                 item->setToolTip(0, meta.description.c_str());
 
                 for (std::size_t i = 0, n = meta.enum_values.size(); i < n; ++i) {
+                    if (!IsPlatformSupported(meta.enum_values[i].platform_flags)) continue;
+                    if (meta.enum_values[i].view == SETTING_VIEW_HIDDEN) continue;
+
                     WidgetSettingFlag *widget = new WidgetSettingFlag(meta, data, meta.enum_values[i].key.c_str());
                     QTreeWidgetItem *place_holder = new QTreeWidgetItem();
                     item->addChild(place_holder);

--- a/vkconfig/settings_validation_areas.h
+++ b/vkconfig/settings_validation_areas.h
@@ -63,7 +63,8 @@ class SettingsValidationAreas : public QObject {
     QTreeWidgetItem *_best_practices_box;
     QTreeWidgetItem *_best_practices_arm_box;
 
-    QTreeWidgetItem *AddTreeWidgetItem(QTreeWidgetItem *parent, const SettingEnumValue &enum_value);
+    QTreeWidgetItem *AddItem(QTreeWidgetItem *parent, const SettingEnumValue *enum_value, bool enabled);
+    QTreeWidgetItem *AddItem(QTreeWidgetItem *parent, const SettingMetaBool *setting);
 
    public Q_SLOTS:
     void itemChanged(QTreeWidgetItem *item, int column);

--- a/vkconfig/settings_validation_areas.h
+++ b/vkconfig/settings_validation_areas.h
@@ -63,6 +63,8 @@ class SettingsValidationAreas : public QObject {
     QTreeWidgetItem *_best_practices_box;
     QTreeWidgetItem *_best_practices_arm_box;
 
+    QTreeWidgetItem *AddTreeWidgetItem(QTreeWidgetItem *parent, const SettingEnumValue &enum_value);
+
    public Q_SLOTS:
     void itemChanged(QTreeWidgetItem *item, int column);
     void itemClicked(QTreeWidgetItem *item, int column);

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -33,6 +33,9 @@ WidgetSettingEnum::WidgetSettingEnum(QTreeWidgetItem* item, const SettingMetaEnu
 
     int selection = 0;
     for (std::size_t i = 0, n = setting_meta.enum_values.size(); i < n; ++i) {
+        if (!IsPlatformSupported(setting_meta.enum_values[i].platform_flags)) continue;
+        if (setting_meta.enum_values[i].view == SETTING_VIEW_HIDDEN) continue;
+
         this->addItem(setting_meta.enum_values[i].label.c_str());
         if (setting_meta.enum_values[i].key == setting_data.value) {
             selection = static_cast<int>(i);

--- a/vkconfig_core/configuration.cpp
+++ b/vkconfig_core/configuration.cpp
@@ -327,7 +327,7 @@ bool Configuration::Save(const std::vector<Layer>& available_layers, const std::
 
             QJsonObject json_setting;
             json_setting.insert("key", parameter.settings[j].key.c_str());
-            json_setting.insert("type", GetSettingToken(setting_data.type));
+            json_setting.insert("type", GetSettingTypeToken(setting_data.type));
 
             switch (setting_data.type) {
                 case SETTING_LOAD_FILE:

--- a/vkconfig_core/header.h
+++ b/vkconfig_core/header.h
@@ -21,15 +21,17 @@
 #pragma once
 
 #include "platform.h"
+#include "setting_type.h"
 
 #include <string>
 
 struct Header {
-    Header() : status(STATUS_STABLE), platform_flags(PLATFORM_ALL_BIT) {}
+    Header() : status(STATUS_STABLE), view(SETTING_VIEW_STANDARD), platform_flags(PLATFORM_ALL_BIT) {}
 
     std::string label;
     std::string description;
     std::string url;
     StatusType status;
+    SettingView view;
     int platform_flags;
 };

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -83,6 +83,9 @@ static void LoadMetaHeader(Header& header, const QJsonObject& json_object) {
     if (json_object.value("status") != QJsonValue::Undefined) {
         header.status = GetStatusType(ReadStringValue(json_object, "status").c_str());
     }
+    if (json_object.value("view") != QJsonValue::Undefined) {
+        header.view = GetSettingView(ReadStringValue(json_object, "view").c_str());
+    }
     if (json_object.value("platforms") != QJsonValue::Undefined) {
         header.platform_flags = GetPlatformFlags(ReadStringArray(json_object, "platforms"));
     }

--- a/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
@@ -157,7 +157,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -251,37 +252,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": [ ]

--- a/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
@@ -157,7 +157,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -251,37 +252,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": []

--- a/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
@@ -181,7 +181,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -275,37 +276,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": [ ]

--- a/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
@@ -181,7 +181,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -6750,37 +6751,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": []

--- a/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
@@ -204,7 +204,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -6773,37 +6774,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -204,7 +204,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -6773,37 +6774,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]

--- a/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
@@ -205,7 +205,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -6774,37 +6775,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]

--- a/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
@@ -268,9 +268,9 @@
             {
                 "key": "duplicate_message_limit",
                 "label": "Duplicated Messages Limit",
-                "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
+                "description": "Limit the number of times any single validation message would be reported. 0 is unlimited.",
                 "type": "INT",
-                "default": 10,
+                "default": 0,
                 "range": {
                     "min": 0
                 }

--- a/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
@@ -204,7 +204,8 @@
                     {
                         "key": "VK_DBG_LAYER_ACTION_CALLBACK",
                         "label": "Callback",
-                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file."
+                        "description": "Call user defined callback function(s) that have been registered via the VK_EXT_debug_report extension. Since application must register callback, this is a NOOP for the settings file.",
+                        "view": "HIDDEN"
                     },
                     {
                         "key": "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT",
@@ -6776,37 +6777,44 @@
                     {
                         "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
                         "label": "Disable Shaders",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                         "label": "Command Buffer State",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                         "label": "Image Layout",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                         "label": "Query",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
                         "label": "Push Constant Range",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                         "label": "Object in Use",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     },
                     {
                         "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
                         "label": "Idle Descritor Set",
-                        "description": ""
+                        "description": "",
+                        "view": "ADVANCED"
                     }
                 ],
                 "default": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]

--- a/vkconfig_core/layers/layers_schema.json
+++ b/vkconfig_core/layers/layers_schema.json
@@ -131,6 +131,11 @@
             "type": "string",
             "enum": [ "ALPHA", "BETA", "STABLE", "DEPRECATED" ]
         },
+        "view": {
+            "description": "The level of visibility of the setting ('STANDARD' by default)",
+            "type": "string",
+            "enum": [ "STANDARD", "ADVANCED", "HIDDEN" ]
+        },
         "platforms": {
             "description": "The platforms where the setting is available (all by default)",
             "type": "array",
@@ -177,6 +182,9 @@
                     },
                     "status": {
                         "$ref": "#/definitions/status"
+                    },
+                    "view": {
+                        "$ref": "#/definitions/view"
                     },
                     "platforms": {
                         "$ref": "#/definitions/platforms"
@@ -335,6 +343,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             }
                         }
                     },
@@ -384,6 +395,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             }
                         }
                     },
@@ -431,6 +445,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             }
                         }
                     },
@@ -477,6 +494,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             }
                         }
                     },
@@ -523,6 +543,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             },
                             "range": {
                                 "$ref": "#/definitions/range"
@@ -580,6 +603,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             }
                         }
                     },
@@ -633,6 +659,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             }
                         }
                     },
@@ -674,6 +703,9 @@
                             },
                             "status": {
                                 "$ref": "#/definitions/status"
+                            },
+                            "view": {
+                                "$ref": "#/definitions/view"
                             },
                             "platforms": {
                                 "$ref": "#/definitions/platforms"

--- a/vkconfig_core/setting_meta.cpp
+++ b/vkconfig_core/setting_meta.cpp
@@ -20,12 +20,17 @@
 
 #include "setting_meta.h"
 
-SettingMeta::SettingMeta(const std::string& key, const SettingType type) : key(key), type(type) { assert(!this->key.empty()); }
+SettingMeta::SettingMeta(const std::string& key, const SettingType type) : key(key), type(type) {
+    assert(!this->key.empty());
+    assert(type >= SETTING_FIRST && type <= SETTING_LAST);
+}
 
 bool SettingMeta::Equal(const SettingMeta& other) const {
     if (this->key != other.key)
         return false;
     else if (this->type != other.type)
+        return false;
+    else if (this->view != other.view)
         return false;
     else if (this->env != other.env)
         return false;
@@ -108,6 +113,7 @@ bool operator==(const SettingEnumValue& a, const SettingEnumValue& b) {
     if (a.description != b.description) return false;
     if (a.url != b.url) return false;
     if (a.status != b.status) return false;
+    if (a.view != b.view) return false;
     if (a.platform_flags != b.platform_flags) return false;
     return true;
 }

--- a/vkconfig_core/setting_type.cpp
+++ b/vkconfig_core/setting_type.cpp
@@ -22,21 +22,26 @@
 #include "util.h"
 #include "version.h"
 
+#include <cassert>
+
 SettingType GetSettingType(const char* token) {
+    assert(token != nullptr);
+    assert(std::strcmp(token, "") != 0);
+
     if (SUPPORT_VKCONFIG_2_1_0 && ToUpperCase(token) == "MULTI_ENUM") return SETTING_FLAGS;
     if (SUPPORT_VKCONFIG_2_2_0 && ToUpperCase(token) == "VUID_EXCLUDE") return SETTING_LIST;
     if (SUPPORT_VKCONFIG_2_2_0 && ToUpperCase(token) == "INT_RANGES") return SETTING_FRAMES;
 
     for (int i = SETTING_FIRST; i <= SETTING_LAST; ++i) {
         const SettingType type = static_cast<SettingType>(i);
-        if (ToUpperCase(token) == GetSettingToken(type)) return type;
+        if (ToUpperCase(token) == GetSettingTypeToken(type)) return type;
     }
 
     assert(0);  // Unknown token
     return static_cast<SettingType>(-1);
 }
 
-const char* GetSettingToken(SettingType type) {
+const char* GetSettingTypeToken(SettingType type) {
     assert(type >= SETTING_FIRST && type <= SETTING_LAST);
 
     static const char* table[] = {
@@ -55,4 +60,30 @@ const char* GetSettingToken(SettingType type) {
     static_assert(countof(table) == SETTING_COUNT, "The tranlation table size doesn't match the enum number of elements");
 
     return table[type];
+}
+
+SettingView GetSettingView(const char* token) {
+    assert(token != nullptr);
+    assert(std::strcmp(token, "") != 0);
+
+    for (int i = SETTING_VIEW_FIRST; i <= SETTING_VIEW_LAST; ++i) {
+        const SettingView state = static_cast<SettingView>(i);
+        if (ToUpperCase(token) == GetSettingViewToken(state)) return state;
+    }
+
+    assert(0);  // Unknown token
+    return static_cast<SettingView>(-1);
+}
+
+const char* GetSettingViewToken(SettingView state) {
+    assert(state >= SETTING_VIEW_FIRST && state <= SETTING_VIEW_LAST);
+
+    static const char* table[] = {
+        "STANDARD",  // SETTING_VIEW_STANDARD
+        "ADVANCED",  // SETTING_VIEW_ADVANCED
+        "HIDDEN",    // SETTING_VIEW_HIDDEN
+    };
+    static_assert(countof(table) == SETTING_VIEW_COUNT, "The tranlation table size doesn't match the enum number of elements");
+
+    return table[state];
 }

--- a/vkconfig_core/setting_type.h
+++ b/vkconfig_core/setting_type.h
@@ -42,7 +42,7 @@ enum SettingType {  // Enum value can't be changed
 enum { SETTING_COUNT = SETTING_LAST - SETTING_FIRST + 1 };
 
 SettingType GetSettingType(const char* token);
-const char* GetSettingToken(SettingType type);
+const char* GetSettingTypeToken(SettingType type);
 
 inline bool IsEnum(SettingType type) {
     assert(type >= SETTING_FIRST && type <= SETTING_LAST);
@@ -55,3 +55,17 @@ inline bool IsPath(SettingType type) {
 
     return type == SETTING_SAVE_FILE || type == SETTING_LOAD_FILE || type == SETTING_SAVE_FOLDER;
 }
+
+enum SettingView {
+    SETTING_VIEW_STANDARD = 0,
+    SETTING_VIEW_ADVANCED,
+    SETTING_VIEW_HIDDEN,
+
+    SETTING_VIEW_FIRST = SETTING_VIEW_STANDARD,
+    SETTING_VIEW_LAST = SETTING_VIEW_HIDDEN
+};
+
+enum { SETTING_VIEW_COUNT = SETTING_VIEW_LAST - SETTING_VIEW_FIRST + 1 };
+
+SettingView GetSettingView(const char* token);
+const char* GetSettingViewToken(SettingView state);

--- a/vkconfig_core/test/Layer 1.4.0 - setting types.json
+++ b/vkconfig_core/test/Layer 1.4.0 - setting types.json
@@ -50,6 +50,7 @@
                 "description": "enum case",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#enum",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS" ],
                 "flags": [
                     {
@@ -58,6 +59,7 @@
                         "description": "My value0",
                         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#value0",
                         "status": "STABLE",
+                        "view": "STANDARD",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
                     {
@@ -66,6 +68,7 @@
                         "description": "My value1",
                         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#value1",
                         "status": "BETA",
+                        "view": "ADVANCED",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
@@ -74,6 +77,7 @@
                         "description": "My value2",
                         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#value2",
                         "status": "ALPHA",
+                        "view": "HIDDEN",
                         "platforms": [ "WINDOWS" ]
                     }
                 ],
@@ -111,6 +115,7 @@
                 "description": "flags case",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flags",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "flags": [
                     {
@@ -119,6 +124,7 @@
                         "description": "My flag0",
                         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flag0",
                         "status": "STABLE",
+                        "view": "STANDARD",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
                     {
@@ -127,6 +133,7 @@
                         "description": "My flag1",
                         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flag1",
                         "status": "BETA",
+                        "view": "ADVANCED",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
@@ -135,6 +142,7 @@
                         "description": "My flag2",
                         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flag2",
                         "status": "ALPHA",
+                        "view": "HIDDEN",
                         "platforms": [ "WINDOWS" ]
                     }
                 ],
@@ -155,6 +163,7 @@
                 "description": "string",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#string",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "default": "A string"
             },
@@ -173,6 +182,7 @@
                 "description": "true or false",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#bool",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "default": true
             },
@@ -191,6 +201,7 @@
                 "description": "Load file path",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#load_file",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "filter": "*.txt",
                 "default": "./test.txt"
@@ -210,6 +221,7 @@
                 "description": "Save file path",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#save_file",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "filter": "*.json",
                 "default": "./test.json"
@@ -229,6 +241,7 @@
                 "description": "Save folder path",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#save_folder",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "default": "./test"
             },
@@ -247,6 +260,7 @@
                 "description": "Integer Description",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#int",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "default": 76,
                 "range": {
@@ -270,6 +284,7 @@
                 "description": "Frames Description",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#frames",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "default": "76-82,75"
             },
@@ -293,6 +308,7 @@
                 "description": "List description",
                 "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#list",
                 "status": "BETA",
+                "view": "ADVANCED",
                 "platforms": [ "WINDOWS", "LINUX" ],
                 "list": [
                     "stringA",

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -113,6 +113,7 @@ TEST(test_layer, load_1_4_0_setting_enum_required_only) {
     EXPECT_STREQ("enum case", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
     EXPECT_EQ(3, setting_meta->enum_values.size());
 
@@ -153,6 +154,7 @@ TEST(test_layer, load_1_4_0_setting_enum_with_optional) {
     EXPECT_STREQ("enum case", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#enum", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT, setting_meta->platform_flags);
     EXPECT_EQ(3, setting_meta->enum_values.size());
 
@@ -162,6 +164,7 @@ TEST(test_layer, load_1_4_0_setting_enum_with_optional) {
     value0.description = "My value0";
     value0.url = "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#value0";
     value0.status = STATUS_STABLE;
+    value0.view = SETTING_VIEW_STANDARD;
     value0.platform_flags = PLATFORM_ALL_BIT;
     EXPECT_EQ(value0, setting_meta->enum_values[0]);
 
@@ -171,6 +174,7 @@ TEST(test_layer, load_1_4_0_setting_enum_with_optional) {
     value1.description = "My value1";
     value1.url = "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#value1";
     value1.status = STATUS_BETA;
+    value1.view = SETTING_VIEW_ADVANCED;
     value1.platform_flags = PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT;
     EXPECT_EQ(value1, setting_meta->enum_values[1]);
 
@@ -180,6 +184,7 @@ TEST(test_layer, load_1_4_0_setting_enum_with_optional) {
     value2.description = "My value2";
     value2.url = "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#value2";
     value2.status = STATUS_ALPHA;
+    value2.view = SETTING_VIEW_HIDDEN;
     value2.platform_flags = PLATFORM_WINDOWS_BIT;
     EXPECT_EQ(value2, setting_meta->enum_values[2]);
 
@@ -202,6 +207,7 @@ TEST(test_layer, load_1_4_0_setting_flags_required_only) {
     EXPECT_STREQ("flags case", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
     EXPECT_EQ(3, setting_meta->enum_values.size());
 
@@ -243,6 +249,7 @@ TEST(test_layer, load_1_4_0_setting_flags_with_optional) {
     EXPECT_STREQ("flags case", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flags", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
     EXPECT_EQ(3, setting_meta->enum_values.size());
 
@@ -252,6 +259,7 @@ TEST(test_layer, load_1_4_0_setting_flags_with_optional) {
     value0.description = "My flag0";
     value0.url = "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flag0";
     value0.status = STATUS_STABLE;
+    value0.view = SETTING_VIEW_STANDARD;
     value0.platform_flags = PLATFORM_ALL_BIT;
     EXPECT_EQ(value0, setting_meta->enum_values[0]);
 
@@ -261,6 +269,7 @@ TEST(test_layer, load_1_4_0_setting_flags_with_optional) {
     value1.description = "My flag1";
     value1.url = "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flag1";
     value1.status = STATUS_BETA;
+    value1.view = SETTING_VIEW_ADVANCED;
     value1.platform_flags = PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT;
     EXPECT_EQ(value1, setting_meta->enum_values[1]);
 
@@ -270,6 +279,7 @@ TEST(test_layer, load_1_4_0_setting_flags_with_optional) {
     value2.description = "My flag2";
     value2.url = "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#flag2";
     value2.status = STATUS_ALPHA;
+    value2.view = SETTING_VIEW_HIDDEN;
     value2.platform_flags = PLATFORM_WINDOWS_BIT;
     EXPECT_EQ(value2, setting_meta->enum_values[2]);
 
@@ -293,6 +303,7 @@ TEST(test_layer, load_1_4_0_setting_string_required_only) {
     EXPECT_STREQ("string", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("A string", setting_meta->default_value.c_str());
@@ -314,6 +325,7 @@ TEST(test_layer, load_1_4_0_setting_string_with_optional) {
     EXPECT_STREQ("string", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#string", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("A string", setting_meta->default_value.c_str());
@@ -335,6 +347,7 @@ TEST(test_layer, load_1_4_0_setting_bool_required_only) {
     EXPECT_STREQ("true or false", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
 
     EXPECT_EQ(true, setting_meta->default_value);
@@ -356,6 +369,7 @@ TEST(test_layer, load_1_4_0_setting_bool_with_optional) {
     EXPECT_STREQ("true or false", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#bool", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
 
     EXPECT_EQ(true, setting_meta->default_value);
@@ -377,6 +391,7 @@ TEST(test_layer, load_1_4_0_setting_load_file_required_only) {
     EXPECT_STREQ("Load file path", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
     EXPECT_TRUE(setting_meta->filter.empty());
 
@@ -399,6 +414,7 @@ TEST(test_layer, load_1_4_0_setting_load_file_with_optional) {
     EXPECT_STREQ("Load file path", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#load_file", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
     EXPECT_STREQ("*.txt", setting_meta->filter.c_str());
 
@@ -421,6 +437,7 @@ TEST(test_layer, load_1_4_0_setting_save_file_required_only) {
     EXPECT_STREQ("Save file path", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
     EXPECT_TRUE(setting_meta->filter.empty());
 
@@ -443,6 +460,7 @@ TEST(test_layer, load_1_4_0_setting_save_file_with_optional) {
     EXPECT_STREQ("Save file path", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#save_file", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
     EXPECT_STREQ("*.json", setting_meta->filter.c_str());
 
@@ -465,6 +483,7 @@ TEST(test_layer, load_1_4_0_setting_save_folder_required_only) {
     EXPECT_STREQ("Save folder path", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("./test", setting_meta->default_value.c_str());
@@ -486,6 +505,7 @@ TEST(test_layer, load_1_4_0_setting_save_folder_with_optional) {
     EXPECT_STREQ("Save folder path", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#save_folder", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("./test", setting_meta->default_value.c_str());
@@ -507,6 +527,7 @@ TEST(test_layer, load_1_4_0_setting_int_required_only) {
     EXPECT_STREQ("Integer Description", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
     EXPECT_EQ(std::numeric_limits<int>::min(), setting_meta->min_value);
     EXPECT_EQ(std::numeric_limits<int>::max(), setting_meta->max_value);
@@ -531,6 +552,7 @@ TEST(test_layer, load_1_4_0_setting_int_with_optional) {
     EXPECT_STREQ("Integer Description", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#int", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
     EXPECT_EQ(75, setting_meta->min_value);
     EXPECT_EQ(82, setting_meta->max_value);
@@ -555,6 +577,7 @@ TEST(test_layer, load_1_4_0_setting_frames_required_only) {
     EXPECT_STREQ("Frames Description", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("76-82,75", setting_meta->default_value.c_str());
@@ -576,6 +599,7 @@ TEST(test_layer, load_1_4_0_setting_frames_with_optional) {
     EXPECT_STREQ("Frames Description", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#frames", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("76-82,75", setting_meta->default_value.c_str());
@@ -597,6 +621,7 @@ TEST(test_layer, load_1_4_0_setting_list_required_only) {
     EXPECT_STREQ("List description", setting_meta->description.c_str());
     EXPECT_TRUE(setting_meta->url.empty());
     EXPECT_EQ(STATUS_STABLE, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_STANDARD, setting_meta->view);
     EXPECT_EQ(PLATFORM_ALL_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("stringA", setting_meta->list[0].c_str());
@@ -623,6 +648,7 @@ TEST(test_layer, load_1_4_0_setting_list_with_optional) {
     EXPECT_STREQ("List description", setting_meta->description.c_str());
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html#list", setting_meta->url.c_str());
     EXPECT_EQ(STATUS_BETA, setting_meta->status);
+    EXPECT_EQ(SETTING_VIEW_ADVANCED, setting_meta->view);
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, setting_meta->platform_flags);
 
     EXPECT_STREQ("stringA", setting_meta->list[0].c_str());

--- a/vkconfig_core/test/test_setting_type.cpp
+++ b/vkconfig_core/test/test_setting_type.cpp
@@ -28,7 +28,7 @@ TEST(test_setting_type, is_enum_true2) { EXPECT_EQ(true, IsEnum(SETTING_FLAGS));
 
 TEST(test_setting_type, is_enum_false) { EXPECT_EQ(false, IsEnum(SETTING_STRING)); }
 
-TEST(test_setting_type, get_setting_token) { EXPECT_STREQ("STRING", GetSettingToken(SETTING_STRING)); }
+TEST(test_setting_type, get_setting_token) { EXPECT_STREQ("STRING", GetSettingTypeToken(SETTING_STRING)); }
 
 TEST(test_setting_type, get_setting_type) { EXPECT_EQ(SETTING_STRING, GetSettingType("STRING")); }
 
@@ -41,3 +41,13 @@ TEST(test_setting_type, get_setting_save_folder) { EXPECT_TRUE(IsPath(SETTING_SA
 TEST(test_setting_type, get_setting_string) { EXPECT_TRUE(!IsPath(SETTING_STRING)); }
 
 TEST(test_setting_type, get_setting_bool) { EXPECT_TRUE(!IsPath(SETTING_BOOL)); }
+
+TEST(test_setting_type, get_setting_state_hidden) {
+    EXPECT_EQ(SETTING_VIEW_HIDDEN, GetSettingView("HIDDEN"));
+    EXPECT_STREQ("HIDDEN", GetSettingViewToken(SETTING_VIEW_HIDDEN));
+}
+
+TEST(test_setting_type, get_setting_state_standard) {
+    EXPECT_EQ(SETTING_VIEW_STANDARD, GetSettingView("STANDARD"));
+    EXPECT_STREQ("STANDARD", GetSettingViewToken(SETTING_VIEW_STANDARD));
+}


### PR DESCRIPTION
- 'view' property to hide settings
- Use 'view' property to hide validation layer VK_DBG_LAYER_ACTION_CALLBACK
- Set 'duplicate_message_limit' default to 0