### PR TITLE
vkconfig: Add interaction with layer env variables

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add 'vk_layer_settings.txt' path in the 'Vulkan Development Status'
 - Add ${VK_LOCAL} and ${VK_APPDATA} built-in variables
 - Add 'expanded' property to layer manifest settings and flags #1497
+- Add settings environment variables checking #1498
 
 ### Improvements:
 - Add link to [Vulkan Guide layers](https://github.com/KhronosGroup/Vulkan-Guide/blob/master/chapters/development_tools.md#vulkan-layers) list within the help menu

--- a/vkconfig/README.md
+++ b/vkconfig/README.md
@@ -133,24 +133,9 @@ With each release of the Vulkan SDK some [manual tests](https://docs.google.com/
 --------------
 ## FAQ
 
-### 1/ How do I use Vulkan Configurator to override only the Vulkan layers of a selected list of applications?
-
-This is typically done by enabling the "Apply only to the selected list of Vulkan applications" check box.
-<p align="center"><img src="https://github.com/LunarG/VulkanTools/blob/master/vkconfig/images/only_list.png" /></p>
-
-If this is not working, it's likely that the *Vulkan Loader* on the system is too old. Version 1.2.141 or newer of the *Vulkan Loader* is required. Update the *Vulkan Loader* by installing the latest *[Vulkan Runtime](https://vulkan.lunarg.com/sdk/home)* to enable this feature.
-
-### 2/ How does my application vk_layer_settings.txt file interacts with Vulkan Configurator?
+### 1/ How does my application vk_layer_settings.txt file interacts with Vulkan Configurator?
 
 When *Vulkan Configurator is used to override layers, the local `vk_layer_settings.txt` file is ignored.
-
-### 3/ How do environment variables settings interact with Vulkan Configurator?
-
-The short answer is that environment variables and *Vulkan Configurator* layers settings are mutually exclusive and the interaction between both is undefined.
-
-This is because the interaction between environment variables and *Vulkan* Configuration layers settings are handled by the layers directly so the responsability of the layers developers.
-
-We are working on defining layers development conventions to resolve this issue properly but in the meantime we highly recommend to use exclusively either environment variables or Vulkan Configurator.
 
 ## Known issues:
 

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -142,7 +142,19 @@ bool Configurator::Init() {
         }
     }
 
-    qputenv("VK_APIDUMP_LOG_FILENAME", "log.txt");
+    /*
+    qputenv("VK_REF_ENUM", "value2");
+    qputenv("VK_REF_FLAGS", "flag0,flag2");
+    qputenv("VK_REF_STRING", "Hello world");
+    qputenv("VK_REF_BOOL", "true");
+    qputenv("VK_REF_LOAD_FILE", "Pouet.txt");
+    qputenv("VK_REF_SAVE_FILE", "Pouet.txt");
+    qputenv("VK_REF_SAVE_FOLDER", "~/VulkanSDK/Pouet");
+    qputenv("VK_REF_INT", "76");
+    qputenv("VK_REF_FLOAT", "0.9999");
+    qputenv("VK_REF_FRAMES", "75-76,82");
+    qputenv("VK_REF_LIST", "76,stringB");
+    */
 
     return true;
 }

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -142,6 +142,8 @@ bool Configurator::Init() {
         }
     }
 
+    qputenv("VK_APIDUMP_LOG_FILENAME", "log.txt");
+
     return true;
 }
 

--- a/vkconfig/widget_setting.cpp
+++ b/vkconfig/widget_setting.cpp
@@ -25,6 +25,27 @@ WidgetSettingBase::WidgetSettingBase(QTreeWidget* tree, QTreeWidgetItem* item) :
     assert(item != nullptr);
 }
 
