### PR TITLE
devsim: add url and introduction to the layer manifest

### DIFF
--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -7,6 +7,8 @@
         "api_version": "@VK_VERSION@",
         "implementation_version": "1.6.0",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/130/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/130/VK_LAYER_LUNARG_device_simulation.json
@@ -6,6 +6,8 @@
         "api_version": "1.1.130",
         "implementation_version": "1.2.6",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/135/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/135/VK_LAYER_LUNARG_device_simulation.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.135",
         "implementation_version": "1.3.0",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/141/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/141/VK_LAYER_LUNARG_device_simulation.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.141",
         "implementation_version": "1.3.0",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/148/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/148/VK_LAYER_LUNARG_device_simulation.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.148",
         "implementation_version": "1.3.0",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/154/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/154/VK_LAYER_LUNARG_device_simulation.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.154",
         "implementation_version": "1.3.0",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/162/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_LUNARG_device_simulation.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.162",
         "implementation_version": "1.4.1",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/170/VK_LAYER_LUNARG_device_simulation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_LUNARG_device_simulation.json
@@ -7,6 +7,7 @@
         "api_version": "1.2.170",
         "implementation_version": "1.4.1",
         "description": "LunarG device simulation layer",
+        "introduction": "The LunarG Device Simulation layer helps test across a wide range of hardware capabilities without requiring a physical copy of every device.",
         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/device_simulation_layer.html",
         "device_extensions": [
             {


### PR DESCRIPTION
Add an introduction and a URL in the devsim manifest. 
These are used by Vulkan Configurator for the Vulkan Developers to find the layer documentation.