### PR TITLE
vkconfig: add validation shader caching UI

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add link to [Vulkan Guide layers](https://github.com/KhronosGroup/Vulkan-Guide/blob/master/chapters/development_tools.md#vulkan-layers) list within the help menu
 - Update built-in VUIDs to the list included in SDK 1.2.176 #1511
 - Refactor the layer window to expose more layer documentation #1519
+- Add shader caching setting to validation built-in UI #1522
 
 ## [Vulkan Configurator 2.3.0 for Vulkan SDK 1.2.176.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.176.0) - Mai 2021
 

--- a/vkconfig/settings_validation_areas.h
+++ b/vkconfig/settings_validation_areas.h
@@ -66,6 +66,9 @@ class WidgetSettingValidation : public WidgetSettingBase {
     QTreeWidgetItem *item_core_push;
     QCheckBox *widget_core_push;
 
+    QTreeWidgetItem *item_core_caching;
+    QCheckBox *widget_core_caching;
+
     QTreeWidgetItem *item_misc_thread;
     QCheckBox *widget_misc_thread;
 
@@ -123,6 +126,7 @@ class WidgetSettingValidation : public WidgetSettingBase {
     void OnCoreDescChecked(bool checked);
     void OnCoreShaderChecked(bool checked);
     void OnCorePushChecked(bool checked);
+    void OnCoreCachingChecked(bool checked);
 
     void OnMiscThreadChecked(bool checked);
     void OnMiscUniqueChecked(bool checked);


### PR DESCRIPTION
Handle this Validation PR: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/2808

The feature requires July SDK validation layer version of to see the UI.
![shader caching](https://user-images.githubusercontent.com/62888873/120772194-51fb9680-c520-11eb-9e50-4c606eb02d59.gif)
