### PR TITLE
vkconfig: Avoid API dump log to go in SDK bin dir #1469

### DIFF
--- a/layersvt/VkLayer_api_dump.json.in
+++ b/layersvt/VkLayer_api_dump.json.in
@@ -49,7 +49,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -69,7 +69,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -89,7 +89,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -87,7 +87,7 @@ void WidgetSettingFilesystem::browseButtonClicked() {
     std::string file;
 
     const char* filter = this->meta.filter.c_str();
-    const std::string path = this->data.value.empty() ? ReplaceBuiltInVariable("${LOCAL}") : this->data.value.c_str();
+    const std::string path = ReplaceBuiltInVariable(this->data.value.empty() ? "${LOCAL}" : this->data.value.c_str());
 
     switch (this->meta.type) {
         case SETTING_LOAD_FILE:

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -87,17 +87,17 @@ void WidgetSettingFilesystem::browseButtonClicked() {
     std::string file;
 
     const char* filter = this->meta.filter.c_str();
-    const char* path = this->data.value.c_str();
+    const std::string path = this->data.value.empty() ? ReplaceBuiltInVariable("${LOCAL}") : this->data.value.c_str();
 
     switch (this->meta.type) {
         case SETTING_LOAD_FILE:
-            file = QFileDialog::getOpenFileName(this->button, "Select file", path, filter).toStdString();
+            file = QFileDialog::getOpenFileName(this->button, "Select file", path.c_str(), filter).toStdString();
             break;
         case SETTING_SAVE_FILE:
-            file = QFileDialog::getSaveFileName(this->button, "Select File", path, filter).toStdString();
+            file = QFileDialog::getSaveFileName(this->button, "Select File", path.c_str(), filter).toStdString();
             break;
         case SETTING_SAVE_FOLDER:
-            file = QFileDialog::getExistingDirectory(this->button, "Select Folder", path).toStdString();
+            file = QFileDialog::getExistingDirectory(this->button, "Select Folder", path.c_str()).toStdString();
             break;
         default:
             assert(0);

--- a/vkconfig_core/layers/130/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/130/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/135/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/135/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/141/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/141/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/148/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/148/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/154/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/154/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/162/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/162/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/170/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/170/VK_LAYER_LUNARG_api_dump.json
@@ -49,7 +49,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -69,7 +69,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -89,7 +89,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.txt"
+                        "value": "${LOCAL}/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.html"
+                        "value": "${LOCAL}/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "vk_apidump.json"
+                        "value": "${LOCAL}/vk_apidump.json"
                     },
                     {
                         "key": "file",


### PR DESCRIPTION
An issue was discovered that if a JSON file is too big and open by
the Vulkan Loader, the loader would crash instantly.
This issue is fixed for SDK 1.2.176 but we can rely on the $LOCAL
built-in variable to prevent this issue to appear.

Change-Id: If100aa5c939e110744eb2920f08440cd3300f282