### PR TITLE
Update scripts to explicitly use python3

### DIFF
--- a/update_external_sources.bat
+++ b/update_external_sources.bat
@@ -14,7 +14,7 @@ git submodule update --init --recursive
    echo.
    echo Building %JSONCPP_DIR%
    cd  "%JSONCPP_DIR%"
-   python amalgamate.py
+   python3 amalgamate.py
 
    if not exist %JSONCPP_DIR%\dist\json\json.h (
       echo.

--- a/update_external_sources.sh
+++ b/update_external_sources.sh
@@ -6,7 +6,7 @@ if [[ $(uname) == "Linux" || $(uname) == "FreeBSD" || $(uname) =~ "CYGWIN" || $(
     CURRENT_DIR="$(dirname "$(readlink -f ${BASH_SOURCE[0]})")"
     CORE_COUNT=$(nproc || echo 4)
 elif [[ $(uname) == "Darwin" ]]; then
-    CURRENT_DIR="$(dirname "$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ${BASH_SOURCE[0]})")"
+    CURRENT_DIR="$(dirname "$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ${BASH_SOURCE[0]})")"
     CORE_COUNT=$(sysctl -n hw.ncpu || echo 4)
 fi
 echo CURRENT_DIR=$CURRENT_DIR
@@ -19,5 +19,5 @@ git submodule update --init --recursive
 
 echo "Building ${BASEDIR}/jsoncpp"
 cd ${BASEDIR}/jsoncpp
-python amalgamate.py
+python3 amalgamate.py
 


### PR DESCRIPTION
Update scripts to explicitly call python3. This is needed for building on macOS version 12.3 or later, and is a better practice overall on other platforms.