### PR TITLE
vkconfig: always add all layers paths to override_paths

### DIFF
--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -63,12 +63,10 @@ bool WriteLayersOverride(const Environment& environment, const std::vector<Layer
         // Extract just the path
         assert(!layer->manifest_path.empty());
         const QFileInfo file(layer->manifest_path.c_str());
-        const std::string absolute_path(ConvertNativeSeparators(file.absolutePath().toStdString()).c_str());
+        const std::string absolute_path(file.absolutePath().toStdString().c_str());
 
         // Make sure the path is not already in the list
         if (layer_override_paths.contains(absolute_path.c_str())) continue;
-
-        if (!path_gui.contains(absolute_path.c_str()) && !path_env.contains(absolute_path.c_str())) continue;
 
         // Okay, add to the list
         layer_override_paths << absolute_path.c_str();
@@ -76,7 +74,7 @@ bool WriteLayersOverride(const Environment& environment, const std::vector<Layer
 
     QJsonArray json_paths;
     for (int i = 0, n = layer_override_paths.count(); i < n; ++i) {
-        json_paths.append(ConvertNativeSeparators(layer_override_paths[i].toStdString()).c_str());
+        json_paths.append(layer_override_paths[i].toStdString().c_str());
     }
 
     QJsonArray json_overridden_layers;

--- a/vkconfig_core/test/override_layers_2_2_2_schema_1_2_1.json
+++ b/vkconfig_core/test/override_layers_2_2_2_schema_1_2_1.json
@@ -14,6 +14,7 @@
         "implementation_version": "1",
         "name": "VK_LAYER_LUNARG_override",
         "override_paths": [
+            ":/"
         ],
         "type": "GLOBAL"
     }


### PR DESCRIPTION
Allows using layers from the system path and user defined paths at the same time.