### PR TITLE
Address validation errors in screenshot layer.

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -265,7 +265,7 @@ void readScreenShotFormatENV(void) {
                                 vk_screenshot_format);
 #else
             fprintf(stderr,
-                    "Selected format:%s\nIs NOT in the list:\nUNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB\n"
+                    "screenshot: Selected format:%s\nIs NOT in the list:\nUNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB\n"
                     "Swapchain Colorspace will be used instead\n",
                     vk_screenshot_format);
 #endif
@@ -345,9 +345,9 @@ static void populate_frame_list(const char *vk_screenshot_frames) {
         int parsingStatus = initScreenShotFrameRange(vk_screenshot_frames, &screenShotFrameRange);
         if (parsingStatus != 0) {
 #ifdef ANDROID
-            __android_log_print(ANDROID_LOG_ERROR, "screenshot", "range error\n");
+            __android_log_print(ANDROID_LOG_ERROR, "screenshot", "Range error\n");
 #else
-            fprintf(stderr, "Screenshot range error\n");
+            fprintf(stderr, "screenshot: Range error\n");
 #endif
         }
     }
@@ -544,7 +544,7 @@ static bool writePPM(const char *filename, VkImage image1) {
 #ifdef ANDROID
         __android_log_print(ANDROID_LOG_ERROR, "screenshot", "Failure - capable queue not found\n");
 #else
-        fprintf(stderr, "Screenshot could not find a capable queue\n");
+        fprintf(stderr, "screenshot: Could not find a capable queue\n");
 #endif
         return false;
     }
@@ -672,7 +672,7 @@ static bool writePPM(const char *filename, VkImage image1) {
                                 "Swapchain format is not in the list:\nUNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB\n");
 #else
             fprintf(stderr,
-                    "Swapchain format is not in the list:\nUNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB\n"
+                    "screenshot: Swapchain format is not in the list:\nUNORM, SNORM, USCALED, SSCALED, UINT, SINT, SRGB\n"
                     "UNORM colorspace will be used instead\n");
 #endif
             printFormatWarning = false;
@@ -681,6 +681,30 @@ static bool writePPM(const char *filename, VkImage image1) {
             destformat = VK_FORMAT_R8G8B8A8_UNORM;
         else
             destformat = VK_FORMAT_R8G8B8_UNORM;
+    }
+
+    // From vulkan spec:
+    //   VUID-vkCmdBlitImage-srcImage-00229
+    //     If either of srcImage or dstImage was created with a signed integer VkFormat,
+    //     the other must also have been created with a signed integer VkFormat
+    //   VUID-vkCmdBlitImage-srcImage-00230
+    //     If either of srcImage or dstImage was created with an unsigned integer VkFormat,
+    //     the other must also have been created with an unsigned integer VkFormat
+    // If the destination format is not compatible, set destintation format to source format and print a warning.
+    // Yes, the expression in the if stmt is correct. It makes sure that the correct signed/unsigned formats
+    // are used for destformat and format.
+    if (FormatIsSINT(format) || FormatIsSINT(destformat) || FormatIsUINT(format) || FormatIsUINT(destformat)) {
+        // Print a warning if we need to change destformat
+        if (destformat != format) {
+            destformat = format;
+#ifdef ANDROID
+            __android_log_print(ANDROID_LOG_INFO, "screenshot",
+                                "Incompatible output format requested, changing output format to %s\n", string_VkFormat(destformat));
+#else
+            fprintf(stderr,
+                    "screenshot: Incompatible output format requested, changing output format to %s\n", string_VkFormat(destformat));
+#endif
+        }
     }
 
     if ((FormatCompatibilityClass(destformat) != FormatCompatibilityClass(format))) {
@@ -738,7 +762,7 @@ static bool writePPM(const char *filename, VkImage image1) {
             __android_log_print(ANDROID_LOG_DEBUG, "screenshot",
                                 "Output format not supported, screen capture failed");
 #else
-            fprintf(stderr, "Output format not supported, screen capture failed\n");
+            fprintf(stderr, "screenshot: Output format not supported, screen capture failed\n");
 #endif
             return false;
         } else if (!bltLinear && bltOptimal) {
@@ -1047,7 +1071,7 @@ static bool writePPM(const char *filename, VkImage image1) {
         __android_log_print(ANDROID_LOG_DEBUG, "screenshot",
                             "Failed to open output file: %s", filename);
 #else
-        fprintf(stderr, "Failed to open output file: %s\n", filename);
+        fprintf(stderr, "screenshot: Failed to open output file: %s\n", filename);
 #endif
         return false;
     }
@@ -1388,14 +1412,14 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
 #ifdef ANDROID
                     __android_log_print(ANDROID_LOG_INFO, "screenshot", "Screen capture file is: %s", fileName.c_str());
 #else
-                    printf("Screen Capture file is: %s \n", fileName.c_str());
+                    printf("screenshot: Capture file is: %s \n", fileName.c_str());
 #endif
                 }
             } else {
 #ifdef ANDROID
                 __android_log_print(ANDROID_LOG_ERROR, "screenshot", "Failure - no swapchain specified\n");
 #else
-                fprintf(stderr, "Screenshot failure - no swapchain specified\n");
+                fprintf(stderr, "screenshot: Failure - no swapchain specified\n");
 #endif
             }
             if (inScreenShotFrames) {


### PR DESCRIPTION
Validation error would occur when VK_SCREENSHOT_FORMAT was set
to SINT/UINT. Added code to override the output format for this
case and set it to the same as the swapchain image format.

Also changed wording in several error messages.

Fixes issue https://github.com/LunarG/VulkanTools/issues/1737