### PR TITLE
vkconfig: fix built-in variables #1474

### DIFF
--- a/layersvt/VkLayer_api_dump.json.in
+++ b/layersvt/VkLayer_api_dump.json.in
@@ -49,7 +49,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -69,7 +69,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -89,7 +89,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -29,7 +29,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
                     }
                 ]
             },
@@ -45,7 +45,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
                     }
                 ]
             },
@@ -61,7 +61,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
                     }
                 ]
             }
@@ -74,7 +74,7 @@
                 "description": "Path of a devsim configuration file to load.",
                 "type": "LOAD_FILE",
                 "filter": "*.json",
-                "default": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                "default": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
             },
             {
                 "key": "debug_enable",

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -87,7 +87,7 @@ void WidgetSettingFilesystem::browseButtonClicked() {
     std::string file;
 
     const char* filter = this->meta.filter.c_str();
-    const std::string path = ReplaceBuiltInVariable(this->data.value.empty() ? "${LOCAL}" : this->data.value.c_str());
+    const std::string path = ReplaceBuiltInVariable(this->data.value.empty() ? "$[LOCAL]" : this->data.value.c_str());
 
     switch (this->meta.type) {
         case SETTING_LOAD_FILE:

--- a/vkconfig_core/configurations/2.2.1/Frame Capture.json
+++ b/vkconfig_core/configurations/2.2.1/Frame Capture.json
@@ -26,7 +26,7 @@
                     {
                         "key": "capture_file",
                         "type": "SAVE_FILE",
-                        "value": "${LOCAL}/gfxrecon_capture.gfxr"
+                        "value": "$[LOCAL]/gfxrecon_capture.gfxr"
                     },
                     {
                         "key": "capture_file_timestamp",

--- a/vkconfig_core/configurations/2.2.1/Portability.json
+++ b/vkconfig_core/configurations/2.2.1/Portability.json
@@ -121,7 +121,7 @@
                     {
                         "key": "filename",
                         "type": "LOAD_FILE",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
                     }
                 ],
                 "state": "OVERRIDDEN"

--- a/vkconfig_core/environment.cpp
+++ b/vkconfig_core/environment.cpp
@@ -757,7 +757,7 @@ static Application CreateDefaultApplication(const DefaultApplication& default_ap
     // initially will be set to the users home folder across all OS's. This is highly visible
     // in the application launcher and should not present a usability issue. The developer can
     // easily change this later to anywhere they like.
-    application.log_file = std::string("${LOCAL}") + default_application.key + ".txt";
+    application.log_file = std::string("$[LOCAL]") + default_application.key + ".txt";
 
     return application;
 }

--- a/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
@@ -315,7 +315,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Activating this feature instruments shader programs to generate additional diagnostic data.",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
@@ -328,7 +328,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     }
                 ],

--- a/vkconfig_core/layers/130/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/130/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
@@ -315,7 +315,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Activating this feature instruments shader programs to generate additional diagnostic data.",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
@@ -328,7 +328,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     }
                 ],

--- a/vkconfig_core/layers/135/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/135/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
@@ -339,7 +339,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
                         "label": "Debug Printf",
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
-                        "url": "${LUNARG_SDK}/debug_printf.html",
+                        "url": "$[LUNARG_SDK]/debug_printf.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
@@ -347,7 +347,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Activating this feature instruments shader programs to generate additional diagnostic data.",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
@@ -360,7 +360,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     }
                 ],

