### PR TITLE
vkconfig: Add Vulkan 1.2 minimum preset

### DIFF
--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -65,6 +65,114 @@
                             "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/iOS_gpu_family_5_portability.json"
                         }
                     ]
+                },
+                {
+                    "label": "Vulkan 1.2 minimum requirements",
+                    "description": "Check the application for Vulkan 1.2 minimum requirements.",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "status": "STABLE",
+                    "settings": [
+                        {
+                            "key": "modify_extension_list",
+                            "value": true
+                        },
+                        {
+                            "key": "filename",
+                            "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/spec_minimum_vulkan_1_2.json"
+                        }
+                    ]
+                },
+                {
+                    "label": "Vulkan 1.1 minimum requirements",
+                    "description": "Check the application for Vulkan 1.1 minimum requirements.",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "status": "STABLE",
+                    "settings": [
+                        {
+                            "key": "modify_extension_list",
+                            "value": true
+                        },
+                        {
+                            "key": "filename",
+                            "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/spec_minimum_vulkan_1_1.json"
+                        }
+                    ]
+                },
+                {
+                    "label": "Vulkan 1.0 minimum requirements",
+                    "description": "Check the application for Vulkan 1.0 minimum requirements.",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "status": "STABLE",
+                    "settings": [
+                        {
+                            "key": "modify_extension_list",
+                            "value": true
+                        },
+                        {
+                            "key": "filename",
+                            "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/spec_minimum_vulkan_1_0.json"
+                        }
+                    ]
+                },
+                {
+                    "label": "Vulkan 1.2 minimum requirements portability",
+                    "description": "Check the application for Vulkan 1.2 minimum requirements.",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "status": "STABLE",
+                    "settings": [
+                        {
+                            "key": "emulate_portability",
+                            "value": true
+                        },
+                        {
+                            "key": "modify_extension_list",
+                            "value": true
+                        },
+                        {
+                            "key": "filename",
+                            "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/portability_minimum_vulkan_1_2.json"
+                        }
+                    ]
+                },
+                {
+                    "label": "Vulkan 1.1 minimum requirements portability",
+                    "description": "Check the application for Vulkan 1.1 minimum requirements.",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "status": "STABLE",
+                    "settings": [
+                        {
+                            "key": "emulate_portability",
+                            "value": true
+                        },
+                        {
+                            "key": "modify_extension_list",
+                            "value": true
+                        },
+                        {
+                            "key": "filename",
+                            "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/portability_minimum_vulkan_1_1.json"
+                        }
+                    ]
+                },
+                {
+                    "label": "Vulkan 1.0 minimum requirements portability",
+                    "description": "Check the application for Vulkan 1.0 minimum requirements.",
+                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "status": "STABLE",
+                    "settings": [
+                        {
+                            "key": "emulate_portability",
+                            "value": true
+                        },
+                        {
+                            "key": "modify_extension_list",
+                            "value": true
+                        },
+                        {
+                            "key": "filename",
+                            "value": "${VULKAN_CONTENT}/VK_LAYER_LUNARG_device_simulation/portability_minimum_vulkan_1_0.json"
+                        }
+                    ]
                 }
             ],
             "settings": [

--- a/layersvt/device_simulation_examples/sdk_sample_configs/portability_minimum_vulkan_1_0.json
+++ b/layersvt/device_simulation_examples/sdk_sample_configs/portability_minimum_vulkan_1_0.json
@@ -1,0 +1,856 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
+	"comments": {
+		"desc": "JSON configuration file for Vulkan 1.0 minimum requirements as defined by the Vulkan Specification."
+	},
+    "VkPhysicalDeviceProperties": {
+        "limits": {
+            "maxImageDimension1D": 4096,
+            "maxImageDimension2D": 4096,
+            "maxImageDimension3D": 256,
+            "maxImageDimensionCube": 4096,
+            "maxImageArrayLayers": 256,
+            "maxTexelBufferElements": 65536,
+            "maxUniformBufferRange": 16384,
+            "maxStorageBufferRange": 67108864,
+            "maxPushConstantsSize": 128,
+            "maxMemoryAllocationCount": 4096,
+            "maxSamplerAllocationCount": 4000,
+            "bufferImageGranularity": 131072,
+            "sparseAddressSpaceSize": 1073741824,
+            "maxBoundDescriptorSets": 4,
+            "maxPerStageDescriptorSamplers": 16,
+            "maxPerStageDescriptorUniformBuffers": 12,
+            "maxPerStageDescriptorStorageBuffers": 4,
+            "maxPerStageDescriptorSampledImages": 16,
+            "maxPerStageDescriptorStorageImages": 4,
+            "maxPerStageDescriptorInputAttachments": 4,
+            "maxPerStageResources": 128,
+            "maxDescriptorSetSamplers": 1536,
+            "maxDescriptorSetUniformBuffers": 864,
+            "maxDescriptorSetUniformBuffersDynamic": 8,
+            "maxDescriptorSetStorageBuffers": 96,
+            "maxDescriptorSetStorageBuffersDynamic": 4,
+            "maxDescriptorSetSampledImages": 1536,
+            "maxDescriptorSetStorageImages": 96,
+            "maxDescriptorSetInputAttachments": 4,
+            "maxVertexInputAttributes": 16,
+            "maxVertexInputBindings": 8,
+            "maxVertexInputAttributeOffset": 2047,
+            "maxVertexInputBindingStride": 2048,
+            "maxVertexOutputComponents": 64,
+            "maxTessellationGenerationLevel": 64,
+            "maxTessellationPatchSize": 32,
+            "maxTessellationControlPerVertexInputComponents": 64,
+            "maxTessellationControlPerVertexOutputComponents": 64,
+            "maxTessellationControlPerPatchOutputComponents": 120,
+            "maxTessellationControlTotalOutputComponents": 2048,
+            "maxTessellationEvaluationInputComponents": 64,
+            "maxTessellationEvaluationOutputComponents": 64,
+            "maxGeometryShaderInvocations": 32,
+            "maxGeometryInputComponents": 64,
+            "maxGeometryOutputComponents": 64,
+            "maxGeometryOutputVertices": 256,
+            "maxGeometryTotalOutputComponents": 1024,
+            "maxFragmentInputComponents": 64,
+            "maxFragmentOutputAttachments": 4,
+            "maxFragmentDualSrcAttachments": 1,
+            "maxFragmentCombinedOutputResources": 4,
+            "maxComputeSharedMemorySize": 16384,
+            "maxComputeWorkGroupCount": [65535, 65535, 65535],
+            "maxComputeWorkGroupInvocations": 128,
+            "maxComputeWorkGroupSize": [128, 128, 64],
+            "subPixelPrecisionBits": 4,
+            "subTexelPrecisionBits": 4,
+            "mipmapPrecisionBits": 4,
+            "maxDrawIndexedIndexValue": 2147483647,
+            "maxDrawIndirectCount": 32767,
+            "maxSamplerLodBias": 2,
+            "maxSamplerAnisotropy": 16,
+            "maxViewports": 16,
+            "maxViewportDimensions": [4096, 4096],
+            "viewportBoundsRange": [-8192, 8191],
+            "viewportSubPixelBits": 0,
+            "minMemoryMapAlignment": 64,
+            "minTexelBufferOffsetAlignment": 256,
+            "minUniformBufferOffsetAlignment": 256,
+            "minStorageBufferOffsetAlignment": 256,
+            "minTexelOffset": -8,
+            "maxTexelOffset": 7,
+            "minTexelGatherOffset": -8,
+            "maxTexelGatherOffset": 7,
+            "minInterpolationOffset": -0.5,
+            "maxInterpolationOffset": 0.4375,
+            "subPixelInterpolationOffsetBits": 4,
+            "maxFramebufferWidth": 4096,
+            "maxFramebufferHeight": 4096,
+            "maxFramebufferLayers": 256,
+            "framebufferColorSampleCounts": 9,
+            "framebufferDepthSampleCounts": 9,
+            "framebufferStencilSampleCounts": 9,
+            "framebufferNoAttachmentsSampleCounts": 9,
+            "maxColorAttachments": 4,
+            "sampledImageColorSampleCounts": 9,
+            "sampledImageIntegerSampleCounts": 1,
+            "sampledImageDepthSampleCounts": 9,
+            "sampledImageStencilSampleCounts": 9,
+            "storageImageSampleCounts": 9,
+            "maxSampleMaskWords": 1,
+            "maxClipDistances": 8,
+            "maxCullDistances": 8,
+            "maxCombinedClipAndCullDistances": 8,
+            "discreteQueuePriorities": 2,
+            "pointSizeRange": [1.0, 63.0],
+            "lineWidthRange": [1.0, 7.0],
+            "pointSizeGranularity": 1.0,
+            "lineWidthGranularity": 1.0,
+            "nonCoherentAtomSize": 256
+        },
+        "sparseProperties": {
+            "residencyStandard2DBlockShape": 0,
+            "residencyStandard2DMultisampleBlockShape": 0,
+            "residencyStandard3DBlockShape": 0,
+            "residencyAlignedMipSize": 0,
+            "residencyNonResidentStrict": 0
+        }
+    },
+    "VkPhysicalDeviceFeatures": {
+        "robustBufferAccess": 0,
+        "fullDrawIndexUint32": 0,
+        "imageCubeArray": 0,
+        "independentBlend": 0,
+        "geometryShader": 0,
+        "tessellationShader": 0,
+        "sampleRateShading": 0,
+        "dualSrcBlend": 0,
+        "logicOp": 0,
+        "multiDrawIndirect": 0,
+        "drawIndirectFirstInstance": 0,
+        "depthClamp": 0,
+        "depthBiasClamp": 0,
+        "fillModeNonSolid": 0,
+        "depthBounds": 0,
+        "wideLines": 0,
+        "largePoints": 0,
+        "alphaToOne": 0,
+        "multiViewport": 0,
+        "samplerAnisotropy": 0,
+        "textureCompressionETC2": 0,
+        "textureCompressionASTC_LDR": 0,
+        "textureCompressionBC": 0,
+        "occlusionQueryPrecise": 0,
+        "pipelineStatisticsQuery": 0,
+        "vertexPipelineStoresAndAtomics": 0,
+        "fragmentStoresAndAtomics": 0,
+        "shaderTessellationAndGeometryPointSize": 0,
+        "shaderImageGatherExtended": 0,
+        "shaderStorageImageExtendedFormats": 0,
+        "shaderStorageImageMultisample": 0,
+        "shaderStorageImageReadWithoutFormat": 0,
+        "shaderStorageImageWriteWithoutFormat": 0,
+        "shaderUniformBufferArrayDynamicIndexing": 0,
+        "shaderSampledImageArrayDynamicIndexing": 0,
+        "shaderStorageBufferArrayDynamicIndexing": 0,
+        "shaderStorageImageArrayDynamicIndexing": 0,
+        "shaderClipDistance": 0,
+        "shaderCullDistance": 0,
+        "shaderFloat64": 0,
+        "shaderInt64": 0,
+        "shaderInt16": 0,
+        "shaderResourceResidency": 0,
+        "shaderResourceMinLod": 0,
+        "sparseBinding": 0,
+        "sparseResidencyBuffer": 0,
+        "sparseResidencyImage2D": 0,
+        "sparseResidencyImage3D": 0,
+        "sparseResidency2Samples": 0,
+        "sparseResidency4Samples": 0,
+        "sparseResidency8Samples": 0,
+        "sparseResidency16Samples": 0,
+        "sparseResidencyAliased": 0,
+        "variableMultisampleRate": 0,
+        "inheritedQueries": 0
+    },
+    "ArrayOfVkFormatProperties": [
+    {
+      "formatID": 3,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 4,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 8,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 9,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 10,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 13,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 14,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 16,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 17,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 20,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 21,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 37,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 38,
+      "linearTilingFeatures": 54275,
+      "optimalTilingFeatures": 54275,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 41,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 42,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 43,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 44,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 50,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 51,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 52,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 55,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 56,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 57,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 64,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 68,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 70,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 71,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 74,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 75,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 76,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 77,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 78,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 81,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 82,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 83,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 91,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 92,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 95,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 96,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 97,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 98,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 99,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 100,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 101,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 102,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 103,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 104,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 105,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 106,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 107,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 108,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 109,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 122,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 123,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 124,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 125,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 126,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 129,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 130,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 131,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 132,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 133,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 134,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 135,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 136,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 137,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 138,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 139,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 140,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 141,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 142,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 143,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 145,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 146,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 147,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 148,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 149,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 150,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 151,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 152,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 153,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 154,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 155,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 156,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 157,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 158,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 159,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 160,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 161,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 162,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 163,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 164,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 165,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 166,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 167,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 168,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 169,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 170,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 171,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 172,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 173,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 174,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 175,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 176,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 177,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 178,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 179,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 180,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 181,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 182,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 183,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 184,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    }
+  ],
+  "ArrayOfVkExtensionProperties": [
+    {
+      "extensionName": "VK_KHR_portability_subset",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_swapchain",
+      "specVersion": 70
+    }
+  ]
+}

