### PR TITLE
devsim: Add surface capabilities modifications

### DIFF
--- a/layersvt/VkLayer_device_simulation.json.in
+++ b/layersvt/VkLayer_device_simulation.json.in
@@ -367,6 +367,76 @@
                         }
                     ],
                     "default": "none"
+                },
+                {
+                    "key": "modify_surface_formats",
+                    "env": "VK_DEVSIM_MODIFY_SURFACE_FORMATS",
+                    "label": "Modify Device Surface Formats",
+                    "description": "Modify the device surface formats from the layer JSON config file.",
+                    "type": "ENUM",
+                    "flags": [
+                        {
+                            "key": "none",
+                            "label": "None",
+                            "description": "Turns off modification of the device's surface formats. Uses the device's real surface formats."
+                        },
+                        {
+                            "key": "replace",
+                            "label": "Replace",
+                            "description": "Fully replaces the device's surface formats with those provided by the devsim configuration file."
+                        },
+                        {
+                            "key": "whitelist",
+                            "label": "Whitelist",
+                            "description": "Includes surface format from the devsim configuration file only if they are supported by the device."
+                        },
+                        {
+                            "key": "blacklist",
+                            "label": "Blacklist",
+                            "description": "Removes device's surface formats if they are included in the devsim configuration file."
+                        },
+                        {
+                            "key": "intersect",
+                            "label": "Intersect",
+                            "description": "Adds the surface formats from the devsim configuration file to the device's surface formats while avoiding repeats."
+                        }
+                    ],
+                    "default": "none"
+                },
+                {
+                    "key": "modify_present_modes",
+                    "env": "VK_DEVSIM_MODIFY_PRESENT_MODES",
+                    "label": "Modify Device Present Modes",
+                    "description": "Modify the device present mode list from the layer JSON config file.",
+                    "type": "ENUM",
+                    "flags": [
+                        {
+                            "key": "none",
+                            "label": "None",
+                            "description": "Turns off modification of the device's present mode list. Uses the device's real present modes."
+                        },
+                        {
+                            "key": "replace",
+                            "label": "Replace",
+                            "description": "Fully replaces the device's present mode list with the list provided by the devsim configuration file."
+                        },
+                        {
+                            "key": "whitelist",
+                            "label": "Whitelist",
+                            "description": "Includes present modes from the devsim configuration file only if they are supported by the device."
+                        },
+                        {
+                            "key": "blacklist",
+                            "label": "Blacklist",
+                            "description": "Removes present modes from the device's list if they are included in the devsim configuration file."
+                        },
+                        {
+                            "key": "intersect",
+                            "label": "Intersect",
+                            "description": "Adds the present modes from the devsim configuration file to the device's list while avoiding repeats."
+                        }
+                    ],
+                    "default": "none"
                 }
             ]
         }

--- a/layersvt/device_simulation.md
+++ b/layersvt/device_simulation.md
@@ -228,6 +228,8 @@ DevSim config files that use this feature should validate to the portability spe
 | `VK_DEVSIM_MODIFY_MEMORY_FLAGS` | `lunarg_device_simulation.modify_memory_flags` | debug.vulkan.devsim.modifymemoryflags | false | Enables modification of the device memory heap flags and memory type flags from the JSON config file. |
 | `VK_DEVSIM_MODIFY_FORMAT_LIST` | `lunarg_device_simulation.modify_format_list` | debug.vulkan.devsim.modifyformatlist | none | Enables modification of the device format list from the JSON config file. Valid options are "none", "replace", "whitelist", "blacklist", and "intersect".|
 | `VK_DEVSIM_MODIFY_FORMAT_PROPERTIES` | `lunarg_device_simulation.modify_format_properties` | debug.vulkan.devsim.modifyformatproperties | none | Enables modification of the device format properties from the JSON config file. Valid options are "none", "replace", "whitelist", "blacklist", and "intersect".|
+| `VK_DEVSIM_MODIFY_SURFACE_FORMATS` | `lunarg_device_simulation.modify_surface_formats` | debug.vulkan.devsim.modifysurfaceformats | none | Enables modification of the device format list from the JSON config file. Valid options are "none", "replace", "whitelist", "blacklist", and "intersect".|
+| `VK_DEVSIM_MODIFY_FORMAT_LIST` | `lunarg_device_simulation.modify_format_list` | debug.vulkan.devsim.modifyformatlist | none | Enables modification of the device format list from the JSON config file. Valid options are "none", "replace", "whitelist", "blacklist", and "intersect".|
 
 **Note:** Environment variables take precedence over `vk_layer_settings.txt` options.
 


### PR DESCRIPTION
Added the ability to modify the following structures with devsim:
    VkSurfaceCapabilitiesKHR
    VkSurfaceFormatKHR list
    VkPresentModeKHR list

Added the following new settings to control surface format and present
mode list modification:
    VK_DEVSIM_MODIFY_SURFACE_FORMATS
    VK_DEVSIM_MODIFY_PRESENT_MODES