### PR TITLE
devsim: Update to Vulkan 1.2

### DIFF
--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -621,6 +621,9 @@ class PhysicalDeviceData {
     // VK_KHR_shader_atomic_int64 structs
     VkPhysicalDeviceShaderAtomicInt64FeaturesKHR physical_device_shader_atomic_int64_features_;
 
+    // VK_KHR_shader_float16_int8 structs
+    VkPhysicalDeviceShaderFloat16Int8FeaturesKHR physical_device_shader_float16_int8_features_;
+
     // VK_KHR_variable_pointers structs
     VkPhysicalDeviceVariablePointersFeaturesKHR physical_device_variable_pointers_features_;
 
@@ -677,6 +680,9 @@ class PhysicalDeviceData {
         // VK_KHR_shader_atomic_int64 structs
         physical_device_shader_atomic_int64_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR};
 
+        // VK_KHR_shader_float16_int8 structs
+        physical_device_shader_float16_int8_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR};
+
         // VK_KHR_variable_pointers structs
         physical_device_variable_pointers_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR};
     }
@@ -719,6 +725,7 @@ class JsonLoader {
         kDevsimSamplerYcbcrConversionKHR,
         kDevsimSeparateDepthStencilLayoutsKHR,
         kDevsimShaderAtomicInt64KHR,
+        kDevsimShaderFloat16Int8KHR,
         kDevsimVariablePointersKHR
     };
 
@@ -741,6 +748,7 @@ class JsonLoader {
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *dest);
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVariablePointersFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, int index, VkMemoryType *dest);
     void GetValue(const Json::Value &parent, int index, VkMemoryHeap *dest);
@@ -1219,6 +1227,17 @@ bool JsonLoader::LoadFile(const char *filename) {
             result = true;
             break;
 
+        case SchemaId::kDevsimShaderFloat16Int8KHR:
+            if (!PhysicalDeviceData::HasExtension(&pdd_, VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME)) {
+                ErrorPrintf(
+                    "JSON file sets variables for structs provided by VK_KHR_shader_float16_int8, but "
+                    "VK_KHR_shader_float16_int8 is "
+                    "not supported by the device.\n");
+            }
+            GetValue(root, "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR", &pdd_.physical_device_shader_float16_int8_features_);
+            result = true;
+            break;
+
         case SchemaId::kDevsimVariablePointersKHR:
             if (!PhysicalDeviceData::HasExtension(&pdd_, VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME)) {
                 ErrorPrintf(
@@ -1276,6 +1295,8 @@ JsonLoader::SchemaId JsonLoader::IdentifySchema(const Json::Value &value) {
         schema_id = SchemaId::kDevsimSeparateDepthStencilLayoutsKHR;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_atomic_int64_1.json#") == 0) {
         schema_id = SchemaId::kDevsimShaderAtomicInt64KHR;
+    } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float16_int8_1.json#") == 0) {
+        schema_id = SchemaId::kDevsimShaderFloat16Int8KHR;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json#") == 0) {
         schema_id = SchemaId::kDevsimVariablePointersKHR;
     }
@@ -1652,6 +1673,16 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysica
     DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceShaderAtomicInt64FeaturesKHR)\n");
     GET_VALUE_WARN(shaderBufferInt64Atomics, WarnIfGreater);
     GET_VALUE_WARN(shaderSharedInt64Atomics, WarnIfGreater);
+}
+
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceShaderFloat16Int8FeaturesKHR)\n");
+    GET_VALUE_WARN(shaderFloat16, WarnIfGreater);
+    GET_VALUE_WARN(shaderInt8, WarnIfGreater);
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVariablePointersFeaturesKHR *dest) {
@@ -2043,6 +2074,12 @@ void FillPNextChain(PhysicalDeviceData *physicalDeviceData, void *place) {
             void *pNext = saisf->pNext;
             *saisf = physicalDeviceData->physical_device_shader_atomic_int64_features_;
             saisf->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR &&
+                   PhysicalDeviceData::HasExtension(physicalDeviceData, VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME)) {
+            VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *sfsief = (VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *)place;
+            void *pNext = sfsief->pNext;
+            *sfsief = physicalDeviceData->physical_device_shader_float16_int8_features_;
+            sfsief->pNext = pNext;
         } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR &&
                    PhysicalDeviceData::HasExtension(physicalDeviceData, VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME)) {
             VkPhysicalDeviceVariablePointersFeaturesKHR *vpf = (VkPhysicalDeviceVariablePointersFeaturesKHR *)place;
@@ -2465,6 +2502,12 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
                     pdd.physical_device_shader_atomic_int64_features_.pNext = feature_chain.pNext;
 
                     feature_chain.pNext = &(pdd.physical_device_shader_atomic_int64_features_);
+                }
+
+                if (PhysicalDeviceData::HasExtension(physical_device, VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME)) {
+                    pdd.physical_device_shader_float16_int8_features_.pNext = feature_chain.pNext;
+
+                    feature_chain.pNext = &(pdd.physical_device_shader_float16_int8_features_);
                 }
 
                 if (PhysicalDeviceData::HasExtension(physical_device, VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME)) {

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -630,6 +630,10 @@ class PhysicalDeviceData {
     // VK_KHR_shader_subgroup_extended_types structs
     VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR physical_device_shader_subgroup_extended_types_features_;
 
+    // VK_KHR_timeline_semaphore structs
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR physical_device_timeline_semaphore_properties_;
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR physical_device_timeline_semaphore_features_;
+
     // VK_KHR_variable_pointers structs
     VkPhysicalDeviceVariablePointersFeaturesKHR physical_device_variable_pointers_features_;
 
@@ -696,6 +700,10 @@ class PhysicalDeviceData {
         physical_device_shader_subgroup_extended_types_features_ = {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES_KHR};
 
+        // VK_KHR_timeline_semaphore structs
+        physical_device_timeline_semaphore_properties_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES_KHR};
+        physical_device_timeline_semaphore_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR};
+
         // VK_KHR_variable_pointers structs
         physical_device_variable_pointers_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR};
     }
@@ -741,6 +749,7 @@ class JsonLoader {
         kDevsimShaderFloatControlsKHR,
         kDevsimShaderFloat16Int8KHR,
         kDevsimShaderSubgroupExtendedTypesKHR,
+        kDevsimTimelineSemaphoreKHR,
         kDevsimVariablePointersKHR
     };
 
@@ -752,6 +761,7 @@ class JsonLoader {
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceMultiviewPropertiesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDevicePointClippingPropertiesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDevicePortabilitySubsetPropertiesKHR *dest);
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceTimelineSemaphorePropertiesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceLimits *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSparseProperties *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceFeatures *dest);
@@ -766,6 +776,7 @@ class JsonLoader {
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR *dest);
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVariablePointersFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, int index, VkMemoryType *dest);
     void GetValue(const Json::Value &parent, int index, VkMemoryHeap *dest);
@@ -1278,6 +1289,18 @@ bool JsonLoader::LoadFile(const char *filename) {
             result = true;
             break;
 
+        case SchemaId::kDevsimTimelineSemaphoreKHR:
+            if (!PhysicalDeviceData::HasExtension(&pdd_, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
+                ErrorPrintf(
+                    "JSON file sets variables for structs provided by VK_KHR_timeline_semaphore, but "
+                    "VK_KHR_timeline_semaphore is "
+                    "not supported by the device.\n");
+            }
+            GetValue(root, "VkPhysicalDeviceTimelineSemaphorePropertiesKHR", &pdd_.physical_device_timeline_semaphore_properties_);
+            GetValue(root, "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR", &pdd_.physical_device_timeline_semaphore_features_);
+            result = true;
+            break;
+
         case SchemaId::kDevsimVariablePointersKHR:
             if (!PhysicalDeviceData::HasExtension(&pdd_, VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME)) {
                 ErrorPrintf(
@@ -1342,6 +1365,8 @@ JsonLoader::SchemaId JsonLoader::IdentifySchema(const Json::Value &value) {
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_subgroup_extended_types_1.json#") ==
                0) {
         schema_id = SchemaId::kDevsimShaderSubgroupExtendedTypesKHR;
+    } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_timeline_semaphore_1.json#") == 0) {
+        schema_id = SchemaId::kDevsimTimelineSemaphoreKHR;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json#") == 0) {
         schema_id = SchemaId::kDevsimVariablePointersKHR;
     }
@@ -1449,6 +1474,15 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysica
     }
     DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDevicePortabilitySubsetPropertiesKHR)\n");
     GET_VALUE_WARN(minVertexInputBindingStrideAlignment, WarnIfLesser);
+}
+
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceTimelineSemaphorePropertiesKHR *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceTimelineSemaphorePropertiesKHR)\n");
+    GET_VALUE_WARN(maxTimelineSemaphoreValueDifference, WarnIfGreater);
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceLimits *dest) {
@@ -1763,6 +1797,15 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name,
     }
     DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceFeatures)\n");
     GET_VALUE_WARN(shaderSubgroupExtendedTypes, WarnIfGreater);