--- a/layersvt/device_simulation_examples/sdk_sample_configs/portability_minimum_vulkan_1_1.json
+++ b/layersvt/device_simulation_examples/sdk_sample_configs/portability_minimum_vulkan_1_1.json
@@ -1,0 +1,955 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/devsim_1_1_0.json#",
+	"comments": {
+		"desc": "JSON configuration file for Vulkan 1.1 minimum requirements as defined by the Vulkan Specification."
+	},
+    "VkPhysicalDeviceProperties": {
+        "limits": {
+            "maxImageDimension1D": 4096,
+            "maxImageDimension2D": 4096,
+            "maxImageDimension3D": 256,
+            "maxImageDimensionCube": 4096,
+            "maxImageArrayLayers": 256,
+            "maxTexelBufferElements": 65536,
+            "maxUniformBufferRange": 16384,
+            "maxStorageBufferRange": 67108864,
+            "maxPushConstantsSize": 128,
+            "maxMemoryAllocationCount": 4096,
+            "maxSamplerAllocationCount": 4000,
+            "bufferImageGranularity": 131072,
+            "sparseAddressSpaceSize": 1073741824,
+            "maxBoundDescriptorSets": 4,
+            "maxPerStageDescriptorSamplers": 16,
+            "maxPerStageDescriptorUniformBuffers": 12,
+            "maxPerStageDescriptorStorageBuffers": 4,
+            "maxPerStageDescriptorSampledImages": 16,
+            "maxPerStageDescriptorStorageImages": 4,
+            "maxPerStageDescriptorInputAttachments": 4,
+            "maxPerStageResources": 128,
+            "maxDescriptorSetSamplers": 1536,
+            "maxDescriptorSetUniformBuffers": 864,
+            "maxDescriptorSetUniformBuffersDynamic": 8,
+            "maxDescriptorSetStorageBuffers": 96,
+            "maxDescriptorSetStorageBuffersDynamic": 4,
+            "maxDescriptorSetSampledImages": 1536,
+            "maxDescriptorSetStorageImages": 96,
+            "maxDescriptorSetInputAttachments": 4,
+            "maxVertexInputAttributes": 16,
+            "maxVertexInputBindings": 8,
+            "maxVertexInputAttributeOffset": 2047,
+            "maxVertexInputBindingStride": 2048,
+            "maxVertexOutputComponents": 64,
+            "maxTessellationGenerationLevel": 64,
+            "maxTessellationPatchSize": 32,
+            "maxTessellationControlPerVertexInputComponents": 64,
+            "maxTessellationControlPerVertexOutputComponents": 64,
+            "maxTessellationControlPerPatchOutputComponents": 120,
+            "maxTessellationControlTotalOutputComponents": 2048,
+            "maxTessellationEvaluationInputComponents": 64,
+            "maxTessellationEvaluationOutputComponents": 64,
+            "maxGeometryShaderInvocations": 32,
+            "maxGeometryInputComponents": 64,
+            "maxGeometryOutputComponents": 64,
+            "maxGeometryOutputVertices": 256,
+            "maxGeometryTotalOutputComponents": 1024,
+            "maxFragmentInputComponents": 64,
+            "maxFragmentOutputAttachments": 4,
+            "maxFragmentDualSrcAttachments": 1,
+            "maxFragmentCombinedOutputResources": 4,
+            "maxComputeSharedMemorySize": 16384,
+            "maxComputeWorkGroupCount": [65535, 65535, 65535],
+            "maxComputeWorkGroupInvocations": 128,
+            "maxComputeWorkGroupSize": [128, 128, 64],
+            "subPixelPrecisionBits": 4,
+            "subTexelPrecisionBits": 4,
+            "mipmapPrecisionBits": 4,
+            "maxDrawIndexedIndexValue": 2147483647,
+            "maxDrawIndirectCount": 32767,
+            "maxSamplerLodBias": 2,
+            "maxSamplerAnisotropy": 16,
+            "maxViewports": 16,
+            "maxViewportDimensions": [4096, 4096],
+            "viewportBoundsRange": [-8192, 8191],
+            "viewportSubPixelBits": 0,
+            "minMemoryMapAlignment": 64,
+            "minTexelBufferOffsetAlignment": 256,
+            "minUniformBufferOffsetAlignment": 256,
+            "minStorageBufferOffsetAlignment": 256,
+            "minTexelOffset": -8,
+            "maxTexelOffset": 7,
+            "minTexelGatherOffset": -8,
+            "maxTexelGatherOffset": 7,
+            "minInterpolationOffset": -0.5,
+            "maxInterpolationOffset": 0.4375,
+            "subPixelInterpolationOffsetBits": 4,
+            "maxFramebufferWidth": 4096,
+            "maxFramebufferHeight": 4096,
+            "maxFramebufferLayers": 256,
+            "framebufferColorSampleCounts": 9,
+            "framebufferDepthSampleCounts": 9,
+            "framebufferStencilSampleCounts": 9,
+            "framebufferNoAttachmentsSampleCounts": 9,
+            "maxColorAttachments": 4,
+            "sampledImageColorSampleCounts": 9,
+            "sampledImageIntegerSampleCounts": 1,
+            "sampledImageDepthSampleCounts": 9,
+            "sampledImageStencilSampleCounts": 9,
+            "storageImageSampleCounts": 9,
+            "maxSampleMaskWords": 1,
+            "maxClipDistances": 8,
+            "maxCullDistances": 8,
+            "maxCombinedClipAndCullDistances": 8,
+            "discreteQueuePriorities": 2,
+            "pointSizeRange": [1.0, 63.0],
+            "lineWidthRange": [1.0, 7.0],
+            "pointSizeGranularity": 1.0,
+            "lineWidthGranularity": 1.0,
+            "nonCoherentAtomSize": 256
+        },
+        "sparseProperties": {
+            "residencyStandard2DBlockShape": 0,
+            "residencyStandard2DMultisampleBlockShape": 0,
+            "residencyStandard3DBlockShape": 0,
+            "residencyAlignedMipSize": 0,
+            "residencyNonResidentStrict": 0
+        }
+    },
+    "VkPhysicalDeviceMaintenance3Properties": {
+        "maxPerSetDescriptors": 1024,
+        "maxMemoryAllocationSize" : 536870912
+    },
+    "VkPhysicalDeviceMultiviewProperties": {
+        "maxMultiviewViewCount": 6,
+        "maxMultiviewInstanceIndex" : 67108863
+    },
+    "VkPhysicalDeviceProtectedMemoryProperties": {
+        "protectedNoFault": 0
+    },
+    "VkPhysicalDeviceFeatures": {
+        "robustBufferAccess": 0,
+        "fullDrawIndexUint32": 0,
+        "imageCubeArray": 0,
+        "independentBlend": 0,
+        "geometryShader": 0,
+        "tessellationShader": 0,
+        "sampleRateShading": 0,
+        "dualSrcBlend": 0,
+        "logicOp": 0,
+        "multiDrawIndirect": 0,
+        "drawIndirectFirstInstance": 0,
+        "depthClamp": 0,
+        "depthBiasClamp": 0,
+        "fillModeNonSolid": 0,
+        "depthBounds": 0,
+        "wideLines": 0,
+        "largePoints": 0,
+        "alphaToOne": 0,
+        "multiViewport": 0,
+        "samplerAnisotropy": 0,
+        "textureCompressionETC2": 0,
+        "textureCompressionASTC_LDR": 0,
+        "textureCompressionBC": 0,
+        "occlusionQueryPrecise": 0,
+        "pipelineStatisticsQuery": 0,
+        "vertexPipelineStoresAndAtomics": 0,
+        "fragmentStoresAndAtomics": 0,
+        "shaderTessellationAndGeometryPointSize": 0,
+        "shaderImageGatherExtended": 0,
+        "shaderStorageImageExtendedFormats": 0,
+        "shaderStorageImageMultisample": 0,
+        "shaderStorageImageReadWithoutFormat": 0,
+        "shaderStorageImageWriteWithoutFormat": 0,
+        "shaderUniformBufferArrayDynamicIndexing": 0,
+        "shaderSampledImageArrayDynamicIndexing": 0,
+        "shaderStorageBufferArrayDynamicIndexing": 0,
+        "shaderStorageImageArrayDynamicIndexing": 0,
+        "shaderClipDistance": 0,
+        "shaderCullDistance": 0,
+        "shaderFloat64": 0,
+        "shaderInt64": 0,
+        "shaderInt16": 0,
+        "shaderResourceResidency": 0,
+        "shaderResourceMinLod": 0,
+        "sparseBinding": 0,
+        "sparseResidencyBuffer": 0,
+        "sparseResidencyImage2D": 0,
+        "sparseResidencyImage3D": 0,
+        "sparseResidency2Samples": 0,
+        "sparseResidency4Samples": 0,
+        "sparseResidency8Samples": 0,
+        "sparseResidency16Samples": 0,
+        "sparseResidencyAliased": 0,
+        "variableMultisampleRate": 0,
+        "inheritedQueries": 0
+    },
+    "VkPhysicalDevice16BitStorageFeatures": {
+        "storageBuffer16BitAccess": 0,
+        "uniformAndStorageBuffer16BitAccess": 0,
+        "storagePushConstant16": 0,
+        "storageInputOutput16": 0
+    },
+    "VkPhysicalDeviceMultiviewFeatures": {
+        "multiview": 1,
+        "multiviewGeometryShader": 0,
+        "multiviewTessellationShader": 0
+    },
+    "VkPhysicalDeviceProtectedMemoryFeatures": {
+        "protectedMemory": 0
+    },
+    "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+        "samplerYcbcrConversion": 0
+    },
+    "VkPhysicalDeviceShaderDrawParametersFeatures": {
+        "shaderDrawParameters": 0
+    },
+    "VkPhysicalDeviceVariablePointersFeatures": {
+        "variablePointersStorageBuffer": 0,
+        "variablePointers": 0
+    },
+    "ArrayOfVkFormatProperties": [
+    {
+      "formatID": 3,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 4,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 8,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 9,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 10,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 13,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 14,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 16,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 17,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 20,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 21,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 37,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 38,
+      "linearTilingFeatures": 54275,
+      "optimalTilingFeatures": 54275,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 41,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 42,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 43,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 44,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 50,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 51,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 52,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 55,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 56,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 57,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 64,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 68,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 70,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 71,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 74,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 75,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 76,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 77,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 78,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 81,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 82,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 83,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 91,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 92,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 95,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 96,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 97,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 98,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 99,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 100,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 101,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 102,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 103,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 104,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 105,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 106,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 107,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 108,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 109,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 122,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 123,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 124,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 125,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 126,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 129,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 130,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 131,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 132,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 133,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 134,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 135,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 136,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 137,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 138,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 139,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 140,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 141,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 142,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 143,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 145,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 146,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 147,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 148,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 149,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 150,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 151,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 152,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 153,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 154,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 155,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 156,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 157,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 158,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 159,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 160,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 161,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 162,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 163,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 164,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 165,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 166,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 167,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 168,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 169,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 170,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 171,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 172,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 173,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 174,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 175,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 176,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 177,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 178,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 179,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 180,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 181,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 182,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 183,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 184,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    }
+  ],
+  "ArrayOfVkExtensionProperties": [
+    {
+      "extensionName": "VK_KHR_bind_memory2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_dedicated_allocation",
+      "specVersion": 3
+    },
+    {
+      "extensionName": "VK_KHR_descriptor_update_template",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_device_group",
+      "specVersion": 4
+    },
+    {
+      "extensionName": "VK_KHR_driver_properties",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_fence",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_memory",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_semaphore",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_get_memory_requirements2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_image_format_list",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance1",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance3",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_multiview",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_portability_subset",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_relaxed_block_layout",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_storage_buffer_storage_class",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_swapchain",
+      "specVersion": 70
+    }
+  ]
+}

