### PR TITLE
vkconfig: Fix grammar in tooltip for layer order

### DIFF
--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -47,7 +47,7 @@
 #include <cassert>
 
 static const char *TOOLTIP_ORDER =
-    "Layers are executed between the Vulkan application and driver the specific order represented here";
+    "Layers are executed between the Vulkan application and driver in the specific order represented here";
 
 SettingsTreeManager::SettingsTreeManager() : tree(nullptr) {}
 


### PR DESCRIPTION
Change-Id: If910d2431bd5f0e15bb3baaf15a5caf8f5ef44d7