### PR TITLE
Removed DevSim references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The repository contains the following Vulkan Tools:
 - [Vulkan Configurator](vkconfig/README.md)
-- [`VK_LAYER_LUNARG_api_dump`, `VK_LAYER_LUNARG_device_simulation`, `VK_LAYER_LUNARG_screenshot` and `VK_LAYER_LUNARG_monitor` layers](layersvt/README.md)
+- [`VK_LAYER_LUNARG_api_dump`, `VK_LAYER_LUNARG_screenshot` and `VK_LAYER_LUNARG_monitor` layers](layersvt/README.md)
 - [Vulkan Installation Analyzer](via/README.md)
 
 These tools have binaries included within the [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/).

--- a/layersvt/README.md
+++ b/layersvt/README.md
@@ -33,9 +33,6 @@ To specify frames to be captured, the environment variable 'VK_SCREENSHOT_FRAMES
 ### View Frames Per Second
 layersvt/monitor.cpp - utility layer that will display an applications FPS in the title bar of a windowed application.
 
-### Device Simulation
-layersvt/device_simulation.cpp (name='VK_LAYER_LUNARG_device_simulation') - A utility layer to simulate a device with different capabilities than the actual hardware in the system.  See device_simulation.md for details.
-
 ## Using Layers
 
 1. Build VK loader using normal steps (cmake and make)


### PR DESCRIPTION
Docs still mentioned `VK_LAYER_LUNARG_device_simulation` in a couple of places.