--- a/vkconfig_core/layers/141/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/141/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/141/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/141/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -160,7 +160,7 @@
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
                 "type": "SAVE_FILE",
                 "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                "default": "$[LOCAL]/gfxrecon_capture.gfxr",
                 "settings": [
                     {
                         "key": "capture_file_timestamp",

--- a/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
@@ -356,7 +356,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
                         "label": "Debug Printf",
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
-                        "url": "${LUNARG_SDK}/debug_printf.html",
+                        "url": "$[LUNARG_SDK]/debug_printf.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
@@ -364,7 +364,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Activating this feature instruments shader programs to generate additional diagnostic data.",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
@@ -377,7 +377,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
                     {

--- a/vkconfig_core/layers/148/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/148/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/148/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/148/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -160,7 +160,7 @@
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
                 "type": "SAVE_FILE",
                 "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                "default": "$[LOCAL]/gfxrecon_capture.gfxr",
                 "settings": [
                     {
                         "key": "capture_file_timestamp",

--- a/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
@@ -379,7 +379,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",
                         "label": "Synchronization",
                         "description": "This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.",
-                        "url": "${LUNARG_SDK}/synchronization_usage.html",
+                        "url": "$[LUNARG_SDK]/synchronization_usage.html",
                         "status": "ALPHA",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
@@ -387,14 +387,14 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
                         "label": "Debug Printf",
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
-                        "url": "${LUNARG_SDK}/debug_printf.html",
+                        "url": "$[LUNARG_SDK]/debug_printf.html",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Activating this feature instruments shader programs to generate additional diagnostic data.",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ]
                     },
                     {
@@ -407,7 +407,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
                     {

--- a/vkconfig_core/layers/154/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/154/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/154/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/154/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -161,7 +161,7 @@
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
                 "type": "SAVE_FILE",
                 "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                "default": "$[LOCAL]/gfxrecon_capture.gfxr",
                 "settings": [
                     {
                         "key": "capture_file_timestamp",

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -379,7 +379,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",
                         "label": "Synchronization",
                         "description": "This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.",
-                        "url": "${LUNARG_SDK}/synchronization_usage.html",
+                        "url": "$[LUNARG_SDK]/synchronization_usage.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
@@ -387,7 +387,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
                         "label": "Debug Printf",
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
-                        "url": "${LUNARG_SDK}/debug_printf.html",
+                        "url": "$[LUNARG_SDK]/debug_printf.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX" ],
                         "settings": [
@@ -450,7 +450,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Check for API usage errors at shader execution time",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ],
                         "settings": [
                             {
@@ -481,7 +481,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
                     {

--- a/vkconfig_core/layers/162/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/162/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/162/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_LUNARG_device_simulation.json
@@ -28,7 +28,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
                     }
                 ]
             },
@@ -44,7 +44,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
                     }
                 ]
             },
@@ -60,7 +60,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
                     }
                 ]
             }
@@ -73,7 +73,7 @@
                 "description": "Path of a devsim configuration file to load.",
                 "type": "LOAD_FILE",
                 "filter": "*.json",
-                "default": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                "default": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
             },
             {
                 "key": "debug_enable",

--- a/vkconfig_core/layers/162/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/162/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -161,7 +161,7 @@
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
                 "type": "SAVE_FILE",
                 "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                "default": "$[LOCAL]/gfxrecon_capture.gfxr",
                 "settings": [
                     {
                         "key": "capture_file_timestamp",

--- a/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
@@ -380,7 +380,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",
                         "label": "Synchronization",
                         "description": "This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.",
-                        "url": "${LUNARG_SDK}/synchronization_usage.html",
+                        "url": "$[LUNARG_SDK]/synchronization_usage.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
@@ -388,7 +388,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
                         "label": "Debug Printf",
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
-                        "url": "${LUNARG_SDK}/debug_printf.html",
+                        "url": "$[LUNARG_SDK]/debug_printf.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX" ],
                         "settings": [
@@ -451,7 +451,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Check for API usage errors at shader execution time",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ],
                         "settings": [
                             {
@@ -482,7 +482,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
                     {

--- a/vkconfig_core/layers/170/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/170/VK_LAYER_LUNARG_api_dump.json
@@ -49,7 +49,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -69,7 +69,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -89,7 +89,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/170/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_LUNARG_device_simulation.json
@@ -29,7 +29,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
                     }
                 ]
             },
@@ -45,7 +45,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
                     }
                 ]
             },
@@ -61,7 +61,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
                     }
                 ]
             }
@@ -74,7 +74,7 @@
                 "description": "Path of a devsim configuration file to load.",
                 "type": "LOAD_FILE",
                 "filter": "*.json",
