### PR TITLE
Vkconfig fix for VULKAN_SDK set on macOS

### DIFF
--- a/vkconfig_core/path.cpp
+++ b/vkconfig_core/path.cpp
@@ -165,7 +165,11 @@ std::string GetPath(BuiltinPath path) {
                 } else {
                     result = GetPath(BUILTIN_PATH_LOCAL);
                 }
+            } else {    // VULKAN_SDK may be set on macOS
+                if(VKC_PLATFORM == VKC_PLATFORM_MACOS)
+                    result += "/share/vulkan";
             }
+
             break;
         }
         case BUILTIN_PATH_VULKAN_CONTENT: {


### PR DESCRIPTION
Fix for this issue:
https://gitlab.khronos.org/vulkan/Vulkan-SDK-Packaging/-/issues/910

Massage or rearrange if needed, but the case where VULKAN_SDK is defined is not handled correctly on macOS without something like this.