### PR TITLE
vkconfig: Remove Qt Warning on Qt 5.11 and older

### DIFF
--- a/vkconfig/widget_setting_list.cpp
+++ b/vkconfig/widget_setting_list.cpp
@@ -67,7 +67,6 @@ WidgetSettingList::WidgetSettingList(QTreeWidget *tree, QTreeWidgetItem *item, c
 
     this->connect(this->field, SIGNAL(textChanged(const QString &)), this, SLOT(OnTextEdited(const QString &)));
     this->connect(this->field, SIGNAL(returnPressed()), this, SLOT(OnElementAppended()), Qt::QueuedConnection);
-    this->connect(this->field, SIGNAL(inputRejected()), this, SLOT(OnElementRejected()), Qt::QueuedConnection);
 
     this->add_button->show();
     this->add_button->setText("+");
@@ -246,8 +245,6 @@ void WidgetSettingList::OnElementRemoved(const QString &element) {
 
     RemoveValue(this->data().value, EnabledNumberOrString(list_value));
 }
-
-void WidgetSettingList::OnElementRejected() { this->OnTextEdited(""); }
 
 void WidgetSettingList::OnSettingChanged() { emit itemChanged(); }
 

--- a/vkconfig/widget_setting_list.h
+++ b/vkconfig/widget_setting_list.h
@@ -45,7 +45,6 @@ class WidgetSettingList : public WidgetSettingBase {
     void OnTextEdited(const QString &value);
     void OnSettingChanged();
     void OnElementRemoved(const QString &value);
-    void OnElementRejected();
 
    Q_SIGNALS:
     void itemSelected(const QString &value);


### PR DESCRIPTION
Vulkan Configurator was emitting a warning on start up when the layers configuration had a list type of setting 
![qt warning](https://user-images.githubusercontent.com/62888873/123851342-59457280-d91b-11eb-9a3e-fb503e85de50.png)