--- a/layersvt/device_simulation_examples/sdk_sample_configs/portability_minimum_vulkan_1_2.json
+++ b/layersvt/device_simulation_examples/sdk_sample_configs/portability_minimum_vulkan_1_2.json
@@ -1,0 +1,1137 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/devsim_1_2_0.json#",
+	"comments": {
+		"desc": "JSON configuration file for Vulkan 1.2 minimum requirements in the portability subset as defined by the Vulkan Specification."
+	},
+    "VkPhysicalDeviceProperties": {
+        "limits": {
+            "maxImageDimension1D": 4096,
+            "maxImageDimension2D": 4096,
+            "maxImageDimension3D": 256,
+            "maxImageDimensionCube": 4096,
+            "maxImageArrayLayers": 256,
+            "maxTexelBufferElements": 65536,
+            "maxUniformBufferRange": 16384,
+            "maxStorageBufferRange": 67108864,
+            "maxPushConstantsSize": 128,
+            "maxMemoryAllocationCount": 4096,
+            "maxSamplerAllocationCount": 4000,
+            "bufferImageGranularity": 131072,
+            "sparseAddressSpaceSize": 1073741824,
+            "maxBoundDescriptorSets": 4,
+            "maxPerStageDescriptorSamplers": 16,
+            "maxPerStageDescriptorUniformBuffers": 12,
+            "maxPerStageDescriptorStorageBuffers": 4,
+            "maxPerStageDescriptorSampledImages": 16,
+            "maxPerStageDescriptorStorageImages": 4,
+            "maxPerStageDescriptorInputAttachments": 4,
+            "maxPerStageResources": 128,
+            "maxDescriptorSetSamplers": 1536,
+            "maxDescriptorSetUniformBuffers": 864,
+            "maxDescriptorSetUniformBuffersDynamic": 8,
+            "maxDescriptorSetStorageBuffers": 96,
+            "maxDescriptorSetStorageBuffersDynamic": 4,
+            "maxDescriptorSetSampledImages": 1536,
+            "maxDescriptorSetStorageImages": 96,
+            "maxDescriptorSetInputAttachments": 4,
+            "maxVertexInputAttributes": 16,
+            "maxVertexInputBindings": 8,
+            "maxVertexInputAttributeOffset": 2047,
+            "maxVertexInputBindingStride": 2048,
+            "maxVertexOutputComponents": 64,
+            "maxTessellationGenerationLevel": 64,
+            "maxTessellationPatchSize": 32,
+            "maxTessellationControlPerVertexInputComponents": 64,
+            "maxTessellationControlPerVertexOutputComponents": 64,
+            "maxTessellationControlPerPatchOutputComponents": 120,
+            "maxTessellationControlTotalOutputComponents": 2048,
+            "maxTessellationEvaluationInputComponents": 64,
+            "maxTessellationEvaluationOutputComponents": 64,
+            "maxGeometryShaderInvocations": 32,
+            "maxGeometryInputComponents": 64,
+            "maxGeometryOutputComponents": 64,
+            "maxGeometryOutputVertices": 256,
+            "maxGeometryTotalOutputComponents": 1024,
+            "maxFragmentInputComponents": 64,
+            "maxFragmentOutputAttachments": 4,
+            "maxFragmentDualSrcAttachments": 1,
+            "maxFragmentCombinedOutputResources": 4,
+            "maxComputeSharedMemorySize": 16384,
+            "maxComputeWorkGroupCount": [65535, 65535, 65535],
+            "maxComputeWorkGroupInvocations": 128,
+            "maxComputeWorkGroupSize": [128, 128, 64],
+            "subPixelPrecisionBits": 4,
+            "subTexelPrecisionBits": 4,
+            "mipmapPrecisionBits": 4,
+            "maxDrawIndexedIndexValue": 2147483647,
+            "maxDrawIndirectCount": 32767,
+            "maxSamplerLodBias": 2,
+            "maxSamplerAnisotropy": 16,
+            "maxViewports": 16,
+            "maxViewportDimensions": [4096, 4096],
+            "viewportBoundsRange": [-8192, 8191],
+            "viewportSubPixelBits": 0,
+            "minMemoryMapAlignment": 64,
+            "minTexelBufferOffsetAlignment": 256,
+            "minUniformBufferOffsetAlignment": 256,
+            "minStorageBufferOffsetAlignment": 256,
+            "minTexelOffset": -8,
+            "maxTexelOffset": 7,
+            "minTexelGatherOffset": -8,
+            "maxTexelGatherOffset": 7,
+            "minInterpolationOffset": -0.5,
+            "maxInterpolationOffset": 0.4375,
+            "subPixelInterpolationOffsetBits": 4,
+            "maxFramebufferWidth": 4096,
+            "maxFramebufferHeight": 4096,
+            "maxFramebufferLayers": 256,
+            "framebufferColorSampleCounts": 9,
+            "framebufferDepthSampleCounts": 9,
+            "framebufferStencilSampleCounts": 9,
+            "framebufferNoAttachmentsSampleCounts": 9,
+            "maxColorAttachments": 4,
+            "sampledImageColorSampleCounts": 9,
+            "sampledImageIntegerSampleCounts": 1,
+            "sampledImageDepthSampleCounts": 9,
+            "sampledImageStencilSampleCounts": 9,
+            "storageImageSampleCounts": 9,
+            "maxSampleMaskWords": 1,
+            "maxClipDistances": 8,
+            "maxCullDistances": 8,
+            "maxCombinedClipAndCullDistances": 8,
+            "discreteQueuePriorities": 2,
+            "pointSizeRange": [1.0, 63.0],
+            "lineWidthRange": [1.0, 7.0],
+            "pointSizeGranularity": 1.0,
+            "lineWidthGranularity": 1.0,
+            "nonCoherentAtomSize": 256
+        },
+        "sparseProperties": {
+            "residencyStandard2DBlockShape": 0,
+            "residencyStandard2DMultisampleBlockShape": 0,
+            "residencyStandard3DBlockShape": 0,
+            "residencyAlignedMipSize": 0,
+            "residencyNonResidentStrict": 0
+        }
+    },
+    "VkPhysicalDeviceDepthStencilResolveProperties": {
+        "supportedDepthResolveModes": 1,
+        "supportedStencilResolveModes": 1,
+        "independentResolveNone": 0,
+        "independentResolve": 0
+    },
+    "VkPhysicalDeviceDescriptorIndexingProperties": {
+        "maxUpdateAfterBindDescriptorsInAllPools": 500000,
+        "shaderUniformBufferArrayNonUniformIndexingNative": 0,
+        "shaderSampledImageArrayNonUniformIndexingNative": 0,
+        "shaderStorageBufferArrayNonUniformIndexingNative": 0,
+        "shaderStorageImageArrayNonUniformIndexingNative": 0,
+        "shaderInputAttachmentArrayNonUniformIndexingNative": 0,
+        "robustBufferAccessUpdateAfterBind": 0,
+        "quadDivergentImplicitLod": 0,
+        "maxPerStageDescriptorUpdateAfterBindSamplers": 500000,
+        "maxPerStageDescriptorUpdateAfterBindUniformBuffers": 12,
+        "maxPerStageDescriptorUpdateAfterBindStorageBuffers": 500000,
+        "maxPerStageDescriptorUpdateAfterBindSampledImages": 500000,
+        "maxPerStageDescriptorUpdateAfterBindStorageImages": 500000,
+        "maxPerStageDescriptorUpdateAfterBindInputAttachments": 4,
+        "maxPerStageUpdateAfterBindResources": 500000,
+        "maxDescriptorSetUpdateAfterBindSamplers": 500000,
+        "maxDescriptorSetUpdateAfterBindUniformBuffers": 72,
+        "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": 8,
+        "maxDescriptorSetUpdateAfterBindStorageBuffers": 500000,
+        "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": 4,
+        "maxDescriptorSetUpdateAfterBindSampledImages": 500000,
+        "maxDescriptorSetUpdateAfterBindStorageImages": 500000,
+        "maxDescriptorSetUpdateAfterBindInputAttachments": 4
+    },
+    "VkPhysicalDeviceFloatControlsProperties": {
+        "denormBehaviorIndependence": 2,
+        "roundingModeIndependence": 2,
+        "shaderSignedZeroInfNanPreserveFloat16": 0,
+        "shaderSignedZeroInfNanPreserveFloat32": 0,
+        "shaderSignedZeroInfNanPreserveFloat64": 0,
+        "shaderDenormPreserveFloat16": 0,
+        "shaderDenormPreserveFloat32": 0,
+        "shaderDenormPreserveFloat64": 0,
+        "shaderDenormFlushToZeroFloat16": 0,
+        "shaderDenormFlushToZeroFloat32": 0,
+        "shaderDenormFlushToZeroFloat64": 0,
+        "shaderRoundingModeRTEFloat16": 0,
+        "shaderRoundingModeRTEFloat32": 0,
+        "shaderRoundingModeRTEFloat64": 0,
+        "shaderRoundingModeRTZFloat16": 0,
+        "shaderRoundingModeRTZFloat32": 0,
+        "shaderRoundingModeRTZFloat64": 0
+    },
+    "VkPhysicalDeviceMaintenance3Properties": {
+        "maxPerSetDescriptors": 1024,
+        "maxMemoryAllocationSize" : 536870912
+    },
+    "VkPhysicalDeviceMultiviewProperties": {
+        "maxMultiviewViewCount": 6,
+        "maxMultiviewInstanceIndex" : 67108863
+    },
+    "VkPhysicalDeviceProtectedMemoryProperties": {
+        "protectedNoFault": 0
+    },
+    "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+        "filterMinmaxSingleComponentFormats": 0,
+        "filterMinmaxImageComponentMapping": 0
+    },
+    "VkPhysicalDeviceTimelineSemaphoreProperties": {
+        "maxTimelineSemaphoreValueDifference": 1073741823
+    },
+    "VkPhysicalDeviceFeatures": {
+        "robustBufferAccess": 0,
+        "fullDrawIndexUint32": 0,
+        "imageCubeArray": 0,
+        "independentBlend": 0,
+        "geometryShader": 0,
+        "tessellationShader": 0,
+        "sampleRateShading": 0,
+        "dualSrcBlend": 0,
+        "logicOp": 0,
+        "multiDrawIndirect": 0,
+        "drawIndirectFirstInstance": 0,
+        "depthClamp": 0,
+        "depthBiasClamp": 0,
+        "fillModeNonSolid": 0,
+        "depthBounds": 0,
+        "wideLines": 0,
+        "largePoints": 0,
+        "alphaToOne": 0,
+        "multiViewport": 0,
+        "samplerAnisotropy": 0,
+        "textureCompressionETC2": 0,
+        "textureCompressionASTC_LDR": 0,
+        "textureCompressionBC": 0,
+        "occlusionQueryPrecise": 0,
+        "pipelineStatisticsQuery": 0,
+        "vertexPipelineStoresAndAtomics": 0,
+        "fragmentStoresAndAtomics": 0,
+        "shaderTessellationAndGeometryPointSize": 0,
+        "shaderImageGatherExtended": 0,
+        "shaderStorageImageExtendedFormats": 0,
+        "shaderStorageImageMultisample": 0,
+        "shaderStorageImageReadWithoutFormat": 0,
+        "shaderStorageImageWriteWithoutFormat": 0,
+        "shaderUniformBufferArrayDynamicIndexing": 0,
+        "shaderSampledImageArrayDynamicIndexing": 0,
+        "shaderStorageBufferArrayDynamicIndexing": 0,
+        "shaderStorageImageArrayDynamicIndexing": 0,
+        "shaderClipDistance": 0,
+        "shaderCullDistance": 0,
+        "shaderFloat64": 0,
+        "shaderInt64": 0,
+        "shaderInt16": 0,
+        "shaderResourceResidency": 0,
+        "shaderResourceMinLod": 0,
+        "sparseBinding": 0,
+        "sparseResidencyBuffer": 0,
+        "sparseResidencyImage2D": 0,
+        "sparseResidencyImage3D": 0,
+        "sparseResidency2Samples": 0,
+        "sparseResidency4Samples": 0,
+        "sparseResidency8Samples": 0,
+        "sparseResidency16Samples": 0,
+        "sparseResidencyAliased": 0,
+        "variableMultisampleRate": 0,
+        "inheritedQueries": 0
+    },
+    "VkPhysicalDevice16BitStorageFeatures": {
+        "storageBuffer16BitAccess": 0,
+        "uniformAndStorageBuffer16BitAccess": 0,
+        "storagePushConstant16": 0,
+        "storageInputOutput16": 0
+    },
+    "VkPhysicalDevice8BitStorageFeatures": {
+        "storageBuffer8BitAccess": 0,
+        "uniformAndStorageBuffer8BitAccess": 0,
+        "storagePushConstant8": 0
+    },
+    "VkPhysicalDeviceDescriptorIndexingFeatures": {
+        "shaderInputAttachmentArrayDynamicIndexing": 0,
+        "shaderUniformTexelBufferArrayDynamicIndexing": 0,
+        "shaderStorageTexelBufferArrayDynamicIndexing": 0,
+        "shaderUniformBufferArrayNonUniformIndexing": 0,
+        "shaderSampledImageArrayNonUniformIndexing": 0,
+        "shaderStorageBufferArrayNonUniformIndexing": 0,
+        "shaderStorageImageArrayNonUniformIndexing": 0,
+        "shaderInputAttachmentArrayNonUniformIndexing": 0,
+        "shaderUniformTexelBufferArrayNonUniformIndexing": 0,
+        "shaderStorageTexelBufferArrayNonUniformIndexing": 0,
+        "descriptorBindingUniformBufferUpdateAfterBind": 0,
+        "descriptorBindingSampledImageUpdateAfterBind": 0,
+        "descriptorBindingStorageImageUpdateAfterBind": 0,
+        "descriptorBindingStorageBufferUpdateAfterBind": 0,
+        "descriptorBindingUniformTexelBufferUpdateAfterBind": 0,
+        "descriptorBindingStorageTexelBufferUpdateAfterBind": 0,
+        "descriptorBindingUpdateUnusedWhilePending": 0,
+        "descriptorBindingPartiallyBound": 0,
+        "descriptorBindingVariableDescriptorCount": 0,
+        "runtimeDescriptorArray": 0
+    },
+    "VkPhysicalDeviceHostQueryResetFeatures": {
+        "hostQueryReset": 0
+    },
+    "VkPhysicalDeviceImagelessFramebufferFeatures": {
+        "imagelessFramebuffer": 0
+    },
+    "VkPhysicalDeviceMultiviewFeatures": {
+        "multiview": 1,
+        "multiviewGeometryShader": 0,
+        "multiviewTessellationShader": 0
+    },
+    "VkPhysicalDeviceProtectedMemoryFeatures": {
+        "protectedMemory": 0
+    },
+    "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+        "samplerYcbcrConversion": 0
+    },
+    "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+        "scalarBlockLayout": 0
+    },
+    "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+        "separateDepthStencilLayouts": 0
+    },
+    "VkPhysicalDeviceShaderAtomicInt64Features": {
+        "shaderBufferInt64Atomics": 0,
+        "shaderSharedInt64Atomics": 0
+    },
+    "VkPhysicalDeviceShaderDrawParametersFeatures": {
+        "shaderDrawParameters": 0
+    },
+    "VkPhysicalDeviceShaderFloat16Int8Features": {
+        "shaderFloat16": 0,
+        "shaderInt8": 0
+    },
+    "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+        "shaderSubgroupExtendedTypes": 1
+    },
+    "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+        "timelineSemaphore": 0
+    },
+    "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+        "uniformBufferStandardLayout": 1
+    },
+    "VkPhysicalDeviceVariablePointersFeatures": {
+        "variablePointersStorageBuffer": 0,
+        "variablePointers": 0
+    },
+    "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+        "vulkanMemoryModel": 0,
+        "vulkanMemoryModelDeviceScope": 0,
+        "vulkanMemoryModelAvailabilityVisibilityChains": 0
+    },
+    "Vulkan12Features": {
+        "samplerMirrorClampToEdge": 0,
+        "shaderOutputViewportIndex": 0,
+        "shaderOutputLayer": 0,
+        "subgroupBroadcastDynamicId": 1,
+        "drawIndirectCount": 0,
+        "descriptorIndexing": 0,
+        "samplerFilterMinmax": 0
+    },
+    "Vulkan12Properties": {
+        "framebufferIntegerColorSampleCounts": 1
+    },
+    "ArrayOfVkFormatProperties": [
+    {
+      "formatID": 3,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 4,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 8,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 9,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 10,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 13,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 14,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 16,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 17,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 20,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 21,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 37,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 38,
+      "linearTilingFeatures": 54275,
+      "optimalTilingFeatures": 54275,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 41,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 42,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 43,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 44,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 50,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 51,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 52,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 55,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 56,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 57,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 64,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 68,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 70,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 71,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 74,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 75,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 76,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 77,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 78,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 81,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 82,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 83,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 91,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 92,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 95,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 96,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 97,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 98,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 99,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 100,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 101,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 102,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 103,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 104,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 105,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 106,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 107,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 108,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 109,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 122,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 123,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 124,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 125,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 126,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 129,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 130,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 131,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 132,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 133,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 134,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 135,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 136,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 137,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 138,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 139,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 140,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 141,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 142,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 143,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 145,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 146,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 147,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 148,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 149,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 150,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 151,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 152,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 153,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 154,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 155,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 156,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 157,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 158,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 159,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 160,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 161,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 162,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 163,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 164,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 165,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 166,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 167,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 168,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 169,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 170,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 171,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 172,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 173,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 174,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 175,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 176,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 177,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 178,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 179,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 180,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 181,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 182,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 183,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 184,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    }
+  ],
+  "ArrayOfVkExtensionProperties": [
+    {
+      "extensionName": "VK_KHR_bind_memory2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_create_renderpass2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_dedicated_allocation",
+      "specVersion": 3
+    },
+    {
+      "extensionName": "VK_KHR_depth_stencil_resolve",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_descriptor_update_template",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_device_group",
+      "specVersion": 4
+    },
+    {
+      "extensionName": "VK_KHR_driver_properties",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_fence",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_memory",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_semaphore",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_get_memory_requirements2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_image_format_list",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_imageless_framebuffer",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance1",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance3",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_multiview",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_portability_subset",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_relaxed_block_layout",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_separate_depth_stencil_layouts",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_shader_float_controls",
+      "specVersion": 4
+    },
+    {
+      "extensionName": "VK_KHR_shader_subgroup_extended_types",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_spirv_1_4",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_storage_buffer_storage_class",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_swapchain",
+      "specVersion": 70
+    },
+    {
+      "extensionName": "VK_KHR_timeline_semaphore",
+      "specVersion": 2
+    },
+    {
+      "extensionName": "VK_KHR_uniform_buffer_standard_layout",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_EXT_host_query_reset",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_EXT_sampler_filter_minmax",
+      "specVersion": 2
+    },
+    {
+      "extensionName": "VK_EXT_separate_stencil_usage",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_EXT_shader_viewport_index_layer",
+      "specVersion": 1
+    }
+  ]
+}