+}
+
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceTimelineSemaphoreFeaturesKHR)\n");
+    GET_VALUE_WARN(timelineSemaphore, WarnIfGreater);
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVariablePointersFeaturesKHR *dest) {
@@ -2173,6 +2216,18 @@ void FillPNextChain(PhysicalDeviceData *physicalDeviceData, void *place) {
             void *pNext = ssetf->pNext;
             *ssetf = physicalDeviceData->physical_device_shader_subgroup_extended_types_features_;
             ssetf->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES_KHR &&
+                   PhysicalDeviceData::HasExtension(physicalDeviceData, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
+            VkPhysicalDeviceTimelineSemaphorePropertiesKHR *tsp = (VkPhysicalDeviceTimelineSemaphorePropertiesKHR *)place;
+            void *pNext = tsp->pNext;
+            *tsp = physicalDeviceData->physical_device_timeline_semaphore_properties_;
+            tsp->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR &&
+                   PhysicalDeviceData::HasExtension(physicalDeviceData, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
+            VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *tsf = (VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *)place;
+            void *pNext = tsf->pNext;
+            *tsf = physicalDeviceData->physical_device_timeline_semaphore_features_;
+            tsf->pNext = pNext;
         } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR &&
                    PhysicalDeviceData::HasExtension(physicalDeviceData, VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME)) {
             VkPhysicalDeviceVariablePointersFeaturesKHR *vpf = (VkPhysicalDeviceVariablePointersFeaturesKHR *)place;
@@ -2613,6 +2668,16 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
                     pdd.physical_device_shader_subgroup_extended_types_features_.pNext = feature_chain.pNext;
 
                     feature_chain.pNext = &(pdd.physical_device_shader_subgroup_extended_types_features_);
+                }
+
+                if (PhysicalDeviceData::HasExtension(physical_device, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)) {
+                    pdd.physical_device_timeline_semaphore_properties_.pNext = property_chain.pNext;
+
+                    property_chain.pNext = &(pdd.physical_device_timeline_semaphore_properties_);
+
+                    pdd.physical_device_timeline_semaphore_features_.pNext = feature_chain.pNext;
+
+                    feature_chain.pNext = &(pdd.physical_device_timeline_semaphore_features_);
                 }
 
                 if (PhysicalDeviceData::HasExtension(physical_device, VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME)) {

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -69,7 +69,7 @@ namespace {
 // layersvt/VkLayer_device_simulation.json.in
 
 const uint32_t kVersionDevsimMajor = 1;
-const uint32_t kVersionDevsimMinor = 6;
+const uint32_t kVersionDevsimMinor = 7;
 const uint32_t kVersionDevsimPatch = 0;
 const uint32_t kVersionDevsimImplementation = VK_MAKE_VERSION(kVersionDevsimMajor, kVersionDevsimMinor, kVersionDevsimPatch);
 
@@ -583,6 +583,9 @@ class PhysicalDeviceData {
     VkPhysicalDeviceVulkan11Properties physical_device_vulkan_1_1_properties_;
     VkPhysicalDeviceVulkan11Features physical_device_vulkan_1_1_features_;
 
+    VkPhysicalDeviceVulkan12Properties physical_device_vulkan_1_2_properties_;
+    VkPhysicalDeviceVulkan12Features physical_device_vulkan_1_2_features_;
+
     // VK_KHR_8bit_storage structs
     VkPhysicalDevice8BitStorageFeaturesKHR physical_device_8bit_storage_features_;
 
@@ -667,6 +670,9 @@ class PhysicalDeviceData {
         // Vulkan 1.2 structs for summarizing core extension properties and features
         physical_device_vulkan_1_1_properties_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES};
         physical_device_vulkan_1_1_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES};
+
+        physical_device_vulkan_1_2_properties_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES};
+        physical_device_vulkan_1_2_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};
 
         // VK_KHR_8bit_storage structs
         physical_device_8bit_storage_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR};
@@ -774,6 +780,7 @@ class JsonLoader {
         kUnknown = 0,
         kDevsim100,
         kDevsim110,
+        kDevsim120,
         kDevsim8BitStorageKHR,
         kDevsim16BitStorageKHR,
         kDevsimBufferDeviceAddressKHR,
@@ -839,6 +846,9 @@ class JsonLoader {
     void GetValue(const Json::Value &parent, int index, DevsimFormatProperties *dest);
     void GetValue(const Json::Value &parent, int index, VkLayerProperties *dest);
     void GetValue(const Json::Value &parent, int index, VkExtensionProperties *dest);
+
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVulkan12Properties *dest);
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVulkan12Features *dest);
 
     // For use as warn_func in GET_VALUE_WARN().  Return true if warning occurred.
     static bool WarnIfGreater(const char *name, const uint64_t new_value, const uint64_t old_value) {
@@ -1174,6 +1184,51 @@ bool JsonLoader::LoadFile(const char *filename) {
             result = true;
             break;
 
+        case SchemaId::kDevsim120:
+            GetValue(root, "VkPhysicalDeviceProperties", &pdd_.physical_device_properties_);
+            GetValue(root, "VkPhysicalDeviceDepthStencilResolveProperties",
+                     &pdd_.physical_device_depth_stencil_resolve_properties_);
+            GetValue(root, "VkPhysicalDeviceDescriptorIndexingProperties", &pdd_.physical_device_descriptor_indexing_properties_);
+            GetValue(root, "VkPhysicalDeviceFloatControlsProperties", &pdd_.physical_device_float_controls_properties_);
+            GetValue(root, "VkPhysicalDeviceHostQueryResetFeatures", &pdd_.physical_device_host_query_reset_features_);
+            GetValue(root, "VkPhysicalDeviceMaintenance3Properties", &pdd_.physical_device_maintenance_3_properties_);
+            GetValue(root, "VkPhysicalDeviceMultiviewProperties", &pdd_.physical_device_multiview_properties_);
+            GetValue(root, "VkPhysicalDevicePointClippingProperties", &pdd_.physical_device_point_clipping_properties_);
+            GetValue(root, "VkPhysicalDeviceTimelineSemaphoreProperties", &pdd_.physical_device_timeline_semaphore_properties_);
+            GetValue(root, "VkPhysicalDeviceFeatures", &pdd_.physical_device_features_);
+            GetValue(root, "VkPhysicalDevice16BitStorageFeatures", &pdd_.physical_device_16bit_storage_features_);
+            GetValue(root, "VkPhysicalDevice8BitStorageFeatures", &pdd_.physical_device_8bit_storage_features_);
+            GetValue(root, "VkPhysicalDeviceBufferDeviceAddressFeatures", &pdd_.physical_device_buffer_device_address_features_);
+            GetValue(root, "VkPhysicalDeviceDescriptorIndexingFeatures", &pdd_.physical_device_descriptor_indexing_features_);
+            GetValue(root, "VkPhysicalDeviceImagelessFramebufferFeatures", &pdd_.physical_device_imageless_framebuffer_features_);
+            GetValue(root, "VkPhysicalDeviceMultiviewFeatures", &pdd_.physical_device_multiview_features_);
+            GetValue(root, "VkPhysicalDeviceSamplerFilterMinmaxProperties",
+                     &pdd_.physical_device_sampler_filter_minmax_properties_);
+            GetValue(root, "VkPhysicalDeviceSamplerYcbcrConversionFeatures",
+                     &pdd_.physical_device_sampler_ycbcr_conversion_features_);
+            GetValue(root, "VkPhysicalDeviceScalarBlockLayoutFeatures", &pdd_.physical_device_scalar_block_layout_features_);
+            GetValue(root, "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures",
+                     &pdd_.physical_device_separate_depth_stencil_layouts_features_);
+            GetValue(root, "VkPhysicalDeviceShaderAtomicInt64Features", &pdd_.physical_device_shader_atomic_int64_features_);
+            GetValue(root, "VkPhysicalDeviceShaderFloat16Int8Features", &pdd_.physical_device_shader_float16_int8_features_);
+            GetValue(root, "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures",
+                     &pdd_.physical_device_shader_subgroup_extended_types_features_);
+            GetValue(root, "VkPhysicalDeviceTimelineSemaphoreFeatures", &pdd_.physical_device_timeline_semaphore_features_);
+            GetValue(root, "VkPhysicalDeviceUniformBufferStandardLayoutFeatures",
+                     &pdd_.physical_device_uniform_buffer_standard_layout_features_);
+            GetValue(root, "VkPhysicalDeviceVariablePointersFeatures", &pdd_.physical_device_variable_pointers_features_);
+            GetValue(root, "VkPhysicalDeviceVulkanMemoryModelFeatures", &pdd_.physical_device_vulkan_memory_model_features_);
+            GetValue(root, "VkPhysicalDeviceMemoryProperties", &pdd_.physical_device_memory_properties_);
+            GetArray(root, "ArrayOfVkQueueFamilyProperties", &pdd_.arrayof_queue_family_properties_);
+            GetArray(root, "ArrayOfVkFormatProperties", &pdd_.arrayof_format_properties_);
+            GetArray(root, "ArrayOfVkLayerProperties", &pdd_.arrayof_layer_properties_);
+            GetArray(root, "ArrayOfVkExtensionProperties", &pdd_.arrayof_extension_properties_);
+
+            GetValue(root, "Vulkan12Features", &pdd_.physical_device_vulkan_1_2_features_);
+            GetValue(root, "Vulkan12Properties", &pdd_.physical_device_vulkan_1_2_properties_);
+            result = true;
+            break;
+
         case SchemaId::kDevsim8BitStorageKHR:
             if (!PhysicalDeviceData::HasExtension(&pdd_, VK_KHR_8BIT_STORAGE_EXTENSION_NAME)) {
                 ErrorPrintf(
@@ -1455,6 +1510,8 @@ JsonLoader::SchemaId JsonLoader::IdentifySchema(const Json::Value &value) {
         schema_id = SchemaId::kDevsim100;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_1_1_0.json#") == 0) {
         schema_id = SchemaId::kDevsim110;
+    } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_1_2_0.json#") == 0) {
+        schema_id = SchemaId::kDevsim120;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_8bit_storage_1.json#") == 0) {
         schema_id = SchemaId::kDevsim8BitStorageKHR;
     } else if (strcmp(schema_string, "https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json#") == 0) {
@@ -2154,6 +2211,28 @@ void JsonLoader::GetValue(const Json::Value &parent, int index, VkExtensionPrope
     GET_VALUE(specVersion);
 }
 
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVulkan12Properties *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    GET_VALUE(framebufferIntegerColorSampleCounts);
+}
+
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceVulkan12Features *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    GET_VALUE_WARN(samplerMirrorClampToEdge, WarnIfGreater);
+    GET_VALUE_WARN(shaderOutputViewportIndex, WarnIfGreater);
+    GET_VALUE_WARN(shaderOutputLayer, WarnIfGreater);
+    GET_VALUE_WARN(subgroupBroadcastDynamicId, WarnIfGreater);
+    GET_VALUE_WARN(drawIndirectCount, WarnIfGreater);
+    GET_VALUE_WARN(descriptorIndexing, WarnIfGreater);
+    GET_VALUE_WARN(samplerFilterMinmax, WarnIfGreater);
+}
+
 #undef GET_VALUE
 #undef GET_ARRAY
 
@@ -2289,8 +2368,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
 
     const VkApplicationInfo *app_info = pCreateInfo->pApplicationInfo;
     const uint32_t requested_version = (app_info && app_info->apiVersion) ? app_info->apiVersion : VK_API_VERSION_1_0;
-    if (requested_version > VK_API_VERSION_1_1) {
-        DebugPrintf("%s currently only supports VK_API_VERSION_1_1 and lower.\n", kOurLayerName);
+    if (requested_version > VK_API_VERSION_1_2) {
+        DebugPrintf("%s currently only supports VK_API_VERSION_1_2 and lower.\n", kOurLayerName);
     }
 
     std::lock_guard<std::mutex> lock(global_lock);
@@ -2533,6 +2612,18 @@ void FillPNextChain(PhysicalDeviceData *physicalDeviceData, void *place) {
             void *pNext = v11f->pNext;
             *v11f = physicalDeviceData->physical_device_vulkan_1_1_features_;
             v11f->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES &&
+                   physicalDeviceData->physical_device_properties_.apiVersion >= VK_API_VERSION_1_2) {
+            VkPhysicalDeviceVulkan12Properties *v12p = (VkPhysicalDeviceVulkan12Properties *)place;
+            void *pNext = v12p->pNext;
+            *v12p = physicalDeviceData->physical_device_vulkan_1_2_properties_;
+            v12p->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES &&
+                   physicalDeviceData->physical_device_properties_.apiVersion >= VK_API_VERSION_1_2) {
+            VkPhysicalDeviceVulkan12Features *v12f = (VkPhysicalDeviceVulkan12Features *)place;
+            void *pNext = v12f->pNext;
+            *v12f = physicalDeviceData->physical_device_vulkan_1_2_features_;
+            v12f->pNext = pNext;
         }
 
         place = structure->pNext;
@@ -2804,6 +2895,195 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevi
     return result;
 }
 
+#define TRANSFER_VALUE(name) dest->name = src->name
+
+// VK_VULKAN_1_1
+
+// Properties
+void TransferValue(VkPhysicalDeviceVulkan11Properties *dest, VkPhysicalDevicePointClippingPropertiesKHR *src) {
+    TRANSFER_VALUE(pointClippingBehavior);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan11Properties *dest, VkPhysicalDeviceMultiviewPropertiesKHR *src) {
+    TRANSFER_VALUE(maxMultiviewViewCount);
+    TRANSFER_VALUE(maxMultiviewInstanceIndex);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan11Properties *dest, VkPhysicalDeviceMaintenance3PropertiesKHR *src) {
+    TRANSFER_VALUE(maxPerSetDescriptors);
+    TRANSFER_VALUE(maxMemoryAllocationSize);
+}
+
+// Features
+void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDevice16BitStorageFeaturesKHR *src) {
+    TRANSFER_VALUE(storageBuffer16BitAccess);
+    TRANSFER_VALUE(uniformAndStorageBuffer16BitAccess);
+    TRANSFER_VALUE(storagePushConstant16);
+    TRANSFER_VALUE(storageInputOutput16);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDeviceMultiviewFeaturesKHR *src) {
+    TRANSFER_VALUE(multiview);
+    TRANSFER_VALUE(multiviewGeometryShader);
+    TRANSFER_VALUE(multiviewTessellationShader);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR *src) {
+    TRANSFER_VALUE(samplerYcbcrConversion);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDeviceVariablePointersFeaturesKHR *src) {
+    TRANSFER_VALUE(variablePointersStorageBuffer);
+    TRANSFER_VALUE(variablePointers);
+}
+
+// VK_VULKAN_1_2
+
+// Properties
+void TransferValue(VkPhysicalDeviceVulkan12Properties *dest, VkPhysicalDeviceDepthStencilResolvePropertiesKHR *src) {
+    TRANSFER_VALUE(supportedDepthResolveModes);
+    TRANSFER_VALUE(supportedStencilResolveModes);
+    TRANSFER_VALUE(independentResolveNone);
+    TRANSFER_VALUE(independentResolve);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Properties *dest, VkPhysicalDeviceDescriptorIndexingPropertiesEXT *src) {
+    TRANSFER_VALUE(maxUpdateAfterBindDescriptorsInAllPools);
+    TRANSFER_VALUE(shaderUniformBufferArrayNonUniformIndexingNative);
+    TRANSFER_VALUE(shaderSampledImageArrayNonUniformIndexingNative);
+    TRANSFER_VALUE(shaderStorageBufferArrayNonUniformIndexingNative);
+    TRANSFER_VALUE(shaderStorageImageArrayNonUniformIndexingNative);
+    TRANSFER_VALUE(shaderInputAttachmentArrayNonUniformIndexingNative);
+    TRANSFER_VALUE(robustBufferAccessUpdateAfterBind);
+    TRANSFER_VALUE(quadDivergentImplicitLod);
+    TRANSFER_VALUE(maxPerStageDescriptorUpdateAfterBindSamplers);
+    TRANSFER_VALUE(maxPerStageDescriptorUpdateAfterBindUniformBuffers);
+    TRANSFER_VALUE(maxPerStageDescriptorUpdateAfterBindStorageBuffers);
+    TRANSFER_VALUE(maxPerStageDescriptorUpdateAfterBindSampledImages);
+    TRANSFER_VALUE(maxPerStageDescriptorUpdateAfterBindStorageImages);
+    TRANSFER_VALUE(maxPerStageDescriptorUpdateAfterBindInputAttachments);
+    TRANSFER_VALUE(maxPerStageUpdateAfterBindResources);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindSamplers);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindUniformBuffers);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindUniformBuffersDynamic);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindStorageBuffers);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindStorageBuffersDynamic);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindSampledImages);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindStorageImages);
+    TRANSFER_VALUE(maxDescriptorSetUpdateAfterBindInputAttachments);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Properties *dest, VkPhysicalDeviceFloatControlsPropertiesKHR *src) {
+    TRANSFER_VALUE(denormBehaviorIndependence);
+    TRANSFER_VALUE(roundingModeIndependence);
+    TRANSFER_VALUE(shaderSignedZeroInfNanPreserveFloat16);
+    TRANSFER_VALUE(shaderSignedZeroInfNanPreserveFloat32);
+    TRANSFER_VALUE(shaderSignedZeroInfNanPreserveFloat64);
+    TRANSFER_VALUE(shaderDenormPreserveFloat16);
+    TRANSFER_VALUE(shaderDenormPreserveFloat32);
+    TRANSFER_VALUE(shaderDenormPreserveFloat64);
+    TRANSFER_VALUE(shaderDenormFlushToZeroFloat16);
+    TRANSFER_VALUE(shaderDenormFlushToZeroFloat32);
+    TRANSFER_VALUE(shaderDenormFlushToZeroFloat64);
+    TRANSFER_VALUE(shaderRoundingModeRTEFloat16);
+    TRANSFER_VALUE(shaderRoundingModeRTEFloat32);
+    TRANSFER_VALUE(shaderRoundingModeRTEFloat64);
+    TRANSFER_VALUE(shaderRoundingModeRTZFloat16);
+    TRANSFER_VALUE(shaderRoundingModeRTZFloat32);
+    TRANSFER_VALUE(shaderRoundingModeRTZFloat64);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Properties *dest, VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT *src) {
+    TRANSFER_VALUE(filterMinmaxSingleComponentFormats);
+    TRANSFER_VALUE(filterMinmaxImageComponentMapping);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Properties *dest, VkPhysicalDeviceTimelineSemaphorePropertiesKHR *src) {
+    TRANSFER_VALUE(maxTimelineSemaphoreValueDifference);
+}
+
+// Features
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDevice8BitStorageFeaturesKHR *src) {
+    TRANSFER_VALUE(storageBuffer8BitAccess);
+    TRANSFER_VALUE(uniformAndStorageBuffer8BitAccess);
+    TRANSFER_VALUE(storagePushConstant8);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceBufferDeviceAddressFeaturesKHR *src) {
+    TRANSFER_VALUE(bufferDeviceAddress);
+    TRANSFER_VALUE(bufferDeviceAddressCaptureReplay);
+    TRANSFER_VALUE(bufferDeviceAddressMultiDevice);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceDescriptorIndexingFeaturesEXT *src) {
+    TRANSFER_VALUE(shaderInputAttachmentArrayDynamicIndexing);
+    TRANSFER_VALUE(shaderUniformTexelBufferArrayDynamicIndexing);
+    TRANSFER_VALUE(shaderStorageTexelBufferArrayDynamicIndexing);
+    TRANSFER_VALUE(shaderUniformBufferArrayNonUniformIndexing);
+    TRANSFER_VALUE(shaderSampledImageArrayNonUniformIndexing);
+    TRANSFER_VALUE(shaderStorageBufferArrayNonUniformIndexing);
+    TRANSFER_VALUE(shaderStorageImageArrayNonUniformIndexing);
+    TRANSFER_VALUE(shaderInputAttachmentArrayNonUniformIndexing);
+    TRANSFER_VALUE(shaderUniformTexelBufferArrayNonUniformIndexing);
+    TRANSFER_VALUE(shaderStorageTexelBufferArrayNonUniformIndexing);
+    TRANSFER_VALUE(descriptorBindingUniformBufferUpdateAfterBind);
+    TRANSFER_VALUE(descriptorBindingSampledImageUpdateAfterBind);
+    TRANSFER_VALUE(descriptorBindingStorageImageUpdateAfterBind);
+    TRANSFER_VALUE(descriptorBindingStorageBufferUpdateAfterBind);
+    TRANSFER_VALUE(descriptorBindingUniformTexelBufferUpdateAfterBind);
+    TRANSFER_VALUE(descriptorBindingStorageTexelBufferUpdateAfterBind);
+    TRANSFER_VALUE(descriptorBindingUpdateUnusedWhilePending);
+    TRANSFER_VALUE(descriptorBindingPartiallyBound);
+    TRANSFER_VALUE(descriptorBindingVariableDescriptorCount);
+    TRANSFER_VALUE(runtimeDescriptorArray);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceHostQueryResetFeaturesEXT *src) {
+    TRANSFER_VALUE(hostQueryReset);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceImagelessFramebufferFeaturesKHR *src) {
+    TRANSFER_VALUE(imagelessFramebuffer);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceScalarBlockLayoutFeaturesEXT *src) {
+    TRANSFER_VALUE(scalarBlockLayout);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR *src) {
+    TRANSFER_VALUE(separateDepthStencilLayouts);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *src) {
+    TRANSFER_VALUE(shaderBufferInt64Atomics);
+    TRANSFER_VALUE(shaderSharedInt64Atomics);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *src) {
+    TRANSFER_VALUE(shaderFloat16);
+    TRANSFER_VALUE(shaderInt8);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR *src) {
+    TRANSFER_VALUE(shaderSubgroupExtendedTypes);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *src) {
+    TRANSFER_VALUE(timelineSemaphore);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR *src) {
+    TRANSFER_VALUE(uniformBufferStandardLayout);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan12Features *dest, VkPhysicalDeviceVulkanMemoryModelFeaturesKHR *src) {
+    TRANSFER_VALUE(vulkanMemoryModel);
+    TRANSFER_VALUE(vulkanMemoryModelDeviceScope);
+    TRANSFER_VALUE(vulkanMemoryModelAvailabilityVisibilityChains);
+}
+
+#undef TRANSFER_VALUE
+
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
                                                         VkPhysicalDevice *pPhysicalDevices) {
     // Our layer-specific initialization...
@@ -3014,6 +3294,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
                 }
 
                 if (api_version_above_1_2) {
+                    // VK_VULKAN_1_1
                     pdd.physical_device_vulkan_1_1_properties_.pNext = property_chain.pNext;
 
                     property_chain.pNext = &(pdd.physical_device_vulkan_1_1_properties_);
@@ -3021,6 +3302,15 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
                     pdd.physical_device_vulkan_1_1_features_.pNext = feature_chain.pNext;
 
                     feature_chain.pNext = &(pdd.physical_device_vulkan_1_1_features_);
+
+                    // VK_VULKAN_1_2
+                    pdd.physical_device_vulkan_1_2_properties_.pNext = property_chain.pNext;
+
+                    property_chain.pNext = &(pdd.physical_device_vulkan_1_2_properties_);
+
+                    pdd.physical_device_vulkan_1_2_features_.pNext = feature_chain.pNext;
+
+                    feature_chain.pNext = &(pdd.physical_device_vulkan_1_2_features_);
                 }
 
                 dt->GetPhysicalDeviceProperties2KHR(physical_device, &property_chain);
