### PR TITLE
devsim: add settings to layer manifest

### DIFF
--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -1,6 +1,6 @@
 {
-    "file_format_version" : "1.1.0",
-    "layer" : {
+    "file_format_version" : "1.4.0",
+    "layer": {
         "name": "VK_LAYER_LUNARG_device_simulation",
         "type": "GLOBAL",
         "library_path": "@RELATIVE_LAYER_BINARY@",
@@ -9,12 +9,117 @@
         "description": "LunarG device simulation layer",
         "device_extensions": [
             {
-                 "name": "VK_EXT_tooling_info",
-                 "spec_version": "1",
-                 "entrypoints": ["vkGetPhysicalDeviceToolPropertiesEXT"
-                        ]
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
+            }
+        ],
+        "presets": [
+            {
+                "label": "macOS portability",
+                "description": "Check the application for Vulkan portability subset.",
+                "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "emulate_portability",
+                        "value": true
+                    },
+                    {
+                        "key": "filename",
+                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                    }
+                ]
+            },
+            {
+                "label": "iOS GPU family 3 portability",
+                "description": "Check the application for Vulkan portability subset.",
+                "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "emulate_portability",
+                        "value": true
+                    },
+                    {
+                        "key": "filename",
+                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
+                    }
+                ]
+            },
+            {
+                "label": "iOS GPU family 5 portability",
+                "description": "Check the application for Vulkan portability subset.",
+                "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                "status": "STABLE",
+                "settings": [
+                    {
+                        "key": "emulate_portability",
+                        "value": true
+                    },
+                    {
+                        "key": "filename",
+                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
+                    }
+                ]
+            }
+        ],
+        "settings": [
+            {
+                "key": "filename",
+                "env": "VK_DEVSIM_FILENAME",
+                "label": "Devsim JSON configuration file",
+                "description": "Path of a devsim configuration file to load.",
+                "type": "LOAD_FILE",
+                "filter": "*.json",
+                "default": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+            },
+            {
+                "key": "debug_enable",
+                "env": "VK_DEVSIM_DEBUG_ENABLE",
+                "label": "Debug Enable",
+                "description": "Enables debug message output.",
+                "type": "BOOL",
+                "default": true
+            },
+            {
+                "key": "emulate_portability",
+                "env": "VK_DEVSIM_EMULATE_PORTABILITY_SUBSET_EXTENSION",
+                "label": "Emulate VK_KHR_portability_subset",
+                "description": "Emulate that VK_KHR_portability_subset extension is supported by the device.",
+                "platforms": [
+                    "WINDOWS",
+                    "LINUX"
+                ],
+                "type": "BOOL",
+                "default": true
+            },
+            {
+                "key": "exit_on_error",
+                "env": "VK_DEVSIM_EXIT_ON_ERROR",
+                "label": "Exit on Error",
+                "description": "Enables exit-on-error.",
+                "type": "BOOL",
+                "default": false
+            },
+            {
+                "key": "modify_extension_list",
+                "env": "VK_DEVSIM_MODIFY_EXTENSION_LIST",
+                "label": "Modify Device Extension list",
+                "description": "Modify the device extensions list from the layer JSON config file.",
+                "type": "BOOL",
+                "default": false
+            },
+            {
+                "key": "modify_memory_flags",
+                "env": "VK_DEVSIM_MODIFY_MEMORY_FLAGS",
+                "label": "Modify Device Memory Flags",
+                "description": "Modify the device memory heap flags and memory type flags from the JSON config file.",
+                "type": "BOOL",
+                "default": false
             }
         ]
-
     }
 }

