### PR TITLE
vkconfig: bugfixing

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Refactor the layer window to expose more layer documentation #1519
 - Add shader caching setting to validation built-in UI #1522
 - Improve user-defined paths dialog and workflow #1523
+- Improve UI labels #1551
 
 ### Fixes:
 - Fix message box with no title displayed on macOS #1547

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix message box with no title displayed on macOS #1547
 - Hide excluded layers in configuration that are missing, these may not be supported on the platform #1551
 - Fix crash when renaming a configuration from the layers window #1551
+- Fix validation layer bool setting written in 'vk_layer-setting.txt' #1551
 
 ## [Vulkan Configurator 2.3.0 for Vulkan SDK 1.2.176.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.176.0) - Mai 2021
 

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixes:
 - Fix message box with no title displayed on macOS #1547
+- Hide excluded layers in configuration that are missing, these may not be supported on the platform. #1551
 
 ## [Vulkan Configurator 2.3.0 for Vulkan SDK 1.2.176.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.176.0) - Mai 2021
 

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -32,7 +32,8 @@
 
 ### Fixes:
 - Fix message box with no title displayed on macOS #1547
-- Hide excluded layers in configuration that are missing, these may not be supported on the platform. #1551
+- Hide excluded layers in configuration that are missing, these may not be supported on the platform #1551
+- Fix crash when renaming a configuration from the layers window #1551
 
 ## [Vulkan Configurator 2.3.0 for Vulkan SDK 1.2.176.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.176.0) - Mai 2021
 

--- a/vkconfig/dialog_applications.cpp
+++ b/vkconfig/dialog_applications.cpp
@@ -40,7 +40,7 @@ ApplicationsDialog::ApplicationsDialog(QWidget *parent)
 
     // The header is hidden by default and stays hidden when no checkboxes are used.
     if (!configurator.environment.UseApplicationListOverrideMode())
