### PR TITLE
apidump: Fixup rasterizationSamples in codegen

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -422,7 +422,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
     instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
     {funcStateTrackingCode}
-    dump_body_{funcName}(ApiDumpInstance::current(), {funcNamedParams});    
+    dump_body_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
 }}
 @end function
 
@@ -569,9 +569,9 @@ std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettin
     case {sctStructureTypeIndex}:
         dump_text_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_text_{sctName});
         break;
-        @end if    
+        @end if
     @end struct
-    
+
     case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
     case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
         if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
@@ -585,19 +585,19 @@ std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettin
         settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
         settings.stream() << "UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\n";
     }}
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 inline std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, bool is_dynamic_viewport, bool is_dynamic_scissor)
 {{
     dump_text_pNext<const VkPipelineViewportStateCreateInfo>(static_cast<const VkPipelineViewportStateCreateInfo*>(object), settings, "VkPipelineViewportStateCreateInfo", indents, dump_text_VkPipelineViewportStateCreateInfo, is_dynamic_viewport, is_dynamic_scissor);
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 inline std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, VkCommandBuffer cmd_buffer)
 {{
     dump_text_pNext<const VkCommandBufferBeginInfo>(static_cast<const VkCommandBufferBeginInfo*>(object), settings, "VkCommandBufferBeginInfo", indents, dump_text_VkCommandBufferBeginInfo, cmd_buffer);
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 std::ostream& dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents)
@@ -787,7 +787,7 @@ std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings
     @if({memPtrLevel} == 0)
         @if('{memName}' != 'pNext')
     dump_text_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions});  // AET
-        @end if 
+        @end if
         @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_text_pNext_struct_name(object.{memName}, settings, indents + 1);
@@ -807,7 +807,12 @@ std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings
     dump_text_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // BQA
     @end if
     @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
+    @if('{memLength}' == 'rasterizationSamples')
+    dump_text_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // BQB
+    @end if
+    @if('{memLength}' != 'rasterizationSamples')
     dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // BQB
+    @end if
     @end if
     @end if
 
@@ -906,7 +911,7 @@ std::ostream& dump_text_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
     }}
     if (settings.showTimestamp()) {{
         settings.stream() << "Time " << dump_inst.current_time_since_start().count() << " us";
-    }} 
+    }}
     if (settings.showTimestamp() || settings.showThreadAndFrame()) {{
         settings.stream() << ":\\n";
     }}
@@ -925,7 +930,7 @@ std::ostream& dump_text_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
 @end if
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
-    
+
     @if('{funcReturn}' != 'void')
     settings.stream() << " ";
     dump_text_{funcReturn}(result, settings, 0);
@@ -1022,9 +1027,9 @@ std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettin
     case {sctStructureTypeIndex}:
         dump_html_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_html_{sctName});
         break;
-        @end if    
+        @end if
     @end struct
-    
+
     case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
     case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
         if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
