### PR TITLE
vkconfig: Make built-in validation layer optional

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -13,10 +13,16 @@
 
 ## [Vulkan Configurator 2.5.1](https://github.com/LunarG/VulkanTools/tree/master) - October 2022
 
+### Features:
+- Add ENUM setting type children settings #1746
+
+### Improvements:
+- Allow disabling the validation layer settings built-in UI #1746
+
 ### Fixes:
 - Fix override layer version when some layers are excluded or missing #1743
 
-## [Vulkan Configurator 2.5.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.3.2224.0) - August 2022
+## [Vulkan Configurator 2.5.0](https://github.com/LunarG/VulkanTools/tree/sdk-1.3.224.0) - August 2022
 
 ### Features:
 - Add per layers-configuration user-defined layers paths #1711

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -52,6 +52,21 @@ static const char *TOOLTIP_ORDER =
 
 SettingsTreeManager::SettingsTreeManager() : tree(nullptr) {}
 
+bool SettingsTreeManager::UseBuiltinValidationUI(Parameter &parameter) const {
+    if (parameter.key != "VK_LAYER_KHRONOS_validation") {
+        return false;
+    }
+
+    for (std::size_t j = 0, m = parameter.settings.size(); j < m; ++j) {
+        const SettingData *setting_data = parameter.settings[j];
+        if (setting_data->key == "validation_control") {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
     assert(build_tree);
 
@@ -137,7 +152,7 @@ void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
                 this->connect(presets_combobox, SIGNAL(itemChanged()), this, SLOT(OnPresetChanged()));
             }
 
-            if (parameter.key == "VK_LAYER_KHRONOS_validation") {
+            if (UseBuiltinValidationUI(parameter)) {
                 BuildValidationTree(layer_item, parameter);
             } else {
                 BuildGenericTree(layer_item, parameter);
@@ -284,6 +299,7 @@ static bool IsBuiltinValidationSetting(const Parameter &parameter, const std::st
     keys.push_back("gpuav_buffer_oob");
     keys.push_back("validate_draw_indirect");
     keys.push_back("vma_linear_output");
+    keys.push_back("fine_grained_locking");
 
     return IsStringFound(keys, key);
 }

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -366,6 +366,19 @@ void SettingsTreeManager::BuildTreeItem(QTreeWidgetItem *parent, Parameter &para
 
             WidgetSettingEnum *enum_widget = new WidgetSettingEnum(tree, item, meta, parameter.settings);
             this->connect(enum_widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
+
+            SettingDataEnum *data = FindSetting<SettingDataEnum>(parameter.settings, meta.key.c_str());
+
+            for (std::size_t i = 0, n = meta.enum_values.size(); i < n; ++i) {
+                const SettingEnumValue &value = meta.enum_values[i];
+
+                if (!IsPlatformSupported(value.platform_flags)) continue;
+                if (value.view == SETTING_VIEW_HIDDEN) continue;
+
+                for (std::size_t i = 0, n = value.settings.size(); i < n; ++i) {
+                    this->BuildTreeItem(item, parameter, *value.settings[i]);
+                }
+            }
         } break;
 
         case SETTING_FLAGS: {

--- a/vkconfig/settings_tree.h
+++ b/vkconfig/settings_tree.h
@@ -57,6 +57,8 @@ class SettingsTreeManager : QObject {
     SettingsTreeManager(const SettingsTreeManager &) = delete;
     SettingsTreeManager &operator=(const SettingsTreeManager &) = delete;
 
+    bool UseBuiltinValidationUI(Parameter &parameter) const;
+
     void BuildValidationTree(QTreeWidgetItem *parent, Parameter &parameter);
     void BuildGenericTree(QTreeWidgetItem *parent, Parameter &parameter);
     void BuildTreeItem(QTreeWidgetItem *parent, Parameter &parameter, const SettingMeta &meta);

--- a/vkconfig/widget_setting_bool.cpp
+++ b/vkconfig/widget_setting_bool.cpp
@@ -42,11 +42,12 @@ WidgetSettingBool::WidgetSettingBool(QTreeWidget* tree, QTreeWidgetItem* item, c
 }
 
 void WidgetSettingBool::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, this->data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, this->data_set);
 
-    this->item->setDisabled(!enabled);
-    this->field->setEnabled(enabled);
-    this->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -143,7 +143,9 @@ void WidgetSettingEnum::OnIndexChanged(int index) {
     } else {
         assert(index >= 0 && index < static_cast<int>(this->meta.enum_values.size()));
 
-        this->data().value = this->meta.enum_values[enum_indexes[static_cast<std::size_t>(index)]].key;
+        const std::size_t value_index = enum_indexes[static_cast<std::size_t>(index)];
+        this->data().value = this->meta.enum_values[value_index].key;
+        this->field->setToolTip(this->meta.enum_values[value_index].description.c_str());
     }
 
     emit itemChanged();

--- a/vkconfig/widget_setting_enum.cpp
+++ b/vkconfig/widget_setting_enum.cpp
@@ -56,11 +56,12 @@ WidgetSettingEnum::WidgetSettingEnum(QTreeWidget* tree, QTreeWidgetItem* item, c
 }
 
 void WidgetSettingEnum::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->field->setEnabled(enabled);
-    this->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (meta.default_value == "${VP_DEFAULT}") {
         if (::CheckSettingOverridden(this->meta)) {
@@ -72,7 +73,7 @@ void WidgetSettingEnum::Refresh(RefreshAreas refresh_areas) {
         this->enum_indexes.clear();
 
         const std::vector<std::string>& profiles = GetProfileNames(data_set);
-        this->item->setHidden(profiles.size() <= 1);
+        this->item->setHidden(profiles.size() <= 1 || enabled == SETTING_DEPENDENCE_HIDE);
 
         int selection = 0;
         const std::string value = this->data().value;
@@ -96,6 +97,7 @@ void WidgetSettingEnum::Refresh(RefreshAreas refresh_areas) {
 
         int selection = 0;
         const std::string value = this->data().value;
+
         for (std::size_t i = 0, n = this->meta.enum_values.size(); i < n; ++i) {
             if (!IsSupported(&this->meta.enum_values[i])) continue;
 
@@ -143,6 +145,7 @@ void WidgetSettingEnum::OnIndexChanged(int index) {
 
         this->data().value = this->meta.enum_values[enum_indexes[static_cast<std::size_t>(index)]].key;
     }
+
     emit itemChanged();
 }
 

--- a/vkconfig/widget_setting_filesystem.cpp
+++ b/vkconfig/widget_setting_filesystem.cpp
@@ -62,13 +62,14 @@ WidgetSettingFilesystem::WidgetSettingFilesystem(QTreeWidget* tree, QTreeWidgetI
 }
 
 void WidgetSettingFilesystem::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->item_child->setDisabled(!enabled);
-    this->setEnabled(enabled);
-    this->field->setEnabled(enabled);
-    this->button->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->item_child->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->button->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         LoadFile(this->data().value);

--- a/vkconfig/widget_setting_flags.cpp
+++ b/vkconfig/widget_setting_flags.cpp
@@ -53,11 +53,12 @@ WidgetSettingFlag::WidgetSettingFlag(QTreeWidget* tree, QTreeWidgetItem* item, c
 }
 
 void WidgetSettingFlag::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->field->setEnabled(enabled);
-    this->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {

--- a/vkconfig/widget_setting_float.cpp
+++ b/vkconfig/widget_setting_float.cpp
@@ -68,11 +68,12 @@ WidgetSettingFloat::~WidgetSettingFloat() {
 }
 
 void WidgetSettingFloat::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->setEnabled(enabled);
-    this->field->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {

--- a/vkconfig/widget_setting_frames.cpp
+++ b/vkconfig/widget_setting_frames.cpp
@@ -68,11 +68,12 @@ WidgetSettingFrames::~WidgetSettingFrames() {
 }
 
 void WidgetSettingFrames::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->setEnabled(enabled);
-    this->field->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {

--- a/vkconfig/widget_setting_int.cpp
+++ b/vkconfig/widget_setting_int.cpp
@@ -67,11 +67,12 @@ WidgetSettingInt::~WidgetSettingInt() {
 }
 
 void WidgetSettingInt::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->field->setEnabled(enabled);
-    this->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {

--- a/vkconfig/widget_setting_list.cpp
+++ b/vkconfig/widget_setting_list.cpp
@@ -88,12 +88,13 @@ WidgetSettingList::WidgetSettingList(QTreeWidget *tree, QTreeWidgetItem *item, c
 }
 
 void WidgetSettingList::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->setEnabled(enabled);
-    this->field->setEnabled(enabled && (!this->meta.list_only || !this->list.empty()));
-    this->add_button->setEnabled(enabled && !this->field->text().isEmpty());
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE && (!this->meta.list_only || !this->list.empty()));
+    this->add_button->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE && !this->field->text().isEmpty());
 
     if (this->meta.list_only && this->list.empty()) {
         this->field->hide();

--- a/vkconfig/widget_setting_list_element.cpp
+++ b/vkconfig/widget_setting_list_element.cpp
@@ -57,11 +57,12 @@ WidgetSettingListElement::WidgetSettingListElement(QTreeWidget* tree, QTreeWidge
 }
 
 void WidgetSettingListElement::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->setEnabled(enabled);
-    this->button->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->button->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {

--- a/vkconfig/widget_setting_string.cpp
+++ b/vkconfig/widget_setting_string.cpp
@@ -49,11 +49,12 @@ WidgetSettingString::WidgetSettingString(QTreeWidget* tree, QTreeWidgetItem* ite
 }
 
 void WidgetSettingString::Refresh(RefreshAreas refresh_areas) {
-    const bool enabled = ::CheckDependence(this->meta, data_set);
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, data_set);
 
-    this->item->setDisabled(!enabled);
-    this->field->setEnabled(enabled);
-    this->setEnabled(enabled);
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->field->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
 
     if (refresh_areas == REFRESH_ENABLE_AND_STATE) {
         if (::CheckSettingOverridden(this->meta)) {

--- a/vkconfig_core/override.cpp
+++ b/vkconfig_core/override.cpp
@@ -239,7 +239,7 @@ bool WriteSettingsOverride(const std::vector<Layer>& available_layers, const Con
             stream << "\n";
 
             // If feature has unmet dependency, output it but comment it out
-            if (!::CheckDependence(*meta, parameter.settings)) {
+            if (::CheckDependence(*meta, parameter.settings) != SETTING_DEPENDENCE_ENABLE) {
                 stream << "#";
             }
 

--- a/vkconfig_core/setting.h
+++ b/vkconfig_core/setting.h
@@ -28,6 +28,8 @@
 
 #include <QJsonObject>
 
+enum SettingDependenceMode { SETTING_DEPENDENCE_DISABLE = 0, SETTING_DEPENDENCE_HIDE, SETTING_DEPENDENCE_ENABLE };
+
 enum SettingInputError {
     SETTING_INPUT_NO_ERROR = 0,
     SETTING_INPUT_ERROR_EMPTY,
@@ -197,7 +199,7 @@ bool CheckSettingOverridden(const SettingMeta& meta);
 
 std::string GetSettingOverride(const SettingMeta& meta);
 
-bool CheckDependence(const SettingMeta& meta, const SettingDataSet& data_set);
+SettingDependenceMode CheckDependence(const SettingMeta& meta, const SettingDataSet& data_set);
 
 template <typename SETTING_DATA>
 inline SETTING_DATA* Instantiate(SettingMeta* meta) {


### PR DESCRIPTION
This is what the validation layer settings would look like with the refactor of the layer manfest :

![validation data-driven](https://user-images.githubusercontent.com/62888873/191323990-675f6da2-cac8-480c-8742-eed252343bb7.gif)