--- a/layersvt/device_simulation_examples/sdk_sample_configs/spec_minimum_vulkan_1_0.json
+++ b/layersvt/device_simulation_examples/sdk_sample_configs/spec_minimum_vulkan_1_0.json
@@ -1,0 +1,852 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/devsim_1_0_0.json#",
+	"comments": {
+		"desc": "JSON configuration file for Vulkan 1.0 minimum requirements as defined by the Vulkan Specification."
+	},
+    "VkPhysicalDeviceProperties": {
+        "limits": {
+            "maxImageDimension1D": 4096,
+            "maxImageDimension2D": 4096,
+            "maxImageDimension3D": 256,
+            "maxImageDimensionCube": 4096,
+            "maxImageArrayLayers": 256,
+            "maxTexelBufferElements": 65536,
+            "maxUniformBufferRange": 16384,
+            "maxStorageBufferRange": 67108864,
+            "maxPushConstantsSize": 128,
+            "maxMemoryAllocationCount": 4096,
+            "maxSamplerAllocationCount": 4000,
+            "bufferImageGranularity": 131072,
+            "sparseAddressSpaceSize": 1073741824,
+            "maxBoundDescriptorSets": 4,
+            "maxPerStageDescriptorSamplers": 16,
+            "maxPerStageDescriptorUniformBuffers": 12,
+            "maxPerStageDescriptorStorageBuffers": 4,
+            "maxPerStageDescriptorSampledImages": 16,
+            "maxPerStageDescriptorStorageImages": 4,
+            "maxPerStageDescriptorInputAttachments": 4,
+            "maxPerStageResources": 128,
+            "maxDescriptorSetSamplers": 1536,
+            "maxDescriptorSetUniformBuffers": 864,
+            "maxDescriptorSetUniformBuffersDynamic": 8,
+            "maxDescriptorSetStorageBuffers": 96,
+            "maxDescriptorSetStorageBuffersDynamic": 4,
+            "maxDescriptorSetSampledImages": 1536,
+            "maxDescriptorSetStorageImages": 96,
+            "maxDescriptorSetInputAttachments": 4,
+            "maxVertexInputAttributes": 16,
+            "maxVertexInputBindings": 16,
+            "maxVertexInputAttributeOffset": 2047,
+            "maxVertexInputBindingStride": 2048,
+            "maxVertexOutputComponents": 64,
+            "maxTessellationGenerationLevel": 64,
+            "maxTessellationPatchSize": 32,
+            "maxTessellationControlPerVertexInputComponents": 64,
+            "maxTessellationControlPerVertexOutputComponents": 64,
+            "maxTessellationControlPerPatchOutputComponents": 120,
+            "maxTessellationControlTotalOutputComponents": 2048,
+            "maxTessellationEvaluationInputComponents": 64,
+            "maxTessellationEvaluationOutputComponents": 64,
+            "maxGeometryShaderInvocations": 32,
+            "maxGeometryInputComponents": 64,
+            "maxGeometryOutputComponents": 64,
+            "maxGeometryOutputVertices": 256,
+            "maxGeometryTotalOutputComponents": 1024,
+            "maxFragmentInputComponents": 64,
+            "maxFragmentOutputAttachments": 4,
+            "maxFragmentDualSrcAttachments": 1,
+            "maxFragmentCombinedOutputResources": 4,
+            "maxComputeSharedMemorySize": 16384,
+            "maxComputeWorkGroupCount": [65535, 65535, 65535],
+            "maxComputeWorkGroupInvocations": 128,
+            "maxComputeWorkGroupSize": [128, 128, 64],
+            "subPixelPrecisionBits": 4,
+            "subTexelPrecisionBits": 4,
+            "mipmapPrecisionBits": 4,
+            "maxDrawIndexedIndexValue": 2147483647,
+            "maxDrawIndirectCount": 32767,
+            "maxSamplerLodBias": 2,
+            "maxSamplerAnisotropy": 16,
+            "maxViewports": 16,
+            "maxViewportDimensions": [4096, 4096],
+            "viewportBoundsRange": [-8192, 8191],
+            "viewportSubPixelBits": 0,
+            "minMemoryMapAlignment": 64,
+            "minTexelBufferOffsetAlignment": 256,
+            "minUniformBufferOffsetAlignment": 256,
+            "minStorageBufferOffsetAlignment": 256,
+            "minTexelOffset": -8,
+            "maxTexelOffset": 7,
+            "minTexelGatherOffset": -8,
+            "maxTexelGatherOffset": 7,
+            "minInterpolationOffset": -0.5,
+            "maxInterpolationOffset": 0.4375,
+            "subPixelInterpolationOffsetBits": 4,
+            "maxFramebufferWidth": 4096,
+            "maxFramebufferHeight": 4096,
+            "maxFramebufferLayers": 256,
+            "framebufferColorSampleCounts": 9,
+            "framebufferDepthSampleCounts": 9,
+            "framebufferStencilSampleCounts": 9,
+            "framebufferNoAttachmentsSampleCounts": 9,
+            "maxColorAttachments": 4,
+            "sampledImageColorSampleCounts": 9,
+            "sampledImageIntegerSampleCounts": 1,
+            "sampledImageDepthSampleCounts": 9,
+            "sampledImageStencilSampleCounts": 9,
+            "storageImageSampleCounts": 9,
+            "maxSampleMaskWords": 1,
+            "maxClipDistances": 8,
+            "maxCullDistances": 8,
+            "maxCombinedClipAndCullDistances": 8,
+            "discreteQueuePriorities": 2,
+            "pointSizeRange": [1.0, 63.0],
+            "lineWidthRange": [1.0, 7.0],
+            "pointSizeGranularity": 1.0,
+            "lineWidthGranularity": 1.0,
+            "nonCoherentAtomSize": 256
+        },
+        "sparseProperties": {
+            "residencyStandard2DBlockShape": 0,
+            "residencyStandard2DMultisampleBlockShape": 0,
+            "residencyStandard3DBlockShape": 0,
+            "residencyAlignedMipSize": 0,
+            "residencyNonResidentStrict": 0
+        }
+    },
+    "VkPhysicalDeviceFeatures": {
+        "robustBufferAccess": 1,
+        "fullDrawIndexUint32": 0,
+        "imageCubeArray": 0,
+        "independentBlend": 0,
+        "geometryShader": 0,
+        "tessellationShader": 0,
+        "sampleRateShading": 0,
+        "dualSrcBlend": 0,
+        "logicOp": 0,
+        "multiDrawIndirect": 0,
+        "drawIndirectFirstInstance": 0,
+        "depthClamp": 0,
+        "depthBiasClamp": 0,
+        "fillModeNonSolid": 0,
+        "depthBounds": 0,
+        "wideLines": 0,
+        "largePoints": 0,
+        "alphaToOne": 0,
+        "multiViewport": 0,
+        "samplerAnisotropy": 0,
+        "textureCompressionETC2": 0,
+        "textureCompressionASTC_LDR": 0,
+        "textureCompressionBC": 0,
+        "occlusionQueryPrecise": 0,
+        "pipelineStatisticsQuery": 0,
+        "vertexPipelineStoresAndAtomics": 0,
+        "fragmentStoresAndAtomics": 0,
+        "shaderTessellationAndGeometryPointSize": 0,
+        "shaderImageGatherExtended": 0,
+        "shaderStorageImageExtendedFormats": 0,
+        "shaderStorageImageMultisample": 0,
+        "shaderStorageImageReadWithoutFormat": 0,
+        "shaderStorageImageWriteWithoutFormat": 0,
+        "shaderUniformBufferArrayDynamicIndexing": 0,
+        "shaderSampledImageArrayDynamicIndexing": 0,
+        "shaderStorageBufferArrayDynamicIndexing": 0,
+        "shaderStorageImageArrayDynamicIndexing": 0,
+        "shaderClipDistance": 0,
+        "shaderCullDistance": 0,
+        "shaderFloat64": 0,
+        "shaderInt64": 0,
+        "shaderInt16": 0,
+        "shaderResourceResidency": 0,
+        "shaderResourceMinLod": 0,
+        "sparseBinding": 0,
+        "sparseResidencyBuffer": 0,
+        "sparseResidencyImage2D": 0,
+        "sparseResidencyImage3D": 0,
+        "sparseResidency2Samples": 0,
+        "sparseResidency4Samples": 0,
+        "sparseResidency8Samples": 0,
+        "sparseResidency16Samples": 0,
+        "sparseResidencyAliased": 0,
+        "variableMultisampleRate": 0,
+        "inheritedQueries": 0
+    },
+    "ArrayOfVkFormatProperties": [
+    {
+      "formatID": 3,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 4,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 8,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 9,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 10,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 13,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 14,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 16,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 17,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 20,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 21,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 37,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 38,
+      "linearTilingFeatures": 54275,
+      "optimalTilingFeatures": 54275,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 41,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 42,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 43,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 44,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 50,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 51,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 52,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 55,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 56,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 57,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 64,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 68,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 70,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 71,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 74,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 75,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 76,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 77,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 78,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 81,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 82,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 83,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 91,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 92,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 95,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 96,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 97,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 98,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 99,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 100,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 101,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 102,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 103,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 104,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 105,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 106,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 107,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 108,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 109,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 122,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 123,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 124,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 125,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 126,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 129,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 130,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 131,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 132,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 133,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 134,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 135,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 136,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 137,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 138,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 139,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 140,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 141,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 142,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 143,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 145,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 146,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 147,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 148,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 149,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 150,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 151,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 152,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 153,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 154,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 155,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 156,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 157,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 158,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 159,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 160,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 161,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 162,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 163,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 164,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 165,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 166,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 167,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 168,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 169,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 170,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 171,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 172,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 173,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 174,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 175,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 176,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 177,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 178,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 179,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 180,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 181,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 182,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 183,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 184,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    }
+  ],
+  "ArrayOfVkExtensionProperties": [
+    {
+      "extensionName": "VK_KHR_swapchain",
+      "specVersion": 70
+    }
+  ]
+}