@@ -1040,19 +1045,19 @@ std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettin
         dump_html_nametype(settings.stream(), settings.showType(), "pNext", "const void*");
         settings.stream() << "<div class='val'>UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) <<")</div></summary></details>";
     }}
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 inline std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, bool is_dynamic_viewport, bool is_dynamic_scissor)
 {{
     dump_html_pNext<const VkPipelineViewportStateCreateInfo>(static_cast<const VkPipelineViewportStateCreateInfo*>(object), settings, "VkPipelineViewportStateCreateInfo", indents, dump_html_VkPipelineViewportStateCreateInfo, is_dynamic_viewport, is_dynamic_scissor);
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 inline std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, VkCommandBuffer cmd_buffer)
 {{
     dump_html_pNext<const VkCommandBufferBeginInfo>(static_cast<const VkCommandBufferBeginInfo*>(object), settings, "VkCommandBufferBeginInfo", indents, dump_html_VkCommandBufferBeginInfo, cmd_buffer);
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 //=========================== Type Implementations ==========================//
@@ -1219,7 +1224,7 @@ std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings
     @if({memPtrLevel} == 0)
         @if('{memName}' != 'pNext')
     dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions});
-        @end if 
+        @end if
         @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_html_pNext_trampoline(object.{memName}, settings, indents + 1);
@@ -1239,7 +1244,12 @@ std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings
     dump_html_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRS
     @end if
     @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
+    @if('{memLength}' == 'rasterizationSamples')
+    dump_html_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRT
+    @end if
+    @if('{memLength}' != 'rasterizationSamples')
     dump_html_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRT
+    @end if
     @end if
     @end if
     @if('{sctName}' == 'VkShaderModuleCreateInfo')
@@ -1339,11 +1349,11 @@ std::ostream& dump_html_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
 @foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
 @if('{funcReturn}' != 'void')
 std::ostream& dump_html_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
-@end if 
+@end if
 @if('{funcReturn}' == 'void')
 std::ostream& dump_html_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @end if
-{{ 
+{{
     const ApiDumpSettings& settings(dump_inst.settings());
 
     @if('{funcReturn}' != 'void')
@@ -1440,9 +1450,9 @@ std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettin
     case {sctStructureTypeIndex}:
         dump_json_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_json_{sctName});
         break;
-        @end if    
+        @end if
     @end struct
-    
+
     case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
     case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
         if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
@@ -1462,19 +1472,19 @@ std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettin
         settings.stream() << settings.indentation(indents + 1) << "\\"value\\" : \\"UNKNOWN (\\"" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << "\\")\\n";
         settings.stream() << settings.indentation(indents) << "}}";
     }}
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 inline std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, bool is_dynamic_viewport, bool is_dynamic_scissor)
 {{
     dump_json_pNext<const VkPipelineViewportStateCreateInfo>(static_cast<const VkPipelineViewportStateCreateInfo*>(object), settings, "VkPipelineViewportStateCreateInfo", indents, dump_json_VkPipelineViewportStateCreateInfo, is_dynamic_viewport, is_dynamic_scissor);
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 inline std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, VkCommandBuffer cmd_buffer)
 {{
     dump_json_pNext<const VkCommandBufferBeginInfo>(static_cast<const VkCommandBufferBeginInfo*>(object), settings, "VkCommandBufferBeginInfo", indents, dump_json_VkCommandBufferBeginInfo, cmd_buffer);
-    return settings.stream(); 
+    return settings.stream();
 }}
 
 //=========================== Type Implementations ==========================//
@@ -1630,7 +1640,7 @@ std::ostream& dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings
     @if({memPtrLevel} == 0)
         @if('{memName}' != 'pNext')
     dump_json_value<const {memBaseType}>(object.{memName}, NULL, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions});
-        @end if 
+        @end if
         @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_json_pNext_trampoline(object.{memName}, settings, indents + 1);
@@ -1650,7 +1660,12 @@ std::ostream& dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings
     dump_json_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // JQA
     @end if
     @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
+    @if('{memLength}' == 'rasterizationSamples')
+    dump_json_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // JQA
+    @end if
+    @if('{memLength}' != 'rasterizationSamples')
     dump_json_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // JQA
+    @end if
     @end if
     @end if
     @if('{sctName}' == 'VkShaderModuleCreateInfo')
@@ -2373,9 +2388,10 @@ class VulkanVariable:
             if "ename:" in lengthString or "latexmath:" in lengthString:
                 lengthString = rootNode.get('altlen')
                 # Original form would result in object.(rasterizationSamples + 31)
-                # Count on the fact that + takes precedance over >>
-                if (lengthString == "(rasterizationSamples + 31) / 32"):
-                    lengthString = "rasterizationSamples + 31 >> 5"
+                # We fix it correctly inside the template. Just set it to `rasterizationSamples` to make it easy
+                # to find this situation in the code gen.
+                if lengthString == '(rasterizationSamples + 31) / 32':
+                    lengthString = 'rasterizationSamples'
         lengths = []
         if lengthString is not None:
             lengths = re.split(',', lengthString)
@@ -2467,8 +2483,8 @@ class VulkanEnum:
             self.name = name
             self.comment = comment
             self.multiValue = None
-            
-            if value is not None:         
+
+            if value is not None:
 
                 self.multiValue = not isPow2(StrToInt(value))
 
@@ -2514,7 +2530,7 @@ class VulkanEnum:
                 childValue = extBase + (extNum - 1) * extBlockSize + extOffset
                 if ('dir' in child.keys()):
                     childValue = -childValue
-               
+
             # Check for duplicates
             duplicate = False
             for o in self.options:
@@ -2665,7 +2681,7 @@ class VulkanFunction:
         else:
             self.dispatchType = 'device'
 
-        if self.name in extensions and extensions[self.name].type == 'instance':    
+        if self.name in extensions and extensions[self.name].type == 'instance':
             self.type = 'instance'
         else:
             self.type = self.dispatchType
@@ -2688,7 +2704,7 @@ class VulkanFunction:
             'funcNamedParams': self.namedParams,
             'funcTypedParams': self.typedParams,
             'funcDispatchParam': self.parameters[0].name,
-            'funcDispatchType' : self.dispatchType, 
+            'funcDispatchType' : self.dispatchType,
             'funcStateTrackingCode': self.stateTrackingCode,
             'funcSafeToPrint': self.safeToPrint,
         }
@@ -2761,7 +2777,7 @@ class VulkanStruct:
                     self.conditionVars += ', ' + state['type'] + ' ' + state['name']
 
         self.structureIndex = -1
-        
+
         if(self.structExtends is not None):
             for member in self.members:
                 if(member.structValues is not None):
@@ -2770,7 +2786,7 @@ class VulkanStruct:
                             for opt in enum.options:
                                 if(member.structValues  == opt.name):
                                     self.structureIndex = opt.value
-              
+
     def values(self):
         return {
             'sctName': self.name,


### PR DESCRIPTION
The previous solution relied on `<<` having a lower precedence than `+`.
Except it didn't and clang complains about it. The fix is straightforward,
fix up the codegen inside the template blocks instead of trying to fix it
outside of them.

Fixes #1646 