@@ -3041,36 +3331,39 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
             JsonLoader json_loader(pdd);
             json_loader.LoadFiles();
 
-            pdd.physical_device_vulkan_1_1_properties_.pointClippingBehavior =
-                pdd.physical_device_point_clipping_properties_.pointClippingBehavior;
-            pdd.physical_device_vulkan_1_1_properties_.maxMultiviewViewCount =
-                pdd.physical_device_multiview_properties_.maxMultiviewViewCount;
-            pdd.physical_device_vulkan_1_1_properties_.maxMultiviewInstanceIndex =
-                pdd.physical_device_multiview_properties_.maxMultiviewInstanceIndex;
-            pdd.physical_device_vulkan_1_1_properties_.maxPerSetDescriptors =
-                pdd.physical_device_maintenance_3_properties_.maxPerSetDescriptors;
-            pdd.physical_device_vulkan_1_1_properties_.maxMemoryAllocationSize =
-                pdd.physical_device_maintenance_3_properties_.maxMemoryAllocationSize;
+            // VK_VULKAN_1_1
+            TransferValue(&(pdd.physical_device_vulkan_1_1_properties_), &(pdd.physical_device_point_clipping_properties_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_properties_), &(pdd.physical_device_multiview_properties_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_properties_), &(pdd.physical_device_maintenance_3_properties_));
 
