### PR TITLE
vkconfig: include <limits>

### DIFF
--- a/update_external_sources.sh
+++ b/update_external_sources.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+PYTHON=$(which python python3 | head -1)
+
 set -e
 
 if [[ $(uname) == "Linux" || $(uname) == "FreeBSD" || $(uname) =~ "CYGWIN" || $(uname) =~ "MINGW" ]]; then
     CURRENT_DIR="$(dirname "$(readlink -f ${BASH_SOURCE[0]})")"
     CORE_COUNT=$(nproc || echo 4)
 elif [[ $(uname) == "Darwin" ]]; then
-    CURRENT_DIR="$(dirname "$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ${BASH_SOURCE[0]})")"
+    CURRENT_DIR="$(dirname "$($PYTHON -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ${BASH_SOURCE[0]})")"
     CORE_COUNT=$(sysctl -n hw.ncpu || echo 4)
 fi
 echo CURRENT_DIR=$CURRENT_DIR
@@ -19,5 +21,5 @@ git submodule update --init --recursive
 
 echo "Building ${BASEDIR}/jsoncpp"
 cd ${BASEDIR}/jsoncpp
-python amalgamate.py
+$PYTHON amalgamate.py
 

--- a/vkconfig_core/setting.h
+++ b/vkconfig_core/setting.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <vector>
 #include <cassert>
+#include <limits>
 
 #include <QJsonObject>
 


### PR DESCRIPTION
This seemed to work fine on older Linux distributions (e.g. Ubuntu 16.04),
probably because the header file was implicitly included somewhere;
but it fails on newer distributions (e.g. Ubuntu 22.04).

Always explicitly including <limits> is painless and lets the project
build on all Linux versions.
