### PR TITLE
monitor: add include dlfcn.h

### DIFF
--- a/layersvt/monitor.cpp
+++ b/layersvt/monitor.cpp
@@ -32,6 +32,10 @@
 #include <vulkan/vk_layer.h>
 #include <vulkan/vulkan.h>
 
+#if defined(__linux__ )
+#include <dlfcn.h>
+#endif
+
 #if (!defined(VK_USE_PLATFORM_XCB_KHR) && !defined(VK_USE_PLATFORM_WIN32_KHR))
 #warning "Monitor layer only has code for XCB and Windows at this time"
 #endif


### PR DESCRIPTION
Error building on Ubuntu 20.04.

```
[  1%] Building CXX object layersvt/CMakeFiles/VkLayer_monitor.dir/monitor.cpp.o
/vulkan-sdk/1.3.230.0/source/VulkanTools/layersvt/monitor.cpp: In function 'VkResult vkCreateInstance(const VkInstanceCreateInfo*, const VkAllocationCallbacks*, VkInstance_T**)':
/vulkan-sdk/1.3.230.0/source/VulkanTools/layersvt/monitor.cpp:207:42: error: 'RTLD_NOW' was not declared in this scope
         xcb.xcbLib = dlopen("libxcb.so", RTLD_NOW | RTLD_LOCAL);
                                          ^~~~~~~~
/vulkan-sdk/1.3.230.0/source/VulkanTools/layersvt/monitor.cpp:207:53: error: 'RTLD_LOCAL' was not declared in this scope
         xcb.xcbLib = dlopen("libxcb.so", RTLD_NOW | RTLD_LOCAL);
                                                     ^~~~~~~~~~
/vulkan-sdk/1.3.230.0/source/VulkanTools/layersvt/monitor.cpp:207:22: error: 'dlopen' was not declared in this scope
         xcb.xcbLib = dlopen("libxcb.so", RTLD_NOW | RTLD_LOCAL);
                      ^~~~~~
/vulkan-sdk/1.3.230.0/source/VulkanTools/layersvt/monitor.cpp:207:22: note: suggested alternative: 'popen'
         xcb.xcbLib = dlopen("libxcb.so", RTLD_NOW | RTLD_LOCAL);
                      ^~~~~~
                      popen
/vulkan-sdk/1.3.230.0/source/VulkanTools/layersvt/monitor.cpp:209:85: error: 'dlsym' was not declared in this scope
             xcb.change_property = reinterpret_cast<decltype(xcb_change_property) *>(dlsym(xcb.xcbLib, "xcb_change_property"));

```