### PR TITLE
vkconfig: fix settings output when dependencies is not met

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes:
 - Fix user-defined layer settings not loaded, for older Vulkan API than 1.2.176
+- Fix settings written in 'vk_layer_settings.txt' even when the dependence is not met
 
 ## [Vulkan Configurator 2.4.0 for Vulkan SDK 1.2.182.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.182.0) - July 2021
 

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixes:
 - Fix user-defined layer settings not loaded, for older Vulkan API than 1.2.176
-- Fix settings written in 'vk_layer_settings.txt' even when the dependence is not met
+- Fix settings written in 'vk_layer_settings.txt' even when the dependence is not met #1582
 
 ## [Vulkan Configurator 2.4.0 for Vulkan SDK 1.2.182.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.182.0) - July 2021
 

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -73,7 +73,7 @@ static void WriteSettingsOverview(std::string& text, const Layer& layer, const S
 }
 
 static const std::string GetLayerSettingsDocURL(const Layer& layer) {
-    if (layer.api_version > Version(1, 7, 176)) {
+    if (layer.api_version > Version(1, 7, 182)) {
         return format("https://github.com/LunarG/VulkanTools/tree/sdk-%s.0/vkconfig#vulkan-layers-settings",
                       layer.api_version.str().c_str());
     } else {

--- a/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
@@ -157,6 +157,10 @@
                                 "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
                                 "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
                             ]
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": false
                         }
                     ]
                 }
@@ -251,15 +255,32 @@
                     ]
                 },
                 {
-                    "key": "duplicate_message_limit",
-                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
-                    "label": "Duplicated Messages Limit",
-                    "description": "Limit the number of times any single validation message would be reported. 0 is unlimited.",
-                    "type": "INT",
-                    "default": 10,
-                    "range": {
-                        "min": 0
-                    }
+                    "key": "enable_message_limit",
+                    "label": "Limit Duplicated Messages",
+                    "description": "Enable limitation of duplicate messages.",
+                    "type": "BOOL",
+                    "default": true,
+                    "settings": [
+                        {
+                            "key": "duplicate_message_limit",
+                            "label": "Max Duplicated Messages",
+                            "description": "Maximum number of times any single validation message would be reported.",
+                            "type": "INT",
+                            "default": 10,
+                            "range": {
+                                "min": 1
+                            },
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "enable_message_limit",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        }
+                    ]
                 },
                 {
                     "key": "message_id_filter",

--- a/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/148/VK_LAYER_KHRONOS_validation.json
@@ -263,6 +263,7 @@
                     "settings": [
                         {
                             "key": "duplicate_message_limit",
+                            "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                             "label": "Max Duplicated Messages",
                             "description": "Maximum number of times any single validation message would be reported.",
                             "type": "INT",

--- a/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
@@ -285,6 +285,7 @@
                     "settings": [
                         {
                             "key": "duplicate_message_limit",
+                            "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                             "label": "Max Duplicated Messages",
                             "description": "Maximum number of times any single validation message would be reported.",
                             "type": "INT",

--- a/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/154/VK_LAYER_KHRONOS_validation.json
@@ -179,6 +179,10 @@
                                 "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
                                 "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
                             ]
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": false
                         }
                     ]
                 }
@@ -273,15 +277,32 @@
                     ]
                 },
                 {
-                    "key": "duplicate_message_limit",
-                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
-                    "label": "Duplicated Messages Limit",
-                    "description": "Limit the number of times any single validation message would be reported. 0 is unlimited.",
-                    "type": "INT",
-                    "default": 10,
-                    "range": {
-                        "min": 0
-                    }
+                    "key": "enable_message_limit",
+                    "label": "Limit Duplicated Messages",
+                    "description": "Enable limitation of duplicate messages.",
+                    "type": "BOOL",
+                    "default": true,
+                    "settings": [
+                        {
+                            "key": "duplicate_message_limit",
+                            "label": "Max Duplicated Messages",
+                            "description": "Maximum number of times any single validation message would be reported.",
+                            "type": "INT",
+                            "default": 10,
+                            "range": {
+                                "min": 1
+                            },
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "enable_message_limit",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        }
+                    ]
                 },
                 {
                     "key": "message_id_filter",

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -284,6 +284,7 @@
                     "settings": [
                         {
                             "key": "duplicate_message_limit",
+                            "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                             "label": "Max Duplicated Messages",
                             "description": "Maximum number of times any single validation message would be reported.",
                             "type": "INT",

--- a/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/162/VK_LAYER_KHRONOS_validation.json
@@ -178,6 +178,10 @@
                                 "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
                                 "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
                             ]
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": false
                         }
                     ]
                 }
@@ -272,15 +276,32 @@
                     ]
                 },
                 {
-                    "key": "duplicate_message_limit",
-                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
-                    "label": "Duplicated Messages Limit",
-                    "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
-                    "type": "INT",
-                    "default": 10,
-                    "range": {
-                        "min": 0
-                    }
+                    "key": "enable_message_limit",
+                    "label": "Limit Duplicated Messages",
+                    "description": "Enable limitation of duplicate messages.",
+                    "type": "BOOL",
+                    "default": true,
+                    "settings": [
+                        {
+                            "key": "duplicate_message_limit",
+                            "label": "Max Duplicated Messages",
+                            "description": "Maximum number of times any single validation message would be reported.",
+                            "type": "INT",
+                            "default": 10,
+                            "range": {
+                                "min": 1
+                            },
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "enable_message_limit",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        }
+                    ]
                 },
                 {
                     "key": "message_id_filter",

--- a/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
@@ -177,6 +177,10 @@
                                 "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",
                                 "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"
                             ]
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": false
                         }
                     ]
                 }