-            pdd.physical_device_vulkan_1_1_features_.storageBuffer16BitAccess =
-                pdd.physical_device_16bit_storage_features_.storageBuffer16BitAccess;
-            pdd.physical_device_vulkan_1_1_features_.uniformAndStorageBuffer16BitAccess =
-                pdd.physical_device_16bit_storage_features_.uniformAndStorageBuffer16BitAccess;
-            pdd.physical_device_vulkan_1_1_features_.storagePushConstant16 =
-                pdd.physical_device_16bit_storage_features_.storagePushConstant16;
-            pdd.physical_device_vulkan_1_1_features_.storageInputOutput16 =
-                pdd.physical_device_16bit_storage_features_.storageInputOutput16;
-            pdd.physical_device_vulkan_1_1_features_.multiview = pdd.physical_device_multiview_features_.multiview;
-            pdd.physical_device_vulkan_1_1_features_.multiviewGeometryShader =
-                pdd.physical_device_multiview_features_.multiviewGeometryShader;
-            pdd.physical_device_vulkan_1_1_features_.multiviewTessellationShader =
-                pdd.physical_device_multiview_features_.multiviewTessellationShader;
-            pdd.physical_device_vulkan_1_1_features_.variablePointersStorageBuffer =
-                pdd.physical_device_variable_pointers_features_.variablePointersStorageBuffer;
-            pdd.physical_device_vulkan_1_1_features_.variablePointers =
-                pdd.physical_device_variable_pointers_features_.variablePointers;
-            pdd.physical_device_vulkan_1_1_features_.samplerYcbcrConversion =
-                pdd.physical_device_sampler_ycbcr_conversion_features_.samplerYcbcrConversion;
+            TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_16bit_storage_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_multiview_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_sampler_ycbcr_conversion_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_variable_pointers_features_));
+
+            // VK_VULKAN_1_2
+            TransferValue(&(pdd.physical_device_vulkan_1_2_properties_), &(pdd.physical_device_depth_stencil_resolve_properties_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_properties_), &(pdd.physical_device_descriptor_indexing_properties_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_properties_), &(pdd.physical_device_float_controls_properties_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_properties_), &(pdd.physical_device_sampler_filter_minmax_properties_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_properties_), &(pdd.physical_device_timeline_semaphore_properties_));
+
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_8bit_storage_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_buffer_device_address_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_descriptor_indexing_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_host_query_reset_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_imageless_framebuffer_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_scalar_block_layout_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_),
+                          &(pdd.physical_device_separate_depth_stencil_layouts_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_shader_atomic_int64_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_shader_float16_int8_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_),
+                          &(pdd.physical_device_shader_subgroup_extended_types_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_timeline_semaphore_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_),
+                          &(pdd.physical_device_uniform_buffer_standard_layout_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_2_features_), &(pdd.physical_device_vulkan_memory_model_features_));
         }
         pdd_initialized = true;
     }

