### PR TITLE
Information about deprecation, removal and replacement of vktrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The repository contains the following Vulkan Tools:
 
 These tools have binaries included within the [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/).
 
+VkTrace and VkReplay have been deprecated and replaced by [gfxreconstruct](https://github.com/LunarG/gfxreconstruct).
+Both VkTrace and VkReplay have been removed from VulkanTools and can now be found in the [vktrace](https://github.com/LunarG/vktrace) archive.
+Both these tools are also no longer part of the [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/).
+
 ## CI Build Status
 | Platform | Build Status |
 |:--------:|:------------:|


### PR DESCRIPTION
Providing information about the status of actively used tools as well as communicate their replacements is essential for ensuring the community is aware of these replacements and knows where to find what. Non suspecting developers might compile VulkanTools expecting to get vktrace and vkreplay binaries while these have been removed and superseded by gfxreconstruct.