@@ -271,15 +275,32 @@
                     ]
                 },
                 {
-                    "key": "duplicate_message_limit",
-                    "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
-                    "label": "Duplicated Messages Limit",
-                    "description": "Limit the number of times any single validation message would be reported. Empty is unlimited.",
-                    "type": "INT",
-                    "default": 10,
-                    "range": {
-                        "min": 0
-                    }
+                    "key": "enable_message_limit",
+                    "label": "Limit Duplicated Messages",
+                    "description": "Enable limitation of duplicate messages.",
+                    "type": "BOOL",
+                    "default": true,
+                    "settings": [
+                        {
+                            "key": "duplicate_message_limit",
+                            "label": "Max Duplicated Messages",
+                            "description": "Maximum number of times any single validation message would be reported.",
+                            "type": "INT",
+                            "default": 10,
+                            "range": {
+                                "min": 1
+                            },
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "enable_message_limit",
+                                        "value": true
+                                    }
+                                ]
+                            }
+                        }
+                    ]
                 },
                 {
                     "key": "message_id_filter",

--- a/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
+++ b/vkconfig_core/layers/170/VK_LAYER_KHRONOS_validation.json
@@ -283,6 +283,7 @@
                     "settings": [
                         {
                             "key": "duplicate_message_limit",
+                            "env": "VK_LAYER_DUPLICATE_MESSAGE_LIMIT",
                             "label": "Max Duplicated Messages",
                             "description": "Maximum number of times any single validation message would be reported.",
                             "type": "INT",

--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -182,6 +182,11 @@ bool WriteSettingsOverride(const Environment& environment, const std::vector<Lay
                 continue;
             }
 
+            // Skip settings with dependence not met
+            if (!::CheckDependence(*meta, parameter.settings)) {
+                continue;
+            }
+
             // Skip overriden settings
             if (::CheckSettingOverridden(*meta)) {
                 continue;

--- a/vkconfig_core/test/test_layer_built_in.cpp
+++ b/vkconfig_core/test/test_layer_built_in.cpp
@@ -147,7 +147,7 @@ TEST(test_layer_built_in, layer_141_screenshot) {
 TEST(test_layer_built_in, layer_148_validation) {
     Layer layer;
     EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/148/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
-    EXPECT_EQ(7, CountSettings(layer.settings));
+    EXPECT_EQ(8, CountSettings(layer.settings));
     EXPECT_EQ(5, layer.presets.size());
 }
 
@@ -191,7 +191,7 @@ TEST(test_layer_built_in, layer_148_screenshot) {
 TEST(test_layer_built_in, layer_154_validation) {
     Layer layer;
     EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/154/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
-    EXPECT_EQ(7, CountSettings(layer.settings));
+    EXPECT_EQ(8, CountSettings(layer.settings));
     EXPECT_EQ(6, layer.presets.size());
 }
 
@@ -235,7 +235,7 @@ TEST(test_layer_built_in, layer_154_screenshot) {
 TEST(test_layer_built_in, layer_162_validation) {
     Layer layer;
     EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/162/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
-    EXPECT_EQ(11, CountSettings(layer.settings));
+    EXPECT_EQ(12, CountSettings(layer.settings));
     EXPECT_EQ(6, layer.presets.size());
 }
 
@@ -279,7 +279,7 @@ TEST(test_layer_built_in, layer_162_screenshot) {
 TEST(test_layer_built_in, layer_170_validation) {
     Layer layer;
     EXPECT_TRUE(layer.Load(std::vector<Layer>(), ":/layers/170/VK_LAYER_KHRONOS_validation.json", LAYER_TYPE_EXPLICIT));
-    EXPECT_EQ(11, CountSettings(layer.settings));
+    EXPECT_EQ(12, CountSettings(layer.settings));
     EXPECT_EQ(6, layer.presets.size());
     EXPECT_TRUE(static_cast<SettingDataFlags*>(FindSetting(layer.presets[0].settings, "enables"))->value.empty());
     EXPECT_STREQ("VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",


### PR DESCRIPTION
Standard Preset Before:
```
# VK_LAYER_KHRONOS_validation
khronos_validation.debug_action = 
khronos_validation.log_filename = stdout
khronos_validation.report_flags = error,warn,perf
khronos_validation.enable_message_limit = false
khronos_validation.duplicate_message_limit = 1
khronos_validation.message_id_filter = 
khronos_validation.disables = VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT
khronos_validation.enables = 
khronos_validation.printf_to_stdout = true
khronos_validation.printf_verbose = false
khronos_validation.printf_buffer_size = 1024
khronos_validation.gpuav_buffer_oob = true
```

Standard Preset After:
```
# VK_LAYER_KHRONOS_validation
khronos_validation.debug_action = 
khronos_validation.report_flags = error,warn,perf
khronos_validation.enable_message_limit = false
khronos_validation.message_id_filter = 
khronos_validation.disables = VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT
khronos_validation.enables = 
```
Only the relevant (which dependences are resolved) settings are outputted