--- a/layersvt/device_simulation_examples/sdk_sample_configs/spec_minimum_vulkan_1_1.json
+++ b/layersvt/device_simulation_examples/sdk_sample_configs/spec_minimum_vulkan_1_1.json
@@ -1,0 +1,951 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/devsim_1_1_0.json#",
+	"comments": {
+		"desc": "JSON configuration file for Vulkan 1.1 minimum requirements as defined by the Vulkan Specification."
+	},
+    "VkPhysicalDeviceProperties": {
+        "limits": {
+            "maxImageDimension1D": 4096,
+            "maxImageDimension2D": 4096,
+            "maxImageDimension3D": 256,
+            "maxImageDimensionCube": 4096,
+            "maxImageArrayLayers": 256,
+            "maxTexelBufferElements": 65536,
+            "maxUniformBufferRange": 16384,
+            "maxStorageBufferRange": 67108864,
+            "maxPushConstantsSize": 128,
+            "maxMemoryAllocationCount": 4096,
+            "maxSamplerAllocationCount": 4000,
+            "bufferImageGranularity": 131072,
+            "sparseAddressSpaceSize": 1073741824,
+            "maxBoundDescriptorSets": 4,
+            "maxPerStageDescriptorSamplers": 16,
+            "maxPerStageDescriptorUniformBuffers": 12,
+            "maxPerStageDescriptorStorageBuffers": 4,
+            "maxPerStageDescriptorSampledImages": 16,
+            "maxPerStageDescriptorStorageImages": 4,
+            "maxPerStageDescriptorInputAttachments": 4,
+            "maxPerStageResources": 128,
+            "maxDescriptorSetSamplers": 1536,
+            "maxDescriptorSetUniformBuffers": 864,
+            "maxDescriptorSetUniformBuffersDynamic": 8,
+            "maxDescriptorSetStorageBuffers": 96,
+            "maxDescriptorSetStorageBuffersDynamic": 4,
+            "maxDescriptorSetSampledImages": 1536,
+            "maxDescriptorSetStorageImages": 96,
+            "maxDescriptorSetInputAttachments": 4,
+            "maxVertexInputAttributes": 16,
+            "maxVertexInputBindings": 16,
+            "maxVertexInputAttributeOffset": 2047,
+            "maxVertexInputBindingStride": 2048,
+            "maxVertexOutputComponents": 64,
+            "maxTessellationGenerationLevel": 64,
+            "maxTessellationPatchSize": 32,
+            "maxTessellationControlPerVertexInputComponents": 64,
+            "maxTessellationControlPerVertexOutputComponents": 64,
+            "maxTessellationControlPerPatchOutputComponents": 120,
+            "maxTessellationControlTotalOutputComponents": 2048,
+            "maxTessellationEvaluationInputComponents": 64,
+            "maxTessellationEvaluationOutputComponents": 64,
+            "maxGeometryShaderInvocations": 32,
+            "maxGeometryInputComponents": 64,
+            "maxGeometryOutputComponents": 64,
+            "maxGeometryOutputVertices": 256,
+            "maxGeometryTotalOutputComponents": 1024,
+            "maxFragmentInputComponents": 64,
+            "maxFragmentOutputAttachments": 4,
+            "maxFragmentDualSrcAttachments": 1,
+            "maxFragmentCombinedOutputResources": 4,
+            "maxComputeSharedMemorySize": 16384,
+            "maxComputeWorkGroupCount": [65535, 65535, 65535],
+            "maxComputeWorkGroupInvocations": 128,
+            "maxComputeWorkGroupSize": [128, 128, 64],
+            "subPixelPrecisionBits": 4,
+            "subTexelPrecisionBits": 4,
+            "mipmapPrecisionBits": 4,
+            "maxDrawIndexedIndexValue": 2147483647,
+            "maxDrawIndirectCount": 32767,
+            "maxSamplerLodBias": 2,
+            "maxSamplerAnisotropy": 16,
+            "maxViewports": 16,
+            "maxViewportDimensions": [4096, 4096],
+            "viewportBoundsRange": [-8192, 8191],
+            "viewportSubPixelBits": 0,
+            "minMemoryMapAlignment": 64,
+            "minTexelBufferOffsetAlignment": 256,
+            "minUniformBufferOffsetAlignment": 256,
+            "minStorageBufferOffsetAlignment": 256,
+            "minTexelOffset": -8,
+            "maxTexelOffset": 7,
+            "minTexelGatherOffset": -8,
+            "maxTexelGatherOffset": 7,
+            "minInterpolationOffset": -0.5,
+            "maxInterpolationOffset": 0.4375,
+            "subPixelInterpolationOffsetBits": 4,
+            "maxFramebufferWidth": 4096,
+            "maxFramebufferHeight": 4096,
+            "maxFramebufferLayers": 256,
+            "framebufferColorSampleCounts": 9,
+            "framebufferDepthSampleCounts": 9,
+            "framebufferStencilSampleCounts": 9,
+            "framebufferNoAttachmentsSampleCounts": 9,
+            "maxColorAttachments": 4,
+            "sampledImageColorSampleCounts": 9,
+            "sampledImageIntegerSampleCounts": 1,
+            "sampledImageDepthSampleCounts": 9,
+            "sampledImageStencilSampleCounts": 9,
+            "storageImageSampleCounts": 9,
+            "maxSampleMaskWords": 1,
+            "maxClipDistances": 8,
+            "maxCullDistances": 8,
+            "maxCombinedClipAndCullDistances": 8,
+            "discreteQueuePriorities": 2,
+            "pointSizeRange": [1.0, 63.0],
+            "lineWidthRange": [1.0, 7.0],
+            "pointSizeGranularity": 1.0,
+            "lineWidthGranularity": 1.0,
+            "nonCoherentAtomSize": 256
+        },
+        "sparseProperties": {
+            "residencyStandard2DBlockShape": 0,
+            "residencyStandard2DMultisampleBlockShape": 0,
+            "residencyStandard3DBlockShape": 0,
+            "residencyAlignedMipSize": 0,
+            "residencyNonResidentStrict": 0
+        }
+    },
+    "VkPhysicalDeviceMaintenance3Properties": {
+        "maxPerSetDescriptors": 1024,
+        "maxMemoryAllocationSize" : 536870912
+    },
+    "VkPhysicalDeviceMultiviewProperties": {
+        "maxMultiviewViewCount": 6,
+        "maxMultiviewInstanceIndex" : 67108863
+    },
+    "VkPhysicalDeviceProtectedMemoryProperties": {
+        "protectedNoFault": 0
+    },
+    "VkPhysicalDeviceFeatures": {
+        "robustBufferAccess": 1,
+        "fullDrawIndexUint32": 0,
+        "imageCubeArray": 0,
+        "independentBlend": 0,
+        "geometryShader": 0,
+        "tessellationShader": 0,
+        "sampleRateShading": 0,
+        "dualSrcBlend": 0,
+        "logicOp": 0,
+        "multiDrawIndirect": 0,
+        "drawIndirectFirstInstance": 0,
+        "depthClamp": 0,
+        "depthBiasClamp": 0,
+        "fillModeNonSolid": 0,
+        "depthBounds": 0,
+        "wideLines": 0,
+        "largePoints": 0,
+        "alphaToOne": 0,
+        "multiViewport": 0,
+        "samplerAnisotropy": 0,
+        "textureCompressionETC2": 0,
+        "textureCompressionASTC_LDR": 0,
+        "textureCompressionBC": 0,
+        "occlusionQueryPrecise": 0,
+        "pipelineStatisticsQuery": 0,
+        "vertexPipelineStoresAndAtomics": 0,
+        "fragmentStoresAndAtomics": 0,
+        "shaderTessellationAndGeometryPointSize": 0,
+        "shaderImageGatherExtended": 0,
+        "shaderStorageImageExtendedFormats": 0,
+        "shaderStorageImageMultisample": 0,
+        "shaderStorageImageReadWithoutFormat": 0,
+        "shaderStorageImageWriteWithoutFormat": 0,
+        "shaderUniformBufferArrayDynamicIndexing": 0,
+        "shaderSampledImageArrayDynamicIndexing": 0,
+        "shaderStorageBufferArrayDynamicIndexing": 0,
+        "shaderStorageImageArrayDynamicIndexing": 0,
+        "shaderClipDistance": 0,
+        "shaderCullDistance": 0,
+        "shaderFloat64": 0,
+        "shaderInt64": 0,
+        "shaderInt16": 0,
+        "shaderResourceResidency": 0,
+        "shaderResourceMinLod": 0,
+        "sparseBinding": 0,
+        "sparseResidencyBuffer": 0,
+        "sparseResidencyImage2D": 0,
+        "sparseResidencyImage3D": 0,
+        "sparseResidency2Samples": 0,
+        "sparseResidency4Samples": 0,
+        "sparseResidency8Samples": 0,
+        "sparseResidency16Samples": 0,
+        "sparseResidencyAliased": 0,
+        "variableMultisampleRate": 0,
+        "inheritedQueries": 0
+    },
+    "VkPhysicalDevice16BitStorageFeatures": {
+        "storageBuffer16BitAccess": 0,
+        "uniformAndStorageBuffer16BitAccess": 0,
+        "storagePushConstant16": 0,
+        "storageInputOutput16": 0
+    },
+    "VkPhysicalDeviceMultiviewFeatures": {
+        "multiview": 1,
+        "multiviewGeometryShader": 0,
+        "multiviewTessellationShader": 0
+    },
+    "VkPhysicalDeviceProtectedMemoryFeatures": {
+        "protectedMemory": 0
+    },
+    "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+        "samplerYcbcrConversion": 0
+    },
+    "VkPhysicalDeviceShaderDrawParametersFeatures": {
+        "shaderDrawParameters": 0
+    },
+    "VkPhysicalDeviceVariablePointersFeatures": {
+        "variablePointersStorageBuffer": 0,
+        "variablePointers": 0
+    },
+    "ArrayOfVkFormatProperties": [
+    {
+      "formatID": 3,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 4,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 8,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 9,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 10,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 13,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 14,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 16,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 17,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 20,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 21,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 37,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 38,
+      "linearTilingFeatures": 54275,
+      "optimalTilingFeatures": 54275,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 41,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 42,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 43,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 44,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 50,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 51,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 52,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 55,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 56,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 57,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 64,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 68,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 70,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 71,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 74,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 75,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 76,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 77,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 78,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 81,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 82,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 83,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 91,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 92,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 95,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 96,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 97,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 98,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 99,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 100,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 101,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 102,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 103,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 104,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 105,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 106,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 107,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 108,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 109,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 122,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 123,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 124,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 125,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 126,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 129,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 130,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 131,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 132,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 133,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 134,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 135,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 136,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 137,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 138,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 139,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 140,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 141,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 142,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 143,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 145,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 146,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 147,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 148,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 149,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 150,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 151,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 152,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 153,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 154,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 155,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 156,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 157,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 158,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 159,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 160,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 161,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 162,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 163,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 164,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 165,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 166,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 167,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 168,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 169,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 170,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 171,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 172,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 173,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 174,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 175,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 176,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 177,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 178,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 179,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 180,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 181,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 182,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 183,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 184,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    }
+  ],
+  "ArrayOfVkExtensionProperties": [
+    {
+      "extensionName": "VK_KHR_bind_memory2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_dedicated_allocation",
+      "specVersion": 3
+    },
+    {
+      "extensionName": "VK_KHR_descriptor_update_template",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_device_group",
+      "specVersion": 4
+    },
+    {
+      "extensionName": "VK_KHR_driver_properties",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_fence",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_memory",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_semaphore",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_get_memory_requirements2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_image_format_list",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance1",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance3",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_multiview",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_relaxed_block_layout",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_storage_buffer_storage_class",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_swapchain",
+      "specVersion": 70
+    }
+  ]
+}