--- a/layersvt/device_simulation.cpp
+++ b/layersvt/device_simulation.cpp
@@ -586,6 +586,12 @@ class PhysicalDeviceData {
     VkPhysicalDeviceVulkan12Properties physical_device_vulkan_1_2_properties_;
     VkPhysicalDeviceVulkan12Features physical_device_vulkan_1_2_features_;
 
+    // Vulkan 1.1 structs
+    VkPhysicalDeviceProtectedMemoryProperties physical_device_protected_memory_properties_;
+    VkPhysicalDeviceProtectedMemoryFeatures physical_device_protected_memory_features_;
+
+    VkPhysicalDeviceShaderDrawParametersFeatures physical_device_shader_draw_parameters_features_;
+
     // VK_KHR_8bit_storage structs
     VkPhysicalDevice8BitStorageFeaturesKHR physical_device_8bit_storage_features_;
 
@@ -673,6 +679,12 @@ class PhysicalDeviceData {
 
         physical_device_vulkan_1_2_properties_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES};
         physical_device_vulkan_1_2_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};
+
+        // Vulkan 1.1 structs
+        physical_device_protected_memory_properties_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES};
+        physical_device_protected_memory_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES};
+
+        physical_device_shader_draw_parameters_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES};
 
         // VK_KHR_8bit_storage structs
         physical_device_8bit_storage_features_ = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR};
@@ -815,6 +827,7 @@ class JsonLoader {
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceMultiviewPropertiesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDevicePointClippingPropertiesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDevicePortabilitySubsetPropertiesKHR *dest);
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceProtectedMemoryProperties *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceTimelineSemaphorePropertiesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceLimits *dest);
@@ -828,10 +841,12 @@ class JsonLoader {
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceImagelessFramebufferFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceMultiviewFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDevicePortabilitySubsetFeaturesKHR *dest);
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceProtectedMemoryFeatures *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceScalarBlockLayoutFeaturesEXT *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderAtomicInt64FeaturesKHR *dest);
+    void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderDrawParametersFeatures *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR *dest);
     void GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *dest);
