### PR TITLE
vkconfig: reduce unit test time and optional SDK layers

### DIFF
--- a/vkconfig_core/configuration_manager.cpp
+++ b/vkconfig_core/configuration_manager.cpp
@@ -117,12 +117,12 @@ void ConfigurationManager::LoadConfigurationsPath(const std::vector<Layer> &avai
         Configuration configuration;
         const bool result = configuration.Load(available_layers, info.absoluteFilePath().toStdString());
 
+        if (!result) continue;
+
         if (FindByKey(available_configurations, configuration.key.c_str()) != nullptr) continue;
 
         OrderParameter(configuration.parameters, available_layers);
-        if (result) {
-            available_configurations.push_back(configuration);
-        }
+        available_configurations.push_back(configuration);
     }
 }
 

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -62,7 +62,7 @@ class Layer {
     std::vector<LayerPreset> presets;
 
     // File based layers
-    bool Load(const std::string& full_path_to_file, LayerType layer_type);
+    bool Load(const std::vector<Layer>& available_layers, const std::string& full_path_to_file, LayerType layer_type);
 
     void AddSettingsSet(SettingMetaSet& settings, const QJsonValue& json_settings_value);
     void AddSettingData(SettingDataSet& settings, const QJsonValue& json_setting_value);

--- a/vkconfig_core/layer_manager.cpp
+++ b/vkconfig_core/layer_manager.cpp
@@ -157,9 +157,7 @@ void LayerManager::LoadLayersFromPath(const std::string &path) {
 
     for (int i = 0, n = file_list.FileCount(); i < n; ++i) {
         Layer layer;
-        if (layer.Load(file_list.GetFileName(i).c_str(), type)) {
-            if (layer.key == "VK_LAYER_LUNARG_override") continue;
-
+        if (layer.Load(available_layers, file_list.GetFileName(i).c_str(), type)) {
             // Make sure this layer name has not already been added
             if (FindByKey(available_layers, layer.key.c_str()) != nullptr) continue;
 

--- a/vkconfig_core/layers/layers_schema.json
+++ b/vkconfig_core/layers/layers_schema.json
@@ -46,7 +46,7 @@
                         }
                     },
                     "settings": {
-                        "type": "array"
+                        "$ref": "#/definitions/settings_data"
                     }
                 }
             }
@@ -167,12 +167,112 @@
                         "$ref": "#/definitions/view"
                     },
                     "settings": {
-                        "type": "array"
+                        "$ref": "#/definitions/settings_meta"
                     }
                 }
             }
         },
