### PR TITLE
Fix clang CI

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -81,6 +81,9 @@ jobs:
                               libx11-xcb-dev libxcb-randr0-dev cmake jq wget
     - name: Build and Test VulkanTools 
       run: python3 scripts/github_ci_linux.py --config ${{ matrix.config.type }}
+      env:
+        CC: ${{matrix.config.cc}}
+        CXX: ${{matrix.config.cxx}}
 
   windows:
     runs-on: ${{matrix.os}}

--- a/vkconfig_core/parameter.cpp
+++ b/vkconfig_core/parameter.cpp
@@ -82,8 +82,7 @@ Version ComputeMinApiVersion(const Version api_version, const std::vector<Parame
         const Layer* layer = FindByKey(layers, parameters[i].key.c_str());
         if (layer == nullptr) continue;
 
-        if (parameters[i].state && PARAMETER_RANK_EXCLUDED) continue;
-        if (parameters[i].state && PARAMETER_RANK_MISSING) continue;
+        if (parameters[i].state == LAYER_STATE_EXCLUDED) continue;
 
         min_version = min_version < layer->api_version ? min_version : layer->api_version;
     }


### PR DESCRIPTION
Two minor and related issues fixed here:
- #1744 
- The GitHub Actions clang build was using gcc instead of clang, so the first issue wasn't detected in CI.