@@ -1170,11 +1185,14 @@ bool JsonLoader::LoadFile(const char *filename) {
             GetValue(root, "VkPhysicalDeviceMaintenance3Properties", &pdd_.physical_device_maintenance_3_properties_);
             GetValue(root, "VkPhysicalDeviceMultiviewProperties", &pdd_.physical_device_multiview_properties_);
             GetValue(root, "VkPhysicalDevicePointClippingProperties", &pdd_.physical_device_point_clipping_properties_);
+            GetValue(root, "VkPhysicalDeviceProtectedMemoryProperties", &pdd_.physical_device_protected_memory_properties_);
             GetValue(root, "VkPhysicalDeviceFeatures", &pdd_.physical_device_features_);
             GetValue(root, "VkPhysicalDevice16BitStorageFeatures", &pdd_.physical_device_16bit_storage_features_);
             GetValue(root, "VkPhysicalDeviceMultiviewFeatures", &pdd_.physical_device_multiview_features_);
+            GetValue(root, "VkPhysicalDeviceProtectedMemoryFeatures", &pdd_.physical_device_protected_memory_features_);
             GetValue(root, "VkPhysicalDeviceSamplerYcbcrConversionFeatures",
                 &pdd_.physical_device_sampler_ycbcr_conversion_features_);
+            GetValue(root, "VkPhysicalDeviceShaderDrawParametersFeatures", &pdd_.physical_device_shader_draw_parameters_features_);
             GetValue(root, "VkPhysicalDeviceVariablePointersFeatures", &pdd_.physical_device_variable_pointers_features_);
             GetValue(root, "VkPhysicalDeviceMemoryProperties", &pdd_.physical_device_memory_properties_);
             GetArray(root, "ArrayOfVkQueueFamilyProperties", &pdd_.arrayof_queue_family_properties_);
@@ -1194,6 +1212,7 @@ bool JsonLoader::LoadFile(const char *filename) {
             GetValue(root, "VkPhysicalDeviceMaintenance3Properties", &pdd_.physical_device_maintenance_3_properties_);
             GetValue(root, "VkPhysicalDeviceMultiviewProperties", &pdd_.physical_device_multiview_properties_);
             GetValue(root, "VkPhysicalDevicePointClippingProperties", &pdd_.physical_device_point_clipping_properties_);
+            GetValue(root, "VkPhysicalDeviceProtectedMemoryProperties", &pdd_.physical_device_protected_memory_properties_);
             GetValue(root, "VkPhysicalDeviceTimelineSemaphoreProperties", &pdd_.physical_device_timeline_semaphore_properties_);
             GetValue(root, "VkPhysicalDeviceFeatures", &pdd_.physical_device_features_);
             GetValue(root, "VkPhysicalDevice16BitStorageFeatures", &pdd_.physical_device_16bit_storage_features_);
@@ -1202,6 +1221,7 @@ bool JsonLoader::LoadFile(const char *filename) {
             GetValue(root, "VkPhysicalDeviceDescriptorIndexingFeatures", &pdd_.physical_device_descriptor_indexing_features_);
             GetValue(root, "VkPhysicalDeviceImagelessFramebufferFeatures", &pdd_.physical_device_imageless_framebuffer_features_);
             GetValue(root, "VkPhysicalDeviceMultiviewFeatures", &pdd_.physical_device_multiview_features_);
+            GetValue(root, "VkPhysicalDeviceProtectedMemoryFeatures", &pdd_.physical_device_protected_memory_features_);
             GetValue(root, "VkPhysicalDeviceSamplerFilterMinmaxProperties",
                      &pdd_.physical_device_sampler_filter_minmax_properties_);
             GetValue(root, "VkPhysicalDeviceSamplerYcbcrConversionFeatures",
@@ -1210,6 +1230,7 @@ bool JsonLoader::LoadFile(const char *filename) {
             GetValue(root, "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures",
                      &pdd_.physical_device_separate_depth_stencil_layouts_features_);
             GetValue(root, "VkPhysicalDeviceShaderAtomicInt64Features", &pdd_.physical_device_shader_atomic_int64_features_);
+            GetValue(root, "VkPhysicalDeviceShaderDrawParametersFeatures", &pdd_.physical_device_shader_draw_parameters_features_);
             GetValue(root, "VkPhysicalDeviceShaderFloat16Int8Features", &pdd_.physical_device_shader_float16_int8_features_);
             GetValue(root, "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures",
                      &pdd_.physical_device_shader_subgroup_extended_types_features_);
@@ -1700,6 +1721,15 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysica
     GET_VALUE_WARN(minVertexInputBindingStrideAlignment, WarnIfLesser);
 }
 
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceProtectedMemoryProperties *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceProtectedMemoryProperties)\n");
+    GET_VALUE_WARN(protectedNoFault, WarnIfLesser);
+}
+
 void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT *dest) {
     const Json::Value value = parent[name];
     if (value.type() != Json::objectValue) {
@@ -2021,6 +2051,15 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysica
     GET_VALUE_WARN(vertexAttributeAccessBeyondStride, WarnIfGreater);
 }
 
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceProtectedMemoryFeatures *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceProtectedMemoryFeatures)\n");
+    GET_VALUE_WARN(protectedMemory, WarnIfLesser);
+}
+
 void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR *dest) {
     const Json::Value value = parent[name];
     if (value.type() != Json::objectValue) {
@@ -2057,6 +2096,15 @@ void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysica
     DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceShaderAtomicInt64FeaturesKHR)\n");
     GET_VALUE_WARN(shaderBufferInt64Atomics, WarnIfGreater);
     GET_VALUE_WARN(shaderSharedInt64Atomics, WarnIfGreater);
+}
+
+void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderDrawParametersFeatures *dest) {
+    const Json::Value value = parent[name];
+    if (value.type() != Json::objectValue) {
+        return;
+    }
+    DebugPrintf("\t\tJsonLoader::GetValue(VkPhysicalDeviceShaderAtomicInt64FeaturesKHR)\n");
+    GET_VALUE_WARN(shaderDrawParameters, WarnIfGreater);
 }
 
 void JsonLoader::GetValue(const Json::Value &parent, const char *name, VkPhysicalDeviceShaderFloat16Int8FeaturesKHR *dest) {
@@ -2600,6 +2648,24 @@ void FillPNextChain(PhysicalDeviceData *physicalDeviceData, void *place) {
             void *pNext = vmmf->pNext;
             *vmmf = physicalDeviceData->physical_device_vulkan_memory_model_features_;
             vmmf->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES &&
+                   physicalDeviceData->physical_device_properties_.apiVersion >= VK_API_VERSION_1_1) {
+            VkPhysicalDeviceProtectedMemoryProperties *pmp = (VkPhysicalDeviceProtectedMemoryProperties *)place;
+            void *pNext = pmp->pNext;
+            *pmp = physicalDeviceData->physical_device_protected_memory_properties_;
+            pmp->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES &&
+                   physicalDeviceData->physical_device_properties_.apiVersion >= VK_API_VERSION_1_1) {
+            VkPhysicalDeviceProtectedMemoryFeatures *pmf = (VkPhysicalDeviceProtectedMemoryFeatures *)place;
+            void *pNext = pmf->pNext;
+            *pmf = physicalDeviceData->physical_device_protected_memory_features_;
+            pmf->pNext = pNext;
+        } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES &&
+                   physicalDeviceData->physical_device_properties_.apiVersion >= VK_API_VERSION_1_1) {
+            VkPhysicalDeviceShaderDrawParametersFeatures *sdpf = (VkPhysicalDeviceShaderDrawParametersFeatures *)place;
+            void *pNext = sdpf->pNext;
+            *sdpf = physicalDeviceData->physical_device_shader_draw_parameters_features_;
+            sdpf->pNext = pNext;
         } else if (structure->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES &&
                    physicalDeviceData->physical_device_properties_.apiVersion >= VK_API_VERSION_1_2) {
             VkPhysicalDeviceVulkan11Properties *v11p = (VkPhysicalDeviceVulkan11Properties *)place;
@@ -2914,6 +2980,10 @@ void TransferValue(VkPhysicalDeviceVulkan11Properties *dest, VkPhysicalDeviceMai
     TRANSFER_VALUE(maxMemoryAllocationSize);
 }
 
+void TransferValue(VkPhysicalDeviceVulkan11Properties *dest, VkPhysicalDeviceProtectedMemoryProperties *src) {
+    TRANSFER_VALUE(protectedNoFault);
+}
+
 // Features
 void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDevice16BitStorageFeaturesKHR *src) {
     TRANSFER_VALUE(storageBuffer16BitAccess);
@@ -2935,6 +3005,14 @@ void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDeviceSampl
 void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDeviceVariablePointersFeaturesKHR *src) {
     TRANSFER_VALUE(variablePointersStorageBuffer);
     TRANSFER_VALUE(variablePointers);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDeviceProtectedMemoryFeatures *src) {
+    TRANSFER_VALUE(protectedMemory);
+}
+
+void TransferValue(VkPhysicalDeviceVulkan11Features *dest, VkPhysicalDeviceShaderDrawParametersFeatures *src) {
+    TRANSFER_VALUE(shaderDrawParameters);
 }
 
 // VK_VULKAN_1_2
@@ -3115,6 +3193,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
             });
 
             dt->GetPhysicalDeviceProperties(physical_device, &pdd.physical_device_properties_);
+            bool api_version_above_1_1 = pdd.physical_device_properties_.apiVersion >= VK_API_VERSION_1_1;
             bool api_version_above_1_2 = pdd.physical_device_properties_.apiVersion >= VK_API_VERSION_1_2;
 
             // Initialize PDD members to the actual Vulkan implementation's defaults.
@@ -3293,6 +3372,18 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
                     feature_chain.pNext = &(pdd.physical_device_vulkan_memory_model_features_);
                 }
 