-        "settings": {
+        "settings_data": {
+            "description": "The different kind of settings stored in a preset",
+            "additionalProperties": false,
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "description": "For preset STRING, FRAMES, ENUM, LOAD_FILE, SAVE_FILE, SAVE_FOLDER setting type values",
+                        "type": "object",
+                        "required": [
+                            "key",
+                            "value"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "description": "For preset BOOL setting type values",
+                        "type": "object",
+                        "required": [
+                            "key",
+                            "value"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    {
+                        "description": "For preset INT setting type values",
+                        "type": "object",
+                        "required": [
+                            "key",
+                            "value"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "number"
+                            }
+                        }
+                    },
+                    {
+                        "description": "For preset FLAGS setting type values",
+                        "type": "object",
+                        "required": [
+                            "key",
+                            "value"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "contains": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "description": "For preset LIST setting type values",
+                        "type": "object",
+                        "required": [
+                            "key",
+                            "value"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/enabled_number_or_string"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "settings_meta": {
             "description": "The different kind of settings of layers",
             "type": "array",
             "items": {
@@ -221,7 +321,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -277,7 +377,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -336,7 +436,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -393,7 +493,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -449,7 +549,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -512,7 +612,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -575,7 +675,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -635,7 +735,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -699,7 +799,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     },
@@ -771,7 +871,7 @@
                                 "$ref": "#/definitions/dependence"
                             },
                             "settings": {
-                                "$ref": "#/definitions/settings"
+                                "$ref": "#/definitions/settings_meta"
                             }
                         }
                     }
@@ -817,7 +917,7 @@
                     "type": "string"
                 },
                 "settings": {
-                    "$ref": "#/definitions/settings"
+                    "$ref": "#/definitions/settings_meta"
                 },
                 "presets": {
                     "type": "array",
@@ -845,104 +945,7 @@
                                 "$ref": "#/definitions/status"
                             },
                             "settings": {
-                                "description": "The different kind of settings stored in a preset",
-                                "additionalProperties": false,
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "description": "For preset STRING, FRAMES, ENUM, LOAD_FILE, SAVE_FILE, SAVE_FOLDER setting type values",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "key": {
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "description": "For preset BOOL setting type values",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "key": {
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "type": "boolean"
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "description": "For preset INT setting type values",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "key": {
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "type": "number"
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "description": "For preset FLAGS setting type values",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "key": {
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "type": "array",
-                                                    "contains": {
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "description": "For preset LIST setting type values",
-                                            "type": "object",
-                                            "required": [
-                                                "key",
-                                                "value"
-                                            ],
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "key": {
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/definitions/enabled_number_or_string"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
+                                "$ref": "#/definitions/settings_data"
                             }
                         }
                     }

--- a/vkconfig_core/registry.cpp
+++ b/vkconfig_core/registry.cpp
@@ -103,7 +103,7 @@ static void LoadDeviceRegistry(DEVINST id, const QString &entry, std::vector<Lay
     if (data_type == REG_SZ || data_type == REG_MULTI_SZ) {
         for (wchar_t *curr_filename = path; curr_filename[0] != '\0'; curr_filename += wcslen(curr_filename) + 1) {
             Layer layer;
-            if (layer.Load(QString::fromWCharArray(curr_filename).toStdString(), type)) {
+            if (layer.Load(layers, QString::fromWCharArray(curr_filename).toStdString(), type)) {
                 layers.push_back(layer);
             }
 

--- a/vkconfig_core/test/test_configuration_built_in.cpp
+++ b/vkconfig_core/test/test_configuration_built_in.cpp
@@ -75,11 +75,10 @@ struct TestBuilin {
 
     Configuration Load(const char* configuration_name) {
         Configuration configuration_loaded;
-        EXPECT_TRUE(configuration_loaded.Load(
+        const bool result = configuration_loaded.Load(
             layer_manager.available_layers,
-            format(":/configurations/%s/%s.json", configurations_version.c_str(), configuration_name).c_str()));
-        EXPECT_TRUE(!configuration_loaded.parameters.empty());
-        return configuration_loaded;
+            format(":/configurations/%s/%s.json", configurations_version.c_str(), configuration_name).c_str());
+        return result ? configuration_loaded : Configuration();
     }
 
     Configuration Restore(const Configuration& configuration_loaded) {
@@ -114,9 +113,7 @@ TEST(test_built_in_load, layers_130_with_configuration_210) {
 
     {
         Configuration load_frame_capture = test.Load("Frame Capture");
-        EXPECT_EQ(1, load_frame_capture.Size());
-        Configuration save_frame_capture = test.Restore(load_frame_capture);
-        EXPECT_EQ(save_frame_capture, load_frame_capture);
+        EXPECT_EQ(0, load_frame_capture.Size());
     }
 
     {
@@ -149,9 +146,7 @@ TEST(test_built_in_load, layers_135_with_configuration_210) {
 
     {
         Configuration load_frame_capture = test.Load("Frame Capture");
-        EXPECT_EQ(1, load_frame_capture.Size());
-        Configuration save_frame_capture = test.Restore(load_frame_capture);
-        EXPECT_EQ(save_frame_capture, load_frame_capture);
+        EXPECT_EQ(0, load_frame_capture.Size());
     }
 
     {
@@ -394,9 +389,7 @@ TEST(test_built_in_load, layers_130_with_configuration_220) {
 
     {
         Configuration load_frame_capture = test.Load("Frame Capture");
-        EXPECT_EQ(1, load_frame_capture.Size());
-        Configuration save_frame_capture = test.Restore(load_frame_capture);
-        EXPECT_EQ(save_frame_capture, load_frame_capture);
+        EXPECT_EQ(0, load_frame_capture.Size());
     }
 
     {
@@ -408,9 +401,7 @@ TEST(test_built_in_load, layers_130_with_configuration_220) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -436,9 +427,7 @@ TEST(test_built_in_load, layers_135_with_configuration_220) {
 
     {
         Configuration load_frame_capture = test.Load("Frame Capture");
-        EXPECT_EQ(1, load_frame_capture.Size());
-        Configuration save_frame_capture = test.Restore(load_frame_capture);
-        EXPECT_EQ(save_frame_capture, load_frame_capture);
+        EXPECT_EQ(0, load_frame_capture.Size());
     }
 
     {
@@ -450,9 +439,7 @@ TEST(test_built_in_load, layers_135_with_configuration_220) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -492,9 +479,7 @@ TEST(test_built_in_load, layers_141_with_configuration_220) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -534,9 +519,7 @@ TEST(test_built_in_load, layers_148_with_configuration_220) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -576,9 +559,7 @@ TEST(test_built_in_load, layers_154_with_configuration_220) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -618,9 +599,7 @@ TEST(test_built_in_load, layers_162_with_configuration_220) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -730,9 +709,7 @@ TEST(test_built_in_load, layers_130_with_configuration_221) {
 
     {
         Configuration load_frame_capture = test.Load("Frame Capture");
-        EXPECT_EQ(1, load_frame_capture.Size());
-        Configuration save_frame_capture = test.Restore(load_frame_capture);
-        EXPECT_EQ(save_frame_capture, load_frame_capture);
+        EXPECT_EQ(0, load_frame_capture.Size());
     }
 
     {
@@ -744,9 +721,7 @@ TEST(test_built_in_load, layers_130_with_configuration_221) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -772,9 +747,7 @@ TEST(test_built_in_load, layers_135_with_configuration_221) {
 
     {
         Configuration load_frame_capture = test.Load("Frame Capture");
-        EXPECT_EQ(1, load_frame_capture.Size());
-        Configuration save_frame_capture = test.Restore(load_frame_capture);
-        EXPECT_EQ(save_frame_capture, load_frame_capture);
+        EXPECT_EQ(0, load_frame_capture.Size());
     }
 
     {
@@ -786,9 +759,7 @@ TEST(test_built_in_load, layers_135_with_configuration_221) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -828,9 +799,7 @@ TEST(test_built_in_load, layers_141_with_configuration_221) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -870,9 +839,7 @@ TEST(test_built_in_load, layers_148_with_configuration_221) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -912,9 +879,7 @@ TEST(test_built_in_load, layers_154_with_configuration_221) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {
@@ -954,9 +919,7 @@ TEST(test_built_in_load, layers_162_with_configuration_221) {
 
     {
         Configuration load_synchronization = test.Load("Synchronization");
-        EXPECT_EQ(2, load_synchronization.Size());
-        Configuration save_synchronization = test.Restore(load_synchronization);
-        EXPECT_EQ(save_synchronization, load_synchronization);
+        EXPECT_EQ(0, load_synchronization.Size());
     }
 
     {

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -41,7 +41,7 @@ TEST(test_layer, collect_settings) {
 
 TEST(test_layer, load_1_1_0_header) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_1_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_1_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     EXPECT_EQ(Version(1, 1, 0), layer.file_format_version);
@@ -56,9 +56,9 @@ TEST(test_layer, load_1_1_0_header) {
     EXPECT_TRUE(layer.presets.empty());
 }
 
-TEST(test_layer, load_1_4_0_header) {
+TEST(test_layer, load_1_2_0_header) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     EXPECT_EQ(Version(1, 2, 0), layer.file_format_version);
@@ -73,9 +73,9 @@ TEST(test_layer, load_1_4_0_header) {
     EXPECT_TRUE(!layer.presets.empty());
 }
 
-TEST(test_layer, load_1_4_0_preset_enum) {
+TEST(test_layer, load_1_2_0_preset_enum) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     EXPECT_STREQ("Preset Enum", layer.presets[0].label.c_str());
@@ -86,9 +86,9 @@ TEST(test_layer, load_1_4_0_preset_enum) {
     EXPECT_STREQ("value2", layer.presets[0].settings.Get<SettingDataEnum>("enum_with_optional")->value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_preset_flags) {
+TEST(test_layer, load_1_2_0_preset_flags) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     EXPECT_STREQ("Preset Flags", layer.presets[1].label.c_str());
@@ -101,9 +101,9 @@ TEST(test_layer, load_1_4_0_preset_flags) {
     EXPECT_STREQ("flag2", layer.presets[1].settings.Get<SettingDataFlags>("flags_with_optional")->value[1].c_str());
 }
 
-TEST(test_layer, load_1_4_0_preset_string) {
+TEST(test_layer, load_1_2_0_preset_string) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     EXPECT_STREQ("Preset String", layer.presets[2].label.c_str());
@@ -114,9 +114,9 @@ TEST(test_layer, load_1_4_0_preset_string) {
     EXPECT_STREQ("With Optional", layer.presets[2].settings.Get<SettingDataString>("string_with_optional")->value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_preset_bool) {
+TEST(test_layer, load_1_2_0_preset_bool) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     const std::size_t index = 3;
@@ -129,9 +129,9 @@ TEST(test_layer, load_1_4_0_preset_bool) {
     EXPECT_EQ(false, layer.presets[index].settings.Get<SettingDataBool>("bool_with_optional")->value);
 }
 
-TEST(test_layer, load_1_4_0_preset_load_file) {
+TEST(test_layer, load_1_2_0_preset_load_file) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     const std::size_t index = 4;
@@ -144,9 +144,9 @@ TEST(test_layer, load_1_4_0_preset_load_file) {
     EXPECT_STREQ("./text.log", layer.presets[index].settings.Get<SettingDataString>("load_file_with_optional")->value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_preset_save_file) {
+TEST(test_layer, load_1_2_0_preset_save_file) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     const std::size_t index = 5;
@@ -159,9 +159,9 @@ TEST(test_layer, load_1_4_0_preset_save_file) {
     EXPECT_STREQ("./text.log", layer.presets[index].settings.Get<SettingDataFileSave>("save_file_with_optional")->value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_preset_save_folder) {
+TEST(test_layer, load_1_2_0_preset_save_folder) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     const std::size_t index = 6;
@@ -174,9 +174,9 @@ TEST(test_layer, load_1_4_0_preset_save_folder) {
     EXPECT_STREQ("./text.log", layer.presets[index].settings.Get<SettingDataFileSave>("save_folder_with_optional")->value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_preset_int) {
+TEST(test_layer, load_1_2_0_preset_int) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     const std::size_t index = 7;
@@ -189,9 +189,9 @@ TEST(test_layer, load_1_4_0_preset_int) {
     EXPECT_EQ(77, layer.presets[index].settings.Get<SettingDataInt>("int_with_optional")->value);
 }
 
-TEST(test_layer, load_1_4_0_preset_frames) {
+TEST(test_layer, load_1_2_0_preset_frames) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     const std::size_t index = 8;
@@ -204,9 +204,9 @@ TEST(test_layer, load_1_4_0_preset_frames) {
     EXPECT_STREQ("13-17,24,32", layer.presets[index].settings.Get<SettingDataFrames>("frames_with_optional")->value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_preset_list) {
+TEST(test_layer, load_1_2_0_preset_list) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
 
     const std::size_t index = 9;
@@ -225,9 +225,9 @@ TEST(test_layer, load_1_4_0_preset_list) {
     EXPECT_EQ(false, layer.presets[index].settings.Get<SettingDataList>("list_with_optional")->value[1].enabled);
 }
 
-TEST(test_layer, load_1_4_0_setting_enum_required_only) {
+TEST(test_layer, load_1_2_0_setting_enum_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -266,9 +266,9 @@ TEST(test_layer, load_1_4_0_setting_enum_required_only) {
     EXPECT_STREQ("value1", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_enum_with_optional) {
+TEST(test_layer, load_1_2_0_setting_enum_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -319,9 +319,9 @@ TEST(test_layer, load_1_4_0_setting_enum_with_optional) {
     EXPECT_STREQ("value1", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_flags_required_only) {
+TEST(test_layer, load_1_2_0_setting_flags_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -361,9 +361,9 @@ TEST(test_layer, load_1_4_0_setting_flags_required_only) {
     EXPECT_STREQ("flag1", setting_meta->default_value[1].c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_flags_with_optional) {
+TEST(test_layer, load_1_2_0_setting_flags_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -415,9 +415,9 @@ TEST(test_layer, load_1_4_0_setting_flags_with_optional) {
     EXPECT_STREQ("flag1", setting_meta->default_value[1].c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_string_required_only) {
+TEST(test_layer, load_1_2_0_setting_string_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -437,9 +437,9 @@ TEST(test_layer, load_1_4_0_setting_string_required_only) {
     EXPECT_STREQ("A string", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_string_with_optional) {
+TEST(test_layer, load_1_2_0_setting_string_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -459,9 +459,9 @@ TEST(test_layer, load_1_4_0_setting_string_with_optional) {
     EXPECT_STREQ("A string", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_bool_required_only) {
+TEST(test_layer, load_1_2_0_setting_bool_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -481,9 +481,9 @@ TEST(test_layer, load_1_4_0_setting_bool_required_only) {
     EXPECT_EQ(true, setting_meta->default_value);
 }
 
-TEST(test_layer, load_1_4_0_setting_bool_with_optional) {
+TEST(test_layer, load_1_2_0_setting_bool_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -503,9 +503,9 @@ TEST(test_layer, load_1_4_0_setting_bool_with_optional) {
     EXPECT_EQ(true, setting_meta->default_value);
 }
 
-TEST(test_layer, load_1_4_0_setting_load_file_required_only) {
+TEST(test_layer, load_1_2_0_setting_load_file_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -526,9 +526,9 @@ TEST(test_layer, load_1_4_0_setting_load_file_required_only) {
     EXPECT_STREQ("./test.txt", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_load_file_with_optional) {
+TEST(test_layer, load_1_2_0_setting_load_file_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -549,9 +549,9 @@ TEST(test_layer, load_1_4_0_setting_load_file_with_optional) {
     EXPECT_STREQ("./test.txt", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_save_file_required_only) {
+TEST(test_layer, load_1_2_0_setting_save_file_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -572,9 +572,9 @@ TEST(test_layer, load_1_4_0_setting_save_file_required_only) {
     EXPECT_STREQ("./test.json", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_save_file_with_optional) {
+TEST(test_layer, load_1_2_0_setting_save_file_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -595,9 +595,9 @@ TEST(test_layer, load_1_4_0_setting_save_file_with_optional) {
     EXPECT_STREQ("./test.json", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_save_folder_required_only) {
+TEST(test_layer, load_1_2_0_setting_save_folder_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -617,9 +617,9 @@ TEST(test_layer, load_1_4_0_setting_save_folder_required_only) {
     EXPECT_STREQ("./test", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_save_folder_with_optional) {
+TEST(test_layer, load_1_2_0_setting_save_folder_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -639,9 +639,9 @@ TEST(test_layer, load_1_4_0_setting_save_folder_with_optional) {
     EXPECT_STREQ("./test", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_int_required_only) {
+TEST(test_layer, load_1_2_0_setting_int_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -664,9 +664,9 @@ TEST(test_layer, load_1_4_0_setting_int_required_only) {
     EXPECT_EQ(76, setting_meta->default_value);
 }
 
-TEST(test_layer, load_1_4_0_setting_int_with_optional) {
+TEST(test_layer, load_1_2_0_setting_int_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -689,9 +689,9 @@ TEST(test_layer, load_1_4_0_setting_int_with_optional) {
     EXPECT_EQ(76, setting_meta->default_value);
 }
 
-TEST(test_layer, load_1_4_0_setting_frames_required_only) {
+TEST(test_layer, load_1_2_0_setting_frames_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -711,9 +711,9 @@ TEST(test_layer, load_1_4_0_setting_frames_required_only) {
     EXPECT_STREQ("76-82,75", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_frames_with_optional) {
+TEST(test_layer, load_1_2_0_setting_frames_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -734,9 +734,9 @@ TEST(test_layer, load_1_4_0_setting_frames_with_optional) {
     EXPECT_STREQ("76-82,75", setting_meta->default_value.c_str());
 }
 
-TEST(test_layer, load_1_4_0_setting_list_required_only) {
+TEST(test_layer, load_1_2_0_setting_list_required_only) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -780,9 +780,9 @@ TEST(test_layer, load_1_4_0_setting_list_required_only) {
     EXPECT_EQ(true, setting_meta->default_value[4].enabled);
 }
 
-TEST(test_layer, load_1_4_0_setting_list_with_optional) {
+TEST(test_layer, load_1_2_0_setting_list_with_optional) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 
@@ -832,9 +832,9 @@ TEST(test_layer, load_1_4_0_setting_list_with_optional) {
     EXPECT_EQ(true, setting_meta->default_value[4].enabled);
 }
 
-TEST(test_layer, load_1_4_0_setting_list_empty) {
+TEST(test_layer, load_1_2_0_setting_list_empty) {
     Layer layer;
-    const bool load_loaded = layer.Load(":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
+    const bool load_loaded = layer.Load(std::vector<Layer>(), ":/VK_LAYER_LUNARG_reference_1_2_0.json", LAYER_TYPE_EXPLICIT);
     ASSERT_TRUE(load_loaded);
     ASSERT_TRUE(!layer.settings.Empty());
 

--- a/vkconfig_core/test/test_layer_built_in.cpp
+++ b/vkconfig_core/test/test_layer_built_in.cpp
@@ -27,35 +27,35 @@
 
 TEST(test_layer_built_in, layer_130_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/130/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/130/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(5, CountSettings(layer.settings));
     EXPECT_EQ(4, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_130_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/130/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/130/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_130_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/130/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/130/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_130_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/130/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/130/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_130_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/130/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/130/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
@@ -64,35 +64,35 @@ TEST(test_layer_built_in, layer_130_screenshot) {
 
 TEST(test_layer_built_in, layer_135_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/135/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/135/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(5, CountSettings(layer.settings));
     EXPECT_EQ(4, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_135_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/135/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/135/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_135_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/135/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/135/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_135_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/135/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/135/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_135_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/135/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/135/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
@@ -101,42 +101,42 @@ TEST(test_layer_built_in, layer_135_screenshot) {
 
 TEST(test_layer_built_in, layer_141_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/141/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/141/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(5, CountSettings(layer.settings));
     EXPECT_EQ(5, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_141_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/141/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/141/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_141_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/141/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/141/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_141_gfxreconstruct) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/141/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/141/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(20, CountSettings(layer.settings));
     EXPECT_EQ(2, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_141_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/141/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/141/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_141_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/141/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/141/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
@@ -145,42 +145,42 @@ TEST(test_layer_built_in, layer_141_screenshot) {
 
 TEST(test_layer_built_in, layer_148_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/148/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/148/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(7, CountSettings(layer.settings));
     EXPECT_EQ(5, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_148_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/148/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/148/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_148_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/148/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/148/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_148_gfxreconstruct) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/148/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/148/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(20, CountSettings(layer.settings));
     EXPECT_EQ(2, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_148_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/148/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/148/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_148_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/148/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/148/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
@@ -189,42 +189,42 @@ TEST(test_layer_built_in, layer_148_screenshot) {
 
 TEST(test_layer_built_in, layer_154_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/154/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/154/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(7, CountSettings(layer.settings));
     EXPECT_EQ(6, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_154_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/154/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/154/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_154_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/154/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/154/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_154_gfxreconstruct) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/154/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/154/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(20, CountSettings(layer.settings));
     EXPECT_EQ(2, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_154_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/154/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/154/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_154_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/154/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/154/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
@@ -233,42 +233,42 @@ TEST(test_layer_built_in, layer_154_screenshot) {
 
 TEST(test_layer_built_in, layer_162_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/162/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/162/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(11, CountSettings(layer.settings));
     EXPECT_EQ(6, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_162_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/162/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/162/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_162_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/162/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/162/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(5, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_162_gfxreconstruct) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/162/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/162/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(20, CountSettings(layer.settings));
     EXPECT_EQ(2, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_162_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/162/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/162/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_162_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/162/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/162/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
@@ -277,7 +277,7 @@ TEST(test_layer_built_in, layer_162_screenshot) {
 
 TEST(test_layer_built_in, layer_170_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/170/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(11, CountSettings(layer.settings));
     EXPECT_EQ(6, layer.presets.size());
     EXPECT_TRUE(layer.presets[0].settings.Get<SettingDataFlags>("enables")->value.empty());
@@ -287,42 +287,42 @@ TEST(test_layer_built_in, layer_170_validation) {
 
 TEST(test_layer_built_in, layer_170_synchronization2) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/170/VK_LAYER_KHRONOS_synchronization2.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_KHRONOS_synchronization2.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(1, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_170_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/170/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_170_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/170/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(6, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_170_gfxreconstruct) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/170/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(20, CountSettings(layer.settings));
     EXPECT_EQ(2, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_170_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/170/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_170_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/170/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
@@ -331,7 +331,7 @@ TEST(test_layer_built_in, layer_170_screenshot) {
 
 TEST(test_layer_built_in, layer_latest_validation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/latest/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/latest/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(11, CountSettings(layer.settings));
     EXPECT_EQ(6, layer.presets.size());
     EXPECT_TRUE(layer.presets[0].settings.Get<SettingDataFlags>("enables")->value.empty());
@@ -341,42 +341,42 @@ TEST(test_layer_built_in, layer_latest_validation) {
 
 TEST(test_layer_built_in, layer_latest_synchronization2) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/latest/VK_LAYER_KHRONOS_synchronization2.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/latest/VK_LAYER_KHRONOS_synchronization2.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(1, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_latest_api_dump) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/latest/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/latest/VK_LAYER_LUNARG_api_dump.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(14, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_latest_device_simulation) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/latest/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/latest/VK_LAYER_LUNARG_device_simulation.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(6, CountSettings(layer.settings));
     EXPECT_EQ(3, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_latest_gfxreconstruct) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(20, CountSettings(layer.settings));
     EXPECT_EQ(2, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_latest_monitor) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/latest/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/latest/VK_LAYER_LUNARG_monitor.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(0, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }
 
 TEST(test_layer_built_in, layer_latest_screenshot) {
     Layer layer;
-    EXPECT_TRUE(layer.Load(":/layers/latest/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
+    EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/latest/VK_LAYER_LUNARG_screenshot.json", LAYER_TYPE_EXPLICIT));
     EXPECT_EQ(3, CountSettings(layer.settings));
     EXPECT_EQ(0, layer.presets.size());
 }


### PR DESCRIPTION
As a result of SDK layers being optional, built-in configuration using these layers won't load if these layers are missing