### PR TITLE
vkconfig: Fix message box with no title displayed on macOS #1547

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Add shader caching setting to validation built-in UI #1522
 - Improve user-defined paths dialog and workflow #1523
 
+### Fixes:
+- Fix message box with no title displayed on macOS #1547
+
 ## [Vulkan Configurator 2.3.0 for Vulkan SDK 1.2.176.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.176.0) - Mai 2021
 
 ### Features:

--- a/vkconfig/alert.cpp
+++ b/vkconfig/alert.cpp
@@ -20,11 +20,157 @@
 
 #include "alert.h"
 
-#include <QMessageBox>
+void Alert::LoaderFailure() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Vulkan Development Status failure...");
+    alert.setText("Could not find a Vulkan Loader.");
+    alert.setIcon(QMessageBox::Critical);
+    alert.exec();
+}
+
+void Alert::InstanceFailure() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Vulkan Development Status failure...");
+    alert.setText("Cannot find a compatible Vulkan installable client driver (ICD).");
+    alert.setIcon(QMessageBox::Critical);
+    alert.exec();
+}
+
+void Alert::PhysicalDeviceFailure() {
+    QMessageBox alert;
+    alert.setWindowTitle("Vulkan Development Status failure...");
+    alert.setText("Cannot find any Vulkan Physical Devices.");
+    alert.setIcon(QMessageBox::Critical);
+    alert.exec();
+}
+
+void Alert::ApplicationListUnsupported(const char* message) {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Layers override of a selected list of Vulkan Applications is not available");
+    alert.setTextFormat(Qt::RichText);
+    alert.setText(message);
+    alert.setInformativeText(
+        "In order to apply layers override to only a selected list of Vulkan applications, get the latest Vulkan Runtime from "
+        "<a href='https://vulkan.lunarg.com/sdk/home'>HERE.</a> to use this feature or update your Vulkan drivers");
+    alert.setIcon(QMessageBox::Warning);
+    alert.exec();
+}
+
+void Alert::ApplicationListEmpty() {
+    QMessageBox alert;
+    alert.setIcon(QMessageBox::Warning);
+    alert.QDialog::setWindowTitle("Vulkan Layers overriding will apply globally.");
+    alert.setText("The application list to override is empty. Restricting layers overriding to the selected list is disabled.");
+    alert.setInformativeText("As a result, Vulkan Layers overriding will apply globally, to all Vulkan applications.");
+    alert.exec();
+}
+
+void Alert::LayerInitFailed() {
+    const std::string message =
+        format("No Vulkan Layers were found in standard paths or in the SDK path. Vulkan Layers are required in order to use %s.",
+               VKCONFIG_NAME);
+
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("No Vulkan Layers found");
+    alert.setText(message.c_str());
+    alert.setInformativeText("Please select the path where you have your layers located.");
+    alert.setIcon(QMessageBox::Warning);
+    alert.exec();
+}
+
+QMessageBox::Button Alert::LayerImplicitExcluded(const char* layer_name) {
+    const char* text = "%s was excluded but it is an implicit layer. This may cause undefined behavior, including crashes.";
+
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Implicit layer excluded...");
+    alert.setText(format(text, layer_name).c_str());
+    alert.setInformativeText("Do you want to continue?");
+    alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    alert.setIcon(QMessageBox::Warning);
+    return static_cast<QMessageBox::Button>(alert.exec());
+}
+
+QMessageBox::Button Alert::LayerDevSim() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Overridding or excluding ALL explicit layers is recommanded");
+    alert.setText(
+        "VK_LAYER_LUNARG_device_simulation requires being executed close to the Vulkan drivers. However, "
+        "application-controlled layers are executed after Vulkan Configurator overridden layers.");
+    alert.setInformativeText("Do you want to override ALL explicit layers too?");
+    alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    alert.setIcon(QMessageBox::Warning);
+    return static_cast<QMessageBox::Button>(alert.exec());
+}
+
+void Alert::ConfiguratorSingleton() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle(format("Cannot start another instance of %s", VKCONFIG_NAME).c_str());
+    alert.setIcon(QMessageBox::Critical);
+    alert.setText(format("Another copy of %s is currently running.", VKCONFIG_NAME).c_str());
+    alert.setInformativeText("Please close the other instance and try again.");
+    alert.exec();
+}
+
+void Alert::ConfiguratorInitFailed() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle(VKCONFIG_NAME);
+    alert.setText(format("Could not initialize %s.", VKCONFIG_NAME).c_str());
+    alert.setIcon(QMessageBox::Critical);
+    alert.exec();
+}
+
+void Alert::ConfiguratorRestart() {
+    const char* text =
+        "Vulkan Layers are fully configured when creating a Vulkan Instance which typically happens at Vulkan Application start.";
+
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Any change requires Vulkan Applications restart");
+    alert.setText(text);
+    alert.setInformativeText("For changes to take effect, running Vulkan Applications should be restarted.");
+    alert.setIcon(QMessageBox::Warning);
+    alert.exec();
+}
+
+QMessageBox::Button Alert::ConfiguratorResetAll() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Restoring and Resetting all Layers Configurations to default");
+    alert.setText(
+        "You are about to delete all the user-defined configurations and resetting all default configurations to their default "
+        "state.");
+    alert.setInformativeText("Are you sure you want to continue?");
+    alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    alert.setDefaultButton(QMessageBox::Yes);
+    alert.setIcon(QMessageBox::Warning);
+
+    return static_cast<QMessageBox::Button>(alert.exec());
+}
+
+QMessageBox::Button Alert::ConfiguratorReloadDefault() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Reloading Missing Default Configurations...");
+    alert.setText("Are you sure you want to reload the default configurations?");
+    alert.setInformativeText("Add missing default configurations. Existing configurations are preserved.");
+    alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    alert.setDefaultButton(QMessageBox::No);
+    alert.setIcon(QMessageBox::Warning);
+
+    return static_cast<QMessageBox::Button>(alert.exec());
+}
+
+QMessageBox::Button Alert::ConfiguratorCrashed() {
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle(format("%s crashed during last run...", VKCONFIG_NAME).c_str());
+    alert.setText("Do you want to reset to default resolve the issue?");
+    alert.setInformativeText("All layers configurations will be lost...");
+    alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    alert.setDefaultButton(QMessageBox::No);
+    alert.setIcon(QMessageBox::Critical);
+    return static_cast<QMessageBox::Button>(alert.exec());
+}
 
 void Alert::ConfigurationRenamingFailed() {
     QMessageBox alert;
-    alert.setWindowTitle("Renaming of the layers configuration failed...");
+    alert.QDialog::setWindowTitle("Renaming of the layers configuration failed...");
     alert.setText("There is already a configuration with the same name.");
     alert.setInformativeText("Use a different name for the configuration.");
     alert.setStandardButtons(QMessageBox::Ok);
@@ -35,7 +181,7 @@ void Alert::ConfigurationRenamingFailed() {
 
 void Alert::ConfigurationNameEmpty() {
     QMessageBox alert;
-    alert.setWindowTitle("Renaming of the layers configuration failed...");
+    alert.QDialog::setWindowTitle("Renaming of the layers configuration failed...");
     alert.setText("The configuration name is empty.");
     alert.setInformativeText("The configuration name is required.");
     alert.setStandardButtons(QMessageBox::Ok);
@@ -46,7 +192,7 @@ void Alert::ConfigurationNameEmpty() {
 
 void Alert::ConfigurationNameInvalid() {
     QMessageBox alert;
-    alert.setWindowTitle("Invalid name for a configuration...");
+    alert.QDialog::setWindowTitle("Invalid name for a configuration...");
     alert.setText("The configuration name is used to build a filename.");
     alert.setInformativeText("The name can't contain any of the following characters: \\ / : * \" < > |.");
     alert.setStandardButtons(QMessageBox::Ok);
@@ -101,10 +247,17 @@ void Alert::LayerProperties(const Layer* layer) {
     text += BuildPropertiesLog(*layer);
 
     QMessageBox alert;
-    alert.setWindowTitle(title.c_str());
+    alert.QDialog::setWindowTitle(title.c_str());
     alert.setText(text.c_str());
     alert.setStandardButtons(QMessageBox::Ok);
     alert.setDefaultButton(QMessageBox::Ok);
     alert.setIcon(QMessageBox::Information);
+    alert.exec();
+}
+
+void Alert::LogFileFailed() {
+    QMessageBox alert;
+    alert.setText("Cannot open log file");
+    alert.setIcon(QMessageBox::Warning);
     alert.exec();
 }

--- a/vkconfig/alert.h
+++ b/vkconfig/alert.h
@@ -22,9 +22,32 @@
 
 #include "../vkconfig_core/layer.h"
 
+#include <QMessageBox>
+
 struct Alert {
+    static void LoaderFailure();
+    static void InstanceFailure();
+    static void PhysicalDeviceFailure();
+
+    static void ApplicationListUnsupported(const char* message);
+    static void ApplicationListEmpty();
+
+    static void LayerInitFailed();
+    static QMessageBox::Button LayerImplicitExcluded(const char* layer_name);
+    static QMessageBox::Button LayerDevSim();
+
+    static void ConfiguratorSingleton();
+    static void ConfiguratorInitFailed();
+    static void ConfiguratorRestart();
+    static QMessageBox::Button ConfiguratorResetAll();
+    static QMessageBox::Button ConfiguratorReloadDefault();
+    static QMessageBox::Button ConfiguratorCrashed();
+
     static void ConfigurationRenamingFailed();
     static void ConfigurationNameEmpty();
     static void ConfigurationNameInvalid();
-    static void LayerProperties(const Layer *layer);
+
+    static void LayerProperties(const Layer* layer);
+
+    static void LogFileFailed();
 };

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -22,6 +22,7 @@
 
 #include "configurator.h"
 #include "vulkan.h"
+#include "alert.h"
 
 #include "dialog_custom_paths.h"
 
@@ -65,25 +66,14 @@ bool Configurator::Init() {
 
     // If no layers are found, give the user another chance to add some custom paths
     if (!has_layers) {
-        QMessageBox alert;
-        alert.setWindowTitle("No Vulkan Layers found");
-        alert.setText(
-            "No Vulkan Layers were found in standard paths or in the SDK path. Vulkan Layers are required in order to use Vulkan "
-            "Configurator.");
-        alert.setInformativeText("Please select the path where you have your layers located.");
-        alert.setIcon(QMessageBox::Warning);
-        alert.exec();
+        Alert::LayerInitFailed();
 
         UserDefinedPathsDialog dlg;
         dlg.exec();
     }
 
     if (!has_layers) {
-        QMessageBox alert;
-        alert.setWindowTitle(VKCONFIG_NAME);
-        alert.setText("Could not initialize Vulkan Configurator.");
-        alert.setIcon(QMessageBox::Critical);
-        alert.exec();
+        Alert::ConfiguratorInitFailed();
 
         return false;
     }
@@ -92,14 +82,7 @@ bool Configurator::Init() {
     if (settings.value("crashed", QVariant(false)).toBool()) {
         settings.setValue("crashed", false);
 
-        QMessageBox alert;
-        alert.setWindowTitle("Vulkan Configurator crashed during last run...");
-        alert.setText("Do you want to reset to default resolve the issue?");
-        alert.setInformativeText("All layers configurations will be lost...");
-        alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        alert.setDefaultButton(QMessageBox::No);
-        alert.setIcon(QMessageBox::Critical);
-        if (alert.exec() == QMessageBox::No) {
+        if (Alert::ConfiguratorCrashed() == QMessageBox::No) {
             configurations.LoadAllConfigurations(layers.available_layers);
         }
     } else {
@@ -119,9 +102,9 @@ bool Configurator::Init() {
         if (HasMissingLayer(active_configuration->parameters, layers.available_layers)) {
             if (settings.value("VKCONFIG_WARN_MISSING_LAYERS_IGNORE").toBool() == false) {
                 QMessageBox alert;
-                alert.setWindowTitle("Vulkan Configurator couldn't find some Vulkan layers...");
+                alert.QDialog::setWindowTitle(format("%s couldn't find some Vulkan layers...", VKCONFIG_NAME).c_str());
                 alert.setText(format("%s is missing layers", active_configuration->key.c_str()).c_str());
-                alert.setInformativeText("Do you want to add a custom path to find the layers?");
+                alert.setInformativeText("Do you want to add a path to find the layers?");
                 alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
                 alert.setDefaultButton(QMessageBox::Yes);
                 alert.setIcon(QMessageBox::Warning);

--- a/vkconfig/configurator.cpp
+++ b/vkconfig/configurator.cpp
@@ -22,13 +22,13 @@
 
 #include "configurator.h"
 #include "vulkan.h"
-#include "alert.h"
 
 #include "dialog_custom_paths.h"
 
 #include "../vkconfig_core/util.h"
 #include "../vkconfig_core/path.h"
 #include "../vkconfig_core/override.h"
+#include "../vkconfig_core/alert.h"
 
 #include <QDir>
 #include <QSettings>

--- a/vkconfig/dialog_applications.cpp
+++ b/vkconfig/dialog_applications.cpp
@@ -22,8 +22,8 @@
 #include "dialog_applications.h"
 
 #include "configurator.h"
+#include "alert.h"
 
-#include <QMessageBox>
 #include <QFileDialog>
 #include <QTextStream>
 #include <QCloseEvent>
@@ -98,12 +98,7 @@ void ApplicationsDialog::closeEvent(QCloseEvent *event) {
     if (environment.GetApplications().empty() || !environment.HasOverriddenApplications()) {
         environment.SetMode(OVERRIDE_MODE_LIST, false);
 
-        QMessageBox alert;
-        alert.setIcon(QMessageBox::Warning);
-        alert.setWindowTitle("Vulkan Layers overriding will apply globally.");
-        alert.setText("The application list to override is empty. Restricting layers overriding to the selected list is disabled.");
-        alert.setInformativeText("As a result, Vulkan Layers overriding will apply globally, to all Vulkan applications.");
-        alert.exec();
+        Alert::ApplicationListEmpty();
     }
 }
 

--- a/vkconfig/dialog_applications.cpp
+++ b/vkconfig/dialog_applications.cpp
@@ -20,9 +20,9 @@
  */
 
 #include "dialog_applications.h"
-
 #include "configurator.h"
-#include "alert.h"
+
+#include "../vkconfig_core/alert.h"
 
 #include <QFileDialog>
 #include <QTextStream>

--- a/vkconfig/dialog_layers.cpp
+++ b/vkconfig/dialog_layers.cpp
@@ -23,8 +23,8 @@
 #include "dialog_custom_paths.h"
 
 #include "configurator.h"
-#include "alert.h"
 
+#include "../vkconfig_core/alert.h"
 #include "../vkconfig_core/platform.h"
 #include "../vkconfig_core/util.h"
 #include "../vkconfig_core/doc.h"

--- a/vkconfig/dialog_layers.cpp
+++ b/vkconfig/dialog_layers.cpp
@@ -331,7 +331,7 @@ void LayersDialog::on_button_reset_clicked() {
     Configurator &configurator = Configurator::Get();
 
     QMessageBox alert;
-    alert.setWindowTitle(format("Resetting *%s* configuration...", this->configuration.key.c_str()).c_str());
+    alert.QDialog::setWindowTitle(format("Resetting *%s* configuration...", this->configuration.key.c_str()).c_str());
     alert.setText(format("Are you sure you want to reset the *%s* configuration?", this->configuration.key.c_str()).c_str());
     if (this->configuration.IsBuiltIn())
         alert.setInformativeText(
@@ -476,15 +476,7 @@ void LayersDialog::layerUseChanged(QTreeWidgetItem *item, int selection) {
     LayerState layer_state = static_cast<LayerState>(selection);
 
     if (layer_state == LAYER_STATE_OVERRIDDEN && current_parameter->key == "VK_LAYER_LUNARG_device_simulation") {
-        QMessageBox alert;
-        alert.setWindowTitle("Overridding or excluding ALL explicit layers is recommanded");
-        alert.setText(
-            "VK_LAYER_LUNARG_device_simulation requires being executed close to the Vulkan drivers. However, "
-            "application-controlled layers are executed after Vulkan Configurator overridden layers.");
-        alert.setInformativeText("Do you want to override ALL explicit layers too?");
-        alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        alert.setIcon(QMessageBox::Warning);
-        if (alert.exec() == QMessageBox::Yes) {
+        if (Alert::LayerDevSim() == QMessageBox::Yes) {
             OverrideAllExplicitLayers();
         }
     } else if (layer_state == LAYER_STATE_EXCLUDED) {
@@ -493,16 +485,7 @@ void LayersDialog::layerUseChanged(QTreeWidgetItem *item, int selection) {
 
         if (layer != nullptr) {
             if (layer->type == LAYER_TYPE_IMPLICIT) {
-                QMessageBox alert;
-                alert.setWindowTitle("Implicit layer excluded...");
-                alert.setText(
-                    format("%s was excluded but it is an implicit layer. This may cause undefined behavior, including crashes. ",
-                           tree_layer_item->layer_name.c_str())
-                        .c_str());
-                alert.setInformativeText("Do you want to continue?");
-                alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                alert.setIcon(QMessageBox::Warning);
-                if (alert.exec() == QMessageBox::No) {
+                if (Alert::LayerImplicitExcluded(tree_layer_item->layer_name.c_str()) == QMessageBox::No) {
                     current_parameter->state = LAYER_STATE_APPLICATION_CONTROLLED;
                 }
             }

--- a/vkconfig/main_gui.cpp
+++ b/vkconfig/main_gui.cpp
@@ -21,13 +21,13 @@
 #include "main_gui.h"
 
 #include "mainwindow.h"
+#include "alert.h"
 
 #include "../vkconfig_core/version.h"
 #include "../vkconfig_core/application_singleton.h"
 
 #include <QApplication>
 #include <QCheckBox>
-#include <QMessageBox>
 
 int run_gui(int argc, char* argv[]) {
     QCoreApplication::setOrganizationName("LunarG");
@@ -59,11 +59,7 @@ int run_gui(int argc, char* argv[]) {
     // order to use a QMessageBox and avoid some QThread warnings.
     const ApplicationSingleton singleton("vkconfig_single_instance");
     if (!singleton.IsFirstInstance()) {
-        QMessageBox alert(nullptr);
-        alert.setWindowTitle("Cannot start another instance of Vulkan Configurator");
-        alert.setIcon(QMessageBox::Critical);
-        alert.setText("Another copy of vkconfig is currently running. Please close the other instance and try again.");
-        alert.exec();
+        Alert::ConfiguratorSingleton();
         return -1;
     }
 

--- a/vkconfig/main_gui.cpp
+++ b/vkconfig/main_gui.cpp
@@ -21,8 +21,8 @@
 #include "main_gui.h"
 
 #include "mainwindow.h"
-#include "alert.h"
 
+#include "../vkconfig_core/alert.h"
 #include "../vkconfig_core/version.h"
 #include "../vkconfig_core/application_singleton.h"
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -21,8 +21,6 @@
 
 #include "mainwindow.h"
 
-#include "alert.h"
-
 #include "dialog_about.h"
 #include "dialog_vulkan_analysis.h"
 #include "dialog_vulkan_info.h"
@@ -33,6 +31,7 @@
 #include "configurator.h"
 #include "vulkan.h"
 
+#include "../vkconfig_core/alert.h"
 #include "../vkconfig_core/util.h"
 #include "../vkconfig_core/version.h"
 #include "../vkconfig_core/platform.h"

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -362,15 +362,7 @@ void MainWindow::on_check_box_apply_list_clicked() {
             format("The detected Vulkan loader version is %s but version 1.2.141 or newer is required", version.c_str());
         ui->check_box_apply_list->setToolTip(message.c_str());
 
-        QMessageBox alert(nullptr);
-        alert.setWindowTitle("Layers override of a selected list of Vulkan Applications is not available");
-        alert.setTextFormat(Qt::RichText);
-        alert.setText(message.c_str());
-        alert.setInformativeText(
-            "In order to apply layers override to only a selected list of Vulkan applications, get the latest Vulkan Runtime from "
-            "<a href='https://vulkan.lunarg.com/sdk/home'>HERE.</a> to use this feature or update your Vulkan drivers");
-        alert.setIcon(QMessageBox::Warning);
-        alert.exec();
+        Alert::ApplicationListUnsupported(message.c_str());
 
         ui->check_box_apply_list->setEnabled(false);
         ui->check_box_apply_list->setChecked(false);
@@ -406,17 +398,7 @@ void MainWindow::on_check_box_clear_on_launch_clicked() {
 void MainWindow::toolsResetToDefault(bool checked) {
     (void)checked;
 
-    // Let make sure...
-    QMessageBox alert;
-    alert.setIcon(QMessageBox::Warning);
-    alert.setWindowTitle("Restoring and Resetting all Layers Configurations to default");
-    alert.setText(
-        "You are about to delete all the user-defined configurations and resetting all default configurations to their default "
-        "state.");
-    alert.setInformativeText("Are you sure you want to continue?");
-    alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    alert.setDefaultButton(QMessageBox::Yes);
-    if (alert.exec() == QMessageBox::No) return;
+    if (Alert::ConfiguratorResetAll() == QMessageBox::No) return;
 
     _settings_tree_manager.CleanupGUI();
 
@@ -971,15 +953,7 @@ void MainWindow::ExportClicked(ConfigurationListItem *item) {
 void MainWindow::ReloadDefaultClicked(ConfigurationListItem *item) {
     (void)item;
 
-    QMessageBox alert;
-    alert.setWindowTitle("Reloading Missing Default Configurations...");
-    alert.setText("Are you sure you want to reload the default configurations?");
-    alert.setInformativeText("Add missing default configurations. Existing configurations are preserved.");
-    alert.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    alert.setDefaultButton(QMessageBox::No);
-    alert.setIcon(QMessageBox::Warning);
-
-    if (alert.exec() == QMessageBox::Yes) {
+    if (Alert::ConfiguratorReloadDefault() == QMessageBox::Yes) {
         _settings_tree_manager.CleanupGUI();
 
         Configurator &configurator = Configurator::Get();
@@ -1528,10 +1502,7 @@ void MainWindow::on_push_button_launcher_clicked() {
             if (!ui->check_box_clear_on_launch->isChecked()) mode |= QIODevice::Append;
 
             if (!_log_file.open(mode)) {
-                QMessageBox err;
-                err.setText("Cannot open log file");
-                err.setIcon(QMessageBox::Warning);
-                err.exec();
+                Alert::LogFileFailed();
             }
         }
     }

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -21,6 +21,7 @@
 
 #include "configurator.h"
 #include "settings_tree.h"
+#include "alert.h"
 
 #include "widget_setting.h"
 #include "widget_setting_int.h"
@@ -44,7 +45,6 @@
 #include <QRadioButton>
 #include <QApplication>
 #include <QSettings>
-#include <QMessageBox>
 
 #include <cassert>
 
@@ -453,14 +453,7 @@ void SettingsTreeManager::Refresh(RefreshAreas refresh_areas) {
     if (!settings.value("vkconfig_restart", false).toBool()) {
         settings.setValue("vkconfig_restart", true);
 
-        QMessageBox alert;
-        alert.setText(
-            "Vulkan Layers are fully configured when creating a Vulkan Instance which typically happens at Vulkan Application "
-            "start.\n\n"
-            "For changes to take effect, running Vulkan Applications should be restarted.");
-        alert.setWindowTitle("Any change requires Vulkan Applications restart");
-        alert.setIcon(QMessageBox::Warning);
-        alert.exec();
+        Alert::ConfiguratorRestart();
     }
 
     // Refresh layer configuration

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -21,7 +21,6 @@
 
 #include "configurator.h"
 #include "settings_tree.h"
-#include "alert.h"
 
 #include "widget_setting.h"
 #include "widget_setting_int.h"
@@ -35,6 +34,7 @@
 #include "widget_setting_list_element.h"
 #include "widget_setting_list.h"
 
+#include "../vkconfig_core/alert.h"
 #include "../vkconfig_core/version.h"
 #include "../vkconfig_core/platform.h"
 #include "../vkconfig_core/util.h"

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -28,6 +28,7 @@ Release: DEFINES += QT_NO_DEBUG_OUTPUT QT_NO_WARNING_OUTPUT
 linux: QMAKE_CXXFLAGS += -Wunused-variable
 
 SOURCES += \
+    ../vkconfig_core/alert.cpp \
     ../vkconfig_core/application.cpp \
     ../vkconfig_core/application_singleton.cpp \
     ../vkconfig_core/command_line.cpp \
@@ -63,7 +64,6 @@ SOURCES += \
     ../vkconfig_core/util.cpp \
     ../vkconfig_core/version.cpp \
     vulkan.cpp \
-    alert.cpp \
     widget_preset.cpp \
     widget_setting.cpp \
     widget_setting_bool.cpp \
@@ -94,6 +94,7 @@ SOURCES += \
     configurator.cpp
 
 HEADERS += \
+    ../vkconfig_core/alert.h \
     ../vkconfig_core/application.h \
     ../vkconfig_core/application_singleton.h \
     ../vkconfig_core/command_line.h \
@@ -129,7 +130,6 @@ HEADERS += \
     ../vkconfig_core/util.h \
     ../vkconfig_core/version.h \
     vulkan.h \
-    alert.h \
     widget_preset.h \
     widget_setting.h \
     widget_setting_bool.h \

--- a/vkconfig/vulkan.cpp
+++ b/vkconfig/vulkan.cpp
@@ -20,8 +20,8 @@
 
 #include "vulkan.h"
 #include "configurator.h"
-#include "alert.h"
 
+#include "../vkconfig_core/alert.h"
 #include "../vkconfig_core/util.h"
 #include "../vkconfig_core/platform.h"
 

--- a/vkconfig/vulkan.cpp
+++ b/vkconfig/vulkan.cpp
@@ -20,6 +20,7 @@
 
 #include "vulkan.h"
 #include "configurator.h"
+#include "alert.h"
 
 #include "../vkconfig_core/util.h"
 #include "../vkconfig_core/platform.h"
@@ -28,9 +29,6 @@
 
 #include <QLibrary>
 #include <QtGlobal>
-#include <QFileInfo>
-#include <QDir>
-#include <QMessageBox>
 
 #include <cassert>
 
@@ -108,11 +106,7 @@ std::string GenerateVulkanStatus() {
     const Version loader_version = GetVulkanLoaderVersion();
 
     if (loader_version == Version::VERSION_NULL) {
-        QMessageBox alert(NULL);
-        alert.setWindowTitle("Vulkan Development Status failure...");
-        alert.setText("Could not find a Vulkan Loader.");
-        alert.setIcon(QMessageBox::Critical);
-        alert.exec();
+        Alert::LoaderFailure();
 
         log += "- Could not find a Vulkan Loader.\n";
         return log;
@@ -204,11 +198,7 @@ std::string GenerateVulkanStatus() {
     assert(vkCreateInstance);
     err = vkCreateInstance(&inst_info, NULL, &inst);
     if (err == VK_ERROR_INCOMPATIBLE_DRIVER) {
-        QMessageBox alert(NULL);
-        alert.setWindowTitle("Vulkan Development Status failure...");
-        alert.setText("Cannot find a compatible Vulkan installable client driver (ICD).");
-        alert.setIcon(QMessageBox::Critical);
-        alert.exec();
+        Alert::InstanceFailure();
 
         log += "- Cannot find a compatible Vulkan installable client driver (ICD).\n";
         return log;
@@ -220,11 +210,7 @@ std::string GenerateVulkanStatus() {
 
     // This can fail on a new Linux setup. Check and fail gracefully rather than crash.
     if (err != VK_SUCCESS) {
-        QMessageBox alert(NULL);
-        alert.setWindowTitle("Vulkan Development Status failure...");
-        alert.setText("Cannot find any Vulkan Physical Devices.");
-        alert.setIcon(QMessageBox::Critical);
-        alert.exec();
+        Alert::PhysicalDeviceFailure();
 
         log += "- Cannot find a compatible Vulkan installable client driver (ICD).\n";
         return log;

--- a/vkconfig_core/alert.cpp
+++ b/vkconfig_core/alert.cpp
@@ -78,6 +78,17 @@ void Alert::LayerInitFailed() {
     alert.exec();
 }
 
+void Alert::LayerInvalid(const char* path, const char* message) {
+    const std::string text = format("%s is not a valid layer manifest. \n\n", path) + message;
+
+    QMessageBox alert;
+    alert.QDialog::setWindowTitle("Failed to load a layer manifest...");
+    alert.setText(text.c_str());
+    alert.setInformativeText("The layer is being ignored.");
+    alert.setIcon(QMessageBox::Critical);
+    alert.exec();
+}
+
 QMessageBox::Button Alert::LayerImplicitExcluded(const char* layer_name) {
     const char* text = "%s was excluded but it is an implicit layer. This may cause undefined behavior, including crashes.";
 

--- a/vkconfig_core/alert.h
+++ b/vkconfig_core/alert.h
@@ -33,6 +33,7 @@ struct Alert {
     static void ApplicationListEmpty();
 
     static void LayerInitFailed();
+    static void LayerInvalid(const char* path, const char* message);
     static QMessageBox::Button LayerImplicitExcluded(const char* layer_name);
     static QMessageBox::Button LayerDevSim();
 

--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -10,7 +10,7 @@ function(vkConfigTest NAME)
     set(TEST_NAME vkconfig_${NAME})
 
     file(GLOB FILES_JSON ./*.json)
-    file(GLOB FILES_TEXT ./*0.txt)
+    file(GLOB FILES_TEXT ./*.txt)
     source_group("Test Files" FILES ${FILES_JSON} ${FILES_TEXT})
 
     add_executable(${TEST_NAME} ${TEST_FILE} ${FILES_JSON} ${FILES_TEXT} resources.qrc)


### PR DESCRIPTION
No title were displayed on macOS message box causing quite some confusion considering the convention used when using message boxes in Vulkan Configurator.

Also improve message box for failed layer manifest validation against the layer schema.
![image](https://user-images.githubusercontent.com/62888873/122059188-a9391b00-cdec-11eb-9151-ec96a2906583.png)
