### PR TITLE
vkconfig: fix Linux packages build

### DIFF
--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -145,7 +145,11 @@ MainWindow::MainWindow(QWidget *parent)
 MainWindow::~MainWindow() { ResetLaunchApplication(); }
 
 static std::string GetMainWindowTitle(bool active) {
+#if VKCONFIG_DATE
     std::string title = format("%s %s-%s", VKCONFIG_NAME, Version::VKCONFIG.str().c_str(), GetBuildDate().c_str());
+#else
+    std::string title = format("%s %s", VKCONFIG_NAME, Version::VKCONFIG.str().c_str());
+#endif
     if (active) title += " <ACTIVE>";
     return title;
 }

--- a/vkconfig_core/date.cpp
+++ b/vkconfig_core/date.cpp
@@ -21,6 +21,7 @@
 #include "date.h"
 #include "util.h"
 
+#if VKCONFIG_DATE
 #define COMPUTE_BUILD_YEAR \
     ((__DATE__[7] - '0') * 1000 + (__DATE__[8] - '0') * 100 + (__DATE__[9] - '0') * 10 + (__DATE__[10] - '0'))
 
@@ -71,3 +72,4 @@
 #define BUILD_DAY ((BUILD_DATE_IS_BAD) ? 99 : COMPUTE_BUILD_DAY)
 
 std::string GetBuildDate() { return format("%04d%02d%02d", BUILD_YEAR, BUILD_MONTH, BUILD_DAY); }
+#endif

--- a/vkconfig_core/date.h
+++ b/vkconfig_core/date.h
@@ -20,4 +20,8 @@
 
 #include <string>
 
+#define VKCONFIG_DATE 0
+
+#if VKCONFIG_DATE
 std::string GetBuildDate();
+#endif

--- a/vkconfig_core/test/test_date.cpp
+++ b/vkconfig_core/test/test_date.cpp
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 
+#if VKCONFIG_DATE
 TEST(test_date, lenght) {
     const std::string date = GetBuildDate();
 
@@ -36,3 +37,4 @@ TEST(test_date, digit) {
 
     EXPECT_TRUE(IsNumber(date));
 }
+#endif


### PR DESCRIPTION
Using __DATE__ caused Linux package error due to the reproducible build requirements:
https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#reproducible