### PR TITLE
Change message when layer settings file can't be opened

### DIFF
--- a/via/via_system.cpp
+++ b/via/via_system.cpp
@@ -1574,7 +1574,7 @@ void ViaSystem::GenerateSettingsFileJsonInfo(const std::string& settings_file) {
     if (nullptr == settings_stream || settings_stream->fail()) {
         // No file was found.  This is NOT an error.
         PrintTableElement(ConvertPathFormat(settings_file));
-        PrintTableElement("Failed to open settings file");
+        PrintTableElement("File not found");
         PrintTableElement("");
         PrintEndTableRow();
     } else {


### PR DESCRIPTION
Changed message displayed from "Failed to open settings file" to
"File not found". It's not an error, so changed message so it
doesn't sound so alarming.

Addresses https://github.com/LunarG/VulkanTools/issues/981