### PR TITLE
devsim: Fix portability_desktop_1_0.json

### DIFF
--- a/layersvt/device_simulation_examples/sdk_sample_configs/portability_desktop_1_0.json
+++ b/layersvt/device_simulation_examples/sdk_sample_configs/portability_desktop_1_0.json
@@ -108,7 +108,7 @@
             "sampledImageIntegerSampleCounts": 9,
             "sampledImageDepthSampleCounts": 9,
             "sampledImageStencilSampleCounts": 9,
-            "storageImageSampleCounts": 9,
+            "storageImageSampleCounts": 1,
             "maxSampleMaskWords": 1,
             "maxClipDistances": 8,
             "maxCullDistances": 8,


### PR DESCRIPTION
Fixed `storageImageSampleCounts` value from 9 -> 1

Fixes issue #1594 