--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -1,5 +1,5 @@
 {
-    "file_format_version" : "1.4.0",
+    "file_format_version" : "1.2.0",
     "layer": {
         "name": "VK_LAYER_LUNARG_device_simulation",
         "type": "GLOBAL",

--- a/vkconfig/settings_validation_areas.cpp
+++ b/vkconfig/settings_validation_areas.cpp
@@ -152,7 +152,7 @@ SettingsValidationAreas::SettingsValidationAreas(QTreeWidget *main_tree, QTreeWi
                 _gpu_assisted_reserve_box = this->AddItem(_gpu_assisted_box, enum_gpu_assisted_slot, enabled);
             }
 
-            const SettingMetaBool *meta_gpuav_buffer_oob = settings_meta.Get<SettingMetaBool>("gpuav_buffer_oob");
+            const SettingMetaBool *meta_gpuav_buffer_oob = FindSettingMeta<SettingMetaBool>(settings_meta, "gpuav_buffer_oob");
 
             if (meta_gpuav_buffer_oob != nullptr) {
                 _gpu_assisted_oob_box = this->AddItem(_gpu_assisted_box, meta_gpuav_buffer_oob);
@@ -169,17 +169,17 @@ SettingsValidationAreas::SettingsValidationAreas(QTreeWidget *main_tree, QTreeWi
             _debug_printf_radio = new QRadioButton();
             _main_tree_widget->setItemWidget(_debug_printf_box, 0, _debug_printf_radio);
 
-            const SettingMetaBool *meta_printf_to_stdout = settings_meta.Get<SettingMetaBool>("printf_to_stdout");
+            const SettingMetaBool *meta_printf_to_stdout = FindSettingMeta<SettingMetaBool>(settings_meta, "printf_to_stdout");
             if (meta_printf_to_stdout != nullptr) {
                 _debug_printf_to_stdout = this->AddItem(_debug_printf_box, meta_printf_to_stdout);
             }
 
-            const SettingMetaBool *meta_printf_verbose = settings_meta.Get<SettingMetaBool>("printf_verbose");
+            const SettingMetaBool *meta_printf_verbose = FindSettingMeta<SettingMetaBool>(settings_meta, "printf_verbose");
             if (meta_printf_verbose != nullptr) {
                 _debug_printf_verbose = this->AddItem(_debug_printf_box, meta_printf_verbose);
             }
 
-            const SettingMetaInt *meta_printf_buffer_size = settings_meta.Get<SettingMetaInt>("printf_buffer_size");
+            const SettingMetaInt *meta_printf_buffer_size = FindSettingMeta<SettingMetaInt>(settings_meta, "printf_buffer_size");
             if (meta_printf_buffer_size != nullptr) {
                 _debug_printf_buffer_size = new QTreeWidgetItem();
                 _debug_printf_box->addChild(_debug_printf_buffer_size);

--- a/vkconfig/widget_setting_list.cpp
+++ b/vkconfig/widget_setting_list.cpp
@@ -131,7 +131,7 @@ bool WidgetSettingList::eventFilter(QObject *target, QEvent *event) {
 void WidgetSettingList::ResetCompleter() {
     if (this->search != nullptr) this->search->deleteLater();
 
-    this->search = new QCompleter(ConvertValues(list), this);
+    this->search = new QCompleter(ConvertValues(this->list), this);
     this->search->setCaseSensitivity(Qt::CaseSensitive);
     this->search->setCompletionMode(QCompleter::PopupCompletion);
     this->search->setModelSorting(QCompleter::CaseSensitivelySortedModel);

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -6827,18 +6827,91 @@
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
                         "url": "${LUNARG_SDK}/debug_printf.html",
                         "status": "STABLE",
-                        "platforms": [ "WINDOWS", "LINUX" ]
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "printf_to_stdout",
+                                "label": "Printf to stdout",
+                                "description": "To redirect Debug Printf messages from the debug callback to stdout",
+                                "type": "BOOL",
+                                "default": true,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_verbose",
+                                "label": "Verbose",
+                                "description": "Verbosity of debug printf messages",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_buffer_size",
+                                "label": "Printf buffer size",
+                                "description": "The size in bytes of the buffer used by debug printf",
+                                "type": "INT",
+                                "default": 1024,
+                                "range": {
+                                    "min": 128,
+                                    "max": 1048576
+                                },
+                                "unit": "bytes",
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
                     },
                     {
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
-                        "description": "Activating this feature instruments shader programs to generate additional diagnostic data.",
+                        "description": "Check for API usage errors at shader execution time",
                         "url": "${LUNARG_SDK}/gpu_validation.html",
-                        "platforms": [ "WINDOWS", "LINUX" ]
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "gpuav_buffer_oob",
+                                "label": "Check Out of Bounds ",
+                                "description": "Enable buffer out of bounds checking",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
                     },
                     {
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",
-                        "label": "Reserve a descriptorSet binding slot",
+                        "label": "Reserve Descriptor Set Binding Slot",
                         "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
@@ -6857,39 +6930,6 @@
                     }
                 ],
                 "default": []
-            },
-            {
-                "key": "gpuav_buffer_oob",
-                "label": "Buffer out of bounds check",
-                "description": "Enable buffer out of bounds checking",
-                "type": "BOOL",
-                "default": false
-            },
-            {
-                "key": "printf_to_stdout",
-                "label": "Printf to stdout",
-                "description": "To redirect Debug Printf messages from the debug callback to stdout",
-                "type": "BOOL",
-                "default": true
-            },
-            {
-                "key": "printf_verbose",
-                "label": "Verbose",
-                "description": "Verbosity of debug printf messages",
-                "type": "BOOL",
-                "default": false
-            },
-            {
-                "key": "printf_buffer_size",
-                "label": "Printf buffer size (in bytes)",
-                "description": "The size in bytes of the buffer used by debug printf",
-                "type": "INT",
-                "default": 1024,
-                "range": {
-                    "min": 128,
-                    "max": 1048576
-                },
-                "unit": "bytes"
             }
         ]
     }

--- a/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
@@ -1,5 +1,5 @@
 {
-    "file_format_version" : "1.3.0",
+    "file_format_version": "1.3.0",
     "layer": {
         "name": "VK_LAYER_KHRONOS_validation",
         "type": "GLOBAL",
@@ -6828,18 +6828,91 @@
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
                         "url": "${LUNARG_SDK}/debug_printf.html",
                         "status": "STABLE",
-                        "platforms": [ "WINDOWS", "LINUX" ]
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "printf_to_stdout",
+                                "label": "Printf to stdout",
+                                "description": "To redirect Debug Printf messages from the debug callback to stdout",
+                                "type": "BOOL",
+                                "default": true,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_verbose",
+                                "label": "Verbose",
+                                "description": "Verbosity of debug printf messages",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_buffer_size",
+                                "label": "Printf buffer size",
+                                "description": "The size in bytes of the buffer used by debug printf",
+                                "type": "INT",
+                                "default": 1024,
+                                "range": {
+                                    "min": 128,
+                                    "max": 1048576
+                                },
+                                "unit": "bytes",
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
                     },
                     {
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
-                        "description": "Activating this feature instruments shader programs to generate additional diagnostic data.",
+                        "description": "Check for API usage errors at shader execution time",
                         "url": "${LUNARG_SDK}/gpu_validation.html",
-                        "platforms": [ "WINDOWS", "LINUX" ]
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "gpuav_buffer_oob",
+                                "label": "Check Out of Bounds ",
+                                "description": "Enable buffer out of bounds checking",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
                     },
                     {
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",
-                        "label": "Reserve a descriptorSet binding slot",
+                        "label": "Reserve Descriptor Set Binding Slot",
                         "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
@@ -6858,39 +6931,6 @@
                     }
                 ],
                 "default": []
-            },
-            {
-                "key": "gpuav_buffer_oob",
-                "label": "Buffer out of bounds check",
-                "description": "Enable buffer out of bounds checking",
-                "type": "BOOL",
-                "default": false
-            },
-            {
-                "key": "printf_to_stdout",
-                "label": "Printf to stdout",
-                "description": "To redirect Debug Printf messages from the debug callback to stdout",
-                "type": "BOOL",
-                "default": true
-            },
-            {
-                "key": "printf_verbose",
-                "label": "Verbose",
-                "description": "Verbosity of debug printf messages",
-                "type": "BOOL",
-                "default": false
-            },
-            {
-                "key": "printf_buffer_size",
-                "label": "Printf buffer size (in bytes)",
-                "description": "The size in bytes of the buffer used by debug printf",
-                "type": "INT",
-                "default": 1024,
-                "range": {
-                    "min": 128,
-                    "max": 1048576
-                },
-                "unit": "bytes"
             }
         ]
     }

