### PR TITLE
build: Disable -Werror for vkvia and vkconfig_core

### DIFF
--- a/via/CMakeLists.txt
+++ b/via/CMakeLists.txt
@@ -19,6 +19,8 @@ if(WIN32)
 
 else()
     if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+        # Disable -Werror because of warnings with jsoncpp and GCC 12
+        add_compile_options(-Wno-error)
         set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
         set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -fno-strict-aliasing -fno-builtin-memcmp")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_COMPILE_FLAGS} -fno-rtti")

--- a/vkconfig_core/CMakeLists.txt
+++ b/vkconfig_core/CMakeLists.txt
@@ -57,6 +57,11 @@ if(Qt5_FOUND)
         target_link_libraries(vkconfig_core Cfgmgr32)
     endif()
 
+    if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+        # Disable -Werror because of warnings with jsoncpp and GCC 12
+        add_compile_options(-Wno-error)
+    endif()
+
     target_include_directories(vkconfig_core PRIVATE "${Vulkan_INCLUDE_DIR}")
     target_link_libraries(vkconfig_core vku Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
     target_compile_definitions(vkconfig_core PRIVATE ${VKCONFIG_DEFINITIONS})


### PR DESCRIPTION
GCC 12 emits -Werror=maybe-uninitialized when compiling the jsoncpp dependency with -Werror. The least invasive solution is to just disable -Werror for vkvia and vkconfig_core which use jsoncpp.cpp.