### PR TITLE
devsim: macOS doesn't support Vulkan 1.2

### DIFF
--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -71,7 +71,7 @@
                 {
                     "label": "Vulkan 1.2 minimum requirements",
                     "description": "Check the application for Vulkan 1.2 minimum requirements.",
-                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "platforms": [ "WINDOWS", "LINUX" ],
                     "status": "STABLE",
                     "settings": [
                         {
@@ -119,7 +119,7 @@
                 {
                     "label": "Vulkan 1.2 minimum requirements portability",
                     "description": "Check the application for Vulkan 1.2 minimum requirements.",
-                    "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+                    "platforms": [ "WINDOWS", "LINUX" ],
                     "status": "STABLE",
                     "settings": [
                         {


### PR DESCRIPTION
macOS doesn't support Vulkan 1.2 so there is no point to expose the 1.2 files on macOS. It's just obfuscation of functional features.