### PR TITLE
vkconfig: add user-defined paths in layers window

### DIFF
--- a/vkconfig/dialog_custom_paths.cpp
+++ b/vkconfig/dialog_custom_paths.cpp
@@ -116,7 +116,7 @@ void UserDefinedPathsDialog::RepopulateTree() {
             }
 
             QTreeWidgetItem *child = new QTreeWidgetItem();
-            child->setText(0, layer.key.c_str());
+            child->setText(0, (layer.key + " - " + layer.api_version.str()).c_str());
             item->addChild(child);
         }
     }

--- a/vkconfig/dialog_layers.cpp
+++ b/vkconfig/dialog_layers.cpp
@@ -121,10 +121,15 @@ LayersDialog::LayersDialog(QWidget *parent, const Configuration &configuration)
 
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
+    Configurator &configurator = Configurator::Get();
+    this->layers_paths_saved = this->layers_paths =
+        configurator.environment.GetUserDefinedLayersPaths(USER_DEFINED_LAYERS_PATHS_GUI);
+
     ui->lineEditName->setText(configuration.key.c_str());
     ui->lineEditDescription->setText(configuration.description.c_str());
+    ui->buttonBox->setEnabled(!configurator.layers.Empty());
 
-    Environment &environment = Configurator::Get().environment;
+    Environment &environment = configurator.environment;
     restoreGeometry(environment.Get(LAYOUT_LAYER_GEOMETRY));
 
     const QByteArray &restore_splitter_state = environment.Get(LAYOUT_LAYER_SPLITTER);