--- a/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
@@ -6827,14 +6827,87 @@
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
                         "url": "${LUNARG_SDK}/debug_printf.html",
                         "status": "STABLE",
-                        "platforms": [ "WINDOWS", "LINUX" ]
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "printf_to_stdout",
+                                "label": "Printf to stdout",
+                                "description": "To redirect Debug Printf messages from the debug callback to stdout",
+                                "type": "BOOL",
+                                "default": true,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_verbose",
+                                "label": "Verbose",
+                                "description": "Verbosity of debug printf messages",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "key": "printf_buffer_size",
+                                "label": "Printf buffer size",
+                                "description": "The size in bytes of the buffer used by debug printf",
+                                "type": "INT",
+                                "default": 1024,
+                                "range": {
+                                    "min": 128,
+                                    "max": 1048576
+                                },
+                                "unit": "bytes",
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
                     },
                     {
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Check for API usage errors at shader execution time",
                         "url": "${LUNARG_SDK}/gpu_validation.html",
-                        "platforms": [ "WINDOWS", "LINUX" ]
+                        "platforms": [ "WINDOWS", "LINUX" ],
+                        "settings": [
+                            {
+                                "key": "gpuav_buffer_oob",
+                                "label": "Check Out of Bounds ",
+                                "description": "Enable buffer out of bounds checking",
+                                "type": "BOOL",
+                                "default": false,
+                                "dependence": {
+                                    "mode": "ANY",
+                                    "settings": [
+                                        {
+                                            "key": "enables",
+                                            "value": [ "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT" ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
                     },
                     {
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",
@@ -6857,39 +6930,6 @@
                     }
                 ],
                 "default": []
-            },
-            {
-                "key": "gpuav_buffer_oob",
-                "label": "Check Out of Bounds ",
-                "description": "Enable buffer out of bounds checking",
-                "type": "BOOL",
-                "default": false
-            },
-            {
-                "key": "printf_to_stdout",
-                "label": "Printf to stdout",
-                "description": "To redirect Debug Printf messages from the debug callback to stdout",
-                "type": "BOOL",
-                "default": true
-            },
-            {
-                "key": "printf_verbose",
-                "label": "Verbose",
-                "description": "Verbosity of debug printf messages",
-                "type": "BOOL",
-                "default": false
-            },
-            {
-                "key": "printf_buffer_size",
-                "label": "Printf buffer size",
-                "description": "The size in bytes of the buffer used by debug printf",
-                "type": "INT",
-                "default": 1024,
-                "range": {
-                    "min": 128,
-                    "max": 1048576
-                },
-                "unit": "bytes"
             }
         ]
     }

--- a/vkconfig_core/setting_meta.cpp
+++ b/vkconfig_core/setting_meta.cpp
@@ -158,9 +158,19 @@ const SettingMeta* FindSettingMeta(const SettingMetaSet& settings, const char* k
     if (setting_meta != nullptr) return setting_meta;
 
     for (std::size_t i = 0, n = settings.Size(); i < n; ++i) {
-        const SettingMeta* child = FindSettingMeta(settings[i].children, key);
+        if (settings[i].key == key) return &settings[i];
 
+        const SettingMeta* child = FindSettingMeta(settings[i].children, key);
         if (child != nullptr) return child;
+
+        if (IsEnum(settings[i].type)) {
+            const SettingMetaEnum& setting_meta_enum = static_cast<const SettingMetaEnum&>(settings[i]);
+
+            for (std::size_t j = 0, o = setting_meta_enum.enum_values.size(); j < o; ++j) {
+                const SettingMeta* setting_meta = FindSettingMeta(setting_meta_enum.enum_values[j].settings, key);
+                if (setting_meta != nullptr) return setting_meta;
+            }
+        }
     }
 
     return nullptr;


### PR DESCRIPTION
Surrender devsim layer settings to devsim developers.

Vulkan Configurator will use these settings when loading devsim layer.