### PR TITLE
license: add valijon license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,5 @@
 The majority of files in this project use the Apache 2.0 License.
-There are a few exceptions and their license can be found in the source.
-Any license deviations from Apache 2.0 are "more permissive" licenses.
+There are a few exceptions and their license can either be found in the source or their directory homing the source.
 
 ===========================================================================================
 

--- a/external/valijson/LICENSE
+++ b/external/valijson/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2016, Tristan Penman
+Copyright (c) 2016, Akamai Technolgies, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
The root license file says:
```
The majority of files in this project use the Apache 2.0 License.
There are a few exceptions and their license can be found in the source.
Any license deviations from Apache 2.0 are "more permissive" licenses.
```

Just adding this file seems to resolve the issue. 

compat/optional.hpp has the license embedded within the source so I guess it's ok.
