### PR TITLE
vkconfig: Discard applied layers configuration to ensure the layers never crash Vulkan Configurator

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -11,7 +11,12 @@
 
 # Release notes
 
-## [Vulkan Configurator 2.4.1](https://github.com/LunarG/VulkanTools/tree/master) - September 2021
+## [Vulkan Configurator 2.4.2](https://github.com/LunarG/VulkanTools/tree/master) - November 2021
+
+### Improvements:
+- Discard applied layers configuration to ensure the layers never crash Vulkan Configurator
+
+## [Vulkan Configurator 2.4.1](https://github.com/LunarG/VulkanTools/tree/sdk-1.2.189.0) - September 2021
 
 ### Fixes:
 - Fix user-defined layer settings not loaded, for older Vulkan API than 1.2.176

--- a/vkconfig/vulkan.cpp
+++ b/vkconfig/vulkan.cpp
@@ -24,6 +24,7 @@
 #include "../vkconfig_core/alert.h"
 #include "../vkconfig_core/util.h"
 #include "../vkconfig_core/platform.h"
+#include "../vkconfig_core/override.h"
 
 #include <vulkan/vulkan.h>
 
@@ -139,6 +140,11 @@ std::string GenerateVulkanStatus() {
         return log;
     }
 
+    Configuration *active_configuration = configurator.configurations.GetActiveConfiguration();
+    if (configurator.configurations.HasActiveConfiguration(configurator.layers.available_layers)) {
+        SurrenderConfiguration(configurator.environment);
+    }
+
     QLibrary library(GetVulkanLibrary());
     PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties =
         (PFN_vkEnumerateInstanceLayerProperties)library.resolve("vkEnumerateInstanceLayerProperties");
@@ -241,6 +247,10 @@ std::string GenerateVulkanStatus() {
     }
 
     vkDestroyInstance(inst, NULL);
+
+    if (active_configuration != nullptr) {
+        OverrideConfiguration(configurator.environment, configurator.layers.available_layers, *active_configuration);
+    }
 
     return log;
 }

--- a/vkconfig_core/version.cpp
+++ b/vkconfig_core/version.cpp
@@ -28,7 +28,7 @@
 #include <cassert>
 #include <cstring>
 
-const Version Version::VKCONFIG(2, 4, 1);
+const Version Version::VKCONFIG(2, 4, 2);
 const Version Version::LAYER_CONFIG(2, 2, 1);
 const Version Version::VKHEADER(VK_HEADER_VERSION_COMPLETE);
 const Version Version::VERSION_NULL(0u);


### PR DESCRIPTION
When "break" debug action is selected, the action is triggered by a notification message when active. 

This causes Vulkan Configurator to fail starting when creating a Vulkan Instance because the a notification message is generated.

The Layers configuration no longer apply to Vulkan Configurator to ensure the layers never break the tool that allows us to configure the layers...