### PR TITLE
android: limit parallel builds

### DIFF
--- a/build-android/build_all.sh
+++ b/build-android/build_all.sh
@@ -29,6 +29,7 @@ if [[ $(uname) == "Linux" ]]; then
 elif [[ $(uname) == "Darwin" ]]; then
     cores=$(sysctl -n hw.ncpu) || echo 4
 fi
+use_cores=${VT_BUILD_CORES:-$cores}
 
 function findtool() {
     if [[ ! $(type -t $1) ]]; then
@@ -66,7 +67,7 @@ function create_APK() {
 #
 ./update_external_sources_android.sh --no-build
 ./android-generate.sh
-ndk-build -j $cores
+ndk-build -j $use_cores -l $use_cores
 
 #
 # build VulkanLayerValidationTests APK


### PR DESCRIPTION
The Android build is quite aggressive, attempting to consume all available cores; large builds (particularly the api_dump layer) cause all the processes involved to consume 3+G of memory, causing physical and swap memory to be exhausted, which causes sporadic build failures as the OOM killer kills the compiler processes.

These changes allow the use of an environment variable $VT_BUILD_CORES to limit how many cores are in use; it also prevents the build from using additional parallel jobs if the load average is too high (on one 8-core system, the load average climbed to over 26 before the OOM killer started killing processes).