-        setWindowTitle("Applications Launcher Shortcuts");
+        setWindowTitle("Vulkan Applications Launcher Shortcuts");
     else {
         ui->treeWidget->setHeaderHidden(false);
         ui->treeWidget->setHeaderLabel("Check to override Vulkan layers");

--- a/vkconfig/dialog_applications.h
+++ b/vkconfig/dialog_applications.h
@@ -38,8 +38,8 @@ class ApplicationsDialog : public QDialog {
    private:
     QTreeWidgetItem *CreateApplicationItem(const Application &application) const;
 
-    virtual void closeEvent(QCloseEvent *) override;
-    virtual bool eventFilter(QObject *target, QEvent *event) override;
+    void closeEvent(QCloseEvent *) override;
+    bool eventFilter(QObject *target, QEvent *event) override;
 
    public Q_SLOTS:
     void on_pushButtonAdd_clicked();                                                // Pick the application

--- a/vkconfig/dialog_applications.ui
+++ b/vkconfig/dialog_applications.ui
@@ -17,7 +17,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Applications to override Vulkan Layers</string>
+   <string>Vulkan Applications with overridden Vulkan Layers</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="4" column="0">

--- a/vkconfig/dialog_custom_paths.cpp
+++ b/vkconfig/dialog_custom_paths.cpp
@@ -56,6 +56,13 @@ void UserDefinedPathsDialog::SaveLayersPaths(const std::vector<std::string> &lay
     }
 }
 
+void UserDefinedPathsDialog::reject() {
+    this->SaveLayersPaths(this->layers_paths_saved);
+    this->Reload();
+
+    QDialog::reject();
+}
+
 // Load the tree widget with the current list
 void UserDefinedPathsDialog::RepopulateTree() {
     Configurator &configurator = Configurator::Get();
@@ -94,10 +101,7 @@ void UserDefinedPathsDialog::RepopulateTree() {
     }
 }
 
-void UserDefinedPathsDialog::on_buttonBox_clicked() {
-    this->SaveLayersPaths(layers_paths);
-    this->Reload();
-}
+void UserDefinedPathsDialog::on_buttonBox_clicked() { this->accept(); }
 
 void UserDefinedPathsDialog::on_pushButtonAdd_clicked() {
     Configurator &configurator = Configurator::Get();
@@ -111,11 +115,9 @@ void UserDefinedPathsDialog::on_pushButtonAdd_clicked() {
             item->setText(0, custom_path.c_str());
             ui->treeWidget->addTopLevelItem(item);
 
+            this->SaveLayersPaths(this->layers_paths);
             this->Reload();
             this->RepopulateTree();
-
-            this->SaveLayersPaths(this->layers_paths_saved);
-            this->Reload();
         }
     }
 
@@ -138,11 +140,9 @@ void UserDefinedPathsDialog::on_pushButtonRemove_clicked() {
 
     RemoveString(this->layers_paths, selected->text(0).toStdString());
 
+    this->SaveLayersPaths(this->layers_paths);
+    this->Reload();
     this->RepopulateTree();
-    this->Reload();
-
-    this->SaveLayersPaths(this->layers_paths_saved);
-    this->Reload();
 
     // Nothing is selected, so disable remove button
     ui->buttonBox->setEnabled(!Configurator::Get().layers.Empty());

--- a/vkconfig/dialog_custom_paths.h
+++ b/vkconfig/dialog_custom_paths.h
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 
+#include <QCloseEvent>
+
 class UserDefinedPathsDialog : public QDialog {
     Q_OBJECT
 
@@ -38,6 +40,7 @@ class UserDefinedPathsDialog : public QDialog {
     void on_pushButtonRemove_clicked();
     void on_treeWidget_itemSelectionChanged();
     void on_buttonBox_clicked();
+    void reject();
 
    private:
     UserDefinedPathsDialog(const UserDefinedPathsDialog &) = delete;

--- a/vkconfig/dialog_layers.cpp
+++ b/vkconfig/dialog_layers.cpp
@@ -536,7 +536,7 @@ void LayersDialog::accept() {
     saved_configuration->description = ui->lineEditDescription->text().toStdString();
     saved_configuration->parameters = this->configuration.parameters;
 
-    configurator.configurations.RefreshConfiguration(configurator.layers.available_layers);
+    configurator.configurations.SetActiveConfiguration(configurator.layers.available_layers, saved_configuration);
 
     QDialog::accept();
 }

--- a/vkconfig/dialog_layers.cpp
+++ b/vkconfig/dialog_layers.cpp
@@ -217,14 +217,14 @@ void LayersDialog::AddLayerItem(const Parameter &parameter) {
 
     std::string decorated_name(parameter.key);
 
-    if (layer->status != STATUS_STABLE) {
-        decorated_name += format(" (%s)", GetToken(layer->status));
-    }
-
-    decorated_name += format(" - %s", layer->api_version.str().c_str());
-
     bool is_implicit_layer = false;
     if (layer != nullptr) {
+        if (layer->status != STATUS_STABLE) {
+            decorated_name += format(" (%s)", GetToken(layer->status));
+        }
+
+        decorated_name += format(" - %s", layer->api_version.str().c_str());
+
         if (IsDLL32Bit(layer->manifest_path)) {
             decorated_name += " (32-bit)";
         }
@@ -234,6 +234,10 @@ void LayersDialog::AddLayerItem(const Parameter &parameter) {
             decorated_name += format(" - %s layer", GetLayerTypeLabel(layer->type));
         }
     } else {
+        // A layers configuration may have excluded layer that are misssing because they are not available on this platform
+        // We simply hide these layers to avoid confusing the Vulkan developers
+        if (parameter.state == LAYER_STATE_EXCLUDED) return;
+
         decorated_name += " (Missing)";
     }
 

--- a/vkconfig/dialog_layers.cpp
+++ b/vkconfig/dialog_layers.cpp
@@ -536,6 +536,8 @@ void LayersDialog::accept() {
     saved_configuration->description = ui->lineEditDescription->text().toStdString();
     saved_configuration->parameters = this->configuration.parameters;
 
+    configurator.configurations.RefreshConfiguration(configurator.layers.available_layers);
+
     QDialog::accept();
 }
 

--- a/vkconfig/dialog_layers.h
+++ b/vkconfig/dialog_layers.h
@@ -48,7 +48,7 @@ class LayersDialog : public QDialog {
     void LoadSortedLayersUI();
 
    public Q_SLOTS:
-    virtual void accept() override;  // Save the configuration
+    void accept() override;
 
     void currentLayerChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -1319,7 +1319,7 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             // Create context menu here
             QMenu menu(ui->configuration_tree);
 
-            QAction *edit_action = new QAction("Select Layers...", nullptr);
+            QAction *edit_action = new QAction("Edit Layers...", nullptr);
             edit_action->setEnabled(active && item != nullptr);
             menu.addAction(edit_action);
 

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -899,7 +899,7 @@ void MainWindow::DuplicateClicked(ConfigurationListItem *item) {
 
     Configurator &configurator = Configurator::Get();
     const Configuration &duplicated_configuration =
-        configurator.configurations.CreateConfiguration(configurator.layers.available_layers, item->configuration_name);
+        configurator.configurations.CreateConfiguration(configurator.layers.available_layers, item->configuration_name, true);
 
     item->configuration_name = duplicated_configuration.key;
 

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -72,10 +72,10 @@ class MainWindow : public QMainWindow {
     void LoadConfigurationList();
     void SetupLauncherTree();
 
-    virtual void closeEvent(QCloseEvent *event) override;
-    virtual void showEvent(QShowEvent *event) override;
-    virtual void resizeEvent(QResizeEvent *event) override;
-    virtual bool eventFilter(QObject *target, QEvent *event) override;
+    void closeEvent(QCloseEvent *event) override;
+    void showEvent(QShowEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    bool eventFilter(QObject *target, QEvent *event) override;
 
     std::unique_ptr<QDialog> vk_info_dialog;
     std::unique_ptr<QDialog> vk_installation_dialog;

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -110,7 +110,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Fully controlled by the Vulkan applications</string>
+               <string>Layers Fully Controlled by the Vulkan Applications</string>
               </property>
              </widget>
             </item>
@@ -123,7 +123,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Overridden by the Vulkan Configurator</string>
+               <string>Overriding Layers by the Vulkan Configurator</string>
               </property>
              </widget>
             </item>
@@ -154,38 +154,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Apply only to the selected list of Vulkan applications</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QPushButton" name="push_button_applications">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>80</width>
-                  <height>26</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>100</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-                <property name="font">
-                 <font>
-                  <family>Arial</family>
-                  <pointsize>10</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Edit...</string>
+                 <string>Apply only to the Vulkan Applications List</string>
                 </property>
                </widget>
               </item>
@@ -214,7 +183,38 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Make layers override persistent on exit</string>
+                 <string>Continue Overriding Layers on Exit</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QPushButton" name="push_button_applications">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>136</width>
+                  <height>26</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>136</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <family>Arial</family>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Edit Applications...</string>
                 </property>
                </widget>
               </item>
@@ -569,7 +569,7 @@
               </font>
              </property>
              <property name="text">
-              <string>Select Layers...</string>
+              <string>Edit Layers...</string>
              </property>
             </widget>
            </item>

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -25,13 +25,8 @@
 
 WidgetSettingBool::WidgetSettingBool(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaBool& meta,
                                      SettingDataSet& data_set)
-    : WidgetSettingBase(tree, item),
-      meta(meta),
-      data(*static_cast<SettingDataBool*>(FindSetting(data_set, meta.key.c_str()))),
-      data_set(data_set),
-      field(new QCheckBox(this)) {
+    : WidgetSettingBase(tree, item), meta(meta), data_set(data_set), field(new QCheckBox(this)) {
     assert(&this->meta);
-    assert(&this->data);
 
     this->field->setText(this->meta.label.c_str());
     this->field->setFont(this->tree->font());
@@ -59,13 +54,19 @@ void WidgetSettingBool::Refresh(RefreshAreas refresh_areas) {
         }
 
         this->field->blockSignals(true);
-        this->field->setChecked(this->data.value);
+        this->field->setChecked(this->data().value);
         this->field->blockSignals(false);
     }
 }
 
 void WidgetSettingBool::OnClicked() {
-    this->data.value = this->field->isChecked();
+    this->data().value = this->field->isChecked();
 
     emit itemChanged();
+}
+
+SettingDataBool& WidgetSettingBool::data() {
+    SettingDataBool* data = FindSetting<SettingDataBool>(this->data_set, this->meta.key.c_str());
+    assert(data != nullptr);
+    return *data;
 }

--- a/vkconfig/widget_setting_bool.h
+++ b/vkconfig/widget_setting_bool.h
@@ -42,9 +42,10 @@ class WidgetSettingBool : public WidgetSettingBase {
     void itemChanged();
 
    private:
-    const SettingDataSet& data_set;
-    SettingDataBool& data;
+    SettingDataBool& data();
+
     const SettingMetaBool& meta;
+    SettingDataSet& data_set;
 
     QCheckBox* field;
 };

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -28,13 +28,8 @@ static const int MIN_FIELD_WIDTH = 80;
 
 WidgetSettingEnum::WidgetSettingEnum(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaEnum& meta,
                                      SettingDataSet& data_set)
-    : WidgetSettingBase(tree, item),
-      meta(meta),
-      data(*static_cast<SettingDataEnum*>(FindSetting(data_set, meta.key.c_str()))),
-      data_set(data_set),
-      field(new QComboBox(this)) {
+    : WidgetSettingBase(tree, item), meta(meta), data_set(data_set), field(new QComboBox(this)) {
     assert(&meta);
-    assert(&data);
 
     this->field->show();
 
@@ -67,11 +62,12 @@ void WidgetSettingEnum::Refresh(RefreshAreas refresh_areas) {
         this->enum_indexes.clear();
 
         int selection = 0;
+        const std::string value = data().value;
         for (std::size_t i = 0, n = this->meta.enum_values.size(); i < n; ++i) {
             if (!IsSupported(&this->meta.enum_values[i])) continue;
 
             this->field->addItem(this->meta.enum_values[i].label.c_str());
-            if (this->meta.enum_values[i].key == data.value) {
+            if (this->meta.enum_values[i].key == value) {
                 selection = static_cast<int>(this->enum_indexes.size());
             }
             this->enum_indexes.push_back(i);
@@ -97,6 +93,12 @@ void WidgetSettingEnum::resizeEvent(QResizeEvent* event) {
 void WidgetSettingEnum::OnIndexChanged(int index) {
     assert(index >= 0 && index < static_cast<int>(this->meta.enum_values.size()));
 
-    this->data.value = this->meta.enum_values[enum_indexes[static_cast<std::size_t>(index)]].key;
+    this->data().value = this->meta.enum_values[enum_indexes[static_cast<std::size_t>(index)]].key;
     emit itemChanged();
+}
+
+SettingDataEnum& WidgetSettingEnum::data() {
+    SettingDataEnum* data = FindSetting<SettingDataEnum>(this->data_set, this->meta.key.c_str());
+    assert(data != nullptr);
+    return *data;
 }

--- a/vkconfig/widget_setting_enum.h
+++ b/vkconfig/widget_setting_enum.h
@@ -44,9 +44,11 @@ class WidgetSettingEnum : public WidgetSettingBase {
    private:
     void resizeEvent(QResizeEvent* event) override;
 
-    const SettingDataSet& data_set;
-    SettingDataEnum& data;
+    SettingDataEnum& data();
+
     const SettingMetaEnum& meta;
+    SettingDataSet& data_set;
+
     QComboBox* field;
     std::vector<std::size_t> enum_indexes;
 };

--- a/vkconfig/widget_setting_filesystem.h
+++ b/vkconfig/widget_setting_filesystem.h
@@ -49,11 +49,12 @@ class WidgetSettingFilesystem : public WidgetSettingBase {
     void resizeEvent(QResizeEvent *event) override;
 
    private:
-    QTreeWidgetItem *item_child;
-    const SettingDataSet &data_set;
-    SettingDataString &data;
-    const SettingMetaFilesystem &meta;
+    SettingDataString &data();
 
+    const SettingMetaFilesystem &meta;
+    SettingDataSet &data_set;
+
+    QTreeWidgetItem *item_child;
     QLineEdit *field;
     QPushButton *button;
 };

--- a/vkconfig/widget_setting_flags.cpp
+++ b/vkconfig/widget_setting_flags.cpp
@@ -31,13 +31,7 @@
 
 WidgetSettingFlag::WidgetSettingFlag(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaFlags& meta,
                                      SettingDataSet& data_set, const std::string& flag)
-    : WidgetSettingBase(tree, item),
-      meta(meta),
-      data(*static_cast<SettingDataFlags*>(FindSetting(data_set, meta.key.c_str()))),
-      data_set(data_set),
-      flag(flag),
-      field(new QCheckBox(this)) {
-    assert(&data);
+    : WidgetSettingBase(tree, item), meta(meta), data_set(data_set), flag(flag), field(new QCheckBox(this)) {
     assert(!flag.empty());
 
     const SettingEnumValue* enum_value = FindByKey(meta.enum_values, flag.c_str());
@@ -68,18 +62,26 @@ void WidgetSettingFlag::Refresh(RefreshAreas refresh_areas) {
             this->DisplayOverride(this->field, this->meta);
         }
 
+        const std::vector<std::string>& value = this->data().value;
+
         this->field->blockSignals(true);
-        this->field->setChecked(std::find(data.value.begin(), data.value.end(), flag) != data.value.end());
+        this->field->setChecked(std::find(value.begin(), value.end(), flag) != value.end());
         this->field->blockSignals(false);
     }
 }
 
 void WidgetSettingFlag::OnClicked(bool checked) {
     if (checked) {
-        AppendString(data.value, flag);
+        AppendString(this->data().value, flag);
     } else {
-        RemoveString(data.value, flag);
+        RemoveString(this->data().value, flag);
     }
 
     emit itemChanged();
+}
+
+SettingDataFlags& WidgetSettingFlag::data() {
+    SettingDataFlags* data = FindSetting<SettingDataFlags>(this->data_set, this->meta.key.c_str());
+    assert(data != nullptr);
+    return *data;
 }

--- a/vkconfig/widget_setting_flags.h
+++ b/vkconfig/widget_setting_flags.h
@@ -43,9 +43,10 @@ class WidgetSettingFlag : public WidgetSettingBase {
     void itemChanged();
 
    private:
-    const SettingDataSet& data_set;
-    SettingDataFlags& data;
+    SettingDataFlags& data();
+
     const SettingMetaFlags& meta;
+    SettingDataSet& data_set;
 
     std::string flag;
     QCheckBox* field;

--- a/vkconfig/widget_setting_float.cpp
+++ b/vkconfig/widget_setting_float.cpp
@@ -33,13 +33,11 @@ WidgetSettingFloat::WidgetSettingFloat(QTreeWidget* tree, QTreeWidgetItem* item,
                                        SettingDataSet& data_set)
     : WidgetSettingBase(tree, item),
       meta(meta),
-      data(*static_cast<SettingDataFloat*>(FindSetting(data_set, meta.key.c_str()))),
       data_set(data_set),
       field(new QLineEdit(this)),
       timer_error(new QTimer(this)),
       timer_valid(new QTimer(this)) {
     assert(&meta);
-    assert(&data);
 
     const std::string unit = meta.unit.empty() ? "" : format(" (%s)", meta.unit.c_str());
 
@@ -83,7 +81,7 @@ void WidgetSettingFloat::Refresh(RefreshAreas refresh_areas) {
         const std::string float_format = meta.GetFloatFormat();
 
         this->field->blockSignals(true);
-        this->field->setText(format(float_format.c_str(), data.value).c_str());
+        this->field->setText(format(float_format.c_str(), this->data().value).c_str());
         this->field->blockSignals(false);
     }
 }
@@ -141,7 +139,7 @@ void WidgetSettingFloat::OnErrorValue() {
         if (alert.exec() == QMessageBox::Yes) {
             const std::string field_value = format(this->meta.GetFloatFormat().c_str(), this->meta.default_value);
 
-            this->data.value = this->meta.default_value;
+            this->data().value = this->meta.default_value;
             this->field->setText(field_value.c_str());
             this->field->setPalette(default_palette);
             this->Resize();
@@ -168,7 +166,7 @@ void WidgetSettingFloat::Resize() {
     this->field->setGeometry(button_rect);
 }
 
-SettingInputError WidgetSettingFloat::ProcessInputValue() { return this->data.ProcessInput(this->value_buffer); }
+SettingInputError WidgetSettingFloat::ProcessInputValue() { return this->data().ProcessInput(this->value_buffer); }
 
 void WidgetSettingFloat::OnTextEdited(const QString& new_value) {
     this->timer_error->stop();
@@ -185,4 +183,10 @@ void WidgetSettingFloat::OnTextEdited(const QString& new_value) {
     }
 
     emit itemChanged();
+}
+
+SettingDataFloat& WidgetSettingFloat::data() {
+    SettingDataFloat* data = FindSetting<SettingDataFloat>(this->data_set, this->meta.key.c_str());
+    assert(data != nullptr);
+    return *data;
 }

--- a/vkconfig/widget_setting_float.h
+++ b/vkconfig/widget_setting_float.h
@@ -52,10 +52,10 @@ class WidgetSettingFloat : public WidgetSettingBase {
    private:
     void Resize();
     SettingInputError ProcessInputValue();
+    SettingDataFloat& data();
 
-    const SettingDataSet& data_set;
-    SettingDataFloat& data;
     const SettingMetaFloat& meta;
+    SettingDataSet& data_set;
 
     std::string value_buffer;
     QLineEdit* field;

--- a/vkconfig/widget_setting_frames.cpp
+++ b/vkconfig/widget_setting_frames.cpp
@@ -36,13 +36,11 @@ WidgetSettingFrames::WidgetSettingFrames(QTreeWidget* tree, QTreeWidgetItem* ite
                                          SettingDataSet& data_set)
     : WidgetSettingBase(tree, item),
       meta(meta),
-      data(*static_cast<SettingDataFrames*>(FindSetting(data_set, meta.key.c_str()))),
       data_set(data_set),
       field(new QLineEdit(this)),
       timer_error(new QTimer(this)),
       timer_valid(new QTimer(this)) {
     assert(&meta);
-    assert(&data);
 
     this->field->setFont(tree->font());
     this->field->setToolTip("Use list of comma separated integer ranges. Example: '0-2,16'.");
@@ -82,7 +80,7 @@ void WidgetSettingFrames::Refresh(RefreshAreas refresh_areas) {
         }
 
         this->field->blockSignals(true);
-        this->field->setText(this->data.value.c_str());
+        this->field->setText(this->data().value.c_str());
         this->field->blockSignals(false);
     }
 }
@@ -101,7 +99,7 @@ void WidgetSettingFrames::OnErrorValue() {
     if (settings.value("VKCONFIG_WIDGET_SETTING_FRAMES").toBool() == false) {
         const std::string text =
             format("The setting input '%s' is invalid. Use list of comma separated integer ranges. Example: '0-2,16'.",
-                   this->data.value.c_str());
+                   this->data().value.c_str());
         const std::string info =
             format("Do you want to reset to the setting default value? '%s'", this->meta.default_value.c_str());
 
@@ -114,8 +112,8 @@ void WidgetSettingFrames::OnErrorValue() {
         alert.setIcon(QMessageBox::Critical);
         alert.setCheckBox(new QCheckBox("Do not show again."));
         if (alert.exec() == QMessageBox::Yes) {
-            this->data.value = this->meta.default_value;
-            this->field->setText(data.value.c_str());
+            this->data().value = this->meta.default_value;
+            this->field->setText(this->meta.default_value.c_str());
             this->field->setPalette(default_palette);
             this->Resize();
         }
@@ -141,7 +139,7 @@ void WidgetSettingFrames::Resize() {
     this->field->setGeometry(button_rect);
 }
 
-SettingInputError WidgetSettingFrames::ProcessInputValue() { return this->data.ProcessInput(this->value_buffer); }
+SettingInputError WidgetSettingFrames::ProcessInputValue() { return this->data().ProcessInput(this->value_buffer); }
 
 void WidgetSettingFrames::OnTextEdited(const QString& new_value) {
     this->timer_error->stop();
@@ -158,4 +156,10 @@ void WidgetSettingFrames::OnTextEdited(const QString& new_value) {
     }
 
     emit itemChanged();
+}
+
+SettingDataFrames& WidgetSettingFrames::data() {
+    SettingDataFrames* data = FindSetting<SettingDataFrames>(this->data_set, this->meta.key.c_str());
+    assert(data != nullptr);
+    return *data;
 }

--- a/vkconfig/widget_setting_frames.h
+++ b/vkconfig/widget_setting_frames.h
@@ -53,10 +53,10 @@ class WidgetSettingFrames : public WidgetSettingBase {
    private:
     void Resize();
     SettingInputError ProcessInputValue();
+    SettingDataFrames& data();
 
-    const SettingDataSet& data_set;
-    SettingDataFrames& data;
     const SettingMetaFrames& meta;
+    SettingDataSet& data_set;
 
     std::string value_buffer;
     QLineEdit* field;

--- a/vkconfig/widget_setting_int.cpp
+++ b/vkconfig/widget_setting_int.cpp
@@ -32,13 +32,11 @@ static const int MIN_FIELD_WIDTH = 80;
 WidgetSettingInt::WidgetSettingInt(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaInt& meta, SettingDataSet& data_set)
     : WidgetSettingBase(tree, item),
       meta(meta),
-      data(*static_cast<SettingDataInt*>(FindSetting(data_set, meta.key.c_str()))),
       data_set(data_set),
       field(new QLineEdit(this)),
       timer_error(new QTimer(this)),
       timer_valid(new QTimer(this)) {
     assert(&meta);
-    assert(&data);
 
     const std::string unit = meta.unit.empty() ? "" : format(" (%s)", meta.unit.c_str());
 
@@ -80,7 +78,7 @@ void WidgetSettingInt::Refresh(RefreshAreas refresh_areas) {
         }
 
         this->field->blockSignals(true);
-        this->field->setText(format("%d", this->data.value).c_str());
+        this->field->setText(format("%d", this->data().value).c_str());
         this->field->blockSignals(false);
     }
 }
@@ -130,8 +128,8 @@ void WidgetSettingInt::OnErrorValue() {
         alert.setIcon(QMessageBox::Critical);
         alert.setCheckBox(new QCheckBox("Do not show again."));
         if (alert.exec() == QMessageBox::Yes) {
-            this->data.value = this->meta.default_value;
-            this->field->setText(format("%d", this->data.value).c_str());
+            this->data().value = this->meta.default_value;
+            this->field->setText(format("%d", this->meta.default_value).c_str());
             this->field->setPalette(default_palette);
             this->Resize();
         }
@@ -157,7 +155,7 @@ void WidgetSettingInt::Resize() {
     this->field->setGeometry(button_rect);
 }
 
-SettingInputError WidgetSettingInt::ProcessInputValue() { return data.ProcessInput(this->value_buffer); }
+SettingInputError WidgetSettingInt::ProcessInputValue() { return this->data().ProcessInput(this->value_buffer); }
 
 void WidgetSettingInt::OnTextEdited(const QString& new_value) {
     this->timer_error->stop();
@@ -174,4 +172,10 @@ void WidgetSettingInt::OnTextEdited(const QString& new_value) {
     }
 
     emit itemChanged();
+}
+
+SettingDataInt& WidgetSettingInt::data() {
+    SettingDataInt* data = FindSetting<SettingDataInt>(this->data_set, this->meta.key.c_str());
+    assert(data != nullptr);
+    return *data;
 }

--- a/vkconfig/widget_setting_int.h
+++ b/vkconfig/widget_setting_int.h
@@ -51,10 +51,10 @@ class WidgetSettingInt : public WidgetSettingBase {
    private:
     void Resize();
     SettingInputError ProcessInputValue();
+    SettingDataInt& data();
 
-    const SettingDataSet& data_set;
-    SettingDataInt& data;
     const SettingMetaInt& meta;
+    SettingDataSet& data_set;
 
     std::string value_buffer;
     QLineEdit* field;

--- a/vkconfig/widget_setting_list.h
+++ b/vkconfig/widget_setting_list.h
@@ -60,9 +60,10 @@ class WidgetSettingList : public WidgetSettingBase {
     void AddElement(EnabledNumberOrString &element);
     void ResetCompleter();
 
-    SettingDataSet &data_set;
-    SettingDataList &data;
+    SettingDataList &data();
+
     const SettingMetaList &meta;
+    SettingDataSet &data_set;
 
     QCompleter *search;
     QLineEdit *field;

--- a/vkconfig/widget_setting_list_element.h
+++ b/vkconfig/widget_setting_list_element.h
@@ -48,9 +48,10 @@ class WidgetSettingListElement : public WidgetSettingBase {
     void resizeEvent(QResizeEvent* event) override;
 
    private:
-    const SettingDataSet& data_set;
-    SettingDataList& data;
+    SettingDataList& data();
+
     const SettingMetaList& meta;
+    SettingDataSet& data_set;
 
     EnabledNumberOrString& element;
     QPushButton* button;

--- a/vkconfig/widget_setting_string.cpp
+++ b/vkconfig/widget_setting_string.cpp
@@ -28,15 +28,10 @@ static const int MIN_FIELD_WIDTH = 120;
 
 WidgetSettingString::WidgetSettingString(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaString& meta,
                                          SettingDataSet& data_set)
-    : WidgetSettingBase(tree, item),
-      meta(meta),
-      data(*static_cast<SettingDataString*>(FindSetting(data_set, meta.key.c_str()))),
-      data_set(data_set),
-      field(new QLineEdit(this)) {
+    : WidgetSettingBase(tree, item), meta(meta), data_set(data_set), field(new QLineEdit(this)) {
     assert(&meta);
-    assert(&data);
 
-    this->field->setText(data.value.c_str());
+    this->field->setText(this->data().value.c_str());
     this->field->setFont(tree->font());
     this->field->setToolTip(this->field->text());
     this->field->show();
@@ -65,7 +60,7 @@ void WidgetSettingString::Refresh(RefreshAreas refresh_areas) {
             this->DisplayOverride(this->field, this->meta);
         }
 
-        this->field->setText(data.value.c_str());
+        this->field->setText(this->data().value.c_str());
     }
 }
 
@@ -83,8 +78,14 @@ void WidgetSettingString::resizeEvent(QResizeEvent* event) {
 }
 
 void WidgetSettingString::OnTextEdited(const QString& value) {
-    this->data.value = value.toStdString();
+    this->data().value = value.toStdString();
     this->field->setToolTip(this->field->text());
 
     emit itemChanged();
+}
+
+SettingDataString& WidgetSettingString::data() {
+    SettingDataString* data = FindSetting<SettingDataString>(this->data_set, this->meta.key.c_str());
+    assert(data != nullptr);
+    return *data;
 }

--- a/vkconfig/widget_setting_string.h
+++ b/vkconfig/widget_setting_string.h
@@ -47,10 +47,10 @@ class WidgetSettingString : public WidgetSettingBase {
 
    private:
     void Resize();
+    SettingDataString& data();
 
-    const SettingDataSet& data_set;
     const SettingMetaString& meta;
-    SettingDataString& data;
+    SettingDataSet& data_set;
 
     QLineEdit* field;
     QSize resize;

--- a/vkconfig_core/configuration_manager.cpp
+++ b/vkconfig_core/configuration_manager.cpp
@@ -139,10 +139,10 @@ void ConfigurationManager::SaveAllConfigurations(const std::vector<Layer> &avail
 }
 
 Configuration &ConfigurationManager::CreateConfiguration(const std::vector<Layer> &available_layers,
-                                                         const std::string &configuration_name) {
+                                                         const std::string &configuration_name, bool duplicate) {
     Configuration *duplicate_configuration = FindByKey(available_configurations, configuration_name.c_str());
 
-    Configuration new_configuration = duplicate_configuration != nullptr ? *duplicate_configuration : Configuration();
+    Configuration new_configuration = duplicate_configuration != nullptr && duplicate ? *duplicate_configuration : Configuration();
     new_configuration.key = MakeConfigurationName(available_configurations, configuration_name);
 
     const std::string path = GetPath(BUILTIN_PATH_CONFIG_LAST) + "/" + new_configuration.key + ".json";

--- a/vkconfig_core/configuration_manager.h
+++ b/vkconfig_core/configuration_manager.h
@@ -36,7 +36,8 @@ class ConfigurationManager {
 
     void SaveAllConfigurations(const std::vector<Layer>& available_layers);
 
-    Configuration& CreateConfiguration(const std::vector<Layer>& available_layers, const std::string& configuration_name);
+    Configuration& CreateConfiguration(const std::vector<Layer>& available_layers, const std::string& configuration_name,
+                                       bool duplicate = false);
 
     void RemoveConfiguration(const std::vector<Layer>& available_layers, const std::string& configuration_name);
 

--- a/vkconfig_core/parameter.cpp
+++ b/vkconfig_core/parameter.cpp
@@ -34,8 +34,10 @@ bool Parameter::ApplyPresetSettings(const LayerPreset& preset) {
         SettingData* preset_setting = preset.settings[preset_index];
 
         for (std::size_t i = 0, n = this->settings.size(); i < n; ++i) {
-            if (this->settings[i]->key != preset_setting->key) continue;
-            if (this->settings[i]->type != preset_setting->type) continue;
+            SettingData* current_setting = this->settings[i];
+
+            if (current_setting->key != preset_setting->key) continue;
+            if (current_setting->type != preset_setting->type) continue;
 
             this->settings[i] = preset_setting;
         }

--- a/vkconfig_core/setting.h
+++ b/vkconfig_core/setting.h
@@ -157,11 +157,31 @@ bool IsSupported(const SettingMeta* meta);
 
 SettingMeta* FindSetting(SettingMetaSet& settings, const char* key);
 
+template <typename T>
+T* FindSetting(SettingMetaSet& settings, const char* key) {
+    return static_cast<T*>(FindSetting(settings, key));
+}
+
 const SettingMeta* FindSetting(const SettingMetaSet& settings, const char* key);
+
+template <typename T>
+const T* FindSetting(const SettingMetaSet& settings, const char* key) {
+    return static_cast<const T*>(FindSetting(settings, key));
+}
 
 SettingData* FindSetting(SettingDataSet& settings, const char* key);
 
+template <typename T>
+T* FindSetting(SettingDataSet& settings, const char* key) {
+    return static_cast<T*>(FindSetting(settings, key));
+}
+
 const SettingData* FindSetting(const SettingDataSet& settings, const char* key);
+
+template <typename T>
+const T* FindSetting(const SettingDataSet& settings, const char* key) {
+    return static_cast<const T*>(FindSetting(settings, key));
+}
 
 std::size_t CountSettings(const SettingMetaSet& settings);
 

--- a/vkconfig_core/setting_bool.cpp
+++ b/vkconfig_core/setting_bool.cpp
@@ -44,7 +44,7 @@ bool SettingMetaBool::Load(const QJsonObject& json_setting) {
 
 std::string SettingMetaBool::Export(ExportMode export_mode) const {
     (void)export_mode;
-    return this->default_value ? "TRUE" : "FALSE";
+    return this->default_value ? "true" : "false";
 }
 
 bool SettingMetaBool::Equal(const SettingMeta& other) const {
@@ -72,7 +72,7 @@ bool SettingDataBool::Save(QJsonObject& json_setting) const {
 
 std::string SettingDataBool::Export(ExportMode export_mode) const {
     (void)export_mode;
-    return this->value ? "TRUE" : "FALSE";
+    return this->value ? "true" : "false";
 }
 
 bool SettingDataBool::Equal(const SettingData& other) const {

--- a/vkconfig_core/test/override_settings_2_2_0_schema_1_2_0.txt
+++ b/vkconfig_core/test/override_settings_2_2_0_schema_1_2_0.txt
@@ -1,14 +1,14 @@
 
 # VK_LAYER_LUNARG_reference_1_2_0
-lunarg_reference_1_2_0.toogle = TRUE
+lunarg_reference_1_2_0.toogle = true
 lunarg_reference_1_2_0.enum_required_only = value2
 lunarg_reference_1_2_0.enum_with_optional = value1
 lunarg_reference_1_2_0.flags_required_only = flag0,flag2
 lunarg_reference_1_2_0.flags_with_optional = flag0,flag2
 lunarg_reference_1_2_0.string_required_only = My string
 lunarg_reference_1_2_0.string_with_optional = My string
-lunarg_reference_1_2_0.bool_required_only = TRUE
-lunarg_reference_1_2_0.bool_with_optional = TRUE
+lunarg_reference_1_2_0.bool_required_only = true
+lunarg_reference_1_2_0.bool_with_optional = true
 lunarg_reference_1_2_0.load_file_required_only = ./my_test.txt
 lunarg_reference_1_2_0.load_file_with_optional = ./my_test.txt
 lunarg_reference_1_2_0.save_file_required_only = ./my_test.txt

--- a/vkconfig_core/test/override_settings_2_2_1_schema_1_2_0.txt
+++ b/vkconfig_core/test/override_settings_2_2_1_schema_1_2_0.txt
@@ -1,14 +1,14 @@
 
 # VK_LAYER_LUNARG_reference_1_2_0
-lunarg_reference_1_2_0.toogle = TRUE
+lunarg_reference_1_2_0.toogle = true
 lunarg_reference_1_2_0.enum_required_only = value2
 lunarg_reference_1_2_0.enum_with_optional = value1
 lunarg_reference_1_2_0.flags_required_only = flag0,flag2
 lunarg_reference_1_2_0.flags_with_optional = flag0,flag2
 lunarg_reference_1_2_0.string_required_only = My string
 lunarg_reference_1_2_0.string_with_optional = My string
-lunarg_reference_1_2_0.bool_required_only = TRUE
-lunarg_reference_1_2_0.bool_with_optional = TRUE
+lunarg_reference_1_2_0.bool_required_only = true
+lunarg_reference_1_2_0.bool_with_optional = true
 lunarg_reference_1_2_0.load_file_required_only = ./my_test.txt
 lunarg_reference_1_2_0.load_file_with_optional = ./my_test.txt
 lunarg_reference_1_2_0.save_file_required_only = ./my_test.txt

--- a/vkconfig_core/test/test_setting_type_bool.cpp
+++ b/vkconfig_core/test/test_setting_type_bool.cpp
@@ -66,22 +66,22 @@ TEST(test_setting_type_bool, value) {
     Layer layer;
 
     SettingMetaBool* meta = InstantiateBool(layer, "key");
-    EXPECT_STREQ("FALSE", meta->Export(EXPORT_MODE_DOC).c_str());
-    EXPECT_STREQ("FALSE", meta->Export(EXPORT_MODE_OVERRIDE).c_str());
+    EXPECT_STREQ("false", meta->Export(EXPORT_MODE_DOC).c_str());
+    EXPECT_STREQ("false", meta->Export(EXPORT_MODE_OVERRIDE).c_str());
 
     SettingDataBool* data0 = Instantiate<SettingDataBool>(meta);
     EXPECT_EQ(data0->value, meta->default_value);
 
-    EXPECT_STREQ("FALSE", data0->Export(EXPORT_MODE_DOC).c_str());
-    EXPECT_STREQ("FALSE", data0->Export(EXPORT_MODE_OVERRIDE).c_str());
+    EXPECT_STREQ("false", data0->Export(EXPORT_MODE_DOC).c_str());
+    EXPECT_STREQ("false", data0->Export(EXPORT_MODE_OVERRIDE).c_str());
 
     meta->default_value = true;
-    EXPECT_STREQ("TRUE", meta->Export(EXPORT_MODE_DOC).c_str());
-    EXPECT_STREQ("TRUE", meta->Export(EXPORT_MODE_OVERRIDE).c_str());
+    EXPECT_STREQ("true", meta->Export(EXPORT_MODE_DOC).c_str());
+    EXPECT_STREQ("true", meta->Export(EXPORT_MODE_OVERRIDE).c_str());
 
     SettingDataBool* data1 = Instantiate<SettingDataBool>(meta);
     EXPECT_EQ(data1->value, meta->default_value);
 
-    EXPECT_STREQ("TRUE", data1->Export(EXPORT_MODE_DOC).c_str());
-    EXPECT_STREQ("TRUE", data1->Export(EXPORT_MODE_OVERRIDE).c_str());
+    EXPECT_STREQ("true", data1->Export(EXPORT_MODE_DOC).c_str());
+    EXPECT_STREQ("true", data1->Export(EXPORT_MODE_OVERRIDE).c_str());
 }


### PR DESCRIPTION
- Fix excluded missing layer case
- Fix unstable layer configuration refresh when using the "Select Layers" window.
- Fix new configuration, creates it empty now
- Improve UI labels
- Fix crash when renaming a configuration from the layers window
- Fix broken generic preset 
- Fix user-defined path window refresh
- Fix validation layer bool setting written in 'vk_layer-setting.txt'