+                if (api_version_above_1_1) {
+                    pdd.physical_device_protected_memory_properties_.pNext = property_chain.pNext;
+
+                    property_chain.pNext = &(pdd.physical_device_protected_memory_properties_);
+
+                    pdd.physical_device_protected_memory_features_.pNext = feature_chain.pNext;
+
+                    pdd.physical_device_shader_draw_parameters_features_.pNext = &(pdd.physical_device_protected_memory_features_);
+
+                    feature_chain.pNext = &(pdd.physical_device_shader_draw_parameters_features_);
+                }
+
                 if (api_version_above_1_2) {
                     // VK_VULKAN_1_1
                     pdd.physical_device_vulkan_1_1_properties_.pNext = property_chain.pNext;
@@ -3335,11 +3426,14 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
             TransferValue(&(pdd.physical_device_vulkan_1_1_properties_), &(pdd.physical_device_point_clipping_properties_));
             TransferValue(&(pdd.physical_device_vulkan_1_1_properties_), &(pdd.physical_device_multiview_properties_));
             TransferValue(&(pdd.physical_device_vulkan_1_1_properties_), &(pdd.physical_device_maintenance_3_properties_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_properties_), &(pdd.physical_device_protected_memory_properties_));
 
             TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_16bit_storage_features_));
             TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_multiview_features_));
             TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_sampler_ycbcr_conversion_features_));
             TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_variable_pointers_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_protected_memory_features_));
+            TransferValue(&(pdd.physical_device_vulkan_1_1_features_), &(pdd.physical_device_shader_draw_parameters_features_));
 
             // VK_VULKAN_1_2
             TransferValue(&(pdd.physical_device_vulkan_1_2_properties_), &(pdd.physical_device_depth_stencil_resolve_properties_));

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -99,6 +99,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_8bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_8bit_storage_1.json# |
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_buffer_device_address | https://schema.khronos.org/vulkan/devsim_VK_KHR_buffer_device_address_1.json# |
+| VK_KHR_depth_stencil_resolve | https://schema.khronos.org/vulkan/devsim_VK_KHR_depth_stencil_resolve_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -97,6 +97,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | Vulkan v1.1 | https://schema.khronos.org/vulkan/devsim_1_1_0.json# |
 | VK_KHR_portability_subset | https://schema.khronos.org/vulkan/devsim_VK_KHR_portability_subset-provisional-1.json# |
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
+| VK_KHR_8bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_8bit_storage_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -105,6 +105,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |
 | VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
+| VK_KHR_separate_depth_stencil_layouts | https://schema.khronos.org/vulkan/devsim_VK_KHR_separate_depth_stencil_layouts_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.1 schema.

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -96,8 +96,9 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | Vulkan v1.0 | https://schema.khronos.org/vulkan/devsim_1_0_0.json# |
 | Vulkan v1.1 | https://schema.khronos.org/vulkan/devsim_1_1_0.json# |
 | VK_KHR_portability_subset | https://schema.khronos.org/vulkan/devsim_VK_KHR_portability_subset-provisional-1.json# |
-| VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_8bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_8bit_storage_1.json# |
+| VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
+| VK_KHR_buffer_device_address | https://schema.khronos.org/vulkan/devsim_VK_KHR_buffer_device_address_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -107,6 +107,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
 | VK_KHR_separate_depth_stencil_layouts | https://schema.khronos.org/vulkan/devsim_VK_KHR_separate_depth_stencil_layouts_1.json# |
 | VK_KHR_shader_atomic_int64 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_atomic_int64_1.json# |
+| VK_KHR_shader_float_controls | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float_controls_1.json# |
 | VK_KHR_shader_float16_int8 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float16_int8_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -106,6 +106,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |
 | VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
 | VK_KHR_separate_depth_stencil_layouts | https://schema.khronos.org/vulkan/devsim_VK_KHR_separate_depth_stencil_layouts_1.json# |
+| VK_KHR_shader_atomic_int64 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_atomic_int64_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.1 schema.

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -109,6 +109,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_shader_atomic_int64 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_atomic_int64_1.json# |
 | VK_KHR_shader_float_controls | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float_controls_1.json# |
 | VK_KHR_shader_float16_int8 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float16_int8_1.json# |
+| VK_KHR_shader_subgroup_extended_types | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_subgroup_extended_types_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.1 schema.

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -100,6 +100,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_buffer_device_address | https://schema.khronos.org/vulkan/devsim_VK_KHR_buffer_device_address_1.json# |
 | VK_KHR_depth_stencil_resolve | https://schema.khronos.org/vulkan/devsim_VK_KHR_depth_stencil_resolve_1.json# |
+| VK_KHR_imageless_framebuffer | https://schema.khronos.org/vulkan/devsim_VK_KHR_imageless_framebuffer_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -107,6 +107,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
 | VK_KHR_separate_depth_stencil_layouts | https://schema.khronos.org/vulkan/devsim_VK_KHR_separate_depth_stencil_layouts_1.json# |
 | VK_KHR_shader_atomic_int64 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_atomic_int64_1.json# |
+| VK_KHR_shader_float16_int8 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float16_int8_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.1 schema.

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -111,6 +111,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_shader_float16_int8 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float16_int8_1.json# |
 | VK_KHR_shader_subgroup_extended_types | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_subgroup_extended_types_1.json# |
 | VK_KHR_timeline_semaphore | https://schema.khronos.org/vulkan/devsim_VK_KHR_timeline_semaphore_1.json# |
+| VK_KHR_uniform_buffer_standard_layout | https://schema.khronos.org/vulkan/devsim_VK_KHR_uniform_buffer_standard_layout_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.1 schema.

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -110,6 +110,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_shader_float_controls | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float_controls_1.json# |
 | VK_KHR_shader_float16_int8 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float16_int8_1.json# |
 | VK_KHR_shader_subgroup_extended_types | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_subgroup_extended_types_1.json# |
+| VK_KHR_timeline_semaphore | https://schema.khronos.org/vulkan/devsim_VK_KHR_timeline_semaphore_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.1 schema.

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -100,7 +100,8 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_buffer_device_address | https://schema.khronos.org/vulkan/devsim_VK_KHR_buffer_device_address_1.json# |
 | VK_KHR_depth_stencil_resolve | https://schema.khronos.org/vulkan/devsim_VK_KHR_depth_stencil_resolve_1.json# |
-| VK_KHR_descriptor_indexing | https://schema.khronos.org/vulkan/devsim_VK_KHR_descriptor_indexing_1.json# |
+| VK_EXT_descriptor_indexing | https://schema.khronos.org/vulkan/devsim_VK_EXT_descriptor_indexing_1.json# |
+| VK_EXT_host_query_reset | https://schema.khronos.org/vulkan/devsim_VK_EXT_host_query_reset_1.json# |
 | VK_KHR_imageless_framebuffer | https://schema.khronos.org/vulkan/devsim_VK_KHR_imageless_framebuffer_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -100,6 +100,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
 | VK_KHR_buffer_device_address | https://schema.khronos.org/vulkan/devsim_VK_KHR_buffer_device_address_1.json# |
 | VK_KHR_depth_stencil_resolve | https://schema.khronos.org/vulkan/devsim_VK_KHR_depth_stencil_resolve_1.json# |
+| VK_KHR_descriptor_indexing | https://schema.khronos.org/vulkan/devsim_VK_KHR_descriptor_indexing_1.json# |
 | VK_KHR_imageless_framebuffer | https://schema.khronos.org/vulkan/devsim_VK_KHR_imageless_framebuffer_1.json# |
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -95,6 +95,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 |:----------:|:-------------:|
 | Vulkan v1.0 | https://schema.khronos.org/vulkan/devsim_1_0_0.json# |
 | Vulkan v1.1 | https://schema.khronos.org/vulkan/devsim_1_1_0.json# |
+| Vulkan v1.2 | https://schema.khronos.org/vulkan/devsim_1_2_0.json# |
 | VK_KHR_portability_subset | https://schema.khronos.org/vulkan/devsim_VK_KHR_portability_subset-provisional-1.json# |
 | VK_KHR_8bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_8bit_storage_1.json# |
 | VK_KHR_16bit_storage | https://schema.khronos.org/vulkan/devsim_VK_KHR_16bit_storage_1.json# |
@@ -119,24 +120,43 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
 | VK_KHR_vulkan_memory_model | https://schema.khronos.org/vulkan/devsim_VK_KHR_vulkan_memory_model_1.json# |
 
