### PR TITLE
via: fix compilation on gcc version 11.2

### DIFF
--- a/via/via_system_linux.cpp
+++ b/via/via_system_linux.cpp
@@ -574,7 +574,7 @@ bool ViaSystemLinux::ReadDriverJson(std::string cur_driver_json, bool &found_lib
                     found_lib = true;
                     could_load = VerifyOpen(query_res, load_error);
                 }
-                fclose(fp);
+                pclose(fp);
             }
         } else if (!could_load) {
             PrintBeginTableRow();


### PR DESCRIPTION
vkvia was failing to compile on gcc version 11.2
because of a mismatched-dealloc warning

See issues:
https://github.com/LunarG/VulkanTools/issues/1615
https://vulkan.lunarg.com/issue/view/617b38195df112b7e382a341