### PR TITLE
vkconfig: SDK 1.2.182 fixes

### DIFF
--- a/vkconfig/settings_tree.h
+++ b/vkconfig/settings_tree.h
@@ -60,7 +60,7 @@ class SettingsTreeManager : QObject {
 
     void BuildValidationTree(QTreeWidgetItem *parent, Parameter &parameter);
     void BuildGenericTree(QTreeWidgetItem *parent, Parameter &parameter);
-    void BuildTreeItem(QTreeWidgetItem *parent, SettingDataSet &data_set, const SettingMeta &meta);
+    void BuildTreeItem(QTreeWidgetItem *parent, Parameter &parameter, const SettingMeta &meta);
 
     void RefreshItem(RefreshAreas refresh_areas, QTreeWidgetItem *parent);
 

--- a/vkconfig/settings_validation_areas.cpp
+++ b/vkconfig/settings_validation_areas.cpp
@@ -225,6 +225,8 @@ WidgetSettingValidation::WidgetSettingValidation(QTreeWidget *tree, QTreeWidgetI
             this->item_shader_gpu = new QTreeWidgetItem();
             this->item_shader_gpu->setSizeHint(0, QSize(0, ITEM_HEIGHT));
             this->item_shader->addChild(this->item_shader_gpu);
+            this->item_shader->setExpanded(true);
+            this->item_shader_gpu->setExpanded(true);
 
             this->widget_shader_gpu = new QRadioButton(this);
             this->widget_shader_gpu->setText(value_gpu->label.c_str());
@@ -244,6 +246,7 @@ WidgetSettingValidation::WidgetSettingValidation(QTreeWidget *tree, QTreeWidgetI
                     this->item_shader_gpu_oob = new QTreeWidgetItem();
                     this->item_shader_gpu_oob->setSizeHint(0, QSize(0, ITEM_HEIGHT));
                     this->item_shader_gpu->addChild(this->item_shader_gpu_oob);
+                    this->item_shader_gpu->setExpanded(true);
 
                     this->widget_shader_gpu_oob = new QCheckBox(this);
                     this->widget_shader_gpu_oob->setText(value->label.c_str());
@@ -259,6 +262,7 @@ WidgetSettingValidation::WidgetSettingValidation(QTreeWidget *tree, QTreeWidgetI
                     this->item_shader_gpu_indirect = new QTreeWidgetItem();
                     this->item_shader_gpu_indirect->setSizeHint(0, QSize(0, ITEM_HEIGHT));
                     this->item_shader_gpu->addChild(this->item_shader_gpu_indirect);
+                    this->item_shader_gpu->setExpanded(true);
 
                     this->widget_shader_gpu_indirect = new QCheckBox(this);
                     this->widget_shader_gpu_indirect->setText(value->label.c_str());
@@ -272,6 +276,8 @@ WidgetSettingValidation::WidgetSettingValidation(QTreeWidget *tree, QTreeWidgetI
             this->item_shader_printf = new QTreeWidgetItem();
             this->item_shader_printf->setSizeHint(0, QSize(0, ITEM_HEIGHT));
             this->item_shader->addChild(this->item_shader_printf);
+            this->item_shader->setExpanded(true);
+            this->item_shader_printf->setExpanded(true);
 
             this->widget_shader_printf = new QRadioButton(this);
             this->widget_shader_printf->setText(value_printf->label.c_str());
@@ -285,6 +291,7 @@ WidgetSettingValidation::WidgetSettingValidation(QTreeWidget *tree, QTreeWidgetI
                     this->item_shader_printf_to_stdout = new QTreeWidgetItem();
                     this->item_shader_printf_to_stdout->setSizeHint(0, QSize(0, ITEM_HEIGHT));
                     this->item_shader_printf->addChild(this->item_shader_printf_to_stdout);
+                    this->item_shader_printf->setExpanded(true);
 
                     this->widget_shader_printf_to_stdout = new QCheckBox(this);
                     this->widget_shader_printf_to_stdout->setText(value->label.c_str());
@@ -301,6 +308,7 @@ WidgetSettingValidation::WidgetSettingValidation(QTreeWidget *tree, QTreeWidgetI
                     this->item_shader_printf_verbose = new QTreeWidgetItem();
                     this->item_shader_printf_verbose->setSizeHint(0, QSize(0, ITEM_HEIGHT));
                     this->item_shader_printf->addChild(this->item_shader_printf_verbose);
+                    this->item_shader_printf->setExpanded(true);
 
                     this->widget_shader_printf_verbose = new QCheckBox(this);
                     this->widget_shader_printf_verbose->setText(value->label.c_str());
@@ -316,6 +324,7 @@ WidgetSettingValidation::WidgetSettingValidation(QTreeWidget *tree, QTreeWidgetI
                 if (IsSupported(value)) {
                     this->item_shader_printf_size = new QTreeWidgetItem();
                     this->item_shader_printf->addChild(this->item_shader_printf_size);
+                    this->item_shader_printf->setExpanded(true);
 
                     this->widget_debug_printf_size = new WidgetSettingInt(tree, this->item_shader_printf_size, *value, data_set);
                     this->connect(this->widget_debug_printf_size, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));

--- a/vkconfig/settings_validation_areas.cpp
+++ b/vkconfig/settings_validation_areas.cpp
@@ -66,6 +66,7 @@ QCheckBox *WidgetSettingValidation::CreateWidget(QTreeWidgetItem *parent, QTreeW
     *item = new QTreeWidgetItem();
     (*item)->setSizeHint(0, QSize(0, ITEM_HEIGHT));
     parent->addChild(*item);
+    (*item)->setExpanded(true);
 
     QCheckBox *widget = new QCheckBox(this);
     widget->setText(value->label.c_str());

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -98,7 +98,7 @@ static void WriteSettingsDetails(std::string& text, const Layer& layer, const Se
             } else {
                 text += format("\t<li>Environment Variable: <span class=\"code\">%s</span></li>\n", setting->env.c_str());
             }
-            text += format("\t<li>Platforms Supported: %s</li>\n", BuildPlatformsHTML(setting->platform_flags).c_str());
+            text += format("\t<li>Platforms: %s</li>\n", BuildPlatformsHTML(setting->platform_flags).c_str());
 
             if (setting->view != SETTING_VIEW_STANDARD) {
                 text += format("\t<li>Setting Level: %s</li>\n", GetToken(setting->view));
@@ -116,7 +116,7 @@ static void WriteSettingsDetails(std::string& text, const Layer& layer, const Se
                 text += "<table>\n";
                 text +=
                     "<thead><tr><th>Enum Value</th><th>Label</th><th class=\"desc\">Description</th><th>Platforms "
-                    "Supported</th></tr></thead>\n";
+                    "</th></tr></thead>\n";
                 text += "<tbody>\n";
                 for (std::size_t j = 0, o = setting_enum.enum_values.size(); j < o; ++j) {
                     const SettingEnumValue& value = setting_enum.enum_values[j];
@@ -188,7 +188,7 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
     text += format("\t\t<li>Layer Binary Path: %s</li>\n", layer.binary_path.c_str());
     text += "\t</ul></li>\n";
     if (layer.platforms != 0) {
-        text += format("\t<li>Supported Platforms: %s</li>\n", BuildPlatformsHTML(layer.platforms).c_str());
+        text += format("\t<li>Platforms: %s</li>\n", BuildPlatformsHTML(layer.platforms).c_str());
     }
     if (layer.status != STATUS_STABLE) {
         text += format("\t<li>Status: %s</li>\n", GetToken(layer.status));
@@ -211,7 +211,7 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
         text += "<table><thead><tr>";
         text += format(
             "<th>Setting</th><th>Type</th><th>Default Value</th><th><a href=\"%s\">vk_layer_settings.txt</a> Variable</th>"
-            "<th>Environment Variable</th><th>Supported Platforms</th>",
+            "<th>Environment Variable</th><th>Platforms</th>",
             GetLayerSettingsDocURL(layer).c_str());
         text += "</tr></thead><tbody>\n";
         WriteSettingsOverview(text, layer, layer.settings);

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -105,7 +105,7 @@ std::string Layer::FindPresetLabel(const SettingDataSet& settings) const {
     return NO_PRESET;
 }
 
-SettingMeta* Layer::Instantiate(const std::string& key, const SettingType type) {
+SettingMeta* Layer::Instantiate(SettingMetaSet& meta_set, const std::string& key, const SettingType type) {
     SettingMeta* setting_meta = nullptr;
 
     switch (type) {
@@ -154,8 +154,8 @@ SettingMeta* Layer::Instantiate(const std::string& key, const SettingType type) 
     }
 
     assert(setting_meta != nullptr);
-    this->settings.push_back(setting_meta);
     this->memory.push_back(std::shared_ptr<SettingMeta>(setting_meta));
+    meta_set.push_back(setting_meta);
     return setting_meta;
 }
 
@@ -332,7 +332,7 @@ void Layer::AddSettingsSet(SettingMetaSet& settings, const QJsonValue& json_sett
 
         const std::string key = ReadStringValue(json_setting, "key");
         const SettingType type = GetSettingType(ReadStringValue(json_setting, "type").c_str());
-        SettingMeta* setting_meta = Instantiate(key, type);
+        SettingMeta* setting_meta = Instantiate(settings, key, type);
 
         const QJsonValue& json_children = json_setting.value("settings");
         if (json_children != QJsonValue::Undefined) {

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -46,7 +46,7 @@ class Layer {
 
     std::string FindPresetLabel(const SettingDataSet& settings) const;
 
-    SettingMeta* Instantiate(const std::string& key, const SettingType type);
+    SettingMeta* Instantiate(SettingMetaSet& meta_set, const std::string& key, const SettingType type);
 
     void AddSettingData(SettingDataSet& data_set, const QJsonValue& json_setting_value);
 

--- a/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
@@ -302,7 +302,7 @@
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descritor Set",
+                            "label": "Idle Descriptor Set",
                             "description": "",
                             "view": "ADVANCED"
                         }

--- a/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/130/VK_LAYER_KHRONOS_validation.json
@@ -8,7 +8,7 @@
         "description": "Khronos Validation Layer",
         "introduction": "The main, comprehensive Khronos validation layer.\n\nVulkan is an Explicit API, enabling direct control over how GPUs actually work. By design, minimal error checking is done inside a Vulkan driver. Applications have full control and responsibility for correct operation. Any errors in how Vulkan is used can result in a crash. \n\nThe Khronos Valiation Layer can be enabled to assist development by enabling developers to verify their applications correctly use the Vulkan API.",
         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html",
-        "platforms": [ "WINDOWS", "LINUX", "MACOS" ],
+        "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ],
         "instance_extensions": [
             {
                 "name": "VK_EXT_debug_report",
@@ -235,6 +235,7 @@
                 },
                 {
                     "key": "disables",
+                    "env": "VK_LAYER_DISABLES",
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
@@ -266,26 +267,26 @@
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
-                            "label": "Disable Shaders",
-                            "description": "",
+                            "label": "Shaders",
+                            "description": "Shader checks. These checks can be CPU intensive during application start up, especially if Shader Validation Caching is also disabled.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                             "label": "Command Buffer State",
-                            "description": "",
+                            "description": "Check that all Vulkan objects used by a command buffer have not been destroyed. These checks can be CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                             "label": "Image Layout",
-                            "description": "",
+                            "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                             "label": "Query",
-                            "description": "",
+                            "description": "Checks for commands that use VkQueryPool objects.",
                             "view": "ADVANCED"
                         },
                         {
@@ -297,7 +298,7 @@
                         {
                             "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                             "label": "Object in Use",
-                            "description": "",
+                            "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
@@ -311,6 +312,7 @@
                 },
                 {
                     "key": "enables",
+                    "env": "VK_LAYER_ENABLES",
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",

--- a/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
@@ -302,7 +302,7 @@
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descritor Set",
+                            "label": "Idle Descriptor Set",
                             "description": "",
                             "view": "ADVANCED"
                         }

--- a/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/135/VK_LAYER_KHRONOS_validation.json
@@ -235,6 +235,7 @@
                 },
                 {
                     "key": "disables",
+                    "env": "VK_LAYER_DISABLES",
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
@@ -311,6 +312,7 @@
                 },
                 {
                     "key": "enables",
+                    "env": "VK_LAYER_ENABLES",
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",

--- a/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
@@ -259,6 +259,7 @@
                 },
                 {
                     "key": "disables",
+                    "env": "VK_LAYER_DISABLES",
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
@@ -335,6 +336,7 @@
                 },
                 {
                     "key": "enables",
+                    "env": "VK_LAYER_ENABLES",
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",

--- a/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/141/VK_LAYER_KHRONOS_validation.json
@@ -326,7 +326,7 @@
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descritor Set",
+                            "label": "Idle Descriptor Set",
                             "description": "",
                             "view": "ADVANCED"
                         }

--- a/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
@@ -343,7 +343,7 @@
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descritor Set",
+                            "label": "Idle Descriptor Set",
                             "description": "",
                             "view": "ADVANCED"
                         }

--- a/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
@@ -259,6 +259,7 @@
                 },
                 {
                     "key": "duplicate_message_limit",
+                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                     "label": "Duplicated Messages Limit",
                     "description": "Limit the number of times any single validation message would be reported. 0 is unlimited.",
                     "type": "INT",
@@ -269,6 +270,7 @@
                 },
                 {
                     "key": "message_id_filter",
+                    "env": "VK_LAYER_MESSAGE_ID_FILTER",
                     "label": "Mute Message VUIDs",
                     "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
                     "type": "LIST",
@@ -276,6 +278,7 @@
                 },
                 {
                     "key": "disables",
+                    "env": "VK_LAYER_DISABLES",
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
@@ -352,6 +355,7 @@
                 },
                 {
                     "key": "enables",
+                    "env": "VK_LAYER_ENABLES",
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",

--- a/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
@@ -366,7 +366,7 @@
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descritor Set",
+                            "label": "Idle Descriptor Set",
                             "description": "",
                             "view": "ADVANCED"
                         }

--- a/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
@@ -282,6 +282,7 @@
                 },
                 {
                     "key": "duplicate_message_limit",
+                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                     "label": "Duplicated Messages Limit",
                     "description": "Limit the number of times any single validation message would be reported. 0 is unlimited.",
                     "type": "INT",
@@ -292,6 +293,7 @@
                 },
                 {
                     "key": "message_id_filter",
+                    "env": "VK_LAYER_MESSAGE_ID_FILTER",
                     "label": "Mute Message VUIDs",
                     "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
                     "type": "LIST",
@@ -299,6 +301,7 @@
                 },
                 {
                     "key": "disables",
+                    "env": "VK_LAYER_DISABLES",
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
@@ -375,6 +378,7 @@
                 },
                 {
                     "key": "enables",
+                    "env": "VK_LAYER_ENABLES",
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -282,6 +282,7 @@
                 },
                 {
                     "key": "duplicate_message_limit",
+                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                     "label": "Duplicated Messages Limit",
                     "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
                     "type": "INT",
@@ -292,6 +293,7 @@
                 },
                 {
                     "key": "message_id_filter",
+                    "env": "VK_LAYER_MESSAGE_ID_FILTER",
                     "label": "Mute Message VUIDs",
                     "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
                     "type": "LIST",
@@ -299,6 +301,7 @@
                 },
                 {
                     "key": "disables",
+                    "env": "VK_LAYER_DISABLES",
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
@@ -330,26 +333,26 @@
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
-                            "label": "Disable Shaders",
-                            "description": "",
+                            "label": "Shaders",
+                            "description": "Shader checks. These checks can be CPU intensive during application start up, especially if Shader Validation Caching is also disabled.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                             "label": "Command Buffer State",
-                            "description": "",
+                            "description": "Check that all Vulkan objects used by a command buffer have not been destroyed. These checks can be CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                             "label": "Image Layout",
-                            "description": "",
+                            "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                             "label": "Query",
-                            "description": "",
+                            "description": "Checks for commands that use VkQueryPool objects.",
                             "view": "ADVANCED"
                         },
                         {
@@ -361,7 +364,7 @@
                         {
                             "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                             "label": "Object in Use",
-                            "description": "",
+                            "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
@@ -375,6 +378,7 @@
                 },
                 {
                     "key": "enables",
+                    "env": "VK_LAYER_ENABLES",
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -366,7 +366,7 @@
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descritor Set",
+                            "label": "Idle Descriptor Set",
                             "description": "",
                             "view": "ADVANCED"
                         }

--- a/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
@@ -367,7 +367,7 @@
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descritor Set",
+                            "label": "Idle Descriptor Set",
                             "description": "",
                             "view": "ADVANCED"
                         }

--- a/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
@@ -90,9 +90,7 @@
                                 "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                                 "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                                 "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
-                                "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
-                                "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                                "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE"
+                                "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION"
                             ]
                         }
                     ]
@@ -283,6 +281,7 @@
                 },
                 {
                     "key": "duplicate_message_limit",
+                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                     "label": "Duplicated Messages Limit",
                     "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
                     "type": "INT",
@@ -293,6 +292,7 @@
                 },
                 {
                     "key": "message_id_filter",
+                    "env": "VK_LAYER_MESSAGE_ID_FILTER",
                     "label": "Mute Message VUIDs",
                     "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
                     "type": "LIST",
@@ -300,6 +300,7 @@
                 },
                 {
                     "key": "disables",
+                    "env": "VK_LAYER_DISABLES",
                     "label": "Disables",
                     "description": "Setting an option here will disable areas of validation",
                     "type": "FLAGS",
@@ -331,44 +332,32 @@
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",
-                            "label": "Disable Shaders",
-                            "description": "",
+                            "label": "Shaders",
+                            "description": "Shader checks. These checks can be CPU intensive during application start up, especially if Shader Validation Caching is also disabled.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",
                             "label": "Command Buffer State",
-                            "description": "",
+                            "description": "Check that all Vulkan objects used by a command buffer have not been destroyed. These checks can be CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",
                             "label": "Image Layout",
-                            "description": "",
+                            "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",
                             "label": "Query",
-                            "description": "",
-                            "view": "ADVANCED"
-                        },
-                        {
-                            "key": "VALIDATION_CHECK_DISABLE_PUSH_CONSTANT_RANGE",
-                            "label": "Push Constant Range",
-                            "description": "",
+                            "description": "Checks for commands that use VkQueryPool objects.",
                             "view": "ADVANCED"
                         },
                         {
                             "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                             "label": "Object in Use",
-                            "description": "",
-                            "view": "ADVANCED"
-                        },
-                        {
-                            "key": "VALIDATION_CHECK_DISABLE_IDLE_DESCRIPTOR_SET",
-                            "label": "Idle Descriptor Set",
-                            "description": "",
+                            "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                             "view": "ADVANCED"
                         }
                     ],
@@ -376,6 +365,7 @@
                 },
                 {
                     "key": "enables",
+                    "env": "VK_LAYER_ENABLES",
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -33,7 +33,7 @@
 #include <regex>
 
 inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaString*>(layer.Instantiate(key, SETTING_STRING));
+    return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
 }
 
 TEST(test_layer, collect_settings) {

--- a/vkconfig_core/test/test_layer_preset.cpp
+++ b/vkconfig_core/test/test_layer_preset.cpp
@@ -26,7 +26,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaString*>(layer.Instantiate(key, SETTING_STRING));
+    return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
 }
 
 TEST(test_layer_preset, get_preset) {

--- a/vkconfig_core/test/test_parameter.cpp
+++ b/vkconfig_core/test/test_parameter.cpp
@@ -26,7 +26,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaString*>(layer.Instantiate(key, SETTING_STRING));
+    return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
 }
 
 static std::vector<Layer> GenerateTestLayers() {

--- a/vkconfig_core/test/test_setting_type_bool.cpp
+++ b/vkconfig_core/test/test_setting_type_bool.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaBool* InstantiateBool(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaBool*>(layer.Instantiate(key, SETTING_BOOL));
+    return static_cast<SettingMetaBool*>(layer.Instantiate(layer.settings, key, SETTING_BOOL));
 }
 
 TEST(test_setting_type_bool, init) { EXPECT_EQ(SETTING_BOOL, SettingMetaBool::TYPE); }

--- a/vkconfig_core/test/test_setting_type_bool_numeric.cpp
+++ b/vkconfig_core/test/test_setting_type_bool_numeric.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaBoolNumeric* InstantiateBoolNum(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaBoolNumeric*>(layer.Instantiate(key, SETTING_BOOL_NUMERIC_DEPRECATED));
+    return static_cast<SettingMetaBoolNumeric*>(layer.Instantiate(layer.settings, key, SETTING_BOOL_NUMERIC_DEPRECATED));
 }
 
 TEST(test_setting_type_bool_num, init) { EXPECT_EQ(SETTING_BOOL_NUMERIC_DEPRECATED, SettingMetaBoolNumeric::TYPE); }

--- a/vkconfig_core/test/test_setting_type_enum.cpp
+++ b/vkconfig_core/test/test_setting_type_enum.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaEnum* InstantiateEnum(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaEnum*>(layer.Instantiate(key, SETTING_ENUM));
+    return static_cast<SettingMetaEnum*>(layer.Instantiate(layer.settings, key, SETTING_ENUM));
 }
 
 TEST(test_setting_type_enum, init) { EXPECT_EQ(SETTING_ENUM, SettingMetaEnum::TYPE); }

--- a/vkconfig_core/test/test_setting_type_file_load.cpp
+++ b/vkconfig_core/test/test_setting_type_file_load.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaFileLoad* InstantiateFileLoad(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaFileLoad*>(layer.Instantiate(key, SETTING_LOAD_FILE));
+    return static_cast<SettingMetaFileLoad*>(layer.Instantiate(layer.settings, key, SETTING_LOAD_FILE));
 }
 
 TEST(test_setting_type_file_load, init) { EXPECT_EQ(SETTING_LOAD_FILE, SettingMetaFileLoad::TYPE); }

--- a/vkconfig_core/test/test_setting_type_file_save.cpp
+++ b/vkconfig_core/test/test_setting_type_file_save.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaFileSave* InstantiateFileSave(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaFileSave*>(layer.Instantiate(key, SETTING_SAVE_FILE));
+    return static_cast<SettingMetaFileSave*>(layer.Instantiate(layer.settings, key, SETTING_SAVE_FILE));
 }
 
 TEST(test_setting_type_file_save, init) { EXPECT_EQ(SETTING_SAVE_FILE, SettingMetaFileSave::TYPE); }

--- a/vkconfig_core/test/test_setting_type_flags.cpp
+++ b/vkconfig_core/test/test_setting_type_flags.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaFlags* InstantiateFlags(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaFlags*>(layer.Instantiate(key, SETTING_FLAGS));
+    return static_cast<SettingMetaFlags*>(layer.Instantiate(layer.settings, key, SETTING_FLAGS));
 }
 
 TEST(test_setting_type_flags, init) { EXPECT_EQ(SETTING_FLAGS, SettingMetaFlags::TYPE); }

--- a/vkconfig_core/test/test_setting_type_float.cpp
+++ b/vkconfig_core/test/test_setting_type_float.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaFloat* InstantiateFloat(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaFloat*>(layer.Instantiate(key, SETTING_FLOAT));
+    return static_cast<SettingMetaFloat*>(layer.Instantiate(layer.settings, key, SETTING_FLOAT));
 }
 
 TEST(test_setting_type_float, init) { EXPECT_EQ(SETTING_FLOAT, SettingMetaFloat::TYPE); }

--- a/vkconfig_core/test/test_setting_type_folder_save.cpp
+++ b/vkconfig_core/test/test_setting_type_folder_save.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaFolderSave* InstantiateFolderSave(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaFolderSave*>(layer.Instantiate(key, SETTING_SAVE_FOLDER));
+    return static_cast<SettingMetaFolderSave*>(layer.Instantiate(layer.settings, key, SETTING_SAVE_FOLDER));
 }
 
 TEST(test_setting_type_folder_save, init) { EXPECT_EQ(SETTING_SAVE_FOLDER, SettingMetaFolderSave::TYPE); }

--- a/vkconfig_core/test/test_setting_type_frames.cpp
+++ b/vkconfig_core/test/test_setting_type_frames.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaFrames* InstantiateFrames(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaFrames*>(layer.Instantiate(key, SETTING_FRAMES));
+    return static_cast<SettingMetaFrames*>(layer.Instantiate(layer.settings, key, SETTING_FRAMES));
 }
 
 TEST(test_setting_type_frames, init) { EXPECT_EQ(SETTING_FRAMES, SettingMetaFrames::TYPE); }

--- a/vkconfig_core/test/test_setting_type_group.cpp
+++ b/vkconfig_core/test/test_setting_type_group.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaGroup* InstantiateGroup(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaGroup*>(layer.Instantiate(key, SETTING_GROUP));
+    return static_cast<SettingMetaGroup*>(layer.Instantiate(layer.settings, key, SETTING_GROUP));
 }
 
 TEST(test_setting_type_group, init) { EXPECT_EQ(SETTING_GROUP, SettingMetaGroup::TYPE); }

--- a/vkconfig_core/test/test_setting_type_int.cpp
+++ b/vkconfig_core/test/test_setting_type_int.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaInt* InstantiateInt(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaInt*>(layer.Instantiate(key, SETTING_INT));
+    return static_cast<SettingMetaInt*>(layer.Instantiate(layer.settings, key, SETTING_INT));
 }
 
 TEST(test_setting_type_int, init) { EXPECT_EQ(SETTING_INT, SettingMetaInt::TYPE); }

--- a/vkconfig_core/test/test_setting_type_list.cpp
+++ b/vkconfig_core/test/test_setting_type_list.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaList* InstantiateList(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaList*>(layer.Instantiate(key, SETTING_LIST));
+    return static_cast<SettingMetaList*>(layer.Instantiate(layer.settings, key, SETTING_LIST));
 }
 
 TEST(test_setting_type_list, init) { EXPECT_EQ(SETTING_LIST, SettingMetaList::TYPE); }

--- a/vkconfig_core/test/test_setting_type_string.cpp
+++ b/vkconfig_core/test/test_setting_type_string.cpp
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 
 inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
-    return static_cast<SettingMetaString*>(layer.Instantiate(key, SETTING_STRING));
+    return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
 }
 
 TEST(test_setting_type_string, init) { EXPECT_EQ(SETTING_STRING, SettingMetaString::TYPE); }


### PR DESCRIPTION
- Fix regression introduced while implementing validation layer "validate_draw_indirect" setting
- Fix typo
- Add built-in manifest env var for validation layers
- Avoid crash when not Vulkan loader is found
- Validation areas content expands by default