-Usually you will be using configuration files validated with the Vulkan v1.1 schema.
+Usually you will be using configuration files validated with the Vulkan v1.2 schema.
 
 The top-level sections of such configuration files are processed as follows:
 * `$schema` - Mandatory.  Must be the URI string referencing the JSON schema.
 * `comments` - Optional.  May contain arbitrary comments, description, copyright, etc.
 * `VkPhysicalDeviceProperties` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceDepthStencilResolveProperties` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceDescriptorIndexingProperties` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceFloatControlsProperties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceMaintenance3Properties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceMultiviewProperties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDevicePointClippingProperties` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceSamplerFilterMinmaxProperties` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceTimelineSemaphoreProperties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDevice16BitStorageFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDevice8BitStorageFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceDescriptorIndexingFeatures`
+* `VkPhysicalDeviceHostQueryResetFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceImagelessFramebufferFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceMultiviewFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceSamplerYcbcrConversionFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceScalarBlockLayoutFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceShaderAtomicInt64Features` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceShaderFloat16Int8Features` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceTimelineSemaphoreFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceUniformBufferStandardLayoutFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceVariablePointersFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceVulkanMemoryModelFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceMemoryProperties` - Optional.  Only values specified in the JSON will be modified.
 * `ArrayOfVkQueueFamilyProperties` - Optional.  If present, all values of all elements must be specified.
 * `ArrayOfVkFormatProperties` - Optional.  If present, all values of all elements must be specified.
 * `ArrayOfVkExtensionProperties` - Optional.  If present, all values of all elements must be specified. Modifies the list returned by `vkEnumerateDeviceExtensionProperties`.
+* `Vulkan12Features` - Optional.  Only values specified in the JSON will be modified.
+* `Vulkan12Properties` - Optional.  Only values specified in the JSON will be modified.
 * The remaining top-level sections of the schema are not yet supported by DevSim.
 
 The schema permits additional top-level sections to be optionally included in configuration files;
@@ -146,7 +166,7 @@ The schemas define basic range checking for common Vulkan data types, but they c
 If a configuration defines capabilities beyond what the actual device is natively capable of providing, the results are undefined.
 DevSim has some simple checking of configuration values and writes debug messages (if enabled) for values that are incompatible with the capabilities of the actual device.
 
-This version of DevSim currently supports Vulkan v1.0 and v1.1.
+This version of DevSim currently supports Vulkan v1.2 and below.
 If the application requests an unsupported version of the Vulkan API, DevSim will emit an error message.
 If you wish DevSim to terminate on errors, set the `VK_DEVSIM_EXIT_ON_ERROR` environment variable (see below).
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -113,6 +113,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_timeline_semaphore | https://schema.khronos.org/vulkan/devsim_VK_KHR_timeline_semaphore_1.json# |
 | VK_KHR_uniform_buffer_standard_layout | https://schema.khronos.org/vulkan/devsim_VK_KHR_uniform_buffer_standard_layout_1.json# |
 | VK_KHR_variable_pointers | https://schema.khronos.org/vulkan/devsim_VK_KHR_variable_pointers_1.json# |
+| VK_KHR_vulkan_memory_model | https://schema.khronos.org/vulkan/devsim_VK_KHR_vulkan_memory_model_1.json# |
 
 Usually you will be using configuration files validated with the Vulkan v1.1 schema.
 

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -108,6 +108,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |
 | VK_EXT_sampler_filter_minmax | https://schema.khronos.org/vulkan/devsim_VK_EXT_sampler_filter_minmax_1.json# |
 | VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
+| VK_EXT_scalar_block_layout | https://schema.khronos.org/vulkan/devsim_VK_EXT_scalar_block_layout_1.json# |
 | VK_KHR_separate_depth_stencil_layouts | https://schema.khronos.org/vulkan/devsim_VK_KHR_separate_depth_stencil_layouts_1.json# |
 | VK_KHR_shader_atomic_int64 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_atomic_int64_1.json# |
 | VK_KHR_shader_float_controls | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_float_controls_1.json# |

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -132,19 +132,22 @@ The top-level sections of such configuration files are processed as follows:
 * `VkPhysicalDeviceMaintenance3Properties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceMultiviewProperties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDevicePointClippingProperties` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceProtectedMemoryProperties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceSamplerFilterMinmaxProperties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceTimelineSemaphoreProperties` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDevice16BitStorageFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDevice8BitStorageFeatures` - Optional.  Only values specified in the JSON will be modified.
-* `VkPhysicalDeviceDescriptorIndexingFeatures`
+* `VkPhysicalDeviceDescriptorIndexingFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceHostQueryResetFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceImagelessFramebufferFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceMultiviewFeatures` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceProtectedMemoryFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceSamplerYcbcrConversionFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceScalarBlockLayoutFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceShaderAtomicInt64Features` - Optional.  Only values specified in the JSON will be modified.
+* `VkPhysicalDeviceShaderDrawParametersFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceShaderFloat16Int8Features` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures` - Optional.  Only values specified in the JSON will be modified.
 * `VkPhysicalDeviceTimelineSemaphoreFeatures` - Optional.  Only values specified in the JSON will be modified.

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -106,6 +106,7 @@ JSON file formats consumed by the DevSim layer are specified by one of the JSON 
 | VK_KHR_maintenance2 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance2_1.json# |
 | VK_KHR_maintenance3 | https://schema.khronos.org/vulkan/devsim_VK_KHR_maintenance3_1.json# |
 | VK_KHR_multiview | https://schema.khronos.org/vulkan/devsim_VK_KHR_multiview_1.json# |
+| VK_EXT_sampler_filter_minmax | https://schema.khronos.org/vulkan/devsim_VK_EXT_sampler_filter_minmax_1.json# |
 | VK_KHR_sampler_ycbcr_conversion | https://schema.khronos.org/vulkan/devsim_VK_KHR_sampler_ycbcr_conversion_1.json# |
 | VK_KHR_separate_depth_stencil_layouts | https://schema.khronos.org/vulkan/devsim_VK_KHR_separate_depth_stencil_layouts_1.json# |
 | VK_KHR_shader_atomic_int64 | https://schema.khronos.org/vulkan/devsim_VK_KHR_shader_atomic_int64_1.json# |


### PR DESCRIPTION
Updated Devsim to modify structs provided by the following extensions:
- `VK_KHR_8bit_storage`
- `VK_KHR_buffer_device_address`
- `VK_KHR_depth_stencil_resolve`
- `VK_KHR_imageless_framebuffer`
- `VK_KHR_separate_depth_stencil_layouts`
- `VK_KHR_shader_atomic_int64`
- `VK_KHR_shader_float16_int8`
- `VK_KHR_shader_float_controls`
- `VK_KHR_shader_subgroup_extended_types`
- `VK_KHR_timeline_semaphore`
- `VK_KHR_uniform_buffer_standard_layout`
- `VK_KHR_vulkan_memory_model`
- `VK_EXT_descriptor_indexing`
- `VK_EXT_host_query_reset`
- `VK_EXT_sampler_filter_minmax`
- `VK_EXT_scalar_block_layout`

The following structs are now modified by the Devsim layer:
- `VkPhysicalDevice8BitStorageFeatures`
- `VkPhysicalDeviceBufferDeviceAddressFeatures`
- `VkPhysicalDeviceDepthStencilResolveProperties`
- `VkPhysicalDeviceImagelessFramebufferFeatures`
- `VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures`
- `VkPhysicalDeviceShaderAtomicInt64Features`
- `VkPhysicalDeviceShaderFloat16Int8Features`
- `VkPhysicalDeviceFloatControlsProperties`
- `VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures`
- `VkPhysicalDeviceTimelineSemaphoreFeatures`
- `VkPhysicalDeviceTimelineSemaphoreProperties`
- `VkPhysicalDeviceUniformBufferStandardLayoutFeatures`
- `VkPhysicalDeviceVulkanMemoryModelFeatures`
- `VkPhysicalDeviceDescriptorIndexingFeatures`
- `VkPhysicalDeviceDescriptorIndexingProperties`
- `VkPhysicalDeviceHostQueryResetFeatures`
- `VkPhysicalDeviceSamplerFilterMinmaxProperties`
- `VkPhysicalDeviceScalarBlockLayoutFeatures`
- `VkPhysicalDeviceVulkan12Properties`
- `VkPhysicalDeviceVulkan12Features`

This PR also adds these additional Vulkan 1.1 structs that were overlooked in the previous Devsim update.
- `VkPhysicalDeviceProtectedMemoryProperties`
- `VkPhysicalDeviceProtectedMemoryFeatures`
- `VkPhysicalDeviceShaderDrawParametersFeatures`

These changes will require new JSON schemas to define new Devsim config file formats.
Schemas and example test config files can be provided on request.