--- a/layersvt/device_simulation_examples/sdk_sample_configs/spec_minimum_vulkan_1_2.json
+++ b/layersvt/device_simulation_examples/sdk_sample_configs/spec_minimum_vulkan_1_2.json
@@ -1,0 +1,1133 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/devsim_1_2_0.json#",
+	"comments": {
+		"desc": "JSON configuration file for Vulkan 1.2 minimum requirements as defined by the Vulkan Specification."
+	},
+    "VkPhysicalDeviceProperties": {
+        "limits": {
+            "maxImageDimension1D": 4096,
+            "maxImageDimension2D": 4096,
+            "maxImageDimension3D": 256,
+            "maxImageDimensionCube": 4096,
+            "maxImageArrayLayers": 256,
+            "maxTexelBufferElements": 65536,
+            "maxUniformBufferRange": 16384,
+            "maxStorageBufferRange": 67108864,
+            "maxPushConstantsSize": 128,
+            "maxMemoryAllocationCount": 4096,
+            "maxSamplerAllocationCount": 4000,
+            "bufferImageGranularity": 131072,
+            "sparseAddressSpaceSize": 1073741824,
+            "maxBoundDescriptorSets": 4,
+            "maxPerStageDescriptorSamplers": 16,
+            "maxPerStageDescriptorUniformBuffers": 12,
+            "maxPerStageDescriptorStorageBuffers": 4,
+            "maxPerStageDescriptorSampledImages": 16,
+            "maxPerStageDescriptorStorageImages": 4,
+            "maxPerStageDescriptorInputAttachments": 4,
+            "maxPerStageResources": 128,
+            "maxDescriptorSetSamplers": 1536,
+            "maxDescriptorSetUniformBuffers": 864,
+            "maxDescriptorSetUniformBuffersDynamic": 8,
+            "maxDescriptorSetStorageBuffers": 96,
+            "maxDescriptorSetStorageBuffersDynamic": 4,
+            "maxDescriptorSetSampledImages": 1536,
+            "maxDescriptorSetStorageImages": 96,
+            "maxDescriptorSetInputAttachments": 4,
+            "maxVertexInputAttributes": 16,
+            "maxVertexInputBindings": 16,
+            "maxVertexInputAttributeOffset": 2047,
+            "maxVertexInputBindingStride": 2048,
+            "maxVertexOutputComponents": 64,
+            "maxTessellationGenerationLevel": 64,
+            "maxTessellationPatchSize": 32,
+            "maxTessellationControlPerVertexInputComponents": 64,
+            "maxTessellationControlPerVertexOutputComponents": 64,
+            "maxTessellationControlPerPatchOutputComponents": 120,
+            "maxTessellationControlTotalOutputComponents": 2048,
+            "maxTessellationEvaluationInputComponents": 64,
+            "maxTessellationEvaluationOutputComponents": 64,
+            "maxGeometryShaderInvocations": 32,
+            "maxGeometryInputComponents": 64,
+            "maxGeometryOutputComponents": 64,
+            "maxGeometryOutputVertices": 256,
+            "maxGeometryTotalOutputComponents": 1024,
+            "maxFragmentInputComponents": 64,
+            "maxFragmentOutputAttachments": 4,
+            "maxFragmentDualSrcAttachments": 1,
+            "maxFragmentCombinedOutputResources": 4,
+            "maxComputeSharedMemorySize": 16384,
+            "maxComputeWorkGroupCount": [65535, 65535, 65535],
+            "maxComputeWorkGroupInvocations": 128,
+            "maxComputeWorkGroupSize": [128, 128, 64],
+            "subPixelPrecisionBits": 4,
+            "subTexelPrecisionBits": 4,
+            "mipmapPrecisionBits": 4,
+            "maxDrawIndexedIndexValue": 2147483647,
+            "maxDrawIndirectCount": 32767,
+            "maxSamplerLodBias": 2,
+            "maxSamplerAnisotropy": 16,
+            "maxViewports": 16,
+            "maxViewportDimensions": [4096, 4096],
+            "viewportBoundsRange": [-8192, 8191],
+            "viewportSubPixelBits": 0,
+            "minMemoryMapAlignment": 64,
+            "minTexelBufferOffsetAlignment": 256,
+            "minUniformBufferOffsetAlignment": 256,
+            "minStorageBufferOffsetAlignment": 256,
+            "minTexelOffset": -8,
+            "maxTexelOffset": 7,
+            "minTexelGatherOffset": -8,
+            "maxTexelGatherOffset": 7,
+            "minInterpolationOffset": -0.5,
+            "maxInterpolationOffset": 0.4375,
+            "subPixelInterpolationOffsetBits": 4,
+            "maxFramebufferWidth": 4096,
+            "maxFramebufferHeight": 4096,
+            "maxFramebufferLayers": 256,
+            "framebufferColorSampleCounts": 9,
+            "framebufferDepthSampleCounts": 9,
+            "framebufferStencilSampleCounts": 9,
+            "framebufferNoAttachmentsSampleCounts": 9,
+            "maxColorAttachments": 4,
+            "sampledImageColorSampleCounts": 9,
+            "sampledImageIntegerSampleCounts": 1,
+            "sampledImageDepthSampleCounts": 9,
+            "sampledImageStencilSampleCounts": 9,
+            "storageImageSampleCounts": 9,
+            "maxSampleMaskWords": 1,
+            "maxClipDistances": 8,
+            "maxCullDistances": 8,
+            "maxCombinedClipAndCullDistances": 8,
+            "discreteQueuePriorities": 2,
+            "pointSizeRange": [1.0, 63.0],
+            "lineWidthRange": [1.0, 7.0],
+            "pointSizeGranularity": 1.0,
+            "lineWidthGranularity": 1.0,
+            "nonCoherentAtomSize": 256
+        },
+        "sparseProperties": {
+            "residencyStandard2DBlockShape": 0,
+            "residencyStandard2DMultisampleBlockShape": 0,
+            "residencyStandard3DBlockShape": 0,
+            "residencyAlignedMipSize": 0,
+            "residencyNonResidentStrict": 0
+        }
+    },
+    "VkPhysicalDeviceDepthStencilResolveProperties": {
+        "supportedDepthResolveModes": 1,
+        "supportedStencilResolveModes": 1,
+        "independentResolveNone": 0,
+        "independentResolve": 0
+    },
+    "VkPhysicalDeviceDescriptorIndexingProperties": {
+        "maxUpdateAfterBindDescriptorsInAllPools": 500000,
+        "shaderUniformBufferArrayNonUniformIndexingNative": 0,
+        "shaderSampledImageArrayNonUniformIndexingNative": 0,
+        "shaderStorageBufferArrayNonUniformIndexingNative": 0,
+        "shaderStorageImageArrayNonUniformIndexingNative": 0,
+        "shaderInputAttachmentArrayNonUniformIndexingNative": 0,
+        "robustBufferAccessUpdateAfterBind": 0,
+        "quadDivergentImplicitLod": 0,
+        "maxPerStageDescriptorUpdateAfterBindSamplers": 500000,
+        "maxPerStageDescriptorUpdateAfterBindUniformBuffers": 12,
+        "maxPerStageDescriptorUpdateAfterBindStorageBuffers": 500000,
+        "maxPerStageDescriptorUpdateAfterBindSampledImages": 500000,
+        "maxPerStageDescriptorUpdateAfterBindStorageImages": 500000,
+        "maxPerStageDescriptorUpdateAfterBindInputAttachments": 4,
+        "maxPerStageUpdateAfterBindResources": 500000,
+        "maxDescriptorSetUpdateAfterBindSamplers": 500000,
+        "maxDescriptorSetUpdateAfterBindUniformBuffers": 72,
+        "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": 8,
+        "maxDescriptorSetUpdateAfterBindStorageBuffers": 500000,
+        "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": 4,
+        "maxDescriptorSetUpdateAfterBindSampledImages": 500000,
+        "maxDescriptorSetUpdateAfterBindStorageImages": 500000,
+        "maxDescriptorSetUpdateAfterBindInputAttachments": 4
+    },
+    "VkPhysicalDeviceFloatControlsProperties": {
+        "denormBehaviorIndependence": 2,
+        "roundingModeIndependence": 2,
+        "shaderSignedZeroInfNanPreserveFloat16": 0,
+        "shaderSignedZeroInfNanPreserveFloat32": 0,
+        "shaderSignedZeroInfNanPreserveFloat64": 0,
+        "shaderDenormPreserveFloat16": 0,
+        "shaderDenormPreserveFloat32": 0,
+        "shaderDenormPreserveFloat64": 0,
+        "shaderDenormFlushToZeroFloat16": 0,
+        "shaderDenormFlushToZeroFloat32": 0,
+        "shaderDenormFlushToZeroFloat64": 0,
+        "shaderRoundingModeRTEFloat16": 0,
+        "shaderRoundingModeRTEFloat32": 0,
+        "shaderRoundingModeRTEFloat64": 0,
+        "shaderRoundingModeRTZFloat16": 0,
+        "shaderRoundingModeRTZFloat32": 0,
+        "shaderRoundingModeRTZFloat64": 0
+    },
+    "VkPhysicalDeviceMaintenance3Properties": {
+        "maxPerSetDescriptors": 1024,
+        "maxMemoryAllocationSize" : 536870912
+    },
+    "VkPhysicalDeviceMultiviewProperties": {
+        "maxMultiviewViewCount": 6,
+        "maxMultiviewInstanceIndex" : 67108863
+    },
+    "VkPhysicalDeviceProtectedMemoryProperties": {
+        "protectedNoFault": 0
+    },
+    "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+        "filterMinmaxSingleComponentFormats": 0,
+        "filterMinmaxImageComponentMapping": 0
+    },
+    "VkPhysicalDeviceTimelineSemaphoreProperties": {
+        "maxTimelineSemaphoreValueDifference": 1073741823
+    },
+    "VkPhysicalDeviceFeatures": {
+        "robustBufferAccess": 1,
+        "fullDrawIndexUint32": 0,
+        "imageCubeArray": 0,
+        "independentBlend": 0,
+        "geometryShader": 0,
+        "tessellationShader": 0,
+        "sampleRateShading": 0,
+        "dualSrcBlend": 0,
+        "logicOp": 0,
+        "multiDrawIndirect": 0,
+        "drawIndirectFirstInstance": 0,
+        "depthClamp": 0,
+        "depthBiasClamp": 0,
+        "fillModeNonSolid": 0,
+        "depthBounds": 0,
+        "wideLines": 0,
+        "largePoints": 0,
+        "alphaToOne": 0,
+        "multiViewport": 0,
+        "samplerAnisotropy": 0,
+        "textureCompressionETC2": 0,
+        "textureCompressionASTC_LDR": 0,
+        "textureCompressionBC": 0,
+        "occlusionQueryPrecise": 0,
+        "pipelineStatisticsQuery": 0,
+        "vertexPipelineStoresAndAtomics": 0,
+        "fragmentStoresAndAtomics": 0,
+        "shaderTessellationAndGeometryPointSize": 0,
+        "shaderImageGatherExtended": 0,
+        "shaderStorageImageExtendedFormats": 0,
+        "shaderStorageImageMultisample": 0,
+        "shaderStorageImageReadWithoutFormat": 0,
+        "shaderStorageImageWriteWithoutFormat": 0,
+        "shaderUniformBufferArrayDynamicIndexing": 0,
+        "shaderSampledImageArrayDynamicIndexing": 0,
+        "shaderStorageBufferArrayDynamicIndexing": 0,
+        "shaderStorageImageArrayDynamicIndexing": 0,
+        "shaderClipDistance": 0,
+        "shaderCullDistance": 0,
+        "shaderFloat64": 0,
+        "shaderInt64": 0,
+        "shaderInt16": 0,
+        "shaderResourceResidency": 0,
+        "shaderResourceMinLod": 0,
+        "sparseBinding": 0,
+        "sparseResidencyBuffer": 0,
+        "sparseResidencyImage2D": 0,
+        "sparseResidencyImage3D": 0,
+        "sparseResidency2Samples": 0,
+        "sparseResidency4Samples": 0,
+        "sparseResidency8Samples": 0,
+        "sparseResidency16Samples": 0,
+        "sparseResidencyAliased": 0,
+        "variableMultisampleRate": 0,
+        "inheritedQueries": 0
+    },
+    "VkPhysicalDevice16BitStorageFeatures": {
+        "storageBuffer16BitAccess": 0,
+        "uniformAndStorageBuffer16BitAccess": 0,
+        "storagePushConstant16": 0,
+        "storageInputOutput16": 0
+    },
+    "VkPhysicalDevice8BitStorageFeatures": {
+        "storageBuffer8BitAccess": 0,
+        "uniformAndStorageBuffer8BitAccess": 0,
+        "storagePushConstant8": 0
+    },
+    "VkPhysicalDeviceDescriptorIndexingFeatures": {
+        "shaderInputAttachmentArrayDynamicIndexing": 0,
+        "shaderUniformTexelBufferArrayDynamicIndexing": 0,
+        "shaderStorageTexelBufferArrayDynamicIndexing": 0,
+        "shaderUniformBufferArrayNonUniformIndexing": 0,
+        "shaderSampledImageArrayNonUniformIndexing": 0,
+        "shaderStorageBufferArrayNonUniformIndexing": 0,
+        "shaderStorageImageArrayNonUniformIndexing": 0,
+        "shaderInputAttachmentArrayNonUniformIndexing": 0,
+        "shaderUniformTexelBufferArrayNonUniformIndexing": 0,
+        "shaderStorageTexelBufferArrayNonUniformIndexing": 0,
+        "descriptorBindingUniformBufferUpdateAfterBind": 0,
+        "descriptorBindingSampledImageUpdateAfterBind": 0,
+        "descriptorBindingStorageImageUpdateAfterBind": 0,
+        "descriptorBindingStorageBufferUpdateAfterBind": 0,
+        "descriptorBindingUniformTexelBufferUpdateAfterBind": 0,
+        "descriptorBindingStorageTexelBufferUpdateAfterBind": 0,
+        "descriptorBindingUpdateUnusedWhilePending": 0,
+        "descriptorBindingPartiallyBound": 0,
+        "descriptorBindingVariableDescriptorCount": 0,
+        "runtimeDescriptorArray": 0
+    },
+    "VkPhysicalDeviceHostQueryResetFeatures": {
+        "hostQueryReset": 1
+    },
+    "VkPhysicalDeviceImagelessFramebufferFeatures": {
+        "imagelessFramebuffer": 1
+    },
+    "VkPhysicalDeviceMultiviewFeatures": {
+        "multiview": 1,
+        "multiviewGeometryShader": 0,
+        "multiviewTessellationShader": 0
+    },
+    "VkPhysicalDeviceProtectedMemoryFeatures": {
+        "protectedMemory": 0
+    },
+    "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+        "samplerYcbcrConversion": 0
+    },
+    "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+        "scalarBlockLayout": 0
+    },
+    "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+        "separateDepthStencilLayouts": 1
+    },
+    "VkPhysicalDeviceShaderAtomicInt64Features": {
+        "shaderBufferInt64Atomics": 0,
+        "shaderSharedInt64Atomics": 0
+    },
+    "VkPhysicalDeviceShaderDrawParametersFeatures": {
+        "shaderDrawParameters": 0
+    },
+    "VkPhysicalDeviceShaderFloat16Int8Features": {
+        "shaderFloat16": 0,
+        "shaderInt8": 0
+    },
+    "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+        "shaderSubgroupExtendedTypes": 1
+    },
+    "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+        "timelineSemaphore": 1
+    },
+    "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+        "uniformBufferStandardLayout": 1
+    },
+    "VkPhysicalDeviceVariablePointersFeatures": {
+        "variablePointersStorageBuffer": 0,
+        "variablePointers": 0
+    },
+    "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+        "vulkanMemoryModel": 0,
+        "vulkanMemoryModelDeviceScope": 0,
+        "vulkanMemoryModelAvailabilityVisibilityChains": 0
+    },
+    "Vulkan12Features": {
+        "samplerMirrorClampToEdge": 0,
+        "shaderOutputViewportIndex": 0,
+        "shaderOutputLayer": 0,
+        "subgroupBroadcastDynamicId": 1,
+        "drawIndirectCount": 0,
+        "descriptorIndexing": 0,
+        "samplerFilterMinmax": 0
+    },
+    "Vulkan12Properties": {
+        "framebufferIntegerColorSampleCounts": 1
+    },
+    "ArrayOfVkFormatProperties": [
+    {
+      "formatID": 3,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 4,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 8,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 9,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 10,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 13,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 14,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 16,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 17,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 20,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 21,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 37,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 38,
+      "linearTilingFeatures": 54275,
+      "optimalTilingFeatures": 54275,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 41,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 42,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 43,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 44,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 50,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 51,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 52,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 55,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 56,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 57,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 64,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 68,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 70,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 71,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 74,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 75,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 76,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 77,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 78,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 81,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 82,
+      "linearTilingFeatures": 3201,
+      "optimalTilingFeatures": 3201,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 83,
+      "linearTilingFeatures": 7553,
+      "optimalTilingFeatures": 7553,
+      "bufferFeatures": 72
+    },
+    {
+      "formatID": 91,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 92,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 95,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 96,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 97,
+      "linearTilingFeatures": 56707,
+      "optimalTilingFeatures": 56707,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 98,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 99,
+      "linearTilingFeatures": 52359,
+      "optimalTilingFeatures": 52359,
+      "bufferFeatures": 120
+    },
+    {
+      "formatID": 100,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 101,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 102,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 103,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 104,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 105,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 106,
+      "linearTilingFeatures": 0,
+      "optimalTilingFeatures": 0,
+      "bufferFeatures": 64
+    },
+    {
+      "formatID": 107,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 108,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 109,
+      "linearTilingFeatures": 52355,
+      "optimalTilingFeatures": 52355,
+      "bufferFeatures": 88
+    },
+    {
+      "formatID": 122,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 8
+    },
+    {
+      "formatID": 123,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 124,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 125,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 126,
+      "linearTilingFeatures": 1537,
+      "optimalTilingFeatures": 1537,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 129,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 130,
+      "linearTilingFeatures": 512,
+      "optimalTilingFeatures": 512,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 131,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 132,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 133,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 134,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 135,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 136,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 137,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 138,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 139,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 140,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 141,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 142,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 143,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 145,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 146,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 147,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 148,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 149,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 150,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 151,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 152,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 153,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 154,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 155,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 156,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 157,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 158,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 159,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 160,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 161,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 162,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 163,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 164,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 165,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 166,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 167,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 168,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 169,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 170,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 171,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 172,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 173,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 174,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 175,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },{
+      "formatID": 176,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 177,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 178,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 179,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 180,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 181,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 182,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 183,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    },
+    {
+      "formatID": 184,
+      "linearTilingFeatures": 5121,
+      "optimalTilingFeatures": 5121,
+      "bufferFeatures": 0
+    }
+  ],
+  "ArrayOfVkExtensionProperties": [
+    {
+      "extensionName": "VK_KHR_bind_memory2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_create_renderpass2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_dedicated_allocation",
+      "specVersion": 3
+    },
+    {
+      "extensionName": "VK_KHR_depth_stencil_resolve",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_descriptor_update_template",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_device_group",
+      "specVersion": 4
+    },
+    {
+      "extensionName": "VK_KHR_driver_properties",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_fence",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_memory",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_external_semaphore",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_get_memory_requirements2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_image_format_list",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_imageless_framebuffer",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance1",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance2",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_maintenance3",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_multiview",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_relaxed_block_layout",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_separate_depth_stencil_layouts",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_shader_float_controls",
+      "specVersion": 4
+    },
+    {
+      "extensionName": "VK_KHR_shader_subgroup_extended_types",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_spirv_1_4",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_storage_buffer_storage_class",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_KHR_swapchain",
+      "specVersion": 70
+    },
+    {
+      "extensionName": "VK_KHR_timeline_semaphore",
+      "specVersion": 2
+    },
+    {
+      "extensionName": "VK_KHR_uniform_buffer_standard_layout",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_EXT_host_query_reset",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_EXT_sampler_filter_minmax",
+      "specVersion": 2
+    },
+    {
+      "extensionName": "VK_EXT_separate_stencil_usage",
+      "specVersion": 1
+    },
+    {
+      "extensionName": "VK_EXT_shader_viewport_index_layer",
+      "specVersion": 1
+    }
+  ]
+}


### PR DESCRIPTION
Added the minimum_vulkan_1_2.json devsim config file to the
device_simulation_examples/sdk_sample_configs.

Added the "Vulkan 1.2 minimum requirements" preset to
VkLayer_device_simulation.json.in.