### PR TITLE
vkconfig: fix crash when renaming a configuration #1551

### DIFF
--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -92,10 +92,6 @@ class MainWindow : public QMainWindow {
     QPushButton *_launcher_working_browse_button;
     QPushButton *_launcher_log_file_browse_button;
 
-    ConfigurationListItem *SaveLastItem();
-    bool RestoreLastItem(const char *szOverride = nullptr);
-    std::string _last_item;
-
     void RemoveClicked(ConfigurationListItem *item);
     void ResetClicked(ConfigurationListItem *item);
     void RenameClicked(ConfigurationListItem *item);


### PR DESCRIPTION
Now, this doesn't crash:
![rename-bug](https://user-images.githubusercontent.com/62888873/123849994-be986400-d919-11eb-8e5f-d4e4cfe70153.gif)
