### PR TITLE
[WIP] vkconfig: Only validate what's necessary for devsim

### DIFF
--- a/vkconfig_core/configurations/2.2.1/Portability.json
+++ b/vkconfig_core/configurations/2.2.1/Portability.json
@@ -73,7 +73,7 @@
                     {
                         "key": "disables",
                         "type": "FLAGS",
-                        "value": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT" ]
+                        "value": [ "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT", "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT", "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT", "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION", "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE" ]
                     },
                     {
                         "key": "enables",


### PR DESCRIPTION
The goal of this PR is to make more efficient the use case of testing Vulkan application portability with Vulkan Configurator.

So replacing the the use of the "Standard Preset" by the following setting set in the Vulkan Configurator "Portability" built-in configuration.
![image](https://user-images.githubusercontent.com/62888873/129062218-e589ef8b-5ae7-48f9-82fe-b572c317922f.png)

This need review of the validation layer code to ensure no check is missing...