-                "default": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                "default": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
             },
             {
                 "key": "debug_enable",

--- a/vkconfig_core/layers/170/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/170/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -160,7 +160,7 @@
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
                 "type": "SAVE_FILE",
                 "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                "default": "$[LOCAL]/gfxrecon_capture.gfxr",
                 "settings": [
                     {
                         "key": "capture_file_timestamp",

--- a/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_KHRONOS_validation.json
@@ -379,7 +379,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",
                         "label": "Synchronization",
                         "description": "This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.",
-                        "url": "${LUNARG_SDK}/synchronization_usage.html",
+                        "url": "$[LUNARG_SDK]/synchronization_usage.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
@@ -387,7 +387,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",
                         "label": "Debug Printf",
                         "description": "Enables processing of debug printf instructions in shaders and sending debug strings to the debug callback",
-                        "url": "${LUNARG_SDK}/debug_printf.html",
+                        "url": "$[LUNARG_SDK]/debug_printf.html",
                         "status": "STABLE",
                         "platforms": [ "WINDOWS", "LINUX" ],
                         "settings": [
@@ -450,7 +450,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",
                         "label": "GPU-Assisted",
                         "description": "Check for API usage errors at shader execution time",
-                        "url": "${LUNARG_SDK}/gpu_validation.html",
+                        "url": "$[LUNARG_SDK]/gpu_validation.html",
                         "platforms": [ "WINDOWS", "LINUX" ],
                         "settings": [
                             {
@@ -481,7 +481,7 @@
                         "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",
                         "label": "Best Practices",
                         "description": "Activating this feature enables the output of warnings related to common misuse of the API, but which are not explicitly prohibited by the specification.",
-                        "url": "${LUNARG_SDK}/best_practices.html",
+                        "url": "$[LUNARG_SDK]/best_practices.html",
                         "platforms": [ "WINDOWS", "LINUX", "MACOS" ]
                     },
                     {

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_api_dump.json
@@ -48,7 +48,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.txt"
+                        "value": "$[LOCAL]/vk_apidump.txt"
                     },
                     {
                         "key": "file",
@@ -68,7 +68,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.html"
+                        "value": "$[LOCAL]/vk_apidump.html"
                     },
                     {
                         "key": "file",
@@ -88,7 +88,7 @@
                     },
                     {
                         "key": "log_filename",
-                        "value": "${LOCAL}/vk_apidump.json"
+                        "value": "$[LOCAL]/vk_apidump.json"
                     },
                     {
                         "key": "file",

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_device_simulation.json
@@ -28,7 +28,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
                     }
                 ]
             },
@@ -44,7 +44,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_3_portability.json"
                     }
                 ]
             },
@@ -60,7 +60,7 @@
                     },
                     {
                         "key": "filename",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
+                        "value": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
                     }
                 ]
             }
@@ -73,7 +73,7 @@
                 "description": "Path of a devsim configuration file to load.",
                 "type": "LOAD_FILE",
                 "filter": "*.json",
