### PR TITLE
Implementation of vkconfig doc html|settings|markdown <layername>

### DIFF
--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -21,6 +21,7 @@
 #include "main_gui.h"
 #include "main_reset.h"
 #include "main_layers.h"
+#include "main_doc.h"
 #include "main_signal.h"
 
 #include "../vkconfig_core/command_line.h"
@@ -55,6 +56,9 @@ int main(int argc, char* argv[]) {
         }
         case COMMAND_GUI: {
             return run_gui(argc, argv);
+        }
+        case COMMAND_DOC: {
+            return run_doc(command_line);
         }
         default: {
             assert(0);

--- a/vkconfig/main_doc.cpp
+++ b/vkconfig/main_doc.cpp
@@ -66,7 +66,7 @@ int run_doc_settings(const CommandLine& commandLine) {
     config = configuration_manager.CreateConfiguration(layers.available_layers, "Config");
     config.parameters = GatherParameters(config.parameters, layers.available_layers);
     config.parameters[0].state = LAYER_STATE_OVERRIDDEN;
-    ExportSettingsDoc(environment, layers.available_layers, config, commandLine.doc_out_dir+"/vk_layer_settings.txt");
+    ExportSettingsDoc(layers.available_layers, config, commandLine.doc_out_dir+"/vk_layer_settings.txt");
 
     return rval;
 }

--- a/vkconfig/main_doc.cpp
+++ b/vkconfig/main_doc.cpp
@@ -66,7 +66,7 @@ int run_doc_settings(const CommandLine& commandLine) {
     config = configuration_manager.CreateConfiguration(layers.available_layers, "Config");
     config.parameters = GatherParameters(config.parameters, layers.available_layers);
     config.parameters[0].state = LAYER_STATE_OVERRIDDEN;
-    ExportSettingsDoc(environment, layers.available_layers, config, commandLine.doc_out_dir);
+    ExportSettingsDoc(environment, layers.available_layers, config, commandLine.doc_out_dir+"/vk_layer_settings.txt");
 
     return rval;
 }

--- a/vkconfig/main_doc.cpp
+++ b/vkconfig/main_doc.cpp
@@ -37,7 +37,7 @@ int run_doc_html(const CommandLine& commandLine) {
     for (std::size_t i = 0, n = layers.available_layers.size(); i < n; ++i) {
         const Layer& layer = layers.available_layers[i];
         if (layer.key == commandLine.doc_layer_name) {
-            const std::string path = format("%s/%s.html", GetPath(BUILTIN_PATH_APPDATA).c_str(), layer.key.c_str());
+            const std::string path = format("%s/%s.html", commandLine.doc_out_dir.c_str(), layer.key.c_str());
             ExportHtmlDoc(layer, path);
             return 0;
         }
@@ -55,19 +55,18 @@ int run_doc_settings(const CommandLine& commandLine) {
     ConfigurationManager configuration_manager(paths, environment);
     Configuration config;
     LayerManager layers(environment);
-    const std::string settings_path = GetPath(BUILTIN_PATH_OVERRIDE_SETTINGS);
     Layer *layer;
 
     layers.LoadLayer(commandLine.doc_layer_name);
     layer = FindByKey(layers.available_layers, commandLine.doc_layer_name.c_str());
     if (!layer) {
-       printf("vkconfig: could not find layer %s\n", commandLine.doc_layer_name.c_str());
+       printf("vkconfig: could not load layer %s\n", commandLine.doc_layer_name.c_str());
        return -1;
     }
     config = configuration_manager.CreateConfiguration(layers.available_layers, "Config");
     config.parameters = GatherParameters(config.parameters, layers.available_layers);
     config.parameters[0].state = LAYER_STATE_OVERRIDDEN;
-    ExportSettingsDoc(environment, layers.available_layers, config, settings_path);
+    ExportSettingsDoc(environment, layers.available_layers, config, commandLine.doc_out_dir);
 
     return rval;
 }

--- a/vkconfig/main_doc.cpp
+++ b/vkconfig/main_doc.cpp
@@ -69,7 +69,7 @@ int run_doc_markdown(const CommandLine& commandLine) {
 
 int run_doc_settings(const CommandLine& commandLine) {
 
-    bool rval;
+    int rval = 0;
     PathManager paths;
     Environment environment(paths);
     environment.Reset(Environment::DEFAULT);

--- a/vkconfig/main_doc.cpp
+++ b/vkconfig/main_doc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2022 Valve Corporation
+ * Copyright (c) 2020-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,27 @@ int run_doc_html(const CommandLine& commandLine) {
     return -1;
 }
 
+int run_doc_markdown(const CommandLine& commandLine) {
+
+    PathManager paths;
+    Environment environment(paths);
+    environment.Reset(Environment::DEFAULT);
+
+    LayerManager layers(environment);
+    layers.LoadAllInstalledLayers();
+
+    for (std::size_t i = 0, n = layers.available_layers.size(); i < n; ++i) {
+        const Layer& layer = layers.available_layers[i];
+        if (layer.key == commandLine.doc_layer_name) {
+            const std::string path = format("%s/%s.md", commandLine.doc_out_dir.c_str(), layer.key.c_str());
+            ExportMarkdownDoc(layer, path);
+            return 0;
+        }
+    }
+    fprintf(stderr, "vkconfig: layer %s not found\n", commandLine.doc_layer_name.c_str());
+    return -1;
+}
+
 int run_doc_settings(const CommandLine& commandLine) {
 
     bool rval;
@@ -78,6 +99,9 @@ int run_doc(const CommandLine& command_line) {
     switch (command_line.command_doc_arg) {
         case COMMAND_DOC_HTML: {
             return run_doc_html(command_line);
+        }
+        case COMMAND_DOC_MARKDOWN: {
+            return run_doc_markdown(command_line);
         }
         case COMMAND_DOC_SETTINGS: {
             return run_doc_settings(command_line);

--- a/vkconfig/main_doc.cpp
+++ b/vkconfig/main_doc.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020-2021 Valve Corporation
+ * Copyright (c) 2020-2021 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - David Pinedo <david@lunarg.com>
+ */
+
+#include "main_doc.h"
+#include "../vkconfig_core/layer_manager.h"
+#include "../vkconfig_core/doc.h"
+#include "../vkconfig_core/configuration_manager.h"
+
+#include <cassert>
+
+int run_doc_html(const CommandLine& commandLine) {
+
+    PathManager paths;
+    Environment environment(paths);
+    environment.Reset(Environment::DEFAULT);
+
+    LayerManager layers(environment);
+    layers.LoadAllInstalledLayers();
+
+    for (std::size_t i = 0, n = layers.available_layers.size(); i < n; ++i) {
+        const Layer& layer = layers.available_layers[i];
+        if (layer.key == commandLine.doc_layer_name) {
+            const std::string path = format("%s/%s.html", GetPath(BUILTIN_PATH_APPDATA).c_str(), layer.key.c_str());
+            ExportHtmlDoc(layer, path);
+            return 0;
+        }
+    }
+    fprintf(stderr, "vkconfig: layer %s not found\n", commandLine.doc_layer_name.c_str());
+    return -1;
+}
+
+int run_doc_settings(const CommandLine& commandLine) {
+
+    bool rval;
+    PathManager paths;
+    Environment environment(paths);
+    environment.Reset(Environment::DEFAULT);
+    ConfigurationManager configuration_manager(paths, environment);
+    Configuration config;
+    LayerManager layers(environment);
+    const std::string settings_path = GetPath(BUILTIN_PATH_OVERRIDE_SETTINGS);
+    Layer *layer;
+
+    layers.LoadLayer(commandLine.doc_layer_name);
+    layer = FindByKey(layers.available_layers, commandLine.doc_layer_name.c_str());
+    if (!layer) {
+       printf("vkconfig: could not find layer %s\n", commandLine.doc_layer_name.c_str());
+       return -1;
+    }
+    config = configuration_manager.CreateConfiguration(layers.available_layers, "Config");
+    config.parameters = GatherParameters(config.parameters, layers.available_layers);
+    config.parameters[0].state = LAYER_STATE_OVERRIDDEN;
+    ExportSettingsDoc(environment, layers.available_layers, config, settings_path);
+
+    return rval;
+}
+
+int run_doc(const CommandLine& command_line) {
+    assert(command_line.command == COMMAND_DOC);
+    assert(command_line.error == ERROR_NONE);
+
+    switch (command_line.command_doc_arg) {
+        case COMMAND_DOC_HTML: {
+            return run_doc_html(command_line);
+        }
+        case COMMAND_DOC_SETTINGS: {
+            return run_doc_settings(command_line);
+        }
+        default: {
+            assert(0);
+            return -1;
+        }
+    }
+}

--- a/vkconfig/main_doc.h
+++ b/vkconfig/main_doc.h
@@ -15,14 +15,11 @@
  * limitations under the License.
  *
  * Authors:
- * - Christophe Riccio <christophe@lunarg.com>
+ * - David Pinedo <david@lunarg.com>
  */
 
-#include "layer.h"
-#include "environment.h"
-#include "configuration.h"
+#pragma once
 
-void ExportHtmlDoc(const Layer& layer, const std::string& path);
+#include "../vkconfig_core/command_line.h"
 
-void ExportSettingsDoc(const Environment& environment, const std::vector<Layer>& available_layers,
-                       const Configuration& configuration, const std::string& path);
+int run_doc(const CommandLine& commandLine);

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -1170,6 +1170,9 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             QAction *export_html_action = new QAction("Open Layer HTML Documentation...", nullptr);
             menu.addAction(export_html_action);
 
+            QAction *export_settings_action = new QAction("Open Layer vk_layers_settings.txt...", nullptr);
+            menu.addAction(export_settings_action);
+
             static const char *table[] = {
                 "N/A",            // LAYER_STATE_APPLICATION_CONTROLLED
                 "Exclude Layer",  // LAYER_STATE_OVERRIDDEN
@@ -1220,6 +1223,11 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             } else if (action == export_html_action) {
                 const std::string path = format("%s/%s.html", GetPath(BUILTIN_PATH_APPDATA).c_str(), layer->key.c_str());
                 ExportHtmlDoc(*layer, path);
+                QDesktopServices::openUrl(QUrl(("file:///" + path).c_str()));
+            } else if (action == export_settings_action) {
+                std::vector<Layer> layers= {*layer};
+                const std::string path = GetPath(BUILTIN_PATH_OVERRIDE_SETTINGS);
+                ExportSettingsDoc(layers, *configuration, path);
                 QDesktopServices::openUrl(QUrl(("file:///" + path).c_str()));
             } else {
                 return false;  // Unknown action

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2022 Valve Corporation
+ * Copyright (c) 2020-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1170,6 +1170,9 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             QAction *export_html_action = new QAction("Open Layer HTML Documentation...", nullptr);
             menu.addAction(export_html_action);
 
+            QAction *export_markdown_action = new QAction("Open Layer Markdown Documentation...", nullptr);   // DOES THIS WORK???
+            menu.addAction(export_markdown_action);
+
             QAction *export_settings_action = new QAction("Open Layer vk_layers_settings.txt...", nullptr);
             menu.addAction(export_settings_action);
 
@@ -1223,6 +1226,10 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             } else if (action == export_html_action) {
                 const std::string path = format("%s/%s.html", GetPath(BUILTIN_PATH_APPDATA).c_str(), layer->key.c_str());
                 ExportHtmlDoc(*layer, path);
+                QDesktopServices::openUrl(QUrl(("file:///" + path).c_str()));
+            } else if (action == export_markdown_action) {
+                const std::string path = format("%s/%s.md", GetPath(BUILTIN_PATH_APPDATA).c_str(), layer->key.c_str());
+                ExportMarkdownDoc(*layer, path);
                 QDesktopServices::openUrl(QUrl(("file:///" + path).c_str()));
             } else if (action == export_settings_action) {
                 std::vector<Layer> layers= {*layer};

--- a/vkconfig/vkconfig.pro
+++ b/vkconfig/vkconfig.pro
@@ -89,6 +89,7 @@ SOURCES += \
     main_signal.cpp \
     main_reset.cpp \
     main_layers.cpp \
+    main_doc.cpp \
     mainwindow.cpp \
     settings_tree.cpp \
     settings_validation_areas.cpp \
@@ -155,6 +156,7 @@ HEADERS += \
     main_signal.h \
     main_reset.h \
     main_layers.h \
+    main_doc.h \
     mainwindow.h \
     settings_validation_areas.h \
     settings_tree.h \

--- a/vkconfig_core/command_line.cpp
+++ b/vkconfig_core/command_line.cpp
@@ -37,7 +37,7 @@ struct CommandHelpDesc {
 };
 
 static const CommandHelpDesc command_help_desc[] = {
-    {HELP_HELP, "help"}, {HELP_VERSION, "version"}, {HELP_GUI, "gui"}, {HELP_LAYERS, "layers"}, {HELP_RESET, "reset"},
+    {HELP_HELP, "help"}, {HELP_VERSION, "version"}, {HELP_GUI, "gui"}, {HELP_LAYERS, "layers"}, {HELP_DOC, "doc"}, {HELP_RESET, "reset"},
 };
 
 static HelpType GetCommandHelpId(const char* token) {
@@ -66,6 +66,7 @@ static const ModeDesc mode_desc[] = {
     {COMMAND_VERSION, "version", HELP_VERSION},    // COMMAND_VERSION
     {COMMAND_GUI, "gui", HELP_GUI},                // COMMAND_GUI
     {COMMAND_LAYERS, "layers", HELP_LAYERS},       // COMMAND_LAYERS
+    {COMMAND_DOC, "doc", HELP_DOC},                // COMMAND_DOC
     {COMMAND_RESET, "reset", HELP_RESET}           // COMMAND_RESET
 };
 
@@ -137,6 +138,17 @@ static const CommandLayersDesc command_layers_desc[] = {
     {COMMAND_LAYERS_SURRENDER, "-s", 2},
 };
 
+struct CommandDocDesc {
+    CommandDocArg arguments;
+    const char* token;
+    int required_arguments;
+};
+
+static const CommandDocDesc command_doc_desc[] = {
+    {COMMAND_DOC_HTML, "html", 3},
+    {COMMAND_DOC_SETTINGS, "settings", 3},
+};
+
 static CommandLayersArg GetCommandLayersId(const char* token) {
     assert(token != nullptr);
 
@@ -158,16 +170,40 @@ static const CommandLayersDesc& GetCommandLayers(CommandLayersArg layers_arg) {
     return command_layers_desc[0];
 }
 
+static CommandDocArg GetCommandDocId(const char* token) {
+    assert(token != nullptr);
+
+    for (std::size_t i = 0, n = countof(command_doc_desc); i < n; ++i) {
+        if (std::strcmp(command_doc_desc[i].token, token) == 0) return command_doc_desc[i].arguments;
+    }
+
+    return COMMAND_DOC_NONE;
+}
+
+static const CommandDocDesc& GetCommandDoc(CommandDocArg doc_arg) {
+    assert(doc_arg != COMMAND_DOC_NONE);
+
+    for (std::size_t i = 0, n = countof(command_doc_desc); i < n; ++i) {
+        if (command_doc_desc[i].arguments == doc_arg) return command_doc_desc[i];
+    }
+
+    assert(0);
+    return command_doc_desc[0];
+}
+
 CommandLine::CommandLine(int argc, char* argv[])
     : command(_command),
       command_reset_arg(_command_reset_arg),
       command_layers_arg(_command_layers_arg),
+      command_doc_arg(_command_doc_arg),
       layers_configuration_path(_layers_configuration_path),
+      doc_layer_name(_doc_layer_name),
       error(_error),
       error_args(_error_args),
       _command(COMMAND_GUI),
       _command_reset_arg(COMMAND_RESET_NONE),
       _command_layers_arg(COMMAND_LAYERS_NONE),
+      _command_doc_arg(COMMAND_DOC_NONE),
       _error(ERROR_NONE),
       _help(HELP_DEFAULT) {
     assert(argc >= 1);
@@ -212,6 +248,29 @@ CommandLine::CommandLine(int argc, char* argv[])
                 }
                 break;
             }
+        } break;
+        case COMMAND_DOC: {
+            if (argc <= arg_offset + 1) {
+                _error = ERROR_MISSING_COMMAND_ARGUMENT;
+                _error_args.push_back(argv[arg_offset + 0]);
+                break;
+            }
+
+            if (argc > 4) {
+                _error = ERROR_TOO_MANY_COMMAND_ARGUMENTS;
+                _error_args.push_back(argv[arg_offset + 0]);
+                break;
+            }
+
+            _command_doc_arg = GetCommandDocId(argv[arg_offset + 1]);
+            if (_command_doc_arg == COMMAND_DOC_NONE) {
+                _error = ERROR_INVALID_COMMAND_ARGUMENT;
+                _error_args.push_back(argv[arg_offset + 0]);
+                _error_args.push_back(argv[arg_offset + 1]);
+                break;
+            }
+            _doc_layer_name = argv[arg_offset + 2];
+
         } break;
         case COMMAND_RESET: {
             if (argc <= arg_offset + 1) {
@@ -308,6 +367,7 @@ void CommandLine::usage() const {
             printf("\tversion                   = Display %s version.\n", VKCONFIG_NAME);
             printf("\tgui                       = Launch the %s GUI.\n", VKCONFIG_NAME);
             printf("\tlayers                    = Manage system Vulkan Layers.\n");
+            printf("\tdoc                       = Create doc files for layer.\n");
             printf("\treset                     = Reset layers configurations.\n");
             printf("\n");
             printf("  (Use 'vkconfig help <commamd>' for detailed usage of %s commands.)\n", VKCONFIG_NAME);
@@ -315,7 +375,7 @@ void CommandLine::usage() const {
         }
         case HELP_HELP: {
             printf("Name\n");
-            printf("\t'help' - Displays of the %s commands help pages:\n", VKCONFIG_NAME);
+            printf("\t'help' - Displays the %s command help pages:\n", VKCONFIG_NAME);
             printf("\n");
             printf("Synopsis\n");
             printf("\tvkconfig help [command]\n");
@@ -359,6 +419,22 @@ void CommandLine::usage() const {
             printf("\n");
             printf("\tvkconfig layers (--list-version | -lv)\n");
             printf("\t\tList the Vulkan layers found by %s on the system with locations and versions.\n", VKCONFIG_NAME);
+            break;
+        }
+        case HELP_DOC: {
+            printf("Name\n");
+            printf("\t'doc_html' - Command to create Vulkan layer doc files\n");
+            printf("\n");
+            printf("Synopsis\n");
+            printf("\tvkconfig doc html <layer_name>\n");
+            printf("\tvkconfig doc settings <layer_name>\n");
+            printf("\n");
+            printf("Description\n");
+            printf("\tvkconfig doc html <layer_name>\n");
+            printf("\t\tCreate the html documentation file for the given layer.\n");
+            printf("\n");
+            printf("\tvkconfig doc settings <layer_name>\n");
+            printf("\t\tCreate the vk_layers_settings.txt file for the given layer.\n");
             break;
         }
         case HELP_RESET: {

--- a/vkconfig_core/command_line.cpp
+++ b/vkconfig_core/command_line.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2022 Valve Corporation
+ * Copyright (c) 2020-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,6 +146,7 @@ struct CommandDocDesc {
 
 static const CommandDocDesc command_doc_desc[] = {
     {COMMAND_DOC_HTML, "html", 3},
+    {COMMAND_DOC_MARKDOWN, "markdown", 3},
     {COMMAND_DOC_SETTINGS, "settings", 3},
 };
 
@@ -434,11 +435,16 @@ void CommandLine::usage() const {
             printf("\n");
             printf("Synopsis\n");
             printf("\tvkconfig doc html <layer_name> [<output_dir>]\n");
+            printf("\tvkconfig doc markdown <layer_name> [<output_dir>]\n");
             printf("\tvkconfig doc settings <layer_name> [<output_dir>]\n");
             printf("\n");
             printf("Description\n");
             printf("\tvkconfig doc html <layer_name> [<output_dir>]\n");
             printf("\t\tCreate the html documentation file for the given layer.\n");
+            printf("\t\tThe file is written to <output_dir>, or current directory if not specified.\n");
+            printf("\n");
+            printf("\tvkconfig doc markdown <layer_name> [<output_dir>]\n");
+            printf("\t\tCreate the markdown documentation file for the given layer.\n");
             printf("\t\tThe file is written to <output_dir>, or current directory if not specified.\n");
             printf("\n");
             printf("\tvkconfig doc settings <layer_name> [<output_dir>]\n");

--- a/vkconfig_core/command_line.cpp
+++ b/vkconfig_core/command_line.cpp
@@ -198,6 +198,7 @@ CommandLine::CommandLine(int argc, char* argv[])
       command_doc_arg(_command_doc_arg),
       layers_configuration_path(_layers_configuration_path),
       doc_layer_name(_doc_layer_name),
+      doc_out_dir(_doc_out_dir),
       error(_error),
       error_args(_error_args),
       _command(COMMAND_GUI),
@@ -250,13 +251,13 @@ CommandLine::CommandLine(int argc, char* argv[])
             }
         } break;
         case COMMAND_DOC: {
-            if (argc <= arg_offset + 1) {
+            if (argc <= arg_offset + 2) {
                 _error = ERROR_MISSING_COMMAND_ARGUMENT;
                 _error_args.push_back(argv[arg_offset + 0]);
                 break;
             }
 
-            if (argc > 4) {
+            if (argc > 5) {
                 _error = ERROR_TOO_MANY_COMMAND_ARGUMENTS;
                 _error_args.push_back(argv[arg_offset + 0]);
                 break;
@@ -270,6 +271,12 @@ CommandLine::CommandLine(int argc, char* argv[])
                 break;
             }
             _doc_layer_name = argv[arg_offset + 2];
+            if (argc == 5) {
+                // Output dir arg was specified
+                _doc_out_dir = argv[arg_offset + 3];
+            } else
+                // Output dir arg was not specified
+                _doc_out_dir = ".";
 
         } break;
         case COMMAND_RESET: {
@@ -423,18 +430,20 @@ void CommandLine::usage() const {
         }
         case HELP_DOC: {
             printf("Name\n");
-            printf("\t'doc_html' - Command to create Vulkan layer doc files\n");
+            printf("\t'doc' - Command to create Vulkan layer doc files\n");
             printf("\n");
             printf("Synopsis\n");
-            printf("\tvkconfig doc html <layer_name>\n");
-            printf("\tvkconfig doc settings <layer_name>\n");
+            printf("\tvkconfig doc html <layer_name> [<output_dir>]\n");
+            printf("\tvkconfig doc settings <layer_name> [<output_dir>]\n");
             printf("\n");
             printf("Description\n");
-            printf("\tvkconfig doc html <layer_name>\n");
+            printf("\tvkconfig doc html <layer_name> [<output_dir>]\n");
             printf("\t\tCreate the html documentation file for the given layer.\n");
+            printf("\t\tThe file is written to <output_dir>, or current directory if not specified.\n");
             printf("\n");
-            printf("\tvkconfig doc settings <layer_name>\n");
+            printf("\tvkconfig doc settings <layer_name> [<output_dir>]\n");
             printf("\t\tCreate the vk_layers_settings.txt file for the given layer.\n");
+            printf("\t\tThe file is written to <output_dir>, or current directory if not specified.\n");
             break;
         }
         case HELP_RESET: {

--- a/vkconfig_core/command_line.h
+++ b/vkconfig_core/command_line.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2022 Valve Corporation
+ * Copyright (c) 2020-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ enum CommandLayersArg {
 enum CommandDocArg {
     COMMAND_DOC_NONE = 0,
     COMMAND_DOC_HTML,
+    COMMAND_DOC_MARKDOWN,
     COMMAND_DOC_SETTINGS
 };
 

--- a/vkconfig_core/command_line.h
+++ b/vkconfig_core/command_line.h
@@ -67,6 +67,7 @@ class CommandLine {
     const std::string& layers_configuration_path;
     const CommandDocArg& command_doc_arg;
     const std::string& doc_layer_name;
+    const std::string& doc_out_dir;
 
     const CommandError& error;
     const std::vector<std::string>& error_args;
@@ -81,6 +82,7 @@ class CommandLine {
     std::string _layers_configuration_path;
     CommandDocArg _command_doc_arg;
     std::string _doc_layer_name;
+    std::string _doc_out_dir;
 
     CommandError _error;
     std::vector<std::string> _error_args;

--- a/vkconfig_core/command_line.h
+++ b/vkconfig_core/command_line.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-enum CommandType { COMMAND_NONE = 0, COMMAND_SHOW_USAGE, COMMAND_VERSION, COMMAND_GUI, COMMAND_RESET, COMMAND_LAYERS };
+enum CommandType { COMMAND_NONE = 0, COMMAND_SHOW_USAGE, COMMAND_VERSION, COMMAND_GUI, COMMAND_RESET, COMMAND_LAYERS, COMMAND_DOC};
 
 enum CommandLayersArg {
     COMMAND_LAYERS_NONE = 0,
@@ -32,6 +32,12 @@ enum CommandLayersArg {
     COMMAND_LAYERS_SURRENDER,
     COMMAND_LAYERS_LIST,
     COMMAND_LAYERS_VERBOSE
+};
+
+enum CommandDocArg {
+    COMMAND_DOC_NONE = 0,
+    COMMAND_DOC_HTML,
+    COMMAND_DOC_SETTINGS
 };
 
 enum CommandResetArg { COMMAND_RESET_NONE = 0, COMMAND_RESET_SOFT, COMMAND_RESET_HARD };
@@ -46,7 +52,7 @@ enum CommandError {
     ERROR_FILE_NOTFOUND
 };
 
-enum HelpType { HELP_NONE, HELP_DEFAULT, HELP_HELP, HELP_VERSION, HELP_GUI, HELP_LAYERS, HELP_RESET };
+enum HelpType { HELP_NONE, HELP_DEFAULT, HELP_HELP, HELP_VERSION, HELP_GUI, HELP_LAYERS, HELP_DOC, HELP_RESET };
 
 class CommandLine {
    public:
@@ -59,6 +65,8 @@ class CommandLine {
     const CommandResetArg& command_reset_arg;
     const CommandLayersArg& command_layers_arg;
     const std::string& layers_configuration_path;
+    const CommandDocArg& command_doc_arg;
+    const std::string& doc_layer_name;
 
     const CommandError& error;
     const std::vector<std::string>& error_args;
@@ -71,6 +79,8 @@ class CommandLine {
     CommandResetArg _command_reset_arg;
     CommandLayersArg _command_layers_arg;
     std::string _layers_configuration_path;
+    CommandDocArg _command_doc_arg;
+    std::string _doc_layer_name;
 
     CommandError _error;
     std::vector<std::string> _error_args;

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -160,7 +160,6 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
     text += "<!DOCTYPE html>\n";
     text += "<html>\n";
     text += format("<head><title></title></head>\n", layer.key.c_str());
-    text += "<!--Begin body-->\n";
     text += "<body>\n";
     text += "<style>\n";
     text += "\ta {color: #A41E22;}\n";
@@ -192,7 +191,7 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
         text += format("<p>%s</p>\n", layer.introduction.c_str());
     }
 
-    text += "<!--Begin Layer Properties-->\n";
+    text += "<!--Begin vkconfig generated-->\n";
     text += "<h2>Layer Properties</h2>\n";
     text += "<ul>\n";
     text += format("\t<li>API Version: %s</li>\n", layer.api_version.str().c_str());
@@ -258,7 +257,7 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
         }
     }
 
-    text += "<!--End body-->\n";
+    text += "<!--End vkconfig generated-->\n";
     text += "</body>\n";
     text += "</html>\n";
 

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -204,15 +204,15 @@ static void WriteSettingsDetailsMarkdown(std::string& text, const Layer& layer, 
 
         if (setting->type != SETTING_GROUP && setting->view != SETTING_VIEW_HIDDEN) {
             if (setting->status == STATUS_STABLE) {
-                text += "### " + setting->label;
+                text += "#### " + setting->label;
             } else {
-                text += "### " + setting->label + "(" + GetToken(setting->status) + ")";
+                text += "#### " + setting->label + "(" + GetToken(setting->status) + ")";
             }
             text += "\n";
 
             text += setting->description + "\n";
 
-            text += "#### Setting Properties:\n";
+            text += "##### Setting Properties:\n";
             text += "- vk_layer_settings.txt Variable: " + GetLayerSettingPrefix(layer.key) + setting->key + "\n";
             if (setting->env.empty()) {
                 text += "- Environment Variable: N/A\n";
@@ -379,22 +379,23 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
 void ExportMarkdownDoc(const Layer& layer, const std::string& path) {
     std::string text;
 
-    text += format("# %s\n", layer.key.c_str());
+    text += format("## %s\n", layer.key.c_str());
 
     if (!layer.description.empty()) {
-        text += "## " + layer.description + "\n";
+        text += "### " + layer.description + "\n";
     }
 
     if (!layer.introduction.empty()) {
         text += layer.introduction + "\n";
     }
 
-    text += "## Layer Properties\n\n";
-    text += format("- API Version: %s\n", layer.api_version.str().c_str());
-    text += format("- Implementation Version: %s\n", layer.implementation_version.c_str());
-    text += format("- Layer Manifest: %s\n", QFileInfo(layer.manifest_path.c_str()).fileName().toStdString().c_str());
-    text += format("  - File Format: %s\n", layer.file_format_version.str().c_str());
-    text += format("  - Layer Binary Path: %s\n", layer.binary_path.c_str());
+    text += "### Layer Properties\n\n";
+    text += "- API Version: " + layer.api_version.str() + "\n";
+    text += "- Implementation Version: " + layer.implementation_version + "\n";
+    text += "- Layer Manifest: " + QFileInfo(layer.manifest_path.c_str()).fileName().toStdString() + "\n";
+    text += "  - File Format: " + layer.file_format_version.str() + "\n";
+    text += "  - Layer Binary: ";
+    text += (layer.binary_path.rfind("./", 0) == 0 ? layer.binary_path.substr(2) : layer.binary_path) + "\n";
 
     if (layer.platforms != 0) {
         text += "- Platforms: " + BuildPlatformsMarkdown(layer.platforms) + "\n";
@@ -411,23 +412,23 @@ void ExportMarkdownDoc(const Layer& layer, const std::string& path) {
     text += "\n";
 
     if (!layer.settings.empty()) {
-        text += "## Layer Settings Overview\n";
+        text += "### Layer Settings Overview\n";
         text += "|Setting|Type|Default Value|vk_layer_settings.txt Variable|Environment Variable|Platforms|\n";
         text += "|---|---|---|---|---|---|\n";
         WriteSettingsOverviewMarkdown(text, layer, layer.settings);
 
-        text += "## Layer Settings Details\n";
+        text += "### Layer Settings Details\n";
         WriteSettingsDetailsMarkdown(text, layer, layer.settings);
     }
 
     if (!layer.presets.empty()) {
-        text += "## Layer Presets\n";
+        text += "### Layer Presets\n";
         for (std::size_t i = 0, n = layer.presets.size(); i < n; ++i) {
             const LayerPreset& preset = layer.presets[i];
 
-            text += "### " + preset.label + "\n"; 
-            text += preset.description + "\n"; 
-            text += "#### Preset Setting Values:\n";
+            text += "#### " + preset.label + "\n";
+            text += preset.description + "\n";
+            text += "##### Preset Setting Values:\n";
             for (std::size_t j = 0, o = preset.settings.size(); j < o; ++j) {
                 const SettingData* data = preset.settings[j];
                 const SettingMeta* meta = FindSetting(layer.settings, data->key.c_str());

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -160,6 +160,7 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
     text += "<!DOCTYPE html>\n";
     text += "<html>\n";
     text += format("<head><title></title></head>\n", layer.key.c_str());
+    text += "<!--Begin body-->\n";
     text += "<body>\n";
     text += "<style>\n";
     text += "\ta {color: #A41E22;}\n";
@@ -191,7 +192,8 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
         text += format("<p>%s</p>\n", layer.introduction.c_str());
     }
 
-    text += "<h2><a href=\"#top\">Layer Properties</a></h2>\n";
+    text += "<!--Begin Layer Properties-->\n";
+    text += "<h2>Layer Properties</h2>\n";
     text += "<ul>\n";
     text += format("\t<li>API Version: %s</li>\n", layer.api_version.str().c_str());
     text += format("\t<li>Implementation Version: %s</li>\n", layer.implementation_version.c_str());
@@ -219,7 +221,7 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
     }
 
     if (!layer.settings.empty()) {
-        text += "<h2><a href=\"#top\" id=\"settings\">Layer Settings Overview</a></h2>\n";
+        text += "<h2><a id=\"settings\">Layer Settings Overview</a></h2>\n";
         text += "<table><thead><tr>";
         text += format(
             "<th>Setting</th><th>Type</th><th>Default Value</th><th><a href=\"%s\">vk_layer_settings.txt</a> Variable</th>"
@@ -229,12 +231,12 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
         WriteSettingsOverview(text, layer, layer.settings);
         text += "</tbody></table>\n";
 
-        text += "<h2><a href=\"#top\">Layer Settings Details</a></h2>\n";
+        text += "<h2>Layer Settings Details</h2>\n";
         WriteSettingsDetails(text, layer, layer.settings);
     }
 
     if (!layer.presets.empty()) {
-        text += "<h2><a href=\"#top\" id=\"presets\">Layer Presets</a></h2>\n";
+        text += "<h2><a id=\"presets\">Layer Presets</a></h2>\n";
         for (std::size_t i = 0, n = layer.presets.size(); i < n; ++i) {
             const LayerPreset& preset = layer.presets[i];
 
@@ -256,6 +258,7 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
         }
     }
 
+    text += "<!--End body-->\n";
     text += "</body>\n";
     text += "</html>\n";
 

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -255,6 +255,17 @@ static void WriteSettingsDetailsMarkdown(std::string& text, const Layer& layer, 
     }
 }
 
+uint32_t GetNumSettings(const Layer& layer, const SettingMetaSet& settings) {
+    uint32_t rval = layer.settings.size();
+    for (std::size_t i = 0, n = layer.settings.size(); i < n; ++i) {
+        const SettingMeta* setting = layer.settings[i];
+        if (setting->type != SETTING_GROUP && setting->view != SETTING_VIEW_HIDDEN) {
+            rval += setting->children.size();
+        }
+    }
+    return rval;
+}
+
 void ExportHtmlDoc(const Layer& layer, const std::string& path) {
     std::string text;
 
@@ -307,17 +318,12 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
         text += format("\t<li>Status: %s</li>\n", GetToken(layer.status));
     }
     if (!layer.settings.empty()) {
-        text += format("\t<li><a href=\"#settings\">Number of Layer Settings: %d</a></li>\n", layer.settings.size());
+        text += format("\t<li><a href=\"#settings\">Number of Layer Settings: %d</a></li>\n", GetNumSettings(layer, layer.settings));
     }
     if (!layer.presets.empty()) {
         text += format("\t<li><a href=\"#presets\">Number of Layer Presets: %d</a></li>\n", layer.presets.size());
     }
     text += "</ul>\n";
-
-    if (!layer.url.empty()) {
-        text +=
-            format("<p>Visit <a href=\"%s\">%s home page</a> for more information.</p>\n", layer.url.c_str(), layer.key.c_str());
-    }
 
     if (!layer.settings.empty()) {
         text += "<h2><a id=\"settings\">Layer Settings Overview</a></h2>\n";

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -20,6 +20,7 @@
 
 #include "doc.h"
 #include "setting_flags.h"
+#include "override.h"
 
 #include <QFileInfo>
 
@@ -262,7 +263,17 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
     if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         file.write(text.c_str());
         file.close();
+        printf("vkconfig: html file written to %s\n", path.c_str());
+    } else {
+        printf("vkconfig: could not write %s\n", path.c_str());
     }
 }
 
-void ExportSettingsDoc(const Layer& layer, const std::string& path) {}
+void ExportSettingsDoc(const Environment& environment, const std::vector<Layer>& available_layers,
+                       const Configuration& configuration, const std::string& path) {
+
+    if (WriteSettingsOverride(environment, available_layers, configuration, path))
+        printf("vkconfig: settings written to %s\n", path.c_str());
+    else
+        printf("vkconfig: could not write %s\n", path.c_str());
+}

--- a/vkconfig_core/doc.cpp
+++ b/vkconfig_core/doc.cpp
@@ -271,10 +271,10 @@ void ExportHtmlDoc(const Layer& layer, const std::string& path) {
     }
 }
 
-void ExportSettingsDoc(const Environment& environment, const std::vector<Layer>& available_layers,
+void ExportSettingsDoc(const std::vector<Layer>& available_layers,
                        const Configuration& configuration, const std::string& path) {
 
-    if (WriteSettingsOverride(environment, available_layers, configuration, path))
+    if (WriteSettingsOverride(available_layers, configuration, path))
         printf("vkconfig: settings written to %s\n", path.c_str());
     else
         printf("vkconfig: could not write %s\n", path.c_str());

--- a/vkconfig_core/doc.h
+++ b/vkconfig_core/doc.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2022 Valve Corporation
+ * Copyright (c) 2020-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  *
  * Authors:
  * - Christophe Riccio <christophe@lunarg.com>
+ * - David Pinedo <david@lunarg.com>
  */
 
 #include "layer.h"
@@ -23,6 +24,8 @@
 #include "configuration.h"
 
 void ExportHtmlDoc(const Layer& layer, const std::string& path);
+
+void ExportMarkdownDoc(const Layer& layer, const std::string& path);
 
 void ExportSettingsDoc(const std::vector<Layer>& available_layers,
                        const Configuration& configuration, const std::string& path);

--- a/vkconfig_core/doc.h
+++ b/vkconfig_core/doc.h
@@ -24,5 +24,5 @@
 
 void ExportHtmlDoc(const Layer& layer, const std::string& path);
 
-void ExportSettingsDoc(const Environment& environment, const std::vector<Layer>& available_layers,
+void ExportSettingsDoc(const std::vector<Layer>& available_layers,
                        const Configuration& configuration, const std::string& path);

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -334,6 +334,7 @@ void Layer::AddSettingsSet(SettingMetaSet& settings, const SettingMeta* parent, 
         const QJsonObject& json_setting = json_array[i].toObject();
 
         const std::string key = ReadStringValue(json_setting, "key");
+        const std::string desc = ReadStringValue(json_setting, "description");
         const SettingType type = GetSettingType(ReadStringValue(json_setting, "type").c_str());
         SettingMeta* setting_meta = Instantiate(settings, key, type);
         setting_meta->platform_flags = parent == nullptr ? this->platforms : parent->platform_flags;

--- a/vkconfig_core/layer_manager.cpp
+++ b/vkconfig_core/layer_manager.cpp
@@ -117,6 +117,39 @@ void LayerManager::LoadAllInstalledLayers() {
     }
 }
 
+// Load a single layer
+void LayerManager::LoadLayer(const std::string &layer_name) {
+    available_layers.clear();
+
+    // FIRST: If VK_LAYER_PATH is set it has precedence over other layers.
+    const std::vector<std::string> &env_user_defined_layers_paths =
+        environment.GetUserDefinedLayersPaths(USER_DEFINED_LAYERS_PATHS_ENV);
+    for (std::size_t i = 0, n = env_user_defined_layers_paths.size(); i < n; ++i) {
+        if (LoadLayerFromPath(layer_name, env_user_defined_layers_paths[i]))
+            return;
+    }
+
+    // SECOND: Any user-defined path from Vulkan Configurator? Search for those too
+    const std::vector<std::string> &gui_user_defined_layers_paths =
+        environment.GetUserDefinedLayersPaths(USER_DEFINED_LAYERS_PATHS_GUI);
+    for (std::size_t i = 0, n = gui_user_defined_layers_paths.size(); i < n; ++i) {
+        if (LoadLayerFromPath(layer_name, gui_user_defined_layers_paths[i]))
+            return;
+    }
+
+    // THIRD: Standard layer paths, in standard locations. The above has always taken precedence.
+    for (std::size_t i = 0, n = countof(SEARCH_PATHS); i < n; i++) {
+        if (LoadLayerFromPath(layer_name, SEARCH_PATHS[i]))
+            return;
+    }
+
+    // FOURTH: See if thee is anyting in the VULKAN_SDK path that wasn't already found elsewhere
+    if (!qgetenv("VULKAN_SDK").isEmpty()) {
+        if (LoadLayerFromPath(layer_name, GetPath(BUILTIN_PATH_EXPLICIT_LAYERS)))
+            return;
+    }
+}
+
 /// Search a folder and load up all the layers found there. This does NOT
 /// load the default settings for each layer. This is just a master list of
 /// layers found. Do NOT load duplicate layer names. The type of layer (explicit or implicit) is
@@ -161,4 +194,35 @@ void LayerManager::LoadLayersFromPath(const std::string &path) {
             available_layers.push_back(layer);
         }
     }
+}
+
+// Attempt to load the named layer from the given path
+bool LayerManager::LoadLayerFromPath(const std::string &layer_name, const std::string &path) {
+
+    LayerType type = LAYER_TYPE_USER_DEFINED;
+    if (QString(path.c_str()).contains("explicit", Qt::CaseInsensitive)) type = LAYER_TYPE_EXPLICIT;
+    if (QString(path.c_str()).contains("implicit", Qt::CaseInsensitive)) type = LAYER_TYPE_IMPLICIT;
+
+    PathFinder file_list;
+
+    if (VKC_PLATFORM == VKC_PLATFORM_LINUX || VKC_PLATFORM == VKC_PLATFORM_MACOS) {
+        // On Linux/Mac, we also need the home folder
+        std::string search_path = path;
+        if (path[0] == '.') {
+            search_path = QDir().homePath().toStdString() + "/" + path;
+        }
+        file_list = PathFinder(search_path, true);
+    }
+
+    for (int i = 0, n = file_list.FileCount(); i < n; ++i) {
+        Layer layer;
+        if (layer.Load(available_layers, file_list.GetFileName(i).c_str(), type)) {
+            // Add this layer if the layer name matches, then return
+            if (layer_name == layer.key) {
+               available_layers.push_back(layer);
+               return true;
+            }
+        }
+    }
+    return false;
 }

--- a/vkconfig_core/layer_manager.h
+++ b/vkconfig_core/layer_manager.h
@@ -37,9 +37,12 @@ class LayerManager {
     bool Empty() const;
 
     void LoadAllInstalledLayers();
+    void LoadLayer(const std::string& layer_name);
     void LoadLayersFromPath(const std::string& path);
 
     std::vector<Layer> available_layers;
 
     const Environment& environment;
+   private:
+    bool LoadLayerFromPath(const std::string& layer_name, const std::string& path);
 };

--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -139,9 +139,8 @@ bool WriteLayersOverride(const Environment& environment, const std::vector<Layer
 }
 
 // Create and write vk_layer_settings.txt file
-bool WriteSettingsOverride(const Environment& environment, const std::vector<Layer>& available_layers,
+bool WriteSettingsOverride(const std::vector<Layer>& available_layers,
                            const Configuration& configuration, const std::string& settings_path) {
-    (void)environment;
 
     assert(!settings_path.empty());
     assert(QFileInfo(settings_path.c_str()).absoluteDir().exists());
@@ -242,7 +241,7 @@ bool OverrideConfiguration(const Environment& environment, const std::vector<Lay
     const bool result_layers = WriteLayersOverride(environment, available_layers, configuration, layers_path);
 
     // vk_layer_settings.txt
-    const bool result_settings = WriteSettingsOverride(environment, available_layers, configuration, settings_path);
+    const bool result_settings = WriteSettingsOverride(available_layers, configuration, settings_path);
 
     // On Windows only, we need to write these values to the registry
 #if VKC_PLATFORM == VKC_PLATFORM_WINDOWS

--- a/vkconfig_core/override.h
+++ b/vkconfig_core/override.h
@@ -35,5 +35,5 @@ bool SurrenderConfiguration(const Environment& environment);
 bool HasOverride();
 
 // Write the settings file for override layer
-bool WriteSettingsOverride(const Environment& environment, const std::vector<Layer>& available_layers,
+bool WriteSettingsOverride(const std::vector<Layer>& available_layers,
                            const Configuration& configuration, const std::string& settings_path);

--- a/vkconfig_core/override.h
+++ b/vkconfig_core/override.h
@@ -33,3 +33,7 @@ bool SurrenderConfiguration(const Environment& environment);
 
 // Check whether a layers configuration is activated
 bool HasOverride();
+
+// Write the settings file for override layer
+bool WriteSettingsOverride(const Environment& environment, const std::vector<Layer>& available_layers,
+                           const Configuration& configuration, const std::string& settings_path);

--- a/vkconfig_core/test/override_settings_2_2_1_schema_1_2_0.txt
+++ b/vkconfig_core/test/override_settings_2_2_1_schema_1_2_0.txt
@@ -1,26 +1,147 @@
 
 # VK_LAYER_LUNARG_reference_1_2_0
+
+# toogle
+# =====================
+# <LayerIdentifier>.toogle
+# true or false
 lunarg_reference_1_2_0.toogle = true
+
+# enum
+# =====================
+# <LayerIdentifier>.enum_required_only
+# enum case
 lunarg_reference_1_2_0.enum_required_only = value2
+
+# enum
+# =====================
+# <LayerIdentifier>.enum_with_optional
+# enum case
 lunarg_reference_1_2_0.enum_with_optional = value1
+
+# flags
+# =====================
+# <LayerIdentifier>.flags_required_only
+# flags case
 lunarg_reference_1_2_0.flags_required_only = flag0,flag2
+
+# flags
+# =====================
+# <LayerIdentifier>.flags_with_optional
+# flags case
 lunarg_reference_1_2_0.flags_with_optional = flag0,flag2
+
+# String
+# =====================
+# <LayerIdentifier>.string_required_only
+# string
 lunarg_reference_1_2_0.string_required_only = My string
+
+# String
+# =====================
+# <LayerIdentifier>.string_with_optional
+# string
 lunarg_reference_1_2_0.string_with_optional = My string
+
+# bool
+# =====================
+# <LayerIdentifier>.bool_required_only
+# true or false
 lunarg_reference_1_2_0.bool_required_only = true
+
+# bool
+# =====================
+# <LayerIdentifier>.bool_with_optional
+# true or false
 lunarg_reference_1_2_0.bool_with_optional = true
+
+# Load file
+# =====================
+# <LayerIdentifier>.load_file_required_only
+# Load file path
 lunarg_reference_1_2_0.load_file_required_only = ./my_test.txt
+
+# Load file
+# =====================
+# <LayerIdentifier>.load_file_with_optional
+# Load file path
 lunarg_reference_1_2_0.load_file_with_optional = ./my_test.txt
+
+# Save file
+# =====================
+# <LayerIdentifier>.save_file_required_only
+# Save file path
 lunarg_reference_1_2_0.save_file_required_only = ./my_test.txt
+
+# Save file
+# =====================
+# <LayerIdentifier>.save_file_with_optional
+# Save file path
 lunarg_reference_1_2_0.save_file_with_optional = ./my_test.txt
+
+# Save folder
+# =====================
+# <LayerIdentifier>.save_folder_required_only
+# Save folder path
 lunarg_reference_1_2_0.save_folder_required_only = ./my_test
+
+# Save folder
+# =====================
+# <LayerIdentifier>.save_folder_with_optional
+# Save folder path
 lunarg_reference_1_2_0.save_folder_with_optional = ./my_test
+
+# Integer
+# =====================
+# <LayerIdentifier>.int_required_only
+# Integer Description
 lunarg_reference_1_2_0.int_required_only = 76
+
+# Integer
+# =====================
+# <LayerIdentifier>.int_with_optional
+# Integer Description
 lunarg_reference_1_2_0.int_with_optional = 82
+
+# Float
+# =====================
+# <LayerIdentifier>.float_required_only
+# Float Description
 lunarg_reference_1_2_0.float_required_only = 76.500000
+
+# Float
+# =====================
+# <LayerIdentifier>.float_with_optional
+# Float Description
 lunarg_reference_1_2_0.float_with_optional = 76.500
+
+# Frames
+# =====================
+# <LayerIdentifier>.frames_required_only
+# Frames Description
 lunarg_reference_1_2_0.frames_required_only = 76-82,75
+
+# Frames
+# =====================
+# <LayerIdentifier>.frames_with_optional
+# Frames Description
 lunarg_reference_1_2_0.frames_with_optional = 79-82,75
+
+# List
+# =====================
+# <LayerIdentifier>.list_required_only
+# List description
 lunarg_reference_1_2_0.list_required_only = 76,82,stringB,stringD
+
+# List
+# =====================
+# <LayerIdentifier>.list_with_optional
+# List description
 lunarg_reference_1_2_0.list_with_optional = 76,stringA
+
+# List
+# =====================
+# <LayerIdentifier>.list_empty
+# List description
 lunarg_reference_1_2_0.list_empty = 
+

--- a/vkconfig_core/test/test_override.cpp
+++ b/vkconfig_core/test/test_override.cpp
@@ -33,7 +33,7 @@
 extern bool WriteLayersOverride(const Environment& environment, const std::vector<Layer>& available_layers,
                                 const Configuration& configuration, const std::string& layers_path);
 
-extern bool WriteSettingsOverride(const Environment& environment, const std::vector<Layer>& available_layers,
+extern bool WriteSettingsOverride(const std::vector<Layer>& available_layers,
                                   const Configuration& configuration, const std::string& settings_path);
 
 extern bool EraseLayersOverride(const std::string& layers_path);
@@ -57,7 +57,7 @@ TEST(test_override, write_erase_2_2_1) {
     EXPECT_TRUE(!configuration.parameters.empty());
 
     EXPECT_EQ(true, WriteLayersOverride(env, layer_manager.available_layers, configuration, "." + LAYERS));
-    EXPECT_EQ(true, WriteSettingsOverride(env, layer_manager.available_layers, configuration, "." + SETTINGS));
+    EXPECT_EQ(true, WriteSettingsOverride(layer_manager.available_layers, configuration, "." + SETTINGS));
 
     QFile file_layers_override_ref((":" + LAYERS).c_str());
     const bool result_layers_override_ref = file_layers_override_ref.open(QIODevice::ReadOnly | QIODevice::Text);


### PR DESCRIPTION
This is an initial implementation if adding "doc html|settings <layername>" to the command line options of vkconfig.

May still want to make further changes to add this capability to the GUI, and may want to change the output so as to better integrate the generation of layer documentation files with documentation needed for SDK creation.