+void WidgetSettingBase::DisplayOverride(QWidget* widget, const SettingMeta& meta) const {
+    QCursor cursor = widget->cursor();
+    cursor.setShape(Qt::WhatsThisCursor);
+    widget->setCursor(cursor);
+
+    QPalette palette;
+    palette.setColor(QPalette::Active, QPalette::WindowText, QColor(255, 0, 0));
+    palette.setColor(QPalette::Active, QPalette::Text, QColor(255, 0, 0));
+    palette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(255, 0, 0));
+    palette.setColor(QPalette::Inactive, QPalette::Text, QColor(255, 0, 0));
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(192, 128, 128));
+    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(192, 128, 128));
+
+    widget->setPalette(palette);
+
+    const std::string tip =
+        format("Overridden by '%s' environment variable set to: '%s'", meta.env.c_str(), GetSettingOverride(meta).c_str());
+
+    widget->setToolTip(tip.c_str());
+}
+
 int HorizontalAdvance(const QFontMetrics& fm, const QString& string) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     return fm.horizontalAdvance(string);

--- a/vkconfig/widget_setting.h
+++ b/vkconfig/widget_setting.h
@@ -48,6 +48,8 @@ class WidgetSettingBase : public QWidget {
     WidgetSettingBase& operator=(const WidgetSettingBase&) = delete;
 
    protected:
+    void DisplayOverride(QWidget* widget, const SettingMeta& meta) const;
+
     QTreeWidget* tree;
     QTreeWidgetItem* item;
 };

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -54,6 +54,10 @@ void WidgetSettingBool::Refresh(RefreshAreas refresh_areas) {
     this->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         this->field->blockSignals(true);
         this->field->setChecked(this->data.value);
         this->field->blockSignals(false);

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -58,6 +58,10 @@ void WidgetSettingEnum::Refresh(RefreshAreas refresh_areas) {
     this->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         this->field->blockSignals(true);
         this->field->clear();
         this->enum_indexes.clear();

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -71,9 +71,24 @@ void WidgetSettingFilesystem::Refresh(RefreshAreas refresh_areas) {
     this->button->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            QCursor cursor = this->field->cursor();
+            cursor.setShape(Qt::WhatsThisCursor);
+            this->field->setCursor(cursor);
+
+            QPalette palette;
+            palette.setColor(QPalette::Base, QColor(255, 192, 192));
+            this->field->setPalette(palette);
+
+            const std::string tip = format("Overridden by '%s' environment variable set to: '%s'", this->meta.env.c_str(),
+                                           GetSettingOverride(this->meta).c_str());
+            this->field->setToolTip(tip.c_str());
+        } else {
+            this->field->setToolTip(this->field->text());
+        }
+
         this->field->blockSignals(true);
         this->field->setText(ReplaceBuiltInVariable(data.value).c_str());
-        this->field->setToolTip(this->field->text());
         this->field->blockSignals(false);
     }
 }

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -72,17 +72,7 @@ void WidgetSettingFilesystem::Refresh(RefreshAreas refresh_areas) {
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {
-            QCursor cursor = this->field->cursor();
-            cursor.setShape(Qt::WhatsThisCursor);
-            this->field->setCursor(cursor);
-
-            QPalette palette;
-            palette.setColor(QPalette::Base, QColor(255, 192, 192));
-            this->field->setPalette(palette);
-
-            const std::string tip = format("Overridden by '%s' environment variable set to: '%s'", this->meta.env.c_str(),
-                                           GetSettingOverride(this->meta).c_str());
-            this->field->setToolTip(tip.c_str());
+            this->DisplayOverride(this->field, this->meta);
         } else {
             this->field->setToolTip(this->field->text());
         }

--- a/vkconfig/widget_setting_flags.cpp
+++ b/vkconfig/widget_setting_flags.cpp
@@ -64,6 +64,10 @@ void WidgetSettingFlag::Refresh(RefreshAreas refresh_areas) {
     this->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         this->field->blockSignals(true);
         this->field->setChecked(std::find(data.value.begin(), data.value.end(), flag) != data.value.end());
         this->field->blockSignals(false);

--- a/vkconfig/widget_setting_float.cpp
+++ b/vkconfig/widget_setting_float.cpp
@@ -76,6 +76,10 @@ void WidgetSettingFloat::Refresh(RefreshAreas refresh_areas) {
     this->field->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         const std::string float_format = meta.GetFloatFormat();
 
         this->field->blockSignals(true);

--- a/vkconfig/widget_setting_frames.cpp
+++ b/vkconfig/widget_setting_frames.cpp
@@ -77,6 +77,10 @@ void WidgetSettingFrames::Refresh(RefreshAreas refresh_areas) {
     this->field->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         this->field->blockSignals(true);
         this->field->setText(this->data.value.c_str());
         this->field->blockSignals(false);

--- a/vkconfig/widget_setting_int.cpp
+++ b/vkconfig/widget_setting_int.cpp
@@ -75,6 +75,10 @@ void WidgetSettingInt::Refresh(RefreshAreas refresh_areas) {
     this->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         this->field->blockSignals(true);
         this->field->setText(format("%d", this->data.value).c_str());
         this->field->blockSignals(false);

--- a/vkconfig/widget_setting_list.cpp
+++ b/vkconfig/widget_setting_list.cpp
@@ -120,6 +120,12 @@ void WidgetSettingList::Refresh(RefreshAreas refresh_areas) {
 
         this->tree->blockSignals(false);
     }
+
+    if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+    }
 }
 
 void WidgetSettingList::Resize() {

--- a/vkconfig/widget_setting_list_element.cpp
+++ b/vkconfig/widget_setting_list_element.cpp
@@ -65,6 +65,10 @@ void WidgetSettingListElement::Refresh(RefreshAreas refresh_areas) {
     this->button->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         this->field->blockSignals(true);
         this->field->setChecked(std::find(this->data.value.begin(), this->data.value.end(), this->element)->enabled);
         this->field->blockSignals(false);

--- a/vkconfig/widget_setting_string.cpp
+++ b/vkconfig/widget_setting_string.cpp
@@ -61,6 +61,10 @@ void WidgetSettingString::Refresh(RefreshAreas refresh_areas) {
     this->setEnabled(enabled);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
+        if (::CheckSettingOverridden(this->meta)) {
+            this->DisplayOverride(this->field, this->meta);
+        }
+
         this->field->setText(data.value.c_str());
     }
 }

--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -177,7 +177,15 @@ bool WriteSettingsOverride(const Environment& environment, const std::vector<Lay
             const SettingData& setting_data = parameter.settings[i];
 
             // Skip missing settings
-            if (FindSettingMeta<SettingMetaInt>(layer->settings, setting_data.key.c_str()) == nullptr) continue;
+            const SettingMeta* meta = FindSettingMeta<SettingMeta>(layer->settings, setting_data.key.c_str());
+            if (meta == nullptr) {
+                continue;
+            }
+
+            // Skip overriden settings
+            if (::CheckSettingOverridden(*meta)) {
+                continue;
+            }
 
             stream << lc_layer_name << "." << setting_data.key.c_str() << " = ";
             switch (setting_data.type) {

--- a/vkconfig_core/setting_meta.cpp
+++ b/vkconfig_core/setting_meta.cpp
@@ -262,6 +262,28 @@ std::size_t CountSettings(const SettingMetaSet& settings) {
     return count;
 }
 
+bool CheckSettingOverridden(const SettingMeta& meta) {
+    // If the setting environment variable is set, then the setting is overridden and can't be modified
+    if (!meta.env.empty()) {
+        if (!qgetenv(meta.env.c_str()).isEmpty()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::string GetSettingOverride(const SettingMeta& meta) {
+    std::string result;
+
+    // If the setting environment variable is set, then the setting is overridden and can't be modified
+    if (!meta.env.empty()) {
+        result = qgetenv(meta.env.c_str()).toStdString();
+    }
+
+    return result;
+}
+
 bool CheckDependence(const SettingMeta& meta, const SettingDataSet& data_set) {
     switch (meta.dependence_mode) {
         default:

--- a/vkconfig_core/setting_meta.h
+++ b/vkconfig_core/setting_meta.h
@@ -246,4 +246,8 @@ inline const SETTING_META* FindSettingMeta(const SettingMetaSet& settings, const
 
 std::size_t CountSettings(const SettingMetaSet& settings);
 
+bool CheckSettingOverridden(const SettingMeta& meta);
+
+std::string GetSettingOverride(const SettingMeta& meta);
+
 bool CheckDependence(const SettingMeta& meta, const SettingDataSet& data_set);

--- a/vkconfig_core/test/VK_LAYER_LUNARG_reference_1_2_0.json
+++ b/vkconfig_core/test/VK_LAYER_LUNARG_reference_1_2_0.json
@@ -201,6 +201,7 @@
             "settings": [
                 {
                     "key": "toogle",
+                    "env": "VK_REF_TOGGLE",
                     "label": "toogle",
                     "type": "BOOL",
                     "description": "true or false",
@@ -232,7 +233,7 @@
                 },
                 {
                     "key": "enum_with_optional",
-                    "env": "TEST_ENUM",
+                    "env": "VK_REF_ENUM",
                     "type": "ENUM",
                     "label": "enum",
                     "description": "enum case",
@@ -306,7 +307,7 @@
                 },
                 {
                     "key": "flags_with_optional",
-                    "env": "TEST_FLAGS",
+                    "env": "VK_REF_FLAGS",
                     "type": "FLAGS",
                     "label": "flags",
                     "description": "flags case",
@@ -363,7 +364,7 @@
                 },
                 {
                     "key": "string_with_optional",
-                    "env": "TEST_STRING",
+                    "env": "VK_REF_STRING",
                     "type": "STRING",
                     "label": "String",
                     "description": "string",
@@ -391,7 +392,7 @@
                 },
                 {
                     "key": "bool_with_optional",
-                    "env": "TEST_BOOL",
+                    "env": "VK_REF_BOOL",
                     "type": "BOOL",
                     "label": "bool",
                     "description": "true or false",
@@ -419,7 +420,7 @@
                 },
                 {
                     "key": "load_file_with_optional",
-                    "env": "TEST_LOAD_FILE",
+                    "env": "VK_REF_LOAD_FILE",
                     "type": "LOAD_FILE",
                     "label": "Load file",
                     "description": "Load file path",
@@ -448,7 +449,7 @@
                 },
                 {
                     "key": "save_file_with_optional",
-                    "env": "TEST_SAVE_FILE",
+                    "env": "VK_REF_SAVE_FILE",
                     "type": "SAVE_FILE",
                     "label": "Save file",
                     "description": "Save file path",
@@ -477,7 +478,7 @@
                 },
                 {
                     "key": "save_folder_with_optional",
-                    "env": "TEST_SAVE_FOLDER",
+                    "env": "VK_REF_SAVE_FOLDER",
                     "type": "SAVE_FOLDER",
                     "label": "Save folder",
                     "description": "Save folder path",
@@ -505,7 +506,7 @@
                 },
                 {
                     "key": "int_with_optional",
-                    "env": "TEST_INT",
+                    "env": "VK_REF_INT",
                     "type": "INT",
                     "label": "Integer",
                     "description": "Integer Description",
@@ -538,7 +539,7 @@
                 },
                 {
                     "key": "float_with_optional",
-                    "env": "TEST_FLOAT",
+                    "env": "VK_REF_FLOAT",
                     "type": "FLOAT",
                     "label": "Float",
                     "description": "Float Description",
@@ -573,7 +574,7 @@
                 },
                 {
                     "key": "frames_with_optional",
-                    "env": "TEST_FRAMES",
+                    "env": "VK_REF_FRAMES",
                     "type": "FRAMES",
                     "label": "Frames",
                     "description": "Frames Description",
@@ -622,7 +623,7 @@
                 },
                 {
                     "key": "list_with_optional",
-                    "env": "TEST_LIST",
+                    "env": "VK_REF_LIST",
                     "type": "LIST",
                     "label": "List",
                     "description": "List description",
@@ -672,7 +673,6 @@
                 },
                 {
                     "key": "list_empty",
-                    "env": "TEST_LIST",
                     "type": "LIST",
                     "label": "List",
                     "description": "List description",

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -279,7 +279,7 @@ TEST(test_layer, load_1_2_0_setting_enum_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("enum_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_ENUM", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_ENUM", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_ENUM, setting_meta->type);
     EXPECT_STREQ("enum", setting_meta->label.c_str());
     EXPECT_STREQ("enum case", setting_meta->description.c_str());
@@ -374,7 +374,7 @@ TEST(test_layer, load_1_2_0_setting_flags_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("flags_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_FLAGS", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_FLAGS", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_FLAGS, setting_meta->type);
     EXPECT_STREQ("flags", setting_meta->label.c_str());
     EXPECT_STREQ("flags case", setting_meta->description.c_str());
@@ -450,7 +450,7 @@ TEST(test_layer, load_1_2_0_setting_string_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("string_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_STRING", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_STRING", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_STRING, setting_meta->type);
     EXPECT_STREQ("String", setting_meta->label.c_str());
     EXPECT_STREQ("string", setting_meta->description.c_str());
@@ -494,7 +494,7 @@ TEST(test_layer, load_1_2_0_setting_bool_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("bool_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_BOOL", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_BOOL", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_BOOL, setting_meta->type);
     EXPECT_STREQ("bool", setting_meta->label.c_str());
     EXPECT_STREQ("true or false", setting_meta->description.c_str());
@@ -539,7 +539,7 @@ TEST(test_layer, load_1_2_0_setting_load_file_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("load_file_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_LOAD_FILE", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_LOAD_FILE", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_LOAD_FILE, setting_meta->type);
     EXPECT_STREQ("Load file", setting_meta->label.c_str());
     EXPECT_STREQ("Load file path", setting_meta->description.c_str());
@@ -585,7 +585,7 @@ TEST(test_layer, load_1_2_0_setting_save_file_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("save_file_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_SAVE_FILE", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_SAVE_FILE", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_SAVE_FILE, setting_meta->type);
     EXPECT_STREQ("Save file", setting_meta->label.c_str());
     EXPECT_STREQ("Save file path", setting_meta->description.c_str());
@@ -630,7 +630,7 @@ TEST(test_layer, load_1_2_0_setting_save_folder_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("save_folder_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_SAVE_FOLDER", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_SAVE_FOLDER", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_SAVE_FOLDER, setting_meta->type);
     EXPECT_STREQ("Save folder", setting_meta->label.c_str());
     EXPECT_STREQ("Save folder path", setting_meta->description.c_str());
@@ -677,7 +677,7 @@ TEST(test_layer, load_1_2_0_setting_int_with_optional) {
     ASSERT_TRUE(setting_meta != nullptr);
 
     EXPECT_STREQ("int_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_INT", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_INT", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_INT, setting_meta->type);
     EXPECT_STREQ("Integer", setting_meta->label.c_str());
     EXPECT_STREQ("Integer Description", setting_meta->description.c_str());
@@ -724,7 +724,7 @@ TEST(test_layer, load_1_2_0_setting_frames_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("frames_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_FRAMES", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_FRAMES", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_FRAMES, setting_meta->type);
     EXPECT_STREQ("Frames", setting_meta->label.c_str());
     EXPECT_STREQ("Frames Description", setting_meta->description.c_str());
@@ -793,7 +793,7 @@ TEST(test_layer, load_1_2_0_setting_list_with_optional) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("list_with_optional", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_LIST", setting_meta->env.c_str());
+    EXPECT_STREQ("VK_REF_LIST", setting_meta->env.c_str());
     EXPECT_EQ(SETTING_LIST, setting_meta->type);
     EXPECT_STREQ("List", setting_meta->label.c_str());
     EXPECT_STREQ("List description", setting_meta->description.c_str());
@@ -845,7 +845,7 @@ TEST(test_layer, load_1_2_0_setting_list_empty) {
     ASSERT_TRUE(setting_meta);
 
     EXPECT_STREQ("list_empty", setting_meta->key.c_str());
-    EXPECT_STREQ("TEST_LIST", setting_meta->env.c_str());
+    EXPECT_TRUE(setting_meta->env.empty());
     EXPECT_EQ(SETTING_LIST, setting_meta->type);
     EXPECT_STREQ("List", setting_meta->label.c_str());
     EXPECT_STREQ("List description", setting_meta->description.c_str());


### PR DESCRIPTION
When the environment variable of a layer setting is set while Vulkan Configurator runs, the setting is highlighted and a tool tip is set to the value to state the setting is overridden.

![setting_override](https://user-images.githubusercontent.com/62888873/118298244-8363e200-b4df-11eb-9faa-7a06b1a550d9.gif)
