### PR TITLE
api dump: add url and introduction to the layer manifest

### DIFF
--- a/layersvt/VkLayer_api_dump.json.in
+++ b/layersvt/VkLayer_api_dump.json.in
@@ -7,6 +7,8 @@
         "api_version": "@VK_VERSION@",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/130/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/130/VK_LAYER_LUNARG_api_dump.json
@@ -6,6 +6,8 @@
         "api_version": "1.1.130",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/135/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/135/VK_LAYER_LUNARG_api_dump.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.135",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/141/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/141/VK_LAYER_LUNARG_api_dump.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.141",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/148/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/148/VK_LAYER_LUNARG_api_dump.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.148",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/154/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/154/VK_LAYER_LUNARG_api_dump.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.154",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/162/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/162/VK_LAYER_LUNARG_api_dump.json
@@ -6,6 +6,8 @@
         "api_version": "1.2.162",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {
                 "name": "VK_EXT_tooling_info",

--- a/vkconfig_core/layers/170/VK_LAYER_LUNARG_api_dump.json
+++ b/vkconfig_core/layers/170/VK_LAYER_LUNARG_api_dump.json
@@ -7,6 +7,7 @@
         "api_version": "1.2.170",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
+        "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",
         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/api_dump_layer.html",
         "device_extensions": [
             {


### PR DESCRIPTION
Add an introduction and a URL in the layer manifest.
These are used by Vulkan Configurator for the Vulkan Developers to find the layer documentation.