@@ -157,6 +162,25 @@ LayersDialog::~LayersDialog() {
 
     environment.Set(LAYOUT_LAYER_SPLITTER, ui->splitter->saveState());
     environment.Set(LAYOUT_LAYER_GEOMETRY, saveGeometry());
+}
+
+void LayersDialog::Reload() {
+    Configurator &configurator = Configurator::Get();
+    configurator.configurations.SaveAllConfigurations(configurator.layers.available_layers);
+
+    configurator.layers.LoadAllInstalledLayers();
+    configurator.configurations.LoadAllConfigurations(configurator.layers.available_layers);
+    configurator.configurations.RefreshConfiguration(configurator.layers.available_layers);
+    configurator.request_vulkan_status = true;
+}
+
+void LayersDialog::SaveLayersPaths(const std::vector<std::string> &layers_paths) {
+    Configurator &configurator = Configurator::Get();
+    configurator.environment.ClearCustomLayerPath();
+
+    for (std::size_t i = 0, n = layers_paths.size(); i < n; ++i) {
+        configurator.environment.AppendCustomLayerPath(layers_paths[i]);
+    }
 }
 
 void LayersDialog::UpdateUI() {
@@ -194,6 +218,8 @@ void LayersDialog::UpdateUI() {
 
     const bool has_below_sorted_item = ui->layerTreeSorted->itemBelow(current_sorted_layers) != nullptr;
     ui->pushButtonDown->setEnabled(has_selected_sorted_item && has_below_sorted_item);
+
+    this->RepopulateTreePaths();
 }
 
 void LayersDialog::OnLayerTreeSortedClicked(QTreeWidgetItem *item, int column) {
@@ -507,6 +533,45 @@ void LayersDialog::layerUseChanged(QTreeWidgetItem *item, int selection) {
     UpdateUI();
 }
 
+void LayersDialog::on_treeWidget_itemSelectionChanged() { ui->pushButtonRemove->setEnabled(true); }
+
+void LayersDialog::on_pushButtonAdd_clicked() {
+    Configurator &configurator = Configurator::Get();
+    const std::string custom_path = configurator.path.SelectPath(this, PATH_USER_DEFINED_LAYERS_GUI);
+
+    if (!custom_path.empty()) {
+        if (std::find(layers_paths.begin(), layers_paths.end(), custom_path) == layers_paths.end()) {
+            this->layers_paths.push_back(custom_path);
+
+            this->SaveLayersPaths(this->layers_paths);
+            this->Reload();
+            this->UpdateUI();
+        }
+    }
+
+    ui->buttonBox->setEnabled(!configurator.layers.Empty());
+}
+
+void LayersDialog::on_pushButtonRemove_clicked() {
+    // Which one is selected? We need the top item too
+    QTreeWidgetItem *selected = ui->layerTreePath->currentItem();
+    if (selected == nullptr) {
+        ui->pushButtonRemove->setEnabled(false);
+        return;
+    }
+
+    while (selected->parent() != nullptr) selected = selected->parent();
+
+    RemoveString(this->layers_paths, selected->text(0).toStdString());
+
+    this->SaveLayersPaths(this->layers_paths);
+    this->Reload();
+    this->UpdateUI();
+
+    // Nothing is selected, so disable remove button
+    ui->buttonBox->setEnabled(!Configurator::Get().layers.Empty());
+}
+
 void LayersDialog::accept() {
     if (ui->lineEditName->text().isEmpty()) {
         Alert::ConfigurationNameEmpty();
@@ -550,7 +615,51 @@ void LayersDialog::accept() {
     QDialog::accept();
 }
 
+void LayersDialog::reject() {
+    this->SaveLayersPaths(this->layers_paths_saved);
+    this->Reload();
+
+    QDialog::reject();
+}
+
 void LayersDialog::BuildParameters() {
     Configurator &configurator = Configurator::Get();
     this->configuration.parameters = GatherParameters(this->configuration.parameters, configurator.layers.available_layers);
+}
+
+void LayersDialog::RepopulateTreePaths() {
+    Configurator &configurator = Configurator::Get();
+
+    // Populate the tree
+    ui->layerTreePath->clear();
+
+    // Building the list is not obvious. Each custom path may have multiple layers and there
+    // could be duplicates, which are not allowed. The layer paths are traversed in order, and
+    // layers are used on a first occurance basis. So we can't just show the layers that are
+    // present in the folder (because they may not be used). We have to list the custom layer paths
+    // and then look for layers that are already loaded that are from that path.
+
+    for (std::size_t custom_path_index = 0, count = this->layers_paths.size(); custom_path_index < count; ++custom_path_index) {
+        const std::string user_defined_path(ConvertNativeSeparators(this->layers_paths[custom_path_index]));
+
+        QTreeWidgetItem *item = new QTreeWidgetItem();
+        ui->layerTreePath->addTopLevelItem(item);
+        item->setText(0, user_defined_path.c_str());
+        item->setExpanded(true);
+
+        // Look for layers that are loaded that are also from this folder
+        for (std::size_t i = 0, n = configurator.layers.available_layers.size(); i < n; ++i) {
+            const Layer &layer = configurator.layers.available_layers[i];
+
+            const QFileInfo file_info(layer.manifest_path.c_str());
+            const std::string path(ConvertNativeSeparators(file_info.path().toStdString()));
+            if (path != user_defined_path) {
+                continue;
+            }
+
+            QTreeWidgetItem *child = new QTreeWidgetItem();
+            child->setText(0, (layer.key + " - " + layer.api_version.str()).c_str());
+            item->addChild(child);
+        }
+    }
 }

--- a/vkconfig/dialog_layers.h
+++ b/vkconfig/dialog_layers.h
@@ -44,9 +44,6 @@ class LayersDialog : public QDialog {
     explicit LayersDialog(QWidget *parent, const Configuration &configuration);
     ~LayersDialog();
 
-    void LoadAvailableLayersUI();
-    void LoadSortedLayersUI();
-
    public Q_SLOTS:
     void accept() override;
     void reject() override;
@@ -61,7 +58,7 @@ class LayersDialog : public QDialog {
     void on_pushButtonDown_clicked();
     void on_pushButtonAdd_clicked();
     void on_pushButtonRemove_clicked();
-    void on_treeWidget_itemSelectionChanged();
+    void on_layerTreePath_itemSelectionChanged();
 
     void OnLayerTreeSortedClicked(QTreeWidgetItem *item, int column);
 
@@ -78,8 +75,11 @@ class LayersDialog : public QDialog {
 
     void UpdateButtons();
 
-    void RepopulateTreePaths();
+    void LoadAvailableLayersUI();
+    void LoadSortedLayersUI();
+    void LoadUserDefinedPaths();
     void Reload();
+    void Reinit();
     void SaveLayersPaths(const std::vector<std::string> &layers_paths);
     void AddLayerItem(const Parameter &parameter);
     void BuildParameters();

--- a/vkconfig/dialog_layers.h
+++ b/vkconfig/dialog_layers.h
@@ -49,6 +49,7 @@ class LayersDialog : public QDialog {
 
    public Q_SLOTS:
     void accept() override;
+    void reject() override;
 
     void currentLayerChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
 
@@ -58,6 +59,9 @@ class LayersDialog : public QDialog {
     void on_button_reset_clicked();
     void on_pushButtonUp_clicked();
     void on_pushButtonDown_clicked();
+    void on_pushButtonAdd_clicked();
+    void on_pushButtonRemove_clicked();
+    void on_treeWidget_itemSelectionChanged();
 
     void OnLayerTreeSortedClicked(QTreeWidgetItem *item, int column);
 
@@ -74,6 +78,9 @@ class LayersDialog : public QDialog {
 
     void UpdateButtons();
 
+    void RepopulateTreePaths();
+    void Reload();
+    void SaveLayersPaths(const std::vector<std::string> &layers_paths);
     void AddLayerItem(const Parameter &parameter);
     void BuildParameters();
     void OverrideAllExplicitLayers();
@@ -84,4 +91,6 @@ class LayersDialog : public QDialog {
     std::string selected_sorted_layer_name;
 
     std::unique_ptr<Ui::dialog_layers> ui;
+    std::vector<std::string> layers_paths;
+    std::vector<std::string> layers_paths_saved;
 };

--- a/vkconfig/dialog_layers.ui
+++ b/vkconfig/dialog_layers.ui
@@ -505,7 +505,10 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/vkconfig/dialog_layers.ui
+++ b/vkconfig/dialog_layers.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>500</height>
+    <width>1024</width>
+    <height>640</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>600</width>
-    <height>400</height>
+    <width>1024</width>
+    <height>640</height>
    </size>
   </property>
   <property name="maximumSize">
@@ -37,19 +37,7 @@
   <property name="windowTitle">
    <string>Edit Vulkan Layers</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
-   <property name="leftMargin">
-    <number>9</number>
-   </property>
-   <property name="topMargin">
-    <number>9</number>
-   </property>
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
-   <property name="bottomMargin">
-    <number>9</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
@@ -128,38 +116,17 @@
    </item>
    <item>
     <widget class="QSplitter" name="splitter">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
      <property name="lineWidth">
-      <number>0</number>
-     </property>
-     <property name="midLineWidth">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="opaqueResize">
+      <bool>false</bool>
+     </property>
      <property name="handleWidth">
-      <number>3</number>
+      <number>10</number>
      </property>
      <property name="childrenCollapsible">
       <bool>false</bool>
@@ -197,7 +164,7 @@
         <number>0</number>
        </property>
        <property name="bottomMargin">
-        <number>4</number>
+        <number>0</number>
        </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
@@ -352,7 +319,7 @@
         <height>0</height>
        </size>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
+      <layout class="QVBoxLayout" name="verticalLayout1">
        <property name="spacing">
         <number>1</number>
        </property>
@@ -360,7 +327,7 @@
         <number>0</number>
        </property>
        <property name="topMargin">
-        <number>4</number>
+        <number>0</number>
        </property>
        <property name="rightMargin">
         <number>0</number>
@@ -438,6 +405,85 @@
           <widget class="QPushButton" name="pushButtonDown">
            <property name="text">
             <string>Execute Closer to the Vulkan Drivers</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="widgetVerticalPathList">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTreeWidget" name="layerTreePath">
+         <property name="frameShape">
+          <enum>QFrame::Box</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="columnCount">
+          <number>1</number>
+         </property>
+         <attribute name="headerVisible">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="headerMinimumSectionSize">
+          <number>0</number>
+         </attribute>
+         <attribute name="headerDefaultSectionSize">
+          <number>0</number>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>1</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="pushButtonAdd">
+           <property name="text">
+            <string>Add User-Defined Path...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonRemove">
+           <property name="text">
+            <string>Remove User-Defined Path</string>
            </property>
           </widget>
          </item>

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -202,6 +202,7 @@ void MainWindow::UpdateUI() {
     // Update settings
     ui->push_button_edit->setEnabled(environment.UseOverride() && has_active_configuration);
     ui->push_button_remove->setEnabled(environment.UseOverride() && has_active_configuration);
+    ui->push_button_duplicate->setEnabled(environment.UseOverride() && has_active_configuration);
     ui->push_button_new->setEnabled(environment.UseOverride());
     ui->settings_tree->setEnabled(environment.UseOverride() && has_active_configuration);
     ui->group_box_settings->setTitle(has_active_configuration ? (active_contiguration_name + " Settings").c_str()
@@ -713,6 +714,20 @@ void MainWindow::on_push_button_remove_clicked() {
     Configurator &configurator = Configurator::Get();
 
     this->RemoveConfiguration(configurator.configurations.GetActiveConfiguration()->key);
+}
+
+void MainWindow::on_push_button_duplicate_clicked() {
+    Configurator &configurator = Configurator::Get();
+
+    Configuration *configutation = configurator.configurations.GetActiveConfiguration();
+    assert(configutation != nullptr);
+
+    const Configuration &duplicated_configuration =
+        configurator.configurations.CreateConfiguration(configurator.layers.available_layers, configutation->key, true);
+
+    this->SetActiveConfiguration(duplicated_configuration.key);
+
+    LoadConfigurationList();
 }
 
 void MainWindow::on_push_button_edit_clicked() {

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -95,8 +95,6 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->actionVulkan_Layer_Specification, SIGNAL(triggered(bool)), this, SLOT(OnHelpLayerSpec(bool)));
     connect(ui->actionGPU_Info_Reports, SIGNAL(triggered(bool)), this, SLOT(OnHelpGPUInfo(bool)));
 
-    connect(ui->actionCustom_Layer_Paths, SIGNAL(triggered(bool)), this, SLOT(toolsSetCustomPaths(bool)));
-
     connect(ui->actionVulkan_Installation, SIGNAL(triggered(bool)), this, SLOT(toolsVulkanInstallation(bool)));
     connect(ui->actionRestore_Default_Configurations, SIGNAL(triggered(bool)), this, SLOT(toolsResetToDefault(bool)));
 
@@ -204,7 +202,6 @@ void MainWindow::UpdateUI() {
     // Update settings
     ui->push_button_edit->setEnabled(environment.UseOverride() && has_active_configuration);
     ui->push_button_remove->setEnabled(environment.UseOverride() && has_active_configuration);
-    ui->push_button_find->setEnabled(environment.UseOverride());
     ui->push_button_new->setEnabled(environment.UseOverride());
     ui->settings_tree->setEnabled(environment.UseOverride() && has_active_configuration);
     ui->group_box_settings->setTitle(has_active_configuration ? (active_contiguration_name + " Settings").c_str()
@@ -915,16 +912,6 @@ void MainWindow::ReloadDefaultClicked(ConfigurationListItem *item) {
     }
 }
 
-void MainWindow::EditCustomPathsClicked(ConfigurationListItem *item) {
-    (void)item;
-    FindLayerPaths();
-}
-
-void MainWindow::toolsSetCustomPaths(bool checked) {
-    (void)checked;
-    FindLayerPaths();
-}
-
 void MainWindow::editorExpanded(QTreeWidgetItem *item) {
     (void)item;
     ui->settings_tree->resizeColumnToContents(0);
@@ -1334,7 +1321,7 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             // Create context menu here
             QMenu menu(ui->configuration_tree);
 
-            QAction *edit_action = new QAction("Edit Layers...", nullptr);
+            QAction *edit_action = new QAction("Edit...", nullptr);
             edit_action->setEnabled(active && item != nullptr);
             menu.addAction(edit_action);
 
@@ -1378,12 +1365,6 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
             reload_default_action->setEnabled(true);
             menu.addAction(reload_default_action);
 
-            menu.addSeparator();
-
-            QAction *custom_path_action = new QAction("Edit User-Defined Layers Paths...", nullptr);
-            custom_path_action->setEnabled(true);
-            menu.addAction(custom_path_action);
-
             QPoint point(right_click->globalX(), right_click->globalY());
             QAction *action = menu.exec(point);
 
@@ -1405,8 +1386,6 @@ bool MainWindow::eventFilter(QObject *target, QEvent *event) {
                 ImportClicked(item);
             } else if (action == reload_default_action) {
                 ReloadDefaultClicked(item);
-            } else if (action == custom_path_action) {
-                EditCustomPathsClicked(item);
             } else {
                 return false;  // Unknown action
             }

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -103,12 +103,10 @@ class MainWindow : public QMainWindow {
     void ExportClicked(ConfigurationListItem *item);
     void ImportClicked(ConfigurationListItem *item);
     void ReloadDefaultClicked(ConfigurationListItem *item);
-    void EditCustomPathsClicked(ConfigurationListItem *item);
 
    public Q_SLOTS:
     void toolsVulkanInfo(bool checked);
     void toolsVulkanInstallation(bool checked);
-    void toolsSetCustomPaths(bool checked);
     void toolsResetToDefault(bool checked);
 
     void OnHelpFindLayers(bool checked);

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -144,6 +144,7 @@ class MainWindow : public QMainWindow {
     void on_push_button_find_clicked();
     void on_push_button_new_clicked();
     void on_push_button_remove_clicked();
+    void on_push_button_duplicate_clicked();
 
     void OnConfigurationItemExpanded(QTreeWidgetItem *item);
     void OnConfigurationItemClicked(bool checked);

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -346,6 +346,13 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QPushButton" name="push_button_duplicate">
+                  <property name="text">
+                   <string>Duplicate</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QPushButton" name="push_button_remove">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Minimum" vsizetype="Minimum">

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -371,31 +371,6 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QPushButton" name="push_button_find">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="font">
-                   <font>
-                    <family>Arial</family>
-                    <pointsize>10</pointsize>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string>Find...</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
                  <spacer name="verticalSpacer">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
@@ -533,6 +508,9 @@
              <family>Consolas</family>
              <pointsize>9</pointsize>
             </font>
+           </property>
+           <property name="acceptDrops">
+            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -52,8 +52,6 @@ class Configuration {
     bool IsBuiltIn() const;
 
    private:
-    bool Load2_0(const std::vector<Layer>& available_layers, const QJsonObject& json_root_object, const std::string& full_path);
-    bool Load2_1(const std::vector<Layer>& available_layers, const QJsonObject& json_root_object);
     bool Load2_2(const std::vector<Layer>& available_layers, const QJsonObject& json_root_object);
 };
 


### PR DESCRIPTION
These changes provide:
- Easier UI to edit configuration, no need to switch window to edit layers
- Per layer configuration user-defined paths
- Fully allow preventing users to create a configuration with incompatible layers versions.

![image](https://user-images.githubusercontent.com/62888873/172170594-403fad25-9dfe-434d-93e3-331b9d40ee05.png)
