### PR TITLE
api_dump: avoid creating ApiDumpSettings at ~ApiDumpInstance()

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -693,9 +693,11 @@ class ApiDumpInstance {
     }
 
     inline ~ApiDumpInstance() {
+        if (!dump_settings) return;
+
         if (!first_func_call_on_frame) settings().closeFrameOutput();
 
-        if (dump_settings != NULL) delete dump_settings;
+        delete dump_settings;
     }
 
     inline uint64_t frameCount() {


### PR DESCRIPTION
`first_func_call_on_frame` can be false if no interested vulkan api call has been made yet. However, `settings()` would instantiate `dump_settings` if it was a `nullptr`.