-                "default": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
+                "default": "$[VULKAN_CONTENT]/VK_LAYER_LUNARG_device_simulation/macOS_gpu_family_1_portability.json"
             },
             {
                 "key": "debug_enable",

--- a/vkconfig_core/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json
+++ b/vkconfig_core/layers/latest/VK_LAYER_LUNARG_gfxreconstruct.json
@@ -159,7 +159,7 @@
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
                 "type": "SAVE_FILE",
                 "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                "default": "$[LOCAL]/gfxrecon_capture.gfxr",
                 "settings": [
                     {
                         "key": "capture_file_timestamp",

--- a/vkconfig_core/path.cpp
+++ b/vkconfig_core/path.cpp
@@ -85,12 +85,17 @@ struct BuiltinDesc {
 };
 
 std::string ReplaceBuiltInVariable(const std::string& path) {
-    static const BuiltinDesc VARIABLES[] = {{BUILTIN_PATH_HOME, "${HOME}"},
+    static const BuiltinDesc VARIABLES[] = {{BUILTIN_PATH_HOME, "$[HOME]"},
+                                            {BUILTIN_PATH_HOME, "${HOME}"},
+                                            {BUILTIN_PATH_LOCAL, "$[LOCAL]"},
                                             {BUILTIN_PATH_LOCAL, "${LOCAL}"},
+                                            {BUILTIN_PATH_VULKAN_SDK, "$[VULKAN_SDK]"},
                                             {BUILTIN_PATH_VULKAN_SDK, "${VULKAN_SDK}"},
+                                            {BUILTIN_PATH_VULKAN_LAYER_CONFIG, "$[VULKAN_CONTENT]"},
                                             {BUILTIN_PATH_VULKAN_LAYER_CONFIG, "${VULKAN_CONTENT}"}};
 
-    static_assert(countof(VARIABLES) == BUILTIN_PATH_COUNT, "The tranlation table size doesn't match the enum number of elements");
+    static_assert(countof(VARIABLES) == BUILTIN_PATH_COUNT * 2,
+                  "The tranlation table size doesn't match the enum number of elements");
 
     for (std::size_t i = 0, n = countof(VARIABLES); i < n; ++i) {
         const std::size_t found = path.find(VARIABLES[i].name);

--- a/vkconfig_core/test/test_path.cpp
+++ b/vkconfig_core/test/test_path.cpp
@@ -31,22 +31,46 @@
 // Test that GetPath return the home directory when the stored path is empty
 TEST(test_util, get_path) { EXPECT_STRNE(GetPath(BUILTIN_PATH_HOME).c_str(), ""); }
 
+TEST(test_util, replace_path_local) {
+    const std::string replaced_path = ReplaceBuiltInVariable("$[LOCAL]/test.txt");
+
+    EXPECT_TRUE(replaced_path.find("$[LOCAL]") > replaced_path.size());
+}
+
+TEST(test_util, replace_path_local_legacy) {
+    const std::string replaced_path = ReplaceBuiltInVariable("${LOCAL}/test.txt");
+
+    EXPECT_TRUE(replaced_path.find("${LOCAL}") > replaced_path.size());
+}
+
 TEST(test_util, replace_path_home) {
+    const std::string replaced_path = ReplaceBuiltInVariable("$[HOME]/test.txt");
+
+    EXPECT_TRUE(replaced_path.find("$[HOME]") > replaced_path.size());
+}
+
+TEST(test_util, replace_path_legacy) {
     const std::string replaced_path = ReplaceBuiltInVariable("${HOME}/test.txt");
 
     EXPECT_TRUE(replaced_path.find("${HOME}") > replaced_path.size());
 }
 
 TEST(test_util, replace_path_vulkan_sdk) {
+    const std::string replaced_path = ReplaceBuiltInVariable("$[VULKAN_SDK]/test.txt");
+
+    EXPECT_TRUE(replaced_path.find("$[VULKAN_SDK]") > replaced_path.size());
+}
+
+TEST(test_util, replace_path_vulkan_sdk_legacy) {
     const std::string replaced_path = ReplaceBuiltInVariable("${VULKAN_SDK}/test.txt");
 
     EXPECT_TRUE(replaced_path.find("${VULKAN_SDK}") > replaced_path.size());
 }
 
 TEST(test_util, replace_path_unknown) {
-    const std::string replaced_path = ReplaceBuiltInVariable("${UNKNOWN}/test.txt");
+    const std::string replaced_path = ReplaceBuiltInVariable("$[UNKNOWN]/test.txt");
 
-    EXPECT_STREQ("${UNKNOWN}/test.txt", replaced_path.c_str());
+    EXPECT_STREQ("$[UNKNOWN]/test.txt", replaced_path.c_str());
 }
 
 TEST(test_util, convert_native_separator_empty) {


### PR DESCRIPTION
The script that generates the .json files from .json.in files
erase the variable with the format ${SOMETHING} but these
variables are meant to be used and interpreted by Vulkan Configurator.

Change-Id: If6cb5dab82a29c033053431827a2079cac58ee8a