### PR TITLE
layer_factory: Guard against win32 defines

### DIFF
--- a/scripts/layer_factory_generator.py
+++ b/scripts/layer_factory_generator.py
@@ -167,6 +167,20 @@ class LayerFactoryOutputGenerator(OutputGenerator):
 #include <string.h>
 #include <mutex>
 
+#include <vulkan/vulkan.h>
+
+#if defined(WIN32)
+/* Windows-specific common code: */
+// WinBase.h defines CreateSemaphore and synchapi.h defines CreateEvent
+//  undefine them to avoid conflicts with VkLayerDispatchTable struct members.
+#ifdef CreateSemaphore
+#undef CreateSemaphore
+#endif
+#ifdef CreateEvent
+#undef CreateEvent
+#endif
+#endif
+
 #define VALIDATION_ERROR_MAP_IMPL
 
 #include "vk_dispatch_table_helper.h"


### PR DESCRIPTION
CreateEvent and CreateSemaphore are macros defined in some windows header file, and the Validation layers moved this guard in such a way that the layer factory no longer is protected from it. The simplest fix is to manually include vulkan, which will include various windows headers, undefine the offending names, then include the layer_dispatch_table (which contains the macro defined names).
