### PR TITLE
screenshot: adjust synchronization

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -994,13 +994,14 @@ static void writePPM(const char *filename, VkImage image1) {
     submitInfo.signalSemaphoreCount = 0;
     submitInfo.pSignalSemaphores = NULL;
 
+    // Wait for operations on all queues to complete before performing the image copy.
+    err = pTableDevice->DeviceWaitIdle(device);
+    assert(!err);
+
     err = pTableQueue->QueueSubmit(queue, 1, &submitInfo, nullFence);
     assert(!err);
 
     err = pTableQueue->QueueWaitIdle(queue);
-    assert(!err);
-
-    err = pTableDevice->DeviceWaitIdle(device);
     assert(!err);
 
     // Map the final image so that the CPU can read it.


### PR DESCRIPTION
The screenshot layer was calling both vkQueueWaitIdle and vkDeviceWaitIdle after performing the swapchain image copy, without performing any synchronization before the swapchain image copy.  This change moves the vkDeviceWaitIdle call before the copy, to wait for any outstanding work that may modify the swapchain image to complete.

Because the copy is performed in the layer's implementation of vkQueuePresentKHR, prior to making the actual vkQueuePresentKHR call, it may be possible to further improve synchronization by stealing the wait semaphores intended for vkQueuePresentKHR to use with the vkQueueSubmit that performs the copy so that the vkDeviceWaitIdle call can be removed.