### PR TITLE
Refactor api dump

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -1182,7 +1182,12 @@ void dump_json_function_head(ApiDumpInstance &dump_inst, const char *funcName, c
     }
 
     // Display return value
-    settings.stream() << settings.indentation(3) << "\"returnType\" : \"" << funcReturn << "\",\n";
+    settings.stream() << settings.indentation(3) << "\"returnType\" : \"" << funcReturn << "\"";
+    // Add a trailing comma if the return type isn't void or detailed mode is false - JSON doesn't allow trailing commas in object
+    if (strcmp("void", funcReturn) != 0 || settings.showParams()) {
+        settings.stream() << ",";
+    }
+    settings.stream() << "\n";
 
     settings.shouldFlush() ? settings.stream() << std::flush : settings.stream();
 }
@@ -1356,6 +1361,15 @@ void dump_json_special(const char *text, const ApiDumpSettings &settings, const 
     settings.stream() << ",\n";
     settings.stream() << settings.indentation(indents + 1) << "\"value\" : ";
     settings.stream() << "\"" << text << "\"\n";
+    settings.stream() << settings.indentation(indents) << "}";
+}
+
+void dump_json_UNUSED(const ApiDumpSettings &settings, const char *type_string, const char *name, int indents) {
+    settings.stream() << settings.indentation(indents) << "{\n";
+    settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
+    settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
+    settings.stream() << settings.indentation(indents + 1) << "\"address\" : \"UNUSED\",\n";
+    settings.stream() << settings.indentation(indents + 1) << "\"value\" : \"UNUSED\"\n";
     settings.stream() << settings.indentation(indents) << "}";
 }
 

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -1284,7 +1284,7 @@ extern bool is_struct(const char *t);
 template <typename T>
 void dump_json_value(const T object, const void *pObject, const ApiDumpSettings &settings, const char *type_string,
                      const char *name, int indents, void (*dump)(const T, const ApiDumpSettings &, int)) {
-    bool isPnext = !strcmp(name, "pNext") | !strcmp(name, "pUserData");
+    bool isPnext = !strcmp(name, "pNext") || !strcmp(name, "pUserData");
     const char *star = (isPnext && !strstr(type_string, "void")) ? "*" : "";
     settings.stream() << settings.indentation(indents) << "{\n";
     if (is_union(type_string))
@@ -1312,7 +1312,7 @@ void dump_json_value(const T object, const void *pObject, const ApiDumpSettings 
 template <typename T>
 void dump_json_value(const T &object, const void *pObject, const ApiDumpSettings &settings, const char *type_string,
                      const char *name, int indents, void (*dump)(const T &, const ApiDumpSettings &, int)) {
-    bool isPnext = !strcmp(name, "pNext") | !strcmp(name, "pUserData");
+    bool isPnext = !strcmp(name, "pNext") || !strcmp(name, "pUserData");
     const char *star = (isPnext && !strstr(type_string, "void")) ? "*" : "";
     settings.stream() << settings.indentation(indents) << "{\n";
     if (is_union(type_string))

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -611,7 +611,14 @@ class ApiDumpSettings {
 
     // Utility member to convert from string to a boolean
     bool GetStringBooleanValue(const std::string &value) {
-        if (ToLowerString(value) == "true") {
+        auto lower_str = ToLowerString(value);
+        if (lower_str == "true") {
+            return true;
+        }
+        if (lower_str == "on") {
+            return true;
+        }
+        if (lower_str == "1") {
             return true;
         }
         return false;
@@ -892,7 +899,7 @@ void dump_text_function_head(ApiDumpInstance &dump_inst, const char *funcName, c
 template <typename T>
 void dump_text_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string, const char *child_type,
                      const char *name, int indents, void (*dump)(const T, const ApiDumpSettings &, int)) {
-    settings.formatNameType( indents, name, type_string);
+    settings.formatNameType(indents, name, type_string);
     if (array == NULL) {
         settings.stream() << "NULL\n";
         return;

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -872,8 +872,8 @@ class ApiDumpInstance {
 // Utility to output an address.
 // If the quotes arg is true, the address is encloded in quotes.
 // Used for text, html, and json output.
-void OutputAddress(const ApiDumpSettings &settings, const void *addr, bool quotes) {
-    if (quotes) settings.stream() << "\"";
+void OutputAddress(const ApiDumpSettings &settings, const void *addr) {
+    if (settings.format() == ApiDumpFormat::Json) settings.stream() << "\"";
     if (settings.showAddress())
         if (addr == NULL)
             settings.stream() << "NULL";
@@ -881,21 +881,10 @@ void OutputAddress(const ApiDumpSettings &settings, const void *addr, bool quote
             settings.stream() << addr;
     else
         settings.stream() << "address";
-    if (quotes) settings.stream() << "\"";
+    if (settings.format() == ApiDumpFormat::Json) settings.stream() << "\"";
 }
 
 ApiDumpInstance ApiDumpInstance::current_instance;
-
-//===================================== Common Printers ==========================================//
-
-bool dump_bitmaskOption(const std::string &option, std::ostream &stream, bool isFirst) {
-    if (isFirst)
-        stream << " (";
-    else
-        stream << " | ";
-    stream << option;
-    return false;
-}
 
 //==================================== Text Backend Helpers ======================================//
 
@@ -926,7 +915,7 @@ void dump_text_array(const T *array, size_t len, const ApiDumpSettings &settings
         settings.stream() << "NULL\n";
         return;
     }
-    OutputAddress(settings, array, false);
+    OutputAddress(settings, array);
     settings.stream() << "\n";
     for (size_t i = 0; i < len && array != NULL; ++i) {
         std::stringstream stream;
@@ -944,7 +933,7 @@ void dump_text_array(const T *array, size_t len, const ApiDumpSettings &settings
         settings.stream() << "NULL\n";
         return;
     }
-    OutputAddress(settings, array, false);
+    OutputAddress(settings, array);
     settings.stream() << "\n";
     for (size_t i = 0; i < len && array != NULL; ++i) {
         std::stringstream stream;
@@ -1008,7 +997,7 @@ void dump_text_void(const void *object, const ApiDumpSettings &settings, int ind
         settings.stream() << "NULL";
         return;
     }
-    OutputAddress(settings, object, false);
+    OutputAddress(settings, object);
     settings.stream();
 }
 
@@ -1059,7 +1048,7 @@ void dump_html_array(const T *array, size_t len, const ApiDumpSettings &settings
     settings.stream() << "<details class='data'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
     settings.stream() << "<div class='val'>";
-    OutputAddress(settings, array, false);
+    OutputAddress(settings, array);
     settings.stream() << "\n";
     settings.stream() << "</div></summary>";
     for (size_t i = 0; i < len && array != NULL; ++i) {
@@ -1083,7 +1072,7 @@ void dump_html_array(const T *array, size_t len, const ApiDumpSettings &settings
     settings.stream() << "<details class='data'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
     settings.stream() << "<div class='val'>";
-    OutputAddress(settings, array, false);
+    OutputAddress(settings, array);
     settings.stream() << "\n";
     settings.stream() << "</div></summary>";
     for (size_t i = 0; i < len && array != NULL; ++i) {
@@ -1154,7 +1143,7 @@ void dump_html_cstring(const char *object, const ApiDumpSettings &settings, int 
 
 void dump_html_void(const void *object, const ApiDumpSettings &settings, int indents) {
     settings.stream() << "<div class='val'>";
-    OutputAddress(settings, object, false);
+    OutputAddress(settings, object);
     settings.stream() << "</div>";
 }
 
@@ -1214,7 +1203,7 @@ void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, array, true);
+        OutputAddress(settings, array);
         settings.stream() << "\n";
         settings.stream() << settings.indentation(indents) << "}";
         return;
@@ -1225,7 +1214,7 @@ void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, array, true);
+        OutputAddress(settings, array);
         settings.stream() << ",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"elements\" :\n";
         settings.stream() << settings.indentation(indents + 1) << "[\n";
@@ -1250,7 +1239,7 @@ void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, array, true);
+        OutputAddress(settings, array);
         settings.stream() << "\n";
         settings.stream() << settings.indentation(indents) << "}";
         return;
@@ -1260,7 +1249,7 @@ void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, array, true);
+        OutputAddress(settings, array);
         settings.stream() << ",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"elements\" :\n";
         settings.stream() << settings.indentation(indents + 1) << "[\n";
@@ -1285,8 +1274,7 @@ void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings, const 
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, NULL, true);
-        settings.stream() << "\n";
+        settings.stream() << (settings.showAddress() ? "\"NULL\"" : "\"address\"") << "\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {
         dump_json_value(*pointer, pointer, settings, type_string, name, indents, dump);
@@ -1301,8 +1289,7 @@ void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings, const 
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, NULL, true);
-        settings.stream() << "\n";
+        settings.stream() << (settings.showAddress() ? "\"NULL\"" : "\"address\"") << "\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {
         dump_json_value(*pointer, pointer, settings, type_string, name, indents, dump);
@@ -1326,7 +1313,7 @@ void dump_json_value(const T object, const void *pObject, const ApiDumpSettings 
     if (isPnext || (strchr(type_string, '*') && strcmp(type_string, "const char*") && strcmp(type_string, "const char* const"))) {
         // Print pointers, except for char string pointers
         settings.stream() << ",\n" << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, pObject, true);
+        OutputAddress(settings, pObject);
     }
     if (!isPnext || (isPnext && pObject != nullptr)) {
         settings.stream() << ",\n";
@@ -1354,7 +1341,7 @@ void dump_json_value(const T &object, const void *pObject, const ApiDumpSettings
     if (isPnext || (strchr(type_string, '*') && strcmp(type_string, "const char*") && strcmp(type_string, "const char* const"))) {
         // Print pointers, except for char string pointers
         settings.stream() << ",\n" << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, pObject, true);
+        OutputAddress(settings, pObject);
     }
     if (!isPnext || (isPnext && pObject != nullptr)) {
         settings.stream() << ",\n";
@@ -1373,7 +1360,7 @@ void dump_json_special(const char *text, const ApiDumpSettings &settings, const 
     settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
     settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
     settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-    OutputAddress(settings, text, true);
+    OutputAddress(settings, text);
     settings.stream() << ",\n";
     settings.stream() << settings.indentation(indents + 1) << "\"value\" : ";
     settings.stream() << "\"" << text << "\"\n";
@@ -1388,15 +1375,13 @@ void dump_json_cstring(const char *object, const ApiDumpSettings &settings, int 
 }
 
 void dump_json_void(const void *object, const ApiDumpSettings &settings, int indents) {
-    OutputAddress(settings, object, true);
+    OutputAddress(settings, object);
     settings.stream() << "\n";
-    settings.stream();
 }
 
 void dump_json_int(int object, const ApiDumpSettings &settings, int indents) {
-    settings.stream() << settings.indentation(indents) << "\"value\" : ";
+    settings.stream() << settings.indentation(indents) << "\"value\" : " << '"' << object << "\"";
     settings.stream() << '"' << object << "\"";
-    settings.stream();
 }
 
 template <typename T>
@@ -1409,7 +1394,7 @@ void dump_json_pNext(const T *object, const ApiDumpSettings &settings, const cha
                           << "pNext"
                           << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, NULL, true);
+        OutputAddress(settings, NULL);
         settings.stream() << ",\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {
@@ -1427,7 +1412,7 @@ void dump_json_pNext(const T *object, const ApiDumpSettings &settings, const cha
                           << "pNext"
                           << "\",\n";
         settings.stream() << settings.indentation(indents + 1) << "\"address\" : ";
-        OutputAddress(settings, NULL, true);
+        OutputAddress(settings, NULL);
         settings.stream() << ",\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -528,9 +528,10 @@ class ApiDumpSettings {
 
         if (show_type) {
             if (use_spaces)
-                output_stream << type << std::setw(type_size - (int)strlen(type)) << " = ";
+                output_stream << std::left << std::setw(type_size) << type << " = ";
             else
-                output_stream << type << std::setw((type_size - (int)strlen(type) - 1 + tab_size) / tab_size) << " = ";
+                output_stream << type << std::setw((type_size - (int)strlen(type) - 1 + tab_size) / tab_size) << ""
+                              << " = ";
         } else {
             output_stream << " = ";
         }

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -995,13 +995,12 @@ void dump_text_int(int object, const ApiDumpSettings &settings, int indents) { s
 template <typename T>
 void dump_text_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
                      void (*dump)(const T &, const ApiDumpSettings &, int)) {
-    if (object == NULL)
+    if (object == NULL) {
         settings.stream() << "NULL";
-    else if (settings.showAddress()) {
+    } else {
         settings.formatNameType(indents, "pNext", type_string);
         dump(*object, settings, indents);
-    } else
-        settings.stream() << "address";
+    }
 }
 
 //==================================== Html Backend Helpers ======================================//

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -802,6 +802,8 @@ class ApiDumpInstance {
     void setIsDynamicViewport(bool is_dynamic_viewport) { this->is_dynamic_viewport = is_dynamic_viewport; }
     bool getIsDynamicScissor() const { return is_dynamic_scissor; }
     bool getIsDynamicViewport() const { return is_dynamic_viewport; }
+    void setMemoryHeapCount(uint32_t memory_heap_count) { this->memory_heap_count = memory_heap_count; }
+    uint32_t getMemoryHeapCount() { return memory_heap_count; }
 
     std::chrono::microseconds current_time_since_start() {
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
@@ -854,6 +856,9 @@ class ApiDumpInstance {
     // respective dynamic state is set.
     bool is_dynamic_scissor;
     bool is_dynamic_viewport;
+
+    // Storage for VkPhysicalDeviceMemoryBudgetPropertiesEXT which needs the number of heaps from VkPhysicalDeviceMemoryProperties
+    uint32_t memory_heap_count;
 };
 
 // Utility to output an address.

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -441,6 +441,11 @@ class ApiDumpSettings {
             stream() << "[\n";
         }
 
+        if (use_spaces)
+            stream() << std::setfill(' ');
+        else
+            stream() << std::setfill('\t');
+
         if (isFrameInRange(0)) {
             setupInterFrameOutputFormatting(0);
         }
@@ -519,18 +524,20 @@ class ApiDumpSettings {
 
     std::ostream &formatNameType(std::ostream &stream, int indents, const char *name, const char *type) const {
         stream << indentation(indents) << name << ": ";
-
         if (use_spaces)
-            stream << std::setfill(' ') << std::setw(name_size - (int)strlen(name) - 2);
+            stream << std::setw(name_size - (int)strlen(name) - 2) << "";
         else
-            stream << std::setfill('\t') << std::setw((name_size - (int)strlen(name) - 3 + indent_size) / indent_size);
+            stream << std::setw((name_size - (int)strlen(name) - 3 + indent_size) / indent_size) << "";
 
-        if (show_type && use_spaces)
-            stream << type << std::setfill(' ') << std::setw(type_size - (int)strlen(type));
-        else if (show_type && !use_spaces)
-            stream << type << std::setfill('\t') << std::setw((type_size - (int)strlen(type) - 1 + indent_size) / indent_size);
-
-        return stream << " = ";
+        if (show_type) {
+            if (use_spaces)
+                stream << type << std::setw(type_size - (int)strlen(type)) << " = ";
+            else
+                stream << type << std::setw((type_size - (int)strlen(type) - 1 + indent_size) / indent_size) << " = ";
+        } else {
+            stream << " = ";
+        }
+        return stream;
     }
 
     inline const char *indentation(int indents) const {

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -992,7 +992,6 @@ void dump_text_void(const void *object, const ApiDumpSettings &settings, int ind
         return;
     }
     OutputAddress(settings, object);
-    settings.stream();
 }
 
 void dump_text_int(int object, const ApiDumpSettings &settings, int indents) { settings.stream() << object; }

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -101,7 +101,7 @@ class ConditionalFrameOutput {
         uint32_t length;
     };
 
-    inline NumberToken parseNumber(std::string str, uint32_t current_char) {
+    NumberToken parseNumber(std::string str, uint32_t current_char) {
         uint32_t length = 0;
         while (current_char + length < str.size() && str[current_char + length] >= '0' && str[current_char + length] <= '9') {
             length++;
@@ -114,7 +114,7 @@ class ConditionalFrameOutput {
         }
     }
 
-    inline void printErrorMsg(const char *msg) {
+    void printErrorMsg(const char *msg) {
 #ifdef ANDROID
         __android_log_print(ANDROID_LOG_DEBUG, "api_dump", "%s", msg);
 #else
@@ -520,7 +520,7 @@ class ApiDumpSettings {
         }
     }
 
-    inline ApiDumpFormat format() const { return output_format; }
+    ApiDumpFormat format() const { return output_format; }
 
     std::ostream &formatNameType(std::ostream &stream, int indents, const char *name, const char *type) const {
         stream << indentation(indents) << name << ": ";
@@ -550,36 +550,36 @@ class ApiDumpSettings {
         }
     }
 
-    inline bool shouldFlush() const { return should_flush; }
+    bool shouldFlush() const { return should_flush; }
 
-    inline bool showAddress() const { return show_address; }
+    bool showAddress() const { return show_address; }
 
-    inline bool showParams() const { return show_params; }
+    bool showParams() const { return show_params; }
 
-    inline bool showShader() const { return show_shader; }
+    bool showShader() const { return show_shader; }
 
-    inline bool showType() const { return show_type; }
+    bool showType() const { return show_type; }
 
-    inline bool showTimestamp() const { return show_timestamp; }
+    bool showTimestamp() const { return show_timestamp; }
 
-    inline bool showThreadAndFrame() const { return show_thread_and_frame; }
+    bool showThreadAndFrame() const { return show_thread_and_frame; }
 
-    inline std::ostream &stream() const { return use_cout ? std::cout : *(std::ofstream *)&output_stream; }
+    std::ostream &stream() const { return use_cout ? std::cout : *(std::ofstream *)&output_stream; }
 
-    inline std::string directory() const { return output_dir; }
+    std::string directory() const { return output_dir; }
 
-    inline bool isFrameInRange(uint64_t frame) const { return condFrameOutput.isFrameInRange(frame); }
+    bool isFrameInRange(uint64_t frame) const { return condFrameOutput.isFrameInRange(frame); }
 
    private:
     // Utility member to enable easier comparison by forcing a string to all lower-case
-    inline static std::string ToLowerString(const std::string &value) {
+    static std::string ToLowerString(const std::string &value) {
         std::string lower_value = value;
         std::transform(lower_value.begin(), lower_value.end(), lower_value.begin(), ::tolower);
         return lower_value;
     }
 
     // Utility member for getting a platform environment variable on various platforms.
-    inline std::string GetPlatformEnvVar(const std::string &var) {
+    std::string GetPlatformEnvVar(const std::string &var) {
         std::string ret_string = "";
 #ifdef _WIN32
         char temp[MAX_STRING_LENGTH];
@@ -618,14 +618,14 @@ class ApiDumpSettings {
     }
 
     // Utility member to convert from string to a boolean
-    inline bool GetStringBooleanValue(const std::string &value) {
+    bool GetStringBooleanValue(const std::string &value) {
         if (ToLowerString(value) == "true") {
             return true;
         }
         return false;
     }
 
-    inline static bool readBoolOption(const char *option, bool default_value) {
+    static bool readBoolOption(const char *option, bool default_value) {
         const char *string_option = getLayerOption(option);
         if (string_option == NULL) return default_value;
         std::string lowered_option = ToLowerString(std::string(string_option));
@@ -637,7 +637,7 @@ class ApiDumpSettings {
             return default_value;
     }
 
-    inline static int readIntOption(const char *option, int default_value) {
+    static int readIntOption(const char *option, int default_value) {
         const char *string_option = getLayerOption(option);
         int value;
         if (sscanf(string_option, "%d", &value) != 1) {
@@ -647,7 +647,7 @@ class ApiDumpSettings {
         }
     }
 
-    inline static ApiDumpFormat readFormatOption(const char *option, ApiDumpFormat default_value) {
+    static ApiDumpFormat readFormatOption(const char *option, ApiDumpFormat default_value) {
         const char *string_option = getLayerOption(option);
         std::string lowered_option = ToLowerString(std::string(string_option));
         if (lowered_option == "text")
@@ -683,11 +683,16 @@ class ApiDumpSettings {
 
 class ApiDumpInstance {
    public:
-    inline ApiDumpInstance() : dump_settings(NULL), frame_count(0), thread_count(0) {
+    ApiDumpInstance() noexcept : dump_settings(NULL), frame_count(0), thread_count(0) {
         program_start = std::chrono::system_clock::now();
     }
+    // Can't copy or move this type
+    ApiDumpInstance(const ApiDumpInstance &) = delete;
+    ApiDumpInstance &operator=(const ApiDumpInstance &) = delete;
+    ApiDumpInstance(ApiDumpInstance &&) = delete;
+    ApiDumpInstance &operator=(ApiDumpInstance &&) = delete;
 
-    inline ~ApiDumpInstance() {
+    ~ApiDumpInstance() {
         if (!dump_settings) return;
 
         if (!first_func_call_on_frame) settings().closeFrameOutput();
@@ -695,13 +700,13 @@ class ApiDumpInstance {
         delete dump_settings;
     }
 
-    inline uint64_t frameCount() {
+    uint64_t frameCount() {
         std::lock_guard<std::recursive_mutex> lg(frame_mutex);
         uint64_t count = frame_count;
         return count;
     }
 
-    inline void nextFrame() {
+    void nextFrame() {
         std::lock_guard<std::recursive_mutex> lg(frame_mutex);
         ++frame_count;
 
@@ -710,7 +715,7 @@ class ApiDumpInstance {
         first_func_call_on_frame = true;
     }
 
-    inline bool shouldDumpOutput() {
+    bool shouldDumpOutput() {
         if (!conditional_initialized) {
             should_dump_output = settings().isFrameInRange(frame_count);
             conditional_initialized = true;
@@ -718,7 +723,7 @@ class ApiDumpInstance {
         return should_dump_output;
     }
 
-    inline bool firstFunctionCallOnFrame() {
+    bool firstFunctionCallOnFrame() {
         if (first_func_call_on_frame) {
             first_func_call_on_frame = false;
             return true;
@@ -726,9 +731,9 @@ class ApiDumpInstance {
         return false;
     }
 
-    inline std::recursive_mutex *outputMutex() { return &output_mutex; }
+    std::recursive_mutex *outputMutex() { return &output_mutex; }
 
-    inline const ApiDumpSettings &settings() {
+    const ApiDumpSettings &settings() {
         if (dump_settings == NULL) dump_settings = new ApiDumpSettings();
 
         return *dump_settings;
@@ -753,7 +758,9 @@ class ApiDumpInstance {
         return new_index;
     }
 
-    inline VkCommandBufferLevel getCmdBufferLevel(VkCommandBuffer cmd_buffer) {
+    void setCmdBuffer(VkCommandBuffer cmd_buffer) { this->cmd_buffer = cmd_buffer; }
+
+    VkCommandBufferLevel getCmdBufferLevel() {
         std::lock_guard<std::recursive_mutex> lg(cmd_buffer_state_mutex);
         const auto level_iter = cmd_buffer_level.find(cmd_buffer);
         assert(level_iter != cmd_buffer_level.end());
@@ -761,7 +768,7 @@ class ApiDumpInstance {
         return level;
     }
 
-    inline void eraseCmdBuffers(VkDevice device, VkCommandPool cmd_pool, std::vector<VkCommandBuffer> cmd_buffers) {
+    void eraseCmdBuffers(VkDevice device, VkCommandPool cmd_pool, std::vector<VkCommandBuffer> cmd_buffers) {
         cmd_buffers.erase(std::remove(cmd_buffers.begin(), cmd_buffers.end(), nullptr), cmd_buffers.end());
         if (!cmd_buffers.empty()) {
             std::lock_guard<std::recursive_mutex> lg(cmd_buffer_state_mutex);
@@ -778,8 +785,8 @@ class ApiDumpInstance {
         }
     }
 
-    inline void addCmdBuffers(VkDevice device, VkCommandPool cmd_pool, std::vector<VkCommandBuffer> cmd_buffers,
-                              VkCommandBufferLevel level) {
+    void addCmdBuffers(VkDevice device, VkCommandPool cmd_pool, std::vector<VkCommandBuffer> cmd_buffers,
+                       VkCommandBufferLevel level) {
         std::lock_guard<std::recursive_mutex> lg(cmd_buffer_state_mutex);
         auto &pool_cmd_buffers = cmd_buffer_pools[std::make_pair(device, cmd_pool)];
         pool_cmd_buffers.insert(cmd_buffers.begin(), cmd_buffers.end());
@@ -790,7 +797,7 @@ class ApiDumpInstance {
         }
     }
 
-    inline void eraseCmdBufferPool(VkDevice device, VkCommandPool cmd_pool) {
+    void eraseCmdBufferPool(VkDevice device, VkCommandPool cmd_pool) {
         if (cmd_pool != VK_NULL_HANDLE) {
             std::lock_guard<std::recursive_mutex> lg(cmd_buffer_state_mutex);
 
@@ -805,12 +812,17 @@ class ApiDumpInstance {
         }
     }
 
-    inline std::chrono::microseconds current_time_since_start() {
+    void setIsDynamicScissor(bool is_dynamic_scissor) { this->is_dynamic_scissor = is_dynamic_scissor; }
+    void setIsDynamicViewport(bool is_dynamic_viewport) { this->is_dynamic_viewport = is_dynamic_viewport; }
+    bool getIsDynamicScissor() const { return is_dynamic_scissor; }
+    bool getIsDynamicViewport() const { return is_dynamic_viewport; }
+
+    std::chrono::microseconds current_time_since_start() {
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
         return std::chrono::duration_cast<std::chrono::microseconds>(now - program_start);
     }
 
-    static inline ApiDumpInstance &current() { return current_instance; }
+    static ApiDumpInstance &current() { return current_instance; }
 
     std::unordered_map<uint64_t, std::string> object_name_map;
 
@@ -847,6 +859,15 @@ class ApiDumpInstance {
     // Store the VkInstance handle so we don't use null in the call to
     // vkGetInstanceProcAddr(instance_handle, "vkCreateDevice");
     std::unordered_map<VkPhysicalDevice, VkInstance> vk_instance_map;
+
+    // Storage for getCmdBufferLevel() which is called in a place where it needs access to the cmd_buffer but it isn't present in
+    // the current structure.
+    VkCommandBuffer cmd_buffer;
+
+    // Storage for VkPipelineViewportStateCreateInfo which needs to ignore the scissor and viewport pipeline state if their
+    // respective dynamic state is set.
+    bool is_dynamic_scissor;
+    bool is_dynamic_viewport;
 };
 
 // Utility to output an address.
@@ -868,10 +889,9 @@ ApiDumpInstance ApiDumpInstance::current_instance;
 
 //==================================== Text Backend Helpers ======================================//
 
-template <typename T, typename... Args>
-inline void dump_text_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                            const char *child_type, const char *name, int indents,
-                            std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_text_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string, const char *child_type,
+                     const char *name, int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     settings.formatNameType(settings.stream(), indents, name, type_string);
     if (array == NULL) {
         settings.stream() << "NULL\n";
@@ -883,14 +903,13 @@ inline void dump_text_array(const T *array, size_t len, const ApiDumpSettings &s
         std::stringstream stream;
         stream << name << '[' << i << ']';
         std::string indexName = stream.str();
-        dump_text_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump, args...);
+        dump_text_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_text_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                            const char *child_type, const char *name, int indents,
-                            std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_text_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string, const char *child_type,
+                     const char *name, int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     settings.formatNameType(settings.stream(), indents, name, type_string);
     if (array == NULL) {
         settings.stream() << "NULL\n";
@@ -902,124 +921,52 @@ inline void dump_text_array(const T *array, size_t len, const ApiDumpSettings &s
         std::stringstream stream;
         stream << name << '[' << i << ']';
         std::string indexName = stream.str();
-        dump_text_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump, args...);
+        dump_text_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_text_array_hex(const uint32_t *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                                const char *child_type, const char *name, int indents,
-                                std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
-    settings.formatNameType(settings.stream(), indents, name, type_string);
-    if (array == NULL) {
-        settings.stream() << "NULL\n";
-        return;
-    }
-    OutputAddress(settings, array, false);
-    std::stringstream stream;
-    const uint8_t *arraybyte = reinterpret_cast<const uint8_t *>(array);
-    for (size_t i = 0; i < (len * 4) && array != NULL; ++i) {
-        stream << std::hex << std::setw(2) << std::setfill('0') << (int)arraybyte[i] << " ";
-        if (i % 32 == 31) {
-            stream << "\n";
-        }
-    }
-
-    if (settings.stream().rdbuf() == std::cout.rdbuf()) {
-        settings.stream() << "\n" << stream.str() << "\n";
-    } else {
-        static uint64_t shaderDumpIndex = 0;
-        std::stringstream shaderDumpFileName;
-        shaderDumpFileName << settings.directory() << "shader_" << shaderDumpIndex << ".hex";
-        settings.stream() << " (" << shaderDumpFileName.str() << ")\n";
-        ++shaderDumpIndex;
-        std::ofstream shaderDumpFile;
-        shaderDumpFile.open(shaderDumpFileName.str(), std::ofstream::out | std::ostream::trunc);
-        shaderDumpFile << stream.str() << "\n";
-        shaderDumpFile.close();
-    }
-}
-
-template <typename T, typename... Args>
-inline void dump_text_array_hex(const uint32_t *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                                const char *child_type, const char *name, int indents,
-                                std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
-    settings.formatNameType(settings.stream(), indents, name, type_string);
-    if (array == NULL) {
-        settings.stream() << "NULL\n";
-        return;
-    }
-    OutputAddress(settings, array, false);
-    std::stringstream stream;
-    const uint8_t *arraybyte = reinterpret_cast<const uint8_t *>(array);
-    for (size_t i = 0; i < (len * 4) && array != NULL; ++i) {
-        stream << std::hex << std::setw(2) << std::setfill('0') << (int)arraybyte[i] << " ";
-        if (i % 32 == 31) {
-            stream << "\n";
-        }
-    }
-
-    if (settings.stream().rdbuf() == std::cout.rdbuf()) {
-        settings.stream() << "\n" << stream.str() << "\n";
-    } else {
-        static uint64_t shaderDumpIndex = 0;
-        std::stringstream shaderDumpFileName;
-        shaderDumpFileName << settings.directory() << "shader_" << shaderDumpIndex << ".hex";
-        settings.stream() << " (" << shaderDumpFileName.str() << ")\n";
-        ++shaderDumpIndex;
-        std::ofstream shaderDumpFile;
-        shaderDumpFile.open(shaderDumpFileName.str(), std::ofstream::out | std::ostream::trunc);
-        shaderDumpFile << stream.str() << "\n";
-        shaderDumpFile.close();
-    }
-}
-
-template <typename T, typename... Args>
-inline void dump_text_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args),
-                              Args... args) {
+template <typename T>
+void dump_text_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                       std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     if (pointer == NULL) {
         settings.formatNameType(settings.stream(), indents, name, type_string);
         settings.stream() << "NULL\n";
     } else {
-        dump_text_value(*pointer, settings, type_string, name, indents, dump, args...);
+        dump_text_value(*pointer, settings, type_string, name, indents, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_text_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args),
-                              Args... args) {
+template <typename T>
+void dump_text_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                       std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (pointer == NULL) {
         settings.formatNameType(settings.stream(), indents, name, type_string);
         settings.stream() << "NULL\n";
     } else {
-        dump_text_value(*pointer, settings, type_string, name, indents, dump, args...);
+        dump_text_value(*pointer, settings, type_string, name, indents, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_text_value(const T object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
-                            std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_text_value(const T object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                     std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     settings.formatNameType(settings.stream(), indents, name, type_string);
-    dump(object, settings, indents, args...) << "\n";
+    dump(object, settings, indents) << "\n";
 }
 
-template <typename T, typename... Args>
-inline void dump_text_value(const T &object, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                            int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args),
-                            Args... args) {
+template <typename T>
+void dump_text_value(const T &object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                     std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     settings.formatNameType(settings.stream(), indents, name, type_string);
-    dump(object, settings, indents, args...);
+    dump(object, settings, indents);
 }
 
-inline void dump_text_special(const char *text, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents) {
+void dump_text_special(const char *text, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents) {
     settings.formatNameType(settings.stream(), indents, name, type_string);
     settings.stream() << text << "\n";
 }
 
-inline bool dump_text_bitmaskOption(const std::string &option, std::ostream &stream, bool isFirst) {
+bool dump_text_bitmaskOption(const std::string &option, std::ostream &stream, bool isFirst) {
     if (isFirst)
         stream << " (";
     else
@@ -1028,36 +975,36 @@ inline bool dump_text_bitmaskOption(const std::string &option, std::ostream &str
     return false;
 }
 
-inline std::ostream &dump_text_cstring(const char *object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_text_cstring(const char *object, const ApiDumpSettings &settings, int indents) {
     if (object == NULL)
         return settings.stream() << "NULL";
     else
         return settings.stream() << "\"" << object << "\"";
 }
 
-inline std::ostream &dump_text_void(const void *object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_text_void(const void *object, const ApiDumpSettings &settings, int indents) {
     if (object == NULL) return settings.stream() << "NULL";
     OutputAddress(settings, object, false);
     return settings.stream();
 }
 
-inline std::ostream &dump_text_int(int object, const ApiDumpSettings &settings, int indents) { return settings.stream() << object; }
+std::ostream &dump_text_int(int object, const ApiDumpSettings &settings, int indents) { return settings.stream() << object; }
 
-template <typename T, typename... Args>
-inline void dump_text_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
-                            std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_text_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
+                     std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (object == NULL)
         settings.stream() << "NULL";
     else if (settings.showAddress()) {
         settings.formatNameType(settings.stream(), indents, "pNext", type_string);
-        dump(*object, settings, indents, args...);
+        dump(*object, settings, indents);
     } else
         settings.stream() << "address";
 }
 
 //==================================== Html Backend Helpers ======================================//
 
-inline std::ostream &dump_html_nametype(std::ostream &stream, bool showType, const char *name, const char *type) {
+std::ostream &dump_html_nametype(std::ostream &stream, bool showType, const char *name, const char *type) {
     stream << "<div class='var'>" << name << "</div>";
     if (showType) {
         stream << "<div class='type'>" << type << "</div>";
@@ -1065,10 +1012,9 @@ inline std::ostream &dump_html_nametype(std::ostream &stream, bool showType, con
     return stream;
 }
 
-template <typename T, typename... Args>
-inline void dump_html_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                            const char *child_type, const char *name, int indents,
-                            std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_html_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string, const char *child_type,
+                     const char *name, int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     if (array == NULL) {
         settings.stream() << "<details class='data'><summary>";
         dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
@@ -1086,15 +1032,14 @@ inline void dump_html_array(const T *array, size_t len, const ApiDumpSettings &s
         std::stringstream stream;
         stream << name << '[' << i << ']';
         std::string indexName = stream.str();
-        dump_html_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump, args...);
+        dump_html_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump);
     }
     settings.stream() << "</details>";
 }
 
-template <typename T, typename... Args>
-inline void dump_html_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                            const char *child_type, const char *name, int indents,
-                            std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_html_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string, const char *child_type,
+                     const char *name, int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (array == NULL) {
         settings.stream() << "<details class='data'><summary>";
         dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
@@ -1112,64 +1057,60 @@ inline void dump_html_array(const T *array, size_t len, const ApiDumpSettings &s
         std::stringstream stream;
         stream << name << '[' << i << ']';
         std::string indexName = stream.str();
-        dump_html_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump, args...);
+        dump_html_value(array[i], settings, child_type, indexName.c_str(), indents + 1, dump);
     }
     settings.stream() << "</details>";
 }
 
-template <typename T, typename... Args>
-inline void dump_html_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args),
-                              Args... args) {
+template <typename T>
+void dump_html_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                       std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     if (pointer == NULL) {
         settings.stream() << "<details class='data'><summary>";
         dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
         settings.stream() << "<div class='val'>NULL</div></summary></details>";
     } else {
-        dump_html_value(*pointer, settings, type_string, name, indents, dump, args...);
+        dump_html_value(*pointer, settings, type_string, name, indents, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_html_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args),
-                              Args... args) {
+template <typename T>
+void dump_html_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                       std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (pointer == NULL) {
         settings.stream() << "<details class='data'><summary>";
         dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
         settings.stream() << "<div class='val'>NULL</div></summary></details>";
     } else {
-        dump_html_value(*pointer, settings, type_string, name, indents, dump, args...);
+        dump_html_value(*pointer, settings, type_string, name, indents, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_html_value(const T object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
-                            std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_html_value(const T object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                     std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     settings.stream() << "<details class='data'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
-    dump(object, settings, indents, args...);
+    dump(object, settings, indents);
     settings.stream() << "</details>";
 }
 
-template <typename T, typename... Args>
-inline void dump_html_value(const T &object, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                            int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args),
-                            Args... args) {
+template <typename T>
+void dump_html_value(const T &object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                     std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     settings.stream() << "<details class='data'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
-    dump(object, settings, indents, args...);
+    dump(object, settings, indents);
     settings.stream() << "</details>";
 }
 
-inline void dump_html_special(const char *text, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents) {
+void dump_html_special(const char *text, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents) {
     settings.stream() << "<details class='data'><summary>";
     dump_html_nametype(settings.stream(), settings.showType(), name, type_string);
     settings.stream() << "<div class='val'>" << text << "</div></summary></details>";
 }
 
-inline bool dump_html_bitmaskOption(const std::string &option, std::ostream &stream, bool isFirst) {
+bool dump_html_bitmaskOption(const std::string &option, std::ostream &stream, bool isFirst) {
     if (isFirst)
         stream << " (";
     else
@@ -1178,7 +1119,7 @@ inline bool dump_html_bitmaskOption(const std::string &option, std::ostream &str
     return false;
 }
 
-inline std::ostream &dump_html_cstring(const char *object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_html_cstring(const char *object, const ApiDumpSettings &settings, int indents) {
     settings.stream() << "<div class='val'>";
     if (object == NULL)
         settings.stream() << "NULL";
@@ -1187,36 +1128,35 @@ inline std::ostream &dump_html_cstring(const char *object, const ApiDumpSettings
     return settings.stream() << "</div>";
 }
 
-inline std::ostream &dump_html_void(const void *object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_html_void(const void *object, const ApiDumpSettings &settings, int indents) {
     settings.stream() << "<div class='val'>";
     OutputAddress(settings, object, false);
     return settings.stream() << "</div>";
 }
 
-inline std::ostream &dump_html_int(int object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_html_int(int object, const ApiDumpSettings &settings, int indents) {
     settings.stream() << "<div class='val'>";
     settings.stream() << object;
     return settings.stream() << "</div>";
 }
 
-template <typename T, typename... Args>
-inline void dump_html_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
-                            std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_html_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
+                     std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (object == NULL) {
         settings.stream() << "<details class='data'><summary>";
         dump_html_nametype(settings.stream(), settings.showType(), "pNext", type_string);
         settings.stream() << "<div class='val'>NULL</div></summary></details>";
     } else {
-        dump_html_value(*object, settings, type_string, "pNext", indents, dump, args...);
+        dump_html_value(*object, settings, type_string, "pNext", indents, dump);
     }
 }
 
 //==================================== Json Backend Helpers ======================================//
 
-template <typename T, typename... Args>
-inline void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                            const char *child_type, const char *name, int indents,
-                            std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string, const char *child_type,
+                     const char *name, int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     if (len == 0 || array == NULL) {
         settings.stream() << settings.indentation(indents) << "{\n";
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
@@ -1241,7 +1181,7 @@ inline void dump_json_array(const T *array, size_t len, const ApiDumpSettings &s
             std::stringstream stream;
             stream << "[" << i << "]";
             std::string indexName = stream.str();
-            dump_json_value(array[i], &array[i], settings, child_type, indexName.c_str(), indents + 2, dump, args...);
+            dump_json_value(array[i], &array[i], settings, child_type, indexName.c_str(), indents + 2, dump);
             if (i < len - 1) settings.stream() << ',';
             settings.stream() << "\n";
         }
@@ -1250,10 +1190,9 @@ inline void dump_json_array(const T *array, size_t len, const ApiDumpSettings &s
     settings.stream() << "\n" << settings.indentation(indents) << "}";
 }
 
-template <typename T, typename... Args>
-inline void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string,
-                            const char *child_type, const char *name, int indents,
-                            std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_json_array(const T *array, size_t len, const ApiDumpSettings &settings, const char *type_string, const char *child_type,
+                     const char *name, int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (len == 0 || array == NULL) {
         settings.stream() << settings.indentation(indents) << "{\n";
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
@@ -1277,7 +1216,7 @@ inline void dump_json_array(const T *array, size_t len, const ApiDumpSettings &s
             std::stringstream stream;
             stream << "[" << i << "]";
             std::string indexName = stream.str();
-            dump_json_value(array[i], &array[i], settings, child_type, indexName.c_str(), indents + 2, dump, args...);
+            dump_json_value(array[i], &array[i], settings, child_type, indexName.c_str(), indents + 2, dump);
             if (i < len - 1) settings.stream() << ',';
             settings.stream() << "\n";
         }
@@ -1286,10 +1225,9 @@ inline void dump_json_array(const T *array, size_t len, const ApiDumpSettings &s
     settings.stream() << "\n" << settings.indentation(indents) << "}";
 }
 
-template <typename T, typename... Args>
-inline void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args),
-                              Args... args) {
+template <typename T>
+void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                       std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     if (pointer == NULL) {
         settings.stream() << settings.indentation(indents) << "{\n";
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
@@ -1299,14 +1237,13 @@ inline void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings,
         settings.stream() << "\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {
-        dump_json_value(*pointer, pointer, settings, type_string, name, indents, dump, args...);
+        dump_json_value(*pointer, pointer, settings, type_string, name, indents, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args),
-                              Args... args) {
+template <typename T>
+void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
+                       std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (pointer == NULL) {
         settings.stream() << settings.indentation(indents) << "{\n";
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
@@ -1316,17 +1253,16 @@ inline void dump_json_pointer(const T *pointer, const ApiDumpSettings &settings,
         settings.stream() << "\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {
-        dump_json_value(*pointer, pointer, settings, type_string, name, indents, dump, args...);
+        dump_json_value(*pointer, pointer, settings, type_string, name, indents, dump);
     }
 }
 
 extern bool is_union(const char *t);
 extern bool is_struct(const char *t);
 
-template <typename T, typename... Args>
-inline void dump_json_value(const T object, const void *pObject, const ApiDumpSettings &settings, const char *type_string,
-                            const char *name, int indents,
-                            std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_json_value(const T object, const void *pObject, const ApiDumpSettings &settings, const char *type_string,
+                     const char *name, int indents, std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     bool isPnext = !strcmp(name, "pNext") | !strcmp(name, "pUserData");
     const char *star = (isPnext && !strstr(type_string, "void")) ? "*" : "";
     settings.stream() << settings.indentation(indents) << "{\n";
@@ -1346,16 +1282,15 @@ inline void dump_json_value(const T object, const void *pObject, const ApiDumpSe
             settings.stream() << settings.indentation(indents + 1) << "\"members\" :\n";
         else
             settings.stream() << settings.indentation(indents + 1) << "\"value\" : ";
-        dump(object, settings, indents + 1, args...);
+        dump(object, settings, indents + 1);
     }
     settings.stream() << "\n";
     settings.stream() << settings.indentation(indents) << "}";
 }
 
-template <typename T, typename... Args>
-inline void dump_json_value(const T &object, const void *pObject, const ApiDumpSettings &settings, const char *type_string,
-                            const char *name, int indents,
-                            std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_json_value(const T &object, const void *pObject, const ApiDumpSettings &settings, const char *type_string,
+                     const char *name, int indents, std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     bool isPnext = !strcmp(name, "pNext") | !strcmp(name, "pUserData");
     const char *star = (isPnext && !strstr(type_string, "void")) ? "*" : "";
     settings.stream() << settings.indentation(indents) << "{\n";
@@ -1375,14 +1310,13 @@ inline void dump_json_value(const T &object, const void *pObject, const ApiDumpS
             settings.stream() << settings.indentation(indents + 1) << "\"members\" :\n";
         else
             settings.stream() << settings.indentation(indents + 1) << "\"value\" : ";
-        dump(object, settings, indents + 1, args...);
+        dump(object, settings, indents + 1);
     }
     settings.stream() << "\n";
     settings.stream() << settings.indentation(indents) << "}";
 }
 
-inline void dump_json_special(const char *text, const ApiDumpSettings &settings, const char *type_string, const char *name,
-                              int indents) {
+void dump_json_special(const char *text, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents) {
     settings.stream() << settings.indentation(indents) << "{\n";
     settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "\",\n";
     settings.stream() << settings.indentation(indents + 1) << "\"name\" : \"" << name << "\",\n";
@@ -1394,7 +1328,7 @@ inline void dump_json_special(const char *text, const ApiDumpSettings &settings,
     settings.stream() << settings.indentation(indents) << "}";
 }
 
-inline bool dump_json_bitmaskOption(const std::string &option, std::ostream &stream, bool isFirst) {
+bool dump_json_bitmaskOption(const std::string &option, std::ostream &stream, bool isFirst) {
     if (isFirst)
         stream << "(";
     else
@@ -1403,7 +1337,7 @@ inline bool dump_json_bitmaskOption(const std::string &option, std::ostream &str
     return false;
 }
 
-inline std::ostream &dump_json_cstring(const char *object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_json_cstring(const char *object, const ApiDumpSettings &settings, int indents) {
     if (object == NULL)
         settings.stream() << "\"\"";
     else
@@ -1411,21 +1345,21 @@ inline std::ostream &dump_json_cstring(const char *object, const ApiDumpSettings
     return settings.stream();
 }
 
-inline std::ostream &dump_json_void(const void *object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_json_void(const void *object, const ApiDumpSettings &settings, int indents) {
     OutputAddress(settings, object, true);
     settings.stream() << "\n";
     return settings.stream();
 }
 
-inline std::ostream &dump_json_int(int object, const ApiDumpSettings &settings, int indents) {
+std::ostream &dump_json_int(int object, const ApiDumpSettings &settings, int indents) {
     settings.stream() << settings.indentation(indents) << "\"value\" : ";
     settings.stream() << '"' << object << "\"";
     return settings.stream();
 }
 
-template <typename T, typename... Args>
-inline void dump_json_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
-                            std::ostream &(*dump)(const T, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_json_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
+                     std::ostream &(*dump)(const T, const ApiDumpSettings &, int)) {
     if (object == NULL) {
         settings.stream() << settings.indentation(indents) << "{\n";
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "*\",\n";
@@ -1437,13 +1371,13 @@ inline void dump_json_pNext(const T *object, const ApiDumpSettings &settings, co
         settings.stream() << ",\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {
-        dump_json_value(*object, object, settings, type_string, "pNext", indents, dump, args...);
+        dump_json_value(*object, object, settings, type_string, "pNext", indents, dump);
     }
 }
 
-template <typename T, typename... Args>
-inline void dump_json_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
-                            std::ostream &(*dump)(const T &, const ApiDumpSettings &, int, Args... args), Args... args) {
+template <typename T>
+void dump_json_pNext(const T *object, const ApiDumpSettings &settings, const char *type_string, int indents,
+                     std::ostream &(*dump)(const T &, const ApiDumpSettings &, int)) {
     if (object == NULL) {
         settings.stream() << settings.indentation(indents) << "{\n";
         settings.stream() << settings.indentation(indents + 1) << "\"type\" : \"" << type_string << "*\",\n";
@@ -1455,6 +1389,6 @@ inline void dump_json_pNext(const T *object, const ApiDumpSettings &settings, co
         settings.stream() << ",\n";
         settings.stream() << settings.indentation(indents) << "}";
     } else {
-        dump_json_value(*object, object, settings, type_string, "pNext", indents, dump, args...);
+        dump_json_value(*object, object, settings, type_string, "pNext", indents, dump);
     }
 }

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -804,18 +804,16 @@ typedef VkFlags64 {bitName};
 void dump_text_{bitName}({bitName} object, const ApiDumpSettings& settings, int indents)
 {{
     bool is_first = true;
-    //settings.formatNameType(stream, indents, name, type_string) << object;
     settings.stream() << object;
     @foreach option
         @if('{optMultiValue}' != 'None')
-    if(object == {optValue})
-        is_first = dump_bitmaskOption("{optName}", settings.stream(), is_first);
+    if(object == {optValue}) {{
         @end if
         @if('{optMultiValue}' == 'None')
-    if(object & {optValue})
-        is_first = dump_bitmaskOption("{optName}", settings.stream(), is_first);
+    if(object & {optValue}) {{
         @end if
-
+        settings.stream() << (is_first ? \" (\" : \" | \") << "{optName}"; is_first = false;
+    }}
     @end option
     if(!is_first)
         settings.stream() << ")";
@@ -1198,13 +1196,13 @@ void dump_html_{bitName}({bitName} object, const ApiDumpSettings& settings, int 
     settings.stream() << object;
     @foreach option
         @if('{optMultiValue}' != 'None')
-    if(object == {optValue})
-        is_first = dump_bitmaskOption("{optName}", settings.stream(), is_first);
+    if(object == {optValue}) {{
         @end if
         @if('{optMultiValue}' == 'None')
-    if(object & {optValue})
-        is_first = dump_bitmaskOption("{optName}", settings.stream(), is_first);
+    if(object & {optValue}) {{
         @end if
+        settings.stream() << (is_first ? \" (\" : \" | \") << "{optName}"; is_first = false;
+    }}
     @end option
     if(!is_first)
         settings.stream() << ")";
@@ -1588,13 +1586,13 @@ void dump_json_{bitName}({bitName} object, const ApiDumpSettings& settings, int 
         settings.stream() << ' ';
     @foreach option
         @if('{optMultiValue}' != 'None')
-    if(object == {optValue})
-        is_first = dump_bitmaskOption("{optName}", settings.stream(), is_first);
+    if(object == {optValue}) {{
         @end if
         @if('{optMultiValue}' == 'None')
-    if(object & {optValue})
-        is_first = dump_bitmaskOption("{optName}", settings.stream(), is_first);
+    if(object & {optValue}) {{
         @end if
+        settings.stream() << (is_first ? \" (\" : \" | \") << "{optName}"; is_first = false;
+    }}
     @end option
     if(!is_first)
         settings.stream() << ')';

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -79,7 +79,7 @@ COMMON_CODEGEN = """
 //============================= Dump Functions ==============================//
 
 @foreach function where(not '{funcName}' in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr', 'vkDebugMarkerSetObjectNameEXT','vkSetDebugUtilsObjectNameEXT'])
-inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
+void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     if (!dump_inst.shouldDumpOutput()) return ;
     dump_inst.outputMutex()->lock();
@@ -100,7 +100,7 @@ inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @end function
 
 @foreach function where('{funcReturn}' != 'void' and not '{funcName}' in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr', 'vkDebugMarkerSetObjectNameEXT','vkSetDebugUtilsObjectNameEXT'])
-inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
+void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 {{
     if (!dump_inst.shouldDumpOutput()) return;
 
@@ -122,7 +122,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result
 @end function
 
 @foreach function where('{funcReturn}' == 'void')
-inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
+void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     if (!dump_inst.shouldDumpOutput()) return ;
     //Lock is already held
@@ -144,7 +144,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 
 
 @foreach function where('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
-inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
+void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     dump_inst.outputMutex()->lock();
 
@@ -177,7 +177,7 @@ inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @end function
 
 @foreach function where('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
-inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
+void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 {{
     //Lock is already held
     if (dump_inst.shouldDumpOutput()) {{
@@ -200,7 +200,7 @@ inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result
 @end function
 
 @foreach function where('{funcName}' == 'vkSetDebugUtilsObjectNameEXT')
-inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
+void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 {{
     dump_inst.outputMutex()->lock();
     if (pNameInfo->pObjectName)
@@ -230,7 +230,7 @@ inline void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @end function
 
 @foreach function where('{funcName}' == 'vkSetDebugUtilsObjectNameEXT')
-inline void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
+void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 {{
     //Lock is already held
     if (dump_inst.shouldDumpOutput()) {{
@@ -536,7 +536,7 @@ TEXT_CODEGEN = """
 #include "api_dump.h"
 
 @foreach struct
-std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars});
+std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents);
 @end struct
 @foreach union
 std::ostream& dump_text_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
@@ -552,7 +552,7 @@ std::ostream& dump_text_VkAccelerationStructureTypeNV(VkAccelerationStructureTyp
     return dump_text_VkAccelerationStructureTypeKHR(object, settings, indents);
 }}
 std::ostream& dump_text_VkBuildAccelerationStructureFlagsKHR(VkBuildAccelerationStructureFlagsKHR object, const ApiDumpSettings& settings, int indents);
-inline std::ostream& dump_text_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureFlagsNV object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureFlagsNV object, const ApiDumpSettings& settings, int indents)
 {{
     return dump_text_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
@@ -564,7 +564,7 @@ inline std::ostream& dump_text_VkBuildAccelerationStructureFlagsNV(VkBuildAccele
 std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
 {{
     switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct where('{sctName}' not in ['VkPipelineViewportStateCreateInfo', 'VkCommandBufferBeginInfo'])
+    @foreach struct
         @if({sctStructureTypeIndex} != -1)
     case {sctStructureTypeIndex}:
         dump_text_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_text_{sctName});
@@ -588,22 +588,10 @@ std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettin
     return settings.stream();
 }}
 
-inline std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, bool is_dynamic_viewport, bool is_dynamic_scissor)
-{{
-    dump_text_pNext<const VkPipelineViewportStateCreateInfo>(static_cast<const VkPipelineViewportStateCreateInfo*>(object), settings, "VkPipelineViewportStateCreateInfo", indents, dump_text_VkPipelineViewportStateCreateInfo, is_dynamic_viewport, is_dynamic_scissor);
-    return settings.stream();
-}}
-
-inline std::ostream& dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, VkCommandBuffer cmd_buffer)
-{{
-    dump_text_pNext<const VkCommandBufferBeginInfo>(static_cast<const VkCommandBufferBeginInfo*>(object), settings, "VkCommandBufferBeginInfo", indents, dump_text_VkCommandBufferBeginInfo, cmd_buffer);
-    return settings.stream();
-}}
-
 std::ostream& dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents)
 {{
     switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct where('{sctName}' not in ['VkPipelineViewportStateCreateInfo', 'VkCommandBufferBeginInfo'])
+    @foreach struct
         @if({sctStructureTypeIndex} != -1)
     case {sctStructureTypeIndex}:
         settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
@@ -627,7 +615,7 @@ std::ostream& dump_text_pNext_struct_name(const void* object, const ApiDumpSetti
 //=========================== Type Implementations ==========================//
 
 @foreach type where('{etyName}' != 'void')
-inline std::ostream& dump_text_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
 {{
     @if('{etyName}' != 'uint8_t')
     return settings.stream() << object;
@@ -641,14 +629,14 @@ inline std::ostream& dump_text_{etyName}({etyName} object, const ApiDumpSettings
 //========================= Basetype Implementations ========================//
 
 @foreach basetype where(not '{baseName}' in ['ANativeWindow', 'AHardwareBuffer', 'CAMetalLayer'])
-inline std::ostream& dump_text_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << object;
 }}
 @end basetype
 @foreach basetype where('{baseName}' in ['ANativeWindow', 'AHardwareBuffer'])
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-inline std::ostream& dump_text_{baseName}(const {baseName}* object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{baseName}(const {baseName}* object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << object;
 }}
@@ -656,7 +644,7 @@ inline std::ostream& dump_text_{baseName}(const {baseName}* object, const ApiDum
 @end basetype
 @foreach basetype where('{baseName}' in ['CAMetalLayer'])
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-inline std::ostream& dump_text_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << object;
 }}
@@ -666,7 +654,7 @@ inline std::ostream& dump_text_{baseName}({baseName} object, const ApiDumpSettin
 //======================= System Type Implementations =======================//
 
 @foreach systype
-inline std::ostream& dump_text_{sysName}(const {sysType} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{sysName}(const {sysType} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << object;
 }}
@@ -675,7 +663,7 @@ inline std::ostream& dump_text_{sysName}(const {sysType} object, const ApiDumpSe
 //========================== Handle Implementations =========================//
 
 @foreach handle
-inline std::ostream& dump_text_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
 {{
     if(settings.showAddress()) {{
         settings.stream() << object;
@@ -745,13 +733,13 @@ std::ostream& dump_text_{bitName}({bitName} object, const ApiDumpSettings& setti
 //=========================== Flag Implementations ==========================//
 
 @foreach flag where('{flagEnum}' != 'None')
-inline std::ostream& dump_text_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
 {{
     return dump_text_{flagEnum}(({flagEnum}) object, settings, indents);
 }}
 @end flag
 @foreach flag where('{flagEnum}' == 'None')
-inline std::ostream& dump_text_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << object;
 }}
@@ -760,7 +748,7 @@ inline std::ostream& dump_text_{flagName}({flagName} object, const ApiDumpSettin
 //======================= Func Pointer Implementations ======================//
 
 @foreach funcpointer
-inline std::ostream& dump_text_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_text_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int indents)
 {{
     if(settings.showAddress())
         return settings.stream() << object;
@@ -772,7 +760,7 @@ inline std::ostream& dump_text_{pfnName}({pfnName} object, const ApiDumpSettings
 //========================== Struct Implementations =========================//
 
 @foreach struct where('{sctName}' not in ['VkPhysicalDeviceMemoryProperties','VkPhysicalDeviceGroupProperties'])
-std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars})
+std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents)
 {{
     if(settings.showAddress())
         settings.stream() << &object << ":\\n";
@@ -783,35 +771,37 @@ std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings
     @if('{memCondition}' != 'None')
     if({memCondition})
     @end if
-
+    @if('{memParameterStorage}' != '')
+    {memParameterStorage}
+    @end if
     @if({memPtrLevel} == 0)
         @if('{memName}' != 'pNext')
-    dump_text_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions});  // AET
+    dump_text_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID});  // AET
         @end if
         @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_text_pNext_struct_name(object.{memName}, settings, indents + 1);
     }} else {{
-        dump_text_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // BET
+        dump_text_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID}); // BET
     }}
         @end if
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' == 'None')
-    dump_text_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions});
+    dump_text_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID});
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
-    dump_text_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // AQA
+    dump_text_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // AQA
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
     @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
-    dump_text_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // BQA
+    dump_text_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // BQA
     @end if
     @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
     @if('{memLength}' == 'rasterizationSamples')
-    dump_text_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // BQB
+    dump_text_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // BQB
     @end if
     @if('{memLength}' != 'rasterizationSamples')
-    dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // BQB
+    dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // BQB
     @end if
     @end if
     @end if
@@ -819,7 +809,7 @@ std::ostream& dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings
     @if('{sctName}' == 'VkShaderModuleCreateInfo')
     @if('{memName}' == 'pCode')
     if(settings.showShader())
-        dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}{memInheritedConditions}); // CQA
+        dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // CQA
     else
         dump_text_special("SHADER DATA", settings, "{memType}", "{memName}", indents + 1);
     @end if
@@ -939,14 +929,17 @@ std::ostream& dump_text_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
     if(settings.showParams())
     {{
         @foreach parameter
+        @if('{prmParameterStorage}' != '')
+        {prmParameterStorage}
+        @end if
         @if({prmPtrLevel} == 0)
-        dump_text_value<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_text_{prmTypeID}{prmInheritedConditions}); // MET
+        dump_text_value<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_text_{prmTypeID}); // MET
         @end if
         @if({prmPtrLevel} == 1 and '{prmLength}' == 'None')
-        dump_text_pointer<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_text_{prmTypeID}{prmInheritedConditions});
+        dump_text_pointer<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_text_{prmTypeID});
         @end if
         @if({prmPtrLevel} == 1 and '{prmLength}' != 'None')
-        dump_text_array<const {prmBaseType}>({prmName}, {prmLength}, settings, "{prmType}", "{prmChildType}", "{prmName}", 1, dump_text_{prmTypeID}{prmInheritedConditions}); // HQA
+        dump_text_array<const {prmBaseType}>({prmName}, {prmLength}, settings, "{prmType}", "{prmChildType}", "{prmName}", 1, dump_text_{prmTypeID}); // HQA
         @end if
         @end parameter
     }}
@@ -994,7 +987,7 @@ HTML_CODEGEN = """
 #include "api_dump.h"
 
 @foreach struct
-std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars});
+std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents);
 @end struct
 @foreach union
 std::ostream& dump_html_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
@@ -1010,7 +1003,7 @@ std::ostream& dump_html_VkAccelerationStructureTypeNV(VkAccelerationStructureTyp
     return dump_html_VkAccelerationStructureTypeKHR(object, settings, indents);
 }}
 std::ostream& dump_html_VkBuildAccelerationStructureFlagsKHR(VkBuildAccelerationStructureFlagsKHR object, const ApiDumpSettings& settings, int indents);
-inline std::ostream& dump_html_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureFlagsNV object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureFlagsNV object, const ApiDumpSettings& settings, int indents)
 {{
     return dump_html_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
@@ -1022,7 +1015,7 @@ inline std::ostream& dump_html_VkBuildAccelerationStructureFlagsNV(VkBuildAccele
 std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
 {{
     switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct where('{sctName}' not in ['VkPipelineViewportStateCreateInfo', 'VkCommandBufferBeginInfo'])
+    @foreach struct
         @if({sctStructureTypeIndex} != -1)
     case {sctStructureTypeIndex}:
         dump_html_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_html_{sctName});
@@ -1048,22 +1041,10 @@ std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettin
     return settings.stream();
 }}
 
-inline std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, bool is_dynamic_viewport, bool is_dynamic_scissor)
-{{
-    dump_html_pNext<const VkPipelineViewportStateCreateInfo>(static_cast<const VkPipelineViewportStateCreateInfo*>(object), settings, "VkPipelineViewportStateCreateInfo", indents, dump_html_VkPipelineViewportStateCreateInfo, is_dynamic_viewport, is_dynamic_scissor);
-    return settings.stream();
-}}
-
-inline std::ostream& dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, VkCommandBuffer cmd_buffer)
-{{
-    dump_html_pNext<const VkCommandBufferBeginInfo>(static_cast<const VkCommandBufferBeginInfo*>(object), settings, "VkCommandBufferBeginInfo", indents, dump_html_VkCommandBufferBeginInfo, cmd_buffer);
-    return settings.stream();
-}}
-
 //=========================== Type Implementations ==========================//
 
 @foreach type where('{etyName}' != 'void')
-inline std::ostream& dump_html_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << "<div class='val'>";
     @if('{etyName}' != 'uint8_t')
@@ -1079,14 +1060,14 @@ inline std::ostream& dump_html_{etyName}({etyName} object, const ApiDumpSettings
 //========================= Basetype Implementations ========================//
 
 @foreach basetype where(not '{baseName}' in ['ANativeWindow', 'AHardwareBuffer', 'CAMetalLayer'])
-inline std::ostream& dump_html_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "<div class='val'>" << object << "</div></summary>";
 }}
 @end basetype
 @foreach basetype where('{baseName}' in ['ANativeWindow', 'AHardwareBuffer'])
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-inline std::ostream& dump_html_{baseName}(const {baseName}* object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{baseName}(const {baseName}* object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "<div class='val'>" << object << "</div></summary>";
 }}
@@ -1094,7 +1075,7 @@ inline std::ostream& dump_html_{baseName}(const {baseName}* object, const ApiDum
 @end basetype
 @foreach basetype where('{baseName}' in ['CAMetalLayer'])
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-inline std::ostream& dump_html_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "<div class='val'>" << object << "</div></summary>";
 }}
@@ -1104,7 +1085,7 @@ inline std::ostream& dump_html_{baseName}({baseName} object, const ApiDumpSettin
 //======================= System Type Implementations =======================//
 
 @foreach systype
-inline std::ostream& dump_html_{sysName}(const {sysType} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{sysName}(const {sysType} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "<div class='val'>" << object << "</div></summary>";
 }}
@@ -1113,7 +1094,7 @@ inline std::ostream& dump_html_{sysName}(const {sysType} object, const ApiDumpSe
 //========================== Handle Implementations =========================//
 
 @foreach handle
-inline std::ostream& dump_html_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << "<div class='val'>";
     if(settings.showAddress()) {{
@@ -1177,13 +1158,13 @@ std::ostream& dump_html_{bitName}({bitName} object, const ApiDumpSettings& setti
 //=========================== Flag Implementations ==========================//
 
 @foreach flag where('{flagEnum}' != 'None')
-inline std::ostream& dump_html_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
 {{
     return dump_html_{flagEnum}(({flagEnum}) object, settings, indents);
 }}
 @end flag
 @foreach flag where('{flagEnum}' == 'None')
-inline std::ostream& dump_html_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "<div class=\'val\'>"
                              << object << "</div></summary>";
@@ -1193,7 +1174,7 @@ inline std::ostream& dump_html_{flagName}({flagName} object, const ApiDumpSettin
 //======================= Func Pointer Implementations ======================//
 
 @foreach funcpointer
-inline std::ostream& dump_html_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_html_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << "<div class=\'val\'>";
     if(settings.showAddress())
@@ -1207,7 +1188,7 @@ inline std::ostream& dump_html_{pfnName}({pfnName} object, const ApiDumpSettings
 //========================== Struct Implementations =========================//
 
 @foreach struct where('{sctName}' not in ['VkPhysicalDeviceMemoryProperties' ,'VkPhysicalDeviceGroupProperties'])
-std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars})
+std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << "<div class=\'val\'>";
     if(settings.showAddress())
@@ -1220,42 +1201,44 @@ std::ostream& dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings
     @if('{memCondition}' != 'None')
     if({memCondition})
     @end if
-
+    @if('{memParameterStorage}' != '')
+    {memParameterStorage}
+    @end if
     @if({memPtrLevel} == 0)
         @if('{memName}' != 'pNext')
-    dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions});
+    dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID});
         @end if
         @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_html_pNext_trampoline(object.{memName}, settings, indents + 1);
     }} else {{
-        dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions});
+        dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID});
     }}
         @end if
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' == 'None')
-    dump_html_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions});
+    dump_html_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID});
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
-    dump_html_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRR
+    dump_html_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRR
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
     @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
-    dump_html_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRS
+    dump_html_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRS
     @end if
     @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
     @if('{memLength}' == 'rasterizationSamples')
-    dump_html_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRT
+    dump_html_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRT
     @end if
     @if('{memLength}' != 'rasterizationSamples')
-    dump_html_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRT
+    dump_html_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRT
     @end if
     @end if
     @end if
     @if('{sctName}' == 'VkShaderModuleCreateInfo')
     @if('{memName}' == 'pCode')
     if(settings.showShader())
-        dump_html_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}{memInheritedConditions}); // ZRU
+        dump_html_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRU
     else
         dump_html_special("SHADER DATA", settings, "{memType}", "{memName}", indents + 1);
     @end if
@@ -1364,14 +1347,17 @@ std::ostream& dump_html_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
     if(settings.showParams())
     {{
         @foreach parameter
+        @if('{prmParameterStorage}' != '')
+        {prmParameterStorage}
+        @end if
         @if({prmPtrLevel} == 0)
-        dump_html_value<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_html_{prmTypeID}{prmInheritedConditions});
+        dump_html_value<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_html_{prmTypeID});
         @end if
         @if({prmPtrLevel} == 1 and '{prmLength}' == 'None')
-        dump_html_pointer<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_html_{prmTypeID}{prmInheritedConditions});
+        dump_html_pointer<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 1, dump_html_{prmTypeID});
         @end if
         @if({prmPtrLevel} == 1 and '{prmLength}' != 'None')
-        dump_html_array<const {prmBaseType}>({prmName}, {prmLength}, settings, "{prmType}", "{prmChildType}", "{prmName}", 1, dump_html_{prmTypeID}{prmInheritedConditions}); // ZRZ
+        dump_html_array<const {prmBaseType}>({prmName}, {prmLength}, settings, "{prmType}", "{prmChildType}", "{prmName}", 1, dump_html_{prmTypeID}); // ZRZ
         @end if
         @end parameter
     }}
@@ -1417,7 +1403,7 @@ JSON_CODEGEN = """
 #include "api_dump.h"
 
 @foreach struct
-std::ostream& dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars});
+std::ostream& dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents);
 @end struct
 @foreach union
 std::ostream& dump_json_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
@@ -1433,7 +1419,7 @@ std::ostream& dump_json_VkAccelerationStructureTypeNV(VkAccelerationStructureTyp
     return dump_json_VkAccelerationStructureTypeKHR(object, settings, indents);
 }}
 std::ostream& dump_json_VkBuildAccelerationStructureFlagsKHR(VkBuildAccelerationStructureFlagsKHR object, const ApiDumpSettings& settings, int indents);
-inline std::ostream& dump_json_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureFlagsNV object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureFlagsNV object, const ApiDumpSettings& settings, int indents)
 {{
     return dump_json_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
@@ -1445,7 +1431,7 @@ inline std::ostream& dump_json_VkBuildAccelerationStructureFlagsNV(VkBuildAccele
 std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
 {{
     switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct where('{sctName}' not in ['VkPipelineViewportStateCreateInfo', 'VkCommandBufferBeginInfo'])
+    @foreach struct
         @if({sctStructureTypeIndex} != -1)
     case {sctStructureTypeIndex}:
         dump_json_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_json_{sctName});
@@ -1475,22 +1461,10 @@ std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettin
     return settings.stream();
 }}
 
-inline std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, bool is_dynamic_viewport, bool is_dynamic_scissor)
-{{
-    dump_json_pNext<const VkPipelineViewportStateCreateInfo>(static_cast<const VkPipelineViewportStateCreateInfo*>(object), settings, "VkPipelineViewportStateCreateInfo", indents, dump_json_VkPipelineViewportStateCreateInfo, is_dynamic_viewport, is_dynamic_scissor);
-    return settings.stream();
-}}
-
-inline std::ostream& dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents, VkCommandBuffer cmd_buffer)
-{{
-    dump_json_pNext<const VkCommandBufferBeginInfo>(static_cast<const VkCommandBufferBeginInfo*>(object), settings, "VkCommandBufferBeginInfo", indents, dump_json_VkCommandBufferBeginInfo, cmd_buffer);
-    return settings.stream();
-}}
-
 //=========================== Type Implementations ==========================//
 
 @foreach type where('{etyName}' != 'void')
-inline std::ostream& dump_json_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
 {{
 
     //settings.stream() << settings.indentation(indents);
@@ -1506,14 +1480,14 @@ inline std::ostream& dump_json_{etyName}({etyName} object, const ApiDumpSettings
 //========================= Basetype Implementations ========================//
 
 @foreach basetype where(not '{baseName}' in ['ANativeWindow', 'AHardwareBuffer', 'CAMetalLayer'])
-inline std::ostream& dump_json_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "\\"" << object << "\\"";
 }}
 @end basetype
 @foreach basetype where('{baseName}' in ['ANativeWindow', 'AHardwareBuffer'])
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-inline std::ostream& dump_json_{baseName}(const {baseName}* object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{baseName}(const {baseName}* object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "\\"" << object << "\\"";
 }}
@@ -1521,7 +1495,7 @@ inline std::ostream& dump_json_{baseName}(const {baseName}* object, const ApiDum
 @end basetype
 @foreach basetype where('{baseName}' in ['CAMetalLayer'])
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-inline std::ostream& dump_json_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{baseName}({baseName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "\\"" << object << "\\"";
 }}
@@ -1531,7 +1505,7 @@ inline std::ostream& dump_json_{baseName}({baseName} object, const ApiDumpSettin
 //======================= System Type Implementations =======================//
 
 @foreach systype
-inline std::ostream& dump_json_{sysName}(const {sysType} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{sysName}(const {sysType} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << "\\"" << object << "\\"";
 }}
@@ -1540,7 +1514,7 @@ inline std::ostream& dump_json_{sysName}(const {sysType} object, const ApiDumpSe
 //========================== Handle Implementations =========================//
 
 @foreach handle
-inline std::ostream& dump_json_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{hdlName}(const {hdlName} object, const ApiDumpSettings& settings, int indents)
 {{
     if(settings.showAddress()) {{
         return settings.stream() << "\\"" << object << "\\"";
@@ -1598,13 +1572,13 @@ std::ostream& dump_json_{bitName}({bitName} object, const ApiDumpSettings& setti
 //=========================== Flag Implementations ==========================//
 
 @foreach flag where('{flagEnum}' != 'None')
-inline std::ostream& dump_json_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
 {{
     return dump_json_{flagEnum}(({flagEnum}) object, settings, indents);
 }}
 @end flag
 @foreach flag where('{flagEnum}' == 'None')
-inline std::ostream& dump_json_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{flagName}({flagName} object, const ApiDumpSettings& settings, int indents)
 {{
     return settings.stream() << '"' << object << "\\"";
 }}
@@ -1613,7 +1587,7 @@ inline std::ostream& dump_json_{flagName}({flagName} object, const ApiDumpSettin
 //======================= Func Pointer Implementations ======================//
 
 @foreach funcpointer
-inline std::ostream& dump_json_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int indents)
+std::ostream& dump_json_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int indents)
 {{
     if(settings.showAddress())
        settings.stream() << "\\"" << object << "\\"";
@@ -1626,7 +1600,7 @@ inline std::ostream& dump_json_{pfnName}({pfnName} object, const ApiDumpSettings
 //========================== Struct Implementations =========================//
 
 @foreach struct where('{sctName}' not in ['VkPhysicalDeviceMemoryProperties' ,'VkPhysicalDeviceGroupProperties'])
-std::ostream& dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents{sctConditionVars})
+std::ostream& dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << settings.indentation(indents) << "[\\n";
 
@@ -1636,42 +1610,44 @@ std::ostream& dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings
     @if('{memCondition}' != 'None')
     if({memCondition})
     @end if
-
+    @if('{memParameterStorage}' != '')
+    {memParameterStorage}
+    @end if
     @if({memPtrLevel} == 0)
         @if('{memName}' != 'pNext')
-    dump_json_value<const {memBaseType}>(object.{memName}, NULL, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions});
+    dump_json_value<const {memBaseType}>(object.{memName}, NULL, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID});
         @end if
         @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_json_pNext_trampoline(object.{memName}, settings, indents + 1);
     }} else {{
-        dump_json_value<const {memBaseType}>(object.{memName}, object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions});
+        dump_json_value<const {memBaseType}>(object.{memName}, object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID});
     }}
         @end if
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' == 'None')
-    dump_json_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions});
+    dump_json_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID});
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
-    dump_json_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // IQA
+    dump_json_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // IQA
     @end if
     @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
     @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
-    dump_json_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // JQA
+    dump_json_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // JQA
     @end if
     @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
     @if('{memLength}' == 'rasterizationSamples')
-    dump_json_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // JQA
+    dump_json_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // JQA
     @end if
     @if('{memLength}' != 'rasterizationSamples')
-    dump_json_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // JQA
+    dump_json_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // JQA
     @end if
     @end if
     @end if
     @if('{sctName}' == 'VkShaderModuleCreateInfo')
     @if('{memName}' == 'pCode')
     if(settings.showShader())
-        dump_json_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}{memInheritedConditions}); // KQA
+        dump_json_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // KQA
     else
         dump_json_special("SHADER DATA", settings, "{memType}", "{memName}", indents + 1);
     @end if
@@ -1841,14 +1817,17 @@ std::ostream& dump_json_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedPa
 
         @foreach parameter
         if (needParameterComma) settings.stream() << ",\\n";
+        @if('{prmParameterStorage}' != '')
+        {prmParameterStorage}
+        @end if
         @if({prmPtrLevel} == 0)
-        dump_json_value<const {prmBaseType}>({prmName}, NULL, settings, "{prmType}", "{prmName}", 4, dump_json_{prmTypeID}{prmInheritedConditions});
+        dump_json_value<const {prmBaseType}>({prmName}, NULL, settings, "{prmType}", "{prmName}", 4, dump_json_{prmTypeID});
         @end if
         @if({prmPtrLevel} == 1 and '{prmLength}' == 'None')
-        dump_json_pointer<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 4, dump_json_{prmTypeID}{prmInheritedConditions});
+        dump_json_pointer<const {prmBaseType}>({prmName}, settings, "{prmType}", "{prmName}", 4, dump_json_{prmTypeID});
         @end if
         @if({prmPtrLevel} == 1 and '{prmLength}' != 'None')
-        dump_json_array<const {prmBaseType}>({prmName}, {prmLength}, settings, "{prmType}", "{prmChildType}", "{prmName}", 4, dump_json_{prmTypeID}{prmInheritedConditions}); // PQA
+        dump_json_array<const {prmBaseType}>({prmName}, {prmLength}, settings, "{prmType}", "{prmChildType}", "{prmName}", 4, dump_json_{prmTypeID}); // PQA
         @end if
         needParameterComma = true;
         @end parameter
@@ -1882,30 +1861,32 @@ TRACKED_STATE = {
     ,
 }
 
-INHERITED_STATE = {
+PARAMETER_STATE = {
     'VkPipelineViewportStateCreateInfo': {
         'VkGraphicsPipelineCreateInfo': [
             {
                 'name': 'is_dynamic_viewport',
                 'type': 'bool',
-                'expr':
+                'stmt':
+                    'ApiDumpInstance::current().setIsDynamicViewport(' +
                     'object.pDynamicState && ' +
                     'std::count(' +
                         'object.pDynamicState->pDynamicStates, ' +
                         'object.pDynamicState->pDynamicStates + object.pDynamicState->dynamicStateCount, ' +
                         'VK_DYNAMIC_STATE_VIEWPORT' +
-                    ')',
+                    ') > 0);',
              },
              {
                 'name':'is_dynamic_scissor',
                 'type': 'bool',
-                'expr':
+                'stmt':
+                    'ApiDumpInstance::current().setIsDynamicScissor(' +
                     'object.pDynamicState && ' +
                     'std::count(' +
                         'object.pDynamicState->pDynamicStates, ' +
                         'object.pDynamicState->pDynamicStates + object.pDynamicState->dynamicStateCount, ' +
                         'VK_DYNAMIC_STATE_SCISSOR' +
-                    ')',
+                    '));',
             },
         ],
     },
@@ -1914,7 +1895,7 @@ INHERITED_STATE = {
             {
                 'name': 'cmd_buffer',
                 'type': 'VkCommandBuffer',
-                'expr': 'commandBuffer',
+                'stmt': 'ApiDumpInstance::current().setCmdBuffer(commandBuffer);',
             },
         ],
     },
@@ -1926,7 +1907,7 @@ VALIDITY_CHECKS = {
     },
     'VkCommandBufferBeginInfo': {
         # Tracked state ApiDumpInstance, and inherited cmd_buffer
-        'pInheritanceInfo': 'ApiDumpInstance::current().getCmdBufferLevel(cmd_buffer) == VK_COMMAND_BUFFER_LEVEL_SECONDARY',
+        'pInheritanceInfo': 'ApiDumpInstance::current().getCmdBufferLevel() == VK_COMMAND_BUFFER_LEVEL_SECONDARY',
     },
     'VkDescriptorSetLayoutBinding': {
         'pImmutableSamplers':
@@ -1937,8 +1918,8 @@ VALIDITY_CHECKS = {
         'pQueueFamilyIndices': 'object.sharingMode == VK_SHARING_MODE_CONCURRENT',
     },
     'VkPipelineViewportStateCreateInfo': {
-        'pViewports': '!is_dynamic_viewport', # Inherited state variable is_dynamic_viewport
-        'pScissors': '!is_dynamic_scissor',   # Inherited state variable is_dynamic_scissor
+        'pViewports': '!ApiDumpInstance::current().getIsDynamicViewport()', # Inherited state variable is_dynamic_viewport
+        'pScissors': '!ApiDumpInstance::current().getIsDynamicScissor()',   # Inherited state variable is_dynamic_scissor
     },
     'VkSwapchainCreateInfoKHR': {
         'pQueueFamilyIndices': 'object.imageSharingMode == VK_SHARING_MODE_CONCURRENT',
@@ -2418,10 +2399,10 @@ class VulkanVariable:
             self.pointerLevels -= 1
         assert(self.pointerLevels >= 0)
 
-        self.inheritedConditions = ''
-        if self.typeID in INHERITED_STATE and parentName in INHERITED_STATE[self.typeID]:
-            for states in INHERITED_STATE[self.typeID][parentName]:
-                self.inheritedConditions += ', ' + states['expr']
+        self.parameterStorage = ''
+        if self.typeID in PARAMETER_STATE and parentName in PARAMETER_STATE[self.typeID]:
+            for states in PARAMETER_STATE[self.typeID][parentName]:
+                self.parameterStorage += states['stmt']
 
 class VulkanBasetype:
 
@@ -2658,7 +2639,7 @@ class VulkanFunction:
                 'prmChildType': self.childType,
                 'prmPtrLevel': self.pointerLevels,
                 'prmLength': self.arrayLength,
-                'prmInheritedConditions': self.inheritedConditions,
+                'prmParameterStorage': self.parameterStorage,
             }
 
     def __init__(self, rootNode, constants, aliases, extensions):
@@ -2760,7 +2741,7 @@ class VulkanStruct:
                 'memLength': self.arrayLength,
                 'memLengthIsMember': self.lengthMember,
                 'memCondition': self.condition,
-                'memInheritedConditions': self.inheritedConditions,
+                'memParameterStorage': self.parameterStorage,
             }
 
 
@@ -2770,11 +2751,6 @@ class VulkanStruct:
         self.members = []
         for node in rootNode.findall('member'):
             self.members.append(VulkanStruct.Member(node, constants, self.name))
-        self.conditionVars = ''
-        if self.name in INHERITED_STATE:
-            for parent, states in INHERITED_STATE[self.name].items():
-                for state in states:
-                    self.conditionVars += ', ' + state['type'] + ' ' + state['name']
 
         self.structureIndex = -1
 
@@ -2790,7 +2766,6 @@ class VulkanStruct:
     def values(self):
         return {
             'sctName': self.name,
-            'sctConditionVars': self.conditionVars,
             'sctStructureTypeIndex': self.structureIndex,
         }
 

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1325,8 +1325,6 @@ void dump_json_{bitName}({bitName} object, const ApiDumpSettings& settings, int 
 {{
     bool is_first = true;
     settings.stream() << '"' << object;
-    if (object)
-        settings.stream() << ' ';
     @foreach option
         @if('{optMultiValue}' != 'None')
     if(object == {optValue}) {{

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1441,14 +1441,7 @@ void dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
 
         @if('{memCondition}' != 'None')
     else
-    {{
-        settings.stream() << settings.indentation(indents+1) << "{{\\n";
-        settings.stream() << settings.indentation(indents+2) << "\\"type\\" : \\"{memType}\\",\\n";
-        settings.stream() << settings.indentation(indents+2) << "\\"name\\" : \\"{memName}\\",\\n";
-        settings.stream() << settings.indentation(indents+2) << "\\"address\\" : \\"UNUSED\\",\\n";
-        settings.stream() << settings.indentation(indents+2) << "\\"value\\" : \\"UNUSED\\"\\n";
-        settings.stream() << settings.indentation(indents+1) << "}}";
-    }}
+        dump_json_UNUSED(settings, "{memType}", "{memName}", indents + 1);
         @end if
     @end member
     settings.stream() << "\\n" << settings.indentation(indents) << "]";

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -530,7 +530,10 @@ void dump_text_{sysName}(const {sysType} object, const ApiDumpSettings& settings
     OutputAddress(settings, object);
     @end if
     @if({sysNeedsPointer} == False)
-    settings.stream() << object;
+    if (settings.showAddress())
+        settings.stream() << object;
+    else
+        settings.stream() << "address";
     @end if
 }}
 @end systype
@@ -933,7 +936,10 @@ void dump_html_{sysName}(const {sysType} object, const ApiDumpSettings& settings
     settings.stream() << "</div>";
     @end if
     @if({sysNeedsPointer} == False)
-    settings.stream() << "<div class='val'>" << object << "</div></summary>";
+    if (settings.showAddress())
+        settings.stream() << "<div class='val'>" << object << "</div></summary>";
+    else
+        settings.stream() << "<div class='val'>address</div></summary>";
     @end if
 }}
 @end systype
@@ -1310,7 +1316,10 @@ void dump_json_{sysName}(const {sysType} object, const ApiDumpSettings& settings
     settings.stream() << "\\n";
     @end if
     @if({sysNeedsPointer} == False)
-    settings.stream() << "\\"" << object << "\\"";
+    if (settings.showAddress())
+        settings.stream() << "\\"" << object << "\\"";
+    else
+        settings.stream() << "\\"address\\"";
     @end if
 }}
 @end systype

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2016, 2019, 2021 Valve Corporation
-# Copyright (c) 2015-2016, 2019, 2021 LunarG, Inc.
+# Copyright (c) 2015-2023 Valve Corporation
+# Copyright (c) 2015-2023 LunarG, Inc.
 # Copyright (c) 2015-2016, 2019, 2021 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -426,8 +426,8 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkD
 """
 
 TEXT_CODEGEN = """
-/* Copyright (c) 2015-2016, 2019 Valve Corporation
- * Copyright (c) 2015-2016, 2019 LunarG, Inc.
+/* Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2016, 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -728,10 +728,10 @@ void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& sett
         @if({sctStructureTypeIndex} != -1)
     case {sctStructureTypeIndex}:
         @if({sctIsPNextChainConst} == True)
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        settings.formatNameType(indents, "pNext", "const void*");
         @end if
         @if({sctIsPNextChainConst} == False)
-        settings.formatNameType(settings.stream(), indents, "pNext", "void*");
+        settings.formatNameType(indents, "pNext", "void*");
         @end if
         settings.stream() << "{sctName}\\n";
         break;
@@ -740,11 +740,11 @@ void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& sett
 
     case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
     case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        settings.formatNameType(indents, "pNext", "const void*");
         settings.stream() << "NULL\\n";
         break;
     default:
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        settings.formatNameType(indents, "pNext", "const void*");
         settings.stream() << "UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\n";
     }}
 }}
@@ -765,12 +765,12 @@ void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
             dump_text_pNext_trampoline(static_cast<const void*>(static_cast<const VkBaseInStructure*>(object)->pNext), settings, indents);
         }} else {{
-            settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+            settings.formatNameType(indents, "pNext", "const void*");
             settings.stream() << "NULL\\n";
         }}
         break;
     default:
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        settings.formatNameType(indents, "pNext", "const void*");
         settings.stream() << "UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\n";
     }}
 }}
@@ -820,8 +820,8 @@ void dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 # that are opened are closed in another function. See api_dump.h. This may need refactoring.
 
 HTML_CODEGEN = """
-/* Copyright (c) 2015-2017, 2019 Valve Corporation
- * Copyright (c) 2015-2017, 2019 LunarG, Inc.
+/* Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2017, 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1184,8 +1184,8 @@ void dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 # This JSON Codegen is essentially copied from the HTML section above.
 
 JSON_CODEGEN = """
-/* Copyright (c) 2015-2019, 2019 Valve Corporation
- * Copyright (c) 2015-2019, 2019 LunarG, Inc.
+/* Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2017, 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1489,7 +1489,7 @@ void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         settings.stream() << settings.indentation(indents) << "{{\\n";
         settings.stream() << settings.indentation(indents + 1) << "\\"type\\" : \\"const void*\\",\\n";
         settings.stream() << settings.indentation(indents + 1) << "\\"name\\" : \\"pNext\\",\\n";
-        settings.stream() << settings.indentation(indents + 1) << "\\"value\\" : \\"UNKNOWN (\\"" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << "\\")\\n";
+        settings.stream() << settings.indentation(indents + 1) << "\\"value\\" : \\"UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\"\\n";
         settings.stream() << settings.indentation(indents) << "}}";
     }}
 }}

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -306,13 +306,13 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, 
         switch(ApiDumpInstance::current().settings().format())
         {{
             case ApiDumpFormat::Text:
-                dump_text_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"vVkResult\");
+                dump_text_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"VkResult\");
                 break;
             case ApiDumpFormat::Html:
-                dump_html_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"vVkResult\");
+                dump_html_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"VkResult\");
                 break;
             case ApiDumpFormat::Json:
-                dump_json_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR\", \"vVkResult\");
+                dump_json_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR\", \"VkResult\");
                 break;
         }}
     }}
@@ -656,7 +656,7 @@ void dump_text_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
 void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents)
 {{
     if (object == nullptr) {{
-        dump_text_value<const void*>(object, settings, "const void*", "pNext", indents, dump_text_void);
+        dump_text_value<const void*>(object, settings, "void*", "pNext", indents, dump_text_void);
         return;
     }}
 
@@ -664,7 +664,12 @@ void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& sett
     @foreach struct
         @if({sctStructureTypeIndex} != -1)
     case {sctStructureTypeIndex}:
+        @if({sctIsPNextChainConst} == True)
         settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        @end if
+        @if({sctIsPNextChainConst} == False)
+        settings.formatNameType(settings.stream(), indents, "pNext", "void*");
+        @end if
         settings.stream() << "{sctName}\\n";
         break;
         @end if
@@ -2758,10 +2763,17 @@ class VulkanStruct:
                         if(member.structValues  == opt.name):
                             self.structureIndex = opt.value
 
+        self.isPNextChainConst = False
+        for member in self.members:
+            if member.name == 'pNext' and member.type == "const void*":
+                self.isPNextChainConst = True
+                break
+
     def values(self):
         return {
             'sctName': self.name,
             'sctStructureTypeIndex': self.structureIndex,
+            'sctIsPNextChainConst': self.isPNextChainConst,
         }
 
 class VulkanSystemType:

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -793,7 +793,7 @@ void dump_text_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int 
 
 //========================== Struct Implementations =========================//
 
-@foreach struct where('{sctName}' not in ['VkPhysicalDeviceMemoryProperties','VkPhysicalDeviceGroupProperties'])
+@foreach struct
 void dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents)
 {{
     if(settings.showAddress())
@@ -862,32 +862,6 @@ void dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
     @end member
 }}
 @end struct
-
-void dump_text_VkPhysicalDeviceMemoryProperties(const VkPhysicalDeviceMemoryProperties& object, const ApiDumpSettings& settings, int indents)
-{{
-    if(settings.showAddress())
-        settings.stream() << &object << ":\\n";
-    else
-        settings.stream() << "address:\\n";
-
-    dump_text_value<const uint32_t>(object.memoryTypeCount, settings, "uint32_t", "memoryTypeCount", indents + 1, dump_text_uint32_t); // FET
-    dump_text_array<const VkMemoryType>(object.memoryTypes, object.memoryTypeCount, settings, "VkMemoryType[VK_MAX_MEMORY_TYPES]", "VkMemoryType", "memoryTypes", indents + 1, dump_text_VkMemoryType); // DQA
-    dump_text_value<const uint32_t>(object.memoryHeapCount, settings, "uint32_t", "memoryHeapCount", indents + 1, dump_text_uint32_t); // GET
-    dump_text_array<const VkMemoryHeap>(object.memoryHeaps, object.memoryHeapCount, settings, "VkMemoryHeap[VK_MAX_MEMORY_HEAPS]", "VkMemoryHeap", "memoryHeaps", indents + 1, dump_text_VkMemoryHeap); // EQA
-}}
-
-void dump_text_VkPhysicalDeviceGroupProperties(const VkPhysicalDeviceGroupProperties& object, const ApiDumpSettings& settings, int indents)
-{{
-    if(settings.showAddress())
-        settings.stream() << &object << ":\\n";
-    else
-        settings.stream() << "address:\\n";
-    dump_text_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_text_VkStructureType); // HET
-    dump_text_value<const void*>(object.pNext, settings, "void*", "pNext", indents + 1, dump_text_void); // IET
-    dump_text_value<const uint32_t>(object.physicalDeviceCount, settings, "uint32_t", "physicalDeviceCount", indents + 1, dump_text_uint32_t); // JET
-    dump_text_array<const VkPhysicalDevice>(object.physicalDevices, object.physicalDeviceCount, settings, "VkPhysicalDevice[VK_MAX_DEVICE_GROUP_SIZE]", "VkPhysicalDevice", "physicalDevices", indents + 1, dump_text_VkPhysicalDevice); // FQA
-    dump_text_value<const VkBool32>(object.subsetAllocation, settings, "VkBool32", "subsetAllocation", indents + 1, dump_text_VkBool32); // KET
-}}
 
 //========================== Union Implementations ==========================//
 
@@ -1218,7 +1192,7 @@ void dump_html_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int 
 
 //========================== Struct Implementations =========================//
 
-@foreach struct where('{sctName}' not in ['VkPhysicalDeviceMemoryProperties' ,'VkPhysicalDeviceGroupProperties'])
+@foreach struct
 void dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << "<div class=\'val\'>";
@@ -1282,35 +1256,6 @@ void dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
     @end member
 }}
 @end struct
-
-void dump_html_VkPhysicalDeviceMemoryProperties(const VkPhysicalDeviceMemoryProperties& object, const ApiDumpSettings& settings, int indents)
-{{
-    settings.stream() << "<div class='val'>";
-    if(settings.showAddress())
-        settings.stream() << &object << "\\n";
-    else
-        settings.stream() << "address\\n";
-    settings.stream() << "</div></summary>";
-    dump_html_value<const uint32_t>(object.memoryTypeCount, settings, "uint32_t", "memoryTypeCount", indents + 1, dump_html_uint32_t);
-    dump_html_array<const VkMemoryType>(object.memoryTypes, object.memoryTypeCount, settings, "VkMemoryType[VK_MAX_MEMORY_TYPES]", "VkMemoryType", "memoryTypes", indents + 1, dump_html_VkMemoryType); // ZRV
-    dump_html_value<const uint32_t>(object.memoryHeapCount, settings, "uint32_t", "memoryHeapCount", indents + 1, dump_html_uint32_t);
-    dump_html_array<const VkMemoryHeap>(object.memoryHeaps, object.memoryHeapCount, settings, "VkMemoryHeap[VK_MAX_MEMORY_HEAPS]", "VkMemoryHeap", "memoryHeaps", indents + 1, dump_html_VkMemoryHeap); // ZRW
-}}
-
-void dump_html_VkPhysicalDeviceGroupProperties(const VkPhysicalDeviceGroupProperties& object, const ApiDumpSettings& settings, int indents)
-{{
-    settings.stream() << "<div class='val'>";
-    if(settings.showAddress())
-        settings.stream() << &object << "\\n";
-    else
-        settings.stream() << "address\\n";
-    settings.stream() << "</div></summary>";
-    dump_html_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_html_VkStructureType);
-    dump_html_value<const void*>(object.pNext, settings, "void*", "pNext", indents + 1, dump_html_void);
-    dump_html_value<const uint32_t>(object.physicalDeviceCount, settings, "uint32_t", "physicalDeviceCount", indents + 1, dump_html_uint32_t);
-    dump_html_array<const VkPhysicalDevice>(object.physicalDevices, object.physicalDeviceCount, settings, "VkPhysicalDevice[VK_MAX_DEVICE_GROUP_SIZE]", "VkPhysicalDevice", "physicalDevices", indents + 1, dump_html_VkPhysicalDevice); // ZRX
-    dump_html_value<const VkBool32>(object.subsetAllocation, settings, "VkBool32", "subsetAllocation", indents + 1, dump_html_VkBool32);
-}}
 
 //========================== Union Implementations ==========================//
 
@@ -1600,7 +1545,7 @@ void dump_json_{pfnName}({pfnName} object, const ApiDumpSettings& settings, int 
 
 //========================== Struct Implementations =========================//
 
-@foreach struct where('{sctName}' not in ['VkPhysicalDeviceMemoryProperties' ,'VkPhysicalDeviceGroupProperties'])
+@foreach struct
 void dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << settings.indentation(indents) << "[\\n";
@@ -1681,36 +1626,6 @@ bool is_struct(const char *t)
     if (strncmp("{sctName}", tm, tmlen) == 0 && strlen("{sctName}") == tmlen) return true;
 @end struct
     return false;
-}}
-
-void dump_json_VkPhysicalDeviceMemoryProperties(const VkPhysicalDeviceMemoryProperties& object, const ApiDumpSettings& settings, int indents)
-{{
-    settings.stream() << settings.indentation(indents) << "[\\n";
-
-    dump_json_value<const uint32_t>(object.memoryTypeCount, NULL, settings, "uint32_t", "memoryTypeCount", indents + 1, dump_json_uint32_t);
-    settings.stream() << ",\\n";
-    dump_json_array<const VkMemoryType>(object.memoryTypes, object.memoryTypeCount, settings, "VkMemoryType[VK_MAX_MEMORY_TYPES]", "VkMemoryType", "memoryTypes", indents + 1, dump_json_VkMemoryType); // LQA
-    settings.stream() << ",\\n";
-    dump_json_value<const uint32_t>(object.memoryHeapCount, NULL, settings, "uint32_t", "memoryHeapCount", indents + 1, dump_json_uint32_t);
-    settings.stream() << ",\\n";
-    dump_json_array<const VkMemoryHeap>(object.memoryHeaps, object.memoryHeapCount, settings, "VkMemoryHeap[VK_MAX_MEMORY_HEAPS]", "VkMemoryHeap", "memoryHeaps", indents + 1, dump_json_VkMemoryHeap); // MQA
-    settings.stream() << "\\n" << settings.indentation(indents) << "]";
-}}
-
-void dump_json_VkPhysicalDeviceGroupProperties(const VkPhysicalDeviceGroupProperties& object, const ApiDumpSettings& settings, int indents)
-{{
-    settings.stream() << settings.indentation(indents) << "[\\n";
-
-    dump_json_value<const VkStructureType>(object.sType, NULL, settings, "VkStructureType", "sType", indents + 1, dump_json_VkStructureType);
-    settings.stream() << ",\\n";
-    dump_json_value<const void*>(object.pNext, object.pNext, settings, "void*", "pNext", indents + 1, dump_json_void);
-    settings.stream() << ",\\n";
-    dump_json_value<const uint32_t>(object.physicalDeviceCount, NULL, settings, "uint32_t", "physicalDeviceCount", indents + 1, dump_json_uint32_t);
-    settings.stream() << ",\\n";
-    dump_json_array<const VkPhysicalDevice>(object.physicalDevices, object.physicalDeviceCount, settings, "VkPhysicalDevice[VK_MAX_DEVICE_GROUP_SIZE]", "VkPhysicalDevice", "physicalDevices", indents + 1, dump_json_VkPhysicalDevice); // NQA
-    settings.stream() << ",\\n";
-    dump_json_value<const VkBool32>(object.subsetAllocation, NULL, settings, "VkBool32", "subsetAllocation", indents + 1, dump_json_VkBool32);
-    settings.stream() << "\\n" << settings.indentation(indents) << "]";
 }}
 
 //========================== Union Implementations ==========================//
@@ -2768,6 +2683,20 @@ class VulkanStruct:
             if member.name == 'pNext' and member.type == "const void*":
                 self.isPNextChainConst = True
                 break
+
+        # The xml doesn't contain the relevant information here since the struct contains 'fixed' length arrays.
+        # Thus we have to fix up the variable such that the length member corresponds to the runtime length, not compile time.
+        if self.name in ['VkPhysicalDeviceMemoryProperties','VkPhysicalDeviceGroupProperties']:
+            for member in self.members:
+                if member.name == 'memoryTypes':
+                    member.lengthMember = True
+                    member.arrayLength = 'memoryTypeCount'
+                if member.name == 'memoryHeaps':
+                    member.lengthMember = True
+                    member.arrayLength = 'memoryHeapCount'
+                if member.name == 'physicalDevices':
+                    member.lengthMember = True
+                    member.arrayLength = 'physicalDeviceCount'
 
     def values(self):
         return {

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1633,6 +1633,15 @@ PARAMETER_STATE = {
             },
         ],
     },
+    'VkPhysicalDeviceMemoryProperties': {
+        'VkPhysicalDeviceMemoryProperties2': [
+            {
+                'name': 'memoryProperties',
+                'type': 'VkPhysicalDeviceMemoryProperties',
+                'stmt': 'ApiDumpInstance::current().setMemoryHeapCount(object.memoryProperties.memoryHeapCount);',
+            },
+        ],
+    },
 }
 
 VALIDITY_CHECKS = {
@@ -2512,7 +2521,7 @@ class VulkanStruct:
 
         # The xml doesn't contain the relevant information here since the struct contains 'fixed' length arrays.
         # Thus we have to fix up the variable such that the length member corresponds to the runtime length, not compile time.
-        if self.name in ['VkPhysicalDeviceMemoryProperties','VkPhysicalDeviceGroupProperties']:
+        if self.name in ['VkPhysicalDeviceMemoryProperties','VkPhysicalDeviceGroupProperties', 'VkPhysicalDeviceMemoryBudgetPropertiesEXT']:
             for member in self.members:
                 if member.name == 'memoryTypes':
                     member.lengthMember = True
@@ -2523,6 +2532,12 @@ class VulkanStruct:
                 if member.name == 'physicalDevices':
                     member.lengthMember = True
                     member.arrayLength = 'physicalDeviceCount'
+                if member.name == 'heapBudget':
+                    member.lengthMember = True
+                    member.arrayLength = 'ApiDumpInstance::current().getMemoryHeapCount()'
+                if member.name == 'heapUsage':
+                    member.lengthMember = True
+                    member.arrayLength = 'ApiDumpInstance::current().getMemoryHeapCount()'
 
     def values(self):
         return {

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -2528,7 +2528,7 @@ class VulkanStruct:
 
         # The xml doesn't contain the relevant information here since the struct contains 'fixed' length arrays.
         # Thus we have to fix up the variable such that the length member corresponds to the runtime length, not compile time.
-        if self.name in ['VkPhysicalDeviceMemoryProperties','VkPhysicalDeviceGroupProperties', 'VkPhysicalDeviceMemoryBudgetPropertiesEXT']:
+        if self.name in ['VkPhysicalDeviceMemoryProperties','VkPhysicalDeviceGroupProperties', 'VkPhysicalDeviceMemoryBudgetPropertiesEXT', 'VkQueueFamilyGlobalPriorityPropertiesKHR']:
             for member in self.members:
                 if member.name == 'memoryTypes':
                     member.lengthMember = True
@@ -2545,6 +2545,10 @@ class VulkanStruct:
                 if member.name == 'heapUsage':
                     member.lengthMember = True
                     member.arrayLength = 'ApiDumpInstance::current().getMemoryHeapCount()'
+                if member.name == 'priorities':
+                    member.lengthMember = True
+                    member.arrayLength = 'priorityCount'
+
 
     def values(self):
         return {

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -802,53 +802,53 @@ void dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
         settings.stream() << "address:\\n";
 
     @foreach member
-    @if('{memCondition}' != 'None')
+        @if('{memCondition}' != 'None')
     if({memCondition})
-    @end if
-    @if('{memParameterStorage}' != '')
+        @end if
+        @if('{memParameterStorage}' != '')
     {memParameterStorage}
-    @end if
-    @if({memPtrLevel} == 0)
-        @if('{memName}' != 'pNext')
+        @end if
+        @if({memPtrLevel} == 0)
+            @if('{memName}' != 'pNext')
     dump_text_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID});  // AET
-        @end if
-        @if('{memName}' == 'pNext')
+            @end if
+            @if('{memName}' == 'pNext')
     dump_text_pNext_struct_name(object.{memName}, settings, indents + 1);
+            @end if
         @end if
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' == 'None')
+        @if({memPtrLevel} == 1 and '{memLength}' == 'None')
     dump_text_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_text_{memTypeID});
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
+        @end if
+        @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
     dump_text_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // AQA
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
-    @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
+        @end if
+        @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
+            @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
     dump_text_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // BQA
-    @end if
-    @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
-    @if('{memLength}' == 'rasterizationSamples')
+            @end if
+            @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
+                @if('{memLength}' == 'rasterizationSamples')
     dump_text_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // BQB
-    @end if
-    @if('{memLength}' != 'rasterizationSamples')
+                @end if
+                @if('{memLength}' != 'rasterizationSamples')
     dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // BQB
-    @end if
-    @end if
-    @end if
+                @end if
+            @end if
+        @end if
 
-    @if('{sctName}' == 'VkShaderModuleCreateInfo')
-    @if('{memName}' == 'pCode')
+        @if('{sctName}' == 'VkShaderModuleCreateInfo')
+            @if('{memName}' == 'pCode')
     if(settings.showShader())
         dump_text_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_text_{memTypeID}); // CQA
     else
         dump_text_special("SHADER DATA", settings, "{memType}", "{memName}", indents + 1);
-    @end if
-    @end if
+            @end if
+        @end if
 
-    @if('{memCondition}' != 'None')
+        @if('{memCondition}' != 'None')
     else
         dump_text_special("UNUSED", settings, "{memType}", "{memName}", indents + 1);
-    @end if
+        @end if
     @end member
 
     @foreach member
@@ -1229,56 +1229,56 @@ void dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
     settings.stream() << "</div></summary>";
 
     @foreach member
-    @if('{memCondition}' != 'None')
+        @if('{memCondition}' != 'None')
     if({memCondition})
-    @end if
-    @if('{memParameterStorage}' != '')
-    {memParameterStorage}
-    @end if
-    @if({memPtrLevel} == 0)
-        @if('{memName}' != 'pNext')
-    dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID});
         @end if
-        @if('{memName}' == 'pNext')
+        @if('{memParameterStorage}' != '')
+    {memParameterStorage}
+        @end if
+        @if({memPtrLevel} == 0)
+            @if('{memName}' != 'pNext')
+    dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID});
+            @end if
+            @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_html_pNext_trampoline(object.{memName}, settings, indents + 1);
     }} else {{
         dump_html_value<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID});
     }}
+            @end if
         @end if
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' == 'None')
+        @if({memPtrLevel} == 1 and '{memLength}' == 'None')
     dump_html_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_html_{memTypeID});
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
+        @end if
+        @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
     dump_html_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRR
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
-    @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
+        @end if
+        @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
+            @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
     dump_html_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRS
-    @end if
-    @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
-    @if('{memLength}' == 'rasterizationSamples')
+            @end if
+            @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
+                @if('{memLength}' == 'rasterizationSamples')
     dump_html_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRT
-    @end if
-    @if('{memLength}' != 'rasterizationSamples')
+                @end if
+                @if('{memLength}' != 'rasterizationSamples')
     dump_html_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRT
-    @end if
-    @end if
-    @end if
-    @if('{sctName}' == 'VkShaderModuleCreateInfo')
-    @if('{memName}' == 'pCode')
+                @end if
+            @end if
+        @end if
+        @if('{sctName}' == 'VkShaderModuleCreateInfo')
+            @if('{memName}' == 'pCode')
     if(settings.showShader())
         dump_html_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_html_{memTypeID}); // ZRU
     else
         dump_html_special("SHADER DATA", settings, "{memType}", "{memName}", indents + 1);
-    @end if
-    @end if
+            @end if
+        @end if
 
-    @if('{memCondition}' != 'None')
+        @if('{memCondition}' != 'None')
     else
         dump_html_special("UNUSED", settings, "{memType}", "{memName}", indents + 1);
-    @end if
+        @end if
     @end member
 }}
 @end struct
@@ -1606,56 +1606,56 @@ void dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
     settings.stream() << settings.indentation(indents) << "[\\n";
 
     @foreach member
-    @if({memIndex} != 0)
+        @if({memIndex} != 0)
     settings.stream() << ",\\n";
-    @end if
-    @if('{memCondition}' != 'None')
-    if({memCondition})
-    @end if
-    @if('{memParameterStorage}' != '')
-    {memParameterStorage}
-    @end if
-    @if({memPtrLevel} == 0)
-        @if('{memName}' != 'pNext')
-    dump_json_value<const {memBaseType}>(object.{memName}, NULL, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID});
         @end if
-        @if('{memName}' == 'pNext')
+        @if('{memCondition}' != 'None')
+    if({memCondition})
+        @end if
+        @if('{memParameterStorage}' != '')
+    {memParameterStorage}
+        @end if
+        @if({memPtrLevel} == 0)
+            @if('{memName}' != 'pNext')
+    dump_json_value<const {memBaseType}>(object.{memName}, NULL, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID});
+            @end if
+            @if('{memName}' == 'pNext')
     if(object.pNext != nullptr){{
         dump_json_pNext_trampoline(object.{memName}, settings, indents + 1);
     }} else {{
         dump_json_value<const {memBaseType}>(object.{memName}, object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID});
     }}
+            @end if
         @end if
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' == 'None')
+        @if({memPtrLevel} == 1 and '{memLength}' == 'None')
     dump_json_pointer<const {memBaseType}>(object.{memName}, settings, "{memType}", "{memName}", indents + 1, dump_json_{memTypeID});
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
+        @end if
+        @if({memPtrLevel} == 1 and '{memLength}' != 'None' and not {memLengthIsMember})
     dump_json_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // IQA
-    @end if
-    @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
-    @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
+        @end if
+        @if({memPtrLevel} == 1 and '{memLength}' != 'None' and {memLengthIsMember} and '{memName}' != 'pCode')
+            @if('{memLength}'[0].isdigit() or '{memLength}'[0].isupper())
     dump_json_array<const {memBaseType}>(object.{memName}, {memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // JQA
-    @end if
-    @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
-    @if('{memLength}' == 'rasterizationSamples')
+            @end if
+            @if(not ('{memLength}'[0].isdigit() or '{memLength}'[0].isupper()))
+                @if('{memLength}' == 'rasterizationSamples')
     dump_json_array<const {memBaseType}>(object.{memName}, (object.{memLength} + 31) / 32, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // JQA
-    @end if
-    @if('{memLength}' != 'rasterizationSamples')
+                @end if
+                @if('{memLength}' != 'rasterizationSamples')
     dump_json_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // JQA
-    @end if
-    @end if
-    @end if
-    @if('{sctName}' == 'VkShaderModuleCreateInfo')
-    @if('{memName}' == 'pCode')
+                @end if
+            @end if
+        @end if
+        @if('{sctName}' == 'VkShaderModuleCreateInfo')
+            @if('{memName}' == 'pCode')
     if(settings.showShader())
         dump_json_array<const {memBaseType}>(object.{memName}, object.{memLength}, settings, "{memType}", "{memChildType}", "{memName}", indents + 1, dump_json_{memTypeID}); // KQA
     else
         dump_json_special("SHADER DATA", settings, "{memType}", "{memName}", indents + 1);
-    @end if
-    @end if
+            @end if
+        @end if
 
-    @if('{memCondition}' != 'None')
+        @if('{memCondition}' != 'None')
     else
     {{
         settings.stream() << settings.indentation(indents+1) << "{{\\n";
@@ -1665,7 +1665,7 @@ void dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
         settings.stream() << settings.indentation(indents+2) << "\\"value\\" : \\"UNUSED\\"\\n";
         settings.stream() << settings.indentation(indents+1) << "}}";
     }}
-    @end if
+        @end if
     @end member
     settings.stream() << "\\n" << settings.indentation(indents) << "]";
 }}

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -131,46 +131,6 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstance
     return result;
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator)
-{{
-    ApiDumpInstance::current().outputMutex()->lock();
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_function_head(ApiDumpInstance::current(), \"vkDestroyInstance(instance, pAllocator)\", \"void\");
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_function_head(ApiDumpInstance::current(), \"vkDestroyInstance(instance, pAllocator)\", \"void\");
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_function_head(ApiDumpInstance::current(), \"vkDestroyInstance\", \"void\");
-            break;
-        }}
-    }}
-    // Destroy the dispatch table
-    dispatch_key key = get_dispatch_key(instance);
-    instance_dispatch_table(instance)->DestroyInstance(instance, pAllocator);
-    destroy_instance_dispatch_table(key);
-
-    // Output the API dump
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_vkDestroyInstance(ApiDumpInstance::current(), instance, pAllocator);
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_vkDestroyInstance(ApiDumpInstance::current(), instance, pAllocator);
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_vkDestroyInstance(ApiDumpInstance::current(), instance, pAllocator);
-            break;
-        }}
-    }}
-    ApiDumpInstance::current().outputMutex()->unlock();
-}}
-
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
 {{
     ApiDumpInstance::current().outputMutex()->lock();
@@ -225,47 +185,6 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice p
     return result;
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator)
-{{
-    ApiDumpInstance::current().outputMutex()->lock();
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-            case ApiDumpFormat::Text:
-                dump_text_function_head(ApiDumpInstance::current(), \"vkDestroyDevice(device, pAllocator)\", \"void\");
-                break;
-            case ApiDumpFormat::Html:
-                dump_html_function_head(ApiDumpInstance::current(), \"vkDestroyDevice(device, pAllocator)\", \"void\");
-                break;
-            case ApiDumpFormat::Json:
-                dump_json_function_head(ApiDumpInstance::current(), \"vkDestroyDevice\", \"void\");
-                break;
-        }}
-    }}
-
-    // Destroy the dispatch table
-    dispatch_key key = get_dispatch_key(device);
-    device_dispatch_table(device)->DestroyDevice(device, pAllocator);
-    destroy_device_dispatch_table(key);
-
-    // Output the API dump
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-            case ApiDumpFormat::Text:
-                dump_text_vkDestroyDevice(ApiDumpInstance::current(), device, pAllocator);
-                break;
-            case ApiDumpFormat::Html:
-                dump_html_vkDestroyDevice(ApiDumpInstance::current(), device, pAllocator);
-                break;
-            case ApiDumpFormat::Json:
-                dump_json_vkDestroyDevice(ApiDumpInstance::current(), device, pAllocator);
-                break;
-        }}
-    }}
-    ApiDumpInstance::current().outputMutex()->unlock();
-}}
-
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount, VkExtensionProperties* pProperties)
 {{
     return util_GetExtensionProperties(0, NULL, pPropertyCount, pProperties);
@@ -299,47 +218,9 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(
     return util_GetLayerProperties(ARRAY_SIZE(layerProperties), layerProperties, pPropertyCount, pProperties);
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo)
-{{
-    ApiDumpInstance::current().outputMutex()->lock();
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-            case ApiDumpFormat::Text:
-                dump_text_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"VkResult\");
-                break;
-            case ApiDumpFormat::Html:
-                dump_html_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"VkResult\");
-                break;
-            case ApiDumpFormat::Json:
-                dump_json_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR\", \"VkResult\");
-                break;
-        }}
-    }}
-
-    VkResult result = device_dispatch_table(queue)->QueuePresentKHR(queue, pPresentInfo);
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-            case ApiDumpFormat::Text:
-                dump_text_vkQueuePresentKHR(ApiDumpInstance::current(), result, queue, pPresentInfo);
-                break;
-            case ApiDumpFormat::Html:
-                dump_html_vkQueuePresentKHR(ApiDumpInstance::current(), result, queue, pPresentInfo);
-                break;
-            case ApiDumpFormat::Json:
-                dump_json_vkQueuePresentKHR(ApiDumpInstance::current(), result, queue, pPresentInfo);
-                break;
-        }}
-    }}
-    ApiDumpInstance::current().nextFrame();
-    ApiDumpInstance::current().outputMutex()->unlock();
-    return result;
-}}
-
 // Autogen instance functions
 
-@foreach function where('{funcDispatchType}' == 'instance' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkCreateInstance', 'vkDestroyInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties','vkGetPhysicalDeviceToolPropertiesEXT'])
+@foreach function where('{funcDispatchType}' == 'instance' and '{funcName}' not in ['vkCreateInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
     ApiDumpInstance::current().outputMutex()->lock();
@@ -357,7 +238,31 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
                 break;
         }}
     }}
+
+    @if('{funcName}' == 'vkGetPhysicalDeviceToolPropertiesEXT')
+    static const VkPhysicalDeviceToolPropertiesEXT api_dump_layer_tool_props = {{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
+        nullptr,
+        "API Dump Layer",
+        "2",
+        VK_TOOL_PURPOSE_PROFILING_BIT_EXT | VK_TOOL_PURPOSE_TRACING_BIT_EXT,
+        "The VK_LAYER_LUNARG_api_dump utility layer prints API calls, parameters, and values to the identified output stream.",
+        "VK_LAYER_LUNARG_api_dump"}};
+
+    auto original_pToolProperties = pToolProperties;
+    if (pToolProperties != nullptr) {{
+        *pToolProperties = api_dump_layer_tool_props;
+        pToolProperties = ((*pToolCount > 1) ? &pToolProperties[1] : nullptr);
+        (*pToolCount)--;
+    }}
+    @end if
+
+    @if('{funcReturn}' != 'void')
     {funcReturn} result = instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
+    @end if
+    @if('{funcReturn}' == 'void')
+    instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
+    @end if
     {funcStateTrackingCode}
     @if('{funcName}' == 'vkEnumeratePhysicalDevices')
     if (pPhysicalDeviceCount != nullptr && pPhysicalDevices != nullptr) {{
@@ -366,10 +271,22 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
         }}
     }}
     @end if
+    @if('{funcName}' == 'vkDestroyInstance')
+    destroy_instance_dispatch_table(get_dispatch_key(instance));
+    @end if
+
+    @if('{funcName}' == 'vkGetPhysicalDeviceToolPropertiesEXT')
+    if (original_pToolProperties != nullptr) {{
+        pToolProperties = original_pToolProperties;
+    }}
+
+    (*pToolCount)++;
+    @end if
 
     if (ApiDumpInstance::current().shouldDumpOutput()) {{
         switch(ApiDumpInstance::current().settings().format())
         {{
+            @if('{funcReturn}' != 'void')
             case ApiDumpFormat::Text:
                 dump_text_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
                 break;
@@ -379,54 +296,30 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
             case ApiDumpFormat::Json:
                 dump_json_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
                 break;
+            @end if
+            @if('{funcReturn}' == 'void')
+            case ApiDumpFormat::Text:
+                dump_text_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+                break;
+            @end if
         }}
     }}
     ApiDumpInstance::current().outputMutex()->unlock();
+    @if('{funcReturn}' != 'void')
     return result;
-}}
-@end function
-
-@foreach function where('{funcDispatchType}' == 'instance' and '{funcReturn}' == 'void' and '{funcName}' not in ['vkCreateInstance', 'vkDestroyInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties'])
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
-{{
-    ApiDumpInstance::current().outputMutex()->lock();
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_function_head(ApiDumpInstance::current(), \"{funcName}\", \"{funcReturn}\");
-            break;
-        }}
-    }}
-    instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
-    {funcStateTrackingCode}
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
-            break;
-        }}
-    }}
-    ApiDumpInstance::current().outputMutex()->unlock();
+    @end if
 }}
 @end function
 
 // Autogen device functions
 
-@foreach function where('{funcDispatchType}' == 'device' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkQueuePresentKHR', 'vkGetDeviceProcAddr'])
+@foreach function where('{funcDispatchType}' == 'device' and '{funcName}' not in ['vkGetDeviceProcAddr'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
     ApiDumpInstance::current().outputMutex()->lock();
@@ -456,11 +349,22 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
                 break;
         }}
     }}
+
+    @if('{funcReturn}' != 'void')
     {funcReturn} result = device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
+    @end if
+    @if('{funcReturn}' == 'void')
+    device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
+    @end if
     {funcStateTrackingCode}
+    @if('{funcName}' == 'vkDestroyDevice')
+    destroy_device_dispatch_table(get_dispatch_key(device));
+    @end if
+
     if (ApiDumpInstance::current().shouldDumpOutput()) {{
         switch(ApiDumpInstance::current().settings().format())
         {{
+            @if('{funcReturn}' != 'void')
             case ApiDumpFormat::Text:
                 dump_text_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
                 break;
@@ -470,36 +374,8 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
             case ApiDumpFormat::Json:
                 dump_json_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
                 break;
-        }}
-    }}
-    ApiDumpInstance::current().outputMutex()->unlock();
-    return result;
-}}
-@end function
-
-@foreach function where('{funcDispatchType}' == 'device' and '{funcReturn}' == 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkGetDeviceProcAddr'])
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
-{{
-    ApiDumpInstance::current().outputMutex()->lock();
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-            case ApiDumpFormat::Text:
-                dump_text_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
-                break;
-            case ApiDumpFormat::Html:
-                dump_html_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
-                break;
-            case ApiDumpFormat::Json:
-                dump_json_function_head(ApiDumpInstance::current(), \"{funcName}\", \"{funcReturn}\");
-                break;
-        }}
-    }}
-    device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
-    {funcStateTrackingCode}
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
+            @end if
+            @if('{funcReturn}' == 'void')
             case ApiDumpFormat::Text:
                 dump_text_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
                 break;
@@ -509,79 +385,29 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
             case ApiDumpFormat::Json:
                 dump_json_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
                 break;
+            @end if
         }}
     }}
     ApiDumpInstance::current().outputMutex()->unlock();
+    @if('{funcName}' == 'vkQueuePresentKHR')
+    ApiDumpInstance::current().nextFrame();
+    @end if
+    @if('{funcReturn}' != 'void')
+    return result;
+    @end if
 }}
 @end function
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t *pToolCount, VkPhysicalDeviceToolPropertiesEXT *pToolProperties)
-{{
-    ApiDumpInstance::current().outputMutex()->lock();
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-            case ApiDumpFormat::Text:
-                dump_text_function_head(ApiDumpInstance::current(), \"vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)\", \"VkResult\");
-                break;
-            case ApiDumpFormat::Html:
-                dump_html_function_head(ApiDumpInstance::current(), \"vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)\", \"VkResult\");
-                break;
-            case ApiDumpFormat::Json:
-                dump_json_function_head(ApiDumpInstance::current(), \"vkGetPhysicalDeviceToolPropertiesEXT\", \"VkResult\");
-                break;
-        }}
-    }}
-    static const VkPhysicalDeviceToolPropertiesEXT api_dump_layer_tool_props = {{
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
-        nullptr,
-        "API Dump Layer",
-        "2",
-        VK_TOOL_PURPOSE_PROFILING_BIT_EXT | VK_TOOL_PURPOSE_TRACING_BIT_EXT,
-        "The VK_LAYER_LUNARG_api_dump utility layer prints API calls, parameters, and values to the identified output stream.",
-        "VK_LAYER_LUNARG_api_dump"}};
-
-    auto original_pToolProperties = pToolProperties;
-    if (pToolProperties != nullptr) {{
-        *pToolProperties = api_dump_layer_tool_props;
-        pToolProperties = ((*pToolCount > 1) ? &pToolProperties[1] : nullptr);
-        (*pToolCount)--;
-    }}
-
-    VkLayerInstanceDispatchTable *pInstanceTable = instance_dispatch_table(physicalDevice);
-    VkResult result = pInstanceTable->GetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties);
-
-    if (original_pToolProperties != nullptr) {{
-        pToolProperties = original_pToolProperties;
-    }}
-
-    (*pToolCount)++;
-    if (ApiDumpInstance::current().shouldDumpOutput()) {{
-        switch(ApiDumpInstance::current().settings().format())
-        {{
-            case ApiDumpFormat::Text:
-                dump_text_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
-                break;
-            case ApiDumpFormat::Html:
-                dump_html_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
-                break;
-            case ApiDumpFormat::Json:
-                dump_json_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
-                break;
-        }}
-    }}
-    return result;
-}}
-
 VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName)
 {{
-    @foreach function where('{funcType}' == 'instance'  and '{funcName}' not in [ 'vkEnumerateDeviceExtensionProperties' ])
+    @foreach function where('{funcType}' in ['global', 'instance'] and '{funcName}' not in [ 'vkEnumerateDeviceExtensionProperties' ])
     if(strcmp(pName, "{funcName}") == 0)
         return reinterpret_cast<PFN_vkVoidFunction>({funcName});
     @end function
 
+    // Haven't created an instance yet, exit now since there is no instance_dispatch_table
     if(instance_dispatch_table(instance)->GetInstanceProcAddr == NULL)
-        return NULL;
+        return nullptr;
     return instance_dispatch_table(instance)->GetInstanceProcAddr(instance, pName);
 }}
 
@@ -592,8 +418,9 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkD
         return reinterpret_cast<PFN_vkVoidFunction>({funcName});
     @end function
 
+    // Haven't created a device yet, exit now since there is no device_dispatch_table
     if(device_dispatch_table(device)->GetDeviceProcAddr == NULL)
-        return NULL;
+        return nullptr;
     return device_dispatch_table(device)->GetDeviceProcAddr(device, pName);
 }}
 """
@@ -2576,9 +2403,10 @@ class VulkanFunction:
         self.namedParams = ', '.join(p.name for p in self.parameters)
         self.typedParams = ', '.join(p.text for p in self.parameters)
 
-        if self.parameters[0].type in ['VkInstance', 'VkPhysicalDevice'] or self.name == 'vkCreateInstance':
+        self.dispatchType = 'global'
+        if self.parameters[0].type in ['VkInstance', 'VkPhysicalDevice']:
             self.dispatchType = 'instance'
-        else:
+        elif self.parameters[0].type in ['VkDevice', 'VkCommandBuffer', 'VkQueue']:
             self.dispatchType = 'device'
 
         if self.name in extensions and extensions[self.name].type == 'instance':

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -638,11 +638,18 @@ void dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
         settings.stream() << "address:\\n";
 
     @foreach member
+        @if('{memParameterStorage}' != '' and '{memCondition}' != 'None')
+    if({memCondition})
+        {memParameterStorage}
+        @end if
+        @if('{memParameterStorage}' != '' and '{memCondition}' == 'None')
+    {memParameterStorage}
+        @end if
+    @end member
+
+    @foreach member
         @if('{memCondition}' != 'None')
     if({memCondition})
-        @end if
-        @if('{memParameterStorage}' != '')
-    {memParameterStorage}
         @end if
         @if({memPtrLevel} == 0)
             @if('{memName}' != 'pNext')
@@ -1038,11 +1045,18 @@ void dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
     settings.stream() << "</div></summary>";
 
     @foreach member
+        @if('{memParameterStorage}' != '' and '{memCondition}' != 'None')
+    if({memCondition})
+        {memParameterStorage}
+        @end if
+        @if('{memParameterStorage}' != '' and '{memCondition}' == 'None')
+    {memParameterStorage}
+        @end if
+    @end member
+
+    @foreach member
         @if('{memCondition}' != 'None')
     if({memCondition})
-        @end if
-        @if('{memParameterStorage}' != '')
-    {memParameterStorage}
         @end if
         @if({memPtrLevel} == 0)
             @if('{memName}' != 'pNext')
@@ -1390,14 +1404,21 @@ void dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
     settings.stream() << settings.indentation(indents) << "[\\n";
 
     @foreach member
+        @if('{memParameterStorage}' != '' and '{memCondition}' != 'None')
+    if({memCondition})
+        {memParameterStorage}
+        @end if
+        @if('{memParameterStorage}' != '' and '{memCondition}' == 'None')
+    {memParameterStorage}
+        @end if
+    @end member
+
+    @foreach member
         @if({memIndex} != 0)
     settings.stream() << ",\\n";
         @end if
         @if('{memCondition}' != 'None')
     if({memCondition})
-        @end if
-        @if('{memParameterStorage}' != '')
-    {memParameterStorage}
         @end if
         @if({memPtrLevel} == 0)
             @if('{memName}' != 'pNext')

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -628,9 +628,9 @@ TEXT_CODEGEN = """
 
 #include "api_dump.h"
 
-@foreach struct
-void dump_text_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents);
-@end struct
+void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents);
+void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents);
+
 @foreach union
 void dump_text_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
 @end union
@@ -650,67 +650,6 @@ void dump_text_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
     dump_text_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
 #endif // VK_ENABLE_BETA_EXTENSIONS
-
-//======================== pNext Chain Implementation =======================//
-
-void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents)
-{{
-    if (object == nullptr) {{
-        dump_text_value<const void*>(object, settings, "void*", "pNext", indents, dump_text_void);
-        return;
-    }}
-
-    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct
-        @if({sctStructureTypeIndex} != -1)
-    case {sctStructureTypeIndex}:
-        @if({sctIsPNextChainConst} == True)
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
-        @end if
-        @if({sctIsPNextChainConst} == False)
-        settings.formatNameType(settings.stream(), indents, "pNext", "void*");
-        @end if
-        settings.stream() << "{sctName}\\n";
-        break;
-        @end if
-    @end struct
-
-    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
-    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
-        settings.stream() << "NULL\\n";
-        break;
-    default:
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
-        settings.stream() << "UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\n";
-    }}
-}}
-
-void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
-{{
-    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct
-        @if({sctStructureTypeIndex} != -1)
-    case {sctStructureTypeIndex}:
-        dump_text_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_text_{sctName});
-        break;
-        @end if
-    @end struct
-
-    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
-    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
-        if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
-            dump_text_pNext_trampoline(static_cast<const void*>(static_cast<const VkBaseInStructure*>(object)->pNext), settings, indents);
-        }} else {{
-            settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
-            settings.stream() << "NULL\\n";
-        }}
-        break;
-    default:
-        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
-        settings.stream() << "UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\n";
-    }}
-}}
 
 //=========================== Type Implementations ==========================//
 
@@ -974,6 +913,67 @@ void dump_text_{unName}(const {unName}& object, const ApiDumpSettings& settings,
 }}
 @end union
 
+//======================== pNext Chain Implementation =======================//
+
+void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents)
+{{
+    if (object == nullptr) {{
+        dump_text_value<const void*>(object, settings, "void*", "pNext", indents, dump_text_void);
+        return;
+    }}
+
+    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
+    @foreach struct
+        @if({sctStructureTypeIndex} != -1)
+    case {sctStructureTypeIndex}:
+        @if({sctIsPNextChainConst} == True)
+        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        @end if
+        @if({sctIsPNextChainConst} == False)
+        settings.formatNameType(settings.stream(), indents, "pNext", "void*");
+        @end if
+        settings.stream() << "{sctName}\\n";
+        break;
+        @end if
+    @end struct
+
+    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
+    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
+        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        settings.stream() << "NULL\\n";
+        break;
+    default:
+        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        settings.stream() << "UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\n";
+    }}
+}}
+
+void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
+{{
+    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
+    @foreach struct
+        @if({sctStructureTypeIndex} != -1)
+    case {sctStructureTypeIndex}:
+        dump_text_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_text_{sctName});
+        break;
+        @end if
+    @end struct
+
+    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
+    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
+        if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
+            dump_text_pNext_trampoline(static_cast<const void*>(static_cast<const VkBaseInStructure*>(object)->pNext), settings, indents);
+        }} else {{
+            settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+            settings.stream() << "NULL\\n";
+        }}
+        break;
+    default:
+        settings.formatNameType(settings.stream(), indents, "pNext", "const void*");
+        settings.stream() << "UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\n";
+    }}
+}}
+
 //========================= Function Implementations ========================//
 
 @foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
@@ -1049,9 +1049,8 @@ HTML_CODEGEN = """
 
 #include "api_dump.h"
 
-@foreach struct
-void dump_html_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents);
-@end struct
+void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents);
+
 @foreach union
 void dump_html_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
 @end union
@@ -1072,35 +1071,7 @@ void dump_html_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
 }}
 #endif // VK_ENABLE_BETA_EXTENSIONS
 
-//======================== pNext Chain Implementation =======================//
 
-void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
-{{
-    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct
-        @if({sctStructureTypeIndex} != -1)
-    case {sctStructureTypeIndex}:
-        dump_html_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_html_{sctName});
-        break;
-        @end if
-    @end struct
-
-    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
-    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
-        if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
-            dump_html_pNext_trampoline(static_cast<const void*>(static_cast<const VkBaseInStructure*>(object)->pNext), settings, indents);
-        }} else {{
-            settings.stream() << "<details class='data'><summary>";
-            dump_html_nametype(settings.stream(), settings.showType(), "pNext", "const void*");
-            settings.stream() << "<div class='val'> NULL</div></summary></details>";
-        }}
-        break;
-    default:
-        settings.stream() << "<details class='data'><summary>";
-        dump_html_nametype(settings.stream(), settings.showType(), "pNext", "const void*");
-        settings.stream() << "<div class='val'>UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) <<")</div></summary></details>";
-    }}
-}}
 //=========================== Type Implementations ==========================//
 
 @foreach type where('{etyName}' != 'void')
@@ -1367,6 +1338,36 @@ void dump_html_{unName}(const {unName}& object, const ApiDumpSettings& settings,
 }}
 @end union
 
+//======================== pNext Chain Implementation =======================//
+
+void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
+{{
+    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
+    @foreach struct
+        @if({sctStructureTypeIndex} != -1)
+    case {sctStructureTypeIndex}:
+        dump_html_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_html_{sctName});
+        break;
+        @end if
+    @end struct
+
+    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
+    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
+        if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
+            dump_html_pNext_trampoline(static_cast<const void*>(static_cast<const VkBaseInStructure*>(object)->pNext), settings, indents);
+        }} else {{
+            settings.stream() << "<details class='data'><summary>";
+            dump_html_nametype(settings.stream(), settings.showType(), "pNext", "const void*");
+            settings.stream() << "<div class='val'> NULL</div></summary></details>";
+        }}
+        break;
+    default:
+        settings.stream() << "<details class='data'><summary>";
+        dump_html_nametype(settings.stream(), settings.showType(), "pNext", "const void*");
+        settings.stream() << "<div class='val'>UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) <<")</div></summary></details>";
+    }}
+}}
+
 //========================= Function Implementations ========================//
 
 @foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
@@ -1442,9 +1443,8 @@ JSON_CODEGEN = """
 
 #include "api_dump.h"
 
-@foreach struct
-void dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& settings, int indents);
-@end struct
+void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents);
+
 @foreach union
 void dump_json_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
 @end union
@@ -1464,40 +1464,6 @@ void dump_json_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
     dump_json_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
 #endif // VK_ENABLE_BETA_EXTENSIONS
-
-//======================== pNext Chain Implementation =======================//
-
-void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
-{{
-    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
-    @foreach struct
-        @if({sctStructureTypeIndex} != -1)
-    case {sctStructureTypeIndex}:
-        dump_json_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_json_{sctName});
-        break;
-        @end if
-    @end struct
-
-    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
-    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
-        if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
-            dump_json_pNext_trampoline(static_cast<const void*>(static_cast<const VkBaseInStructure*>(object)->pNext), settings, indents);
-        }} else {{
-            settings.stream() << settings.indentation(indents) << "{{\\n";
-            settings.stream() << settings.indentation(indents + 1) << "\\"type\\" : \\"const void*\\",\\n";
-            settings.stream() << settings.indentation(indents + 1) << "\\"name\\" : \\"pNext\\",\\n";
-            settings.stream() << settings.indentation(indents + 1) << "\\"value\\" : \\"NULL\\"\\n";
-            settings.stream() << settings.indentation(indents) << "}}";
-        }}
-        break;
-    default:
-        settings.stream() << settings.indentation(indents) << "{{\\n";
-        settings.stream() << settings.indentation(indents + 1) << "\\"type\\" : \\"const void*\\",\\n";
-        settings.stream() << settings.indentation(indents + 1) << "\\"name\\" : \\"pNext\\",\\n";
-        settings.stream() << settings.indentation(indents + 1) << "\\"value\\" : \\"UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\"\\n";
-        settings.stream() << settings.indentation(indents) << "}}";
-    }}
-}}
 
 //=========================== Type Implementations ==========================//
 
@@ -1782,6 +1748,40 @@ bool is_union(const char *t)
     if (strncmp("{unName}", tm, tmlen) == 0 && strlen("{unName}") == tmlen) return true;
 @end union
     return false;
+}}
+
+//======================== pNext Chain Implementation =======================//
+
+void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
+{{
+    switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
+    @foreach struct
+        @if({sctStructureTypeIndex} != -1)
+    case {sctStructureTypeIndex}:
+        dump_json_pNext<const {sctName}>(static_cast<const {sctName}*>(object), settings, "{sctName}", indents, dump_json_{sctName});
+        break;
+        @end if
+    @end struct
+
+    case 47: // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
+    case 48: // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
+        if(static_cast<const VkBaseInStructure*>(object)->pNext != nullptr){{
+            dump_json_pNext_trampoline(static_cast<const void*>(static_cast<const VkBaseInStructure*>(object)->pNext), settings, indents);
+        }} else {{
+            settings.stream() << settings.indentation(indents) << "{{\\n";
+            settings.stream() << settings.indentation(indents + 1) << "\\"type\\" : \\"const void*\\",\\n";
+            settings.stream() << settings.indentation(indents + 1) << "\\"name\\" : \\"pNext\\",\\n";
+            settings.stream() << settings.indentation(indents + 1) << "\\"value\\" : \\"NULL\\"\\n";
+            settings.stream() << settings.indentation(indents) << "}}";
+        }}
+        break;
+    default:
+        settings.stream() << settings.indentation(indents) << "{{\\n";
+        settings.stream() << settings.indentation(indents + 1) << "\\"type\\" : \\"const void*\\",\\n";
+        settings.stream() << settings.indentation(indents + 1) << "\\"name\\" : \\"pNext\\",\\n";
+        settings.stream() << settings.indentation(indents + 1) << "\\"value\\" : \\"UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) << ")\\"\\n";
+        settings.stream() << settings.indentation(indents) << "}}";
+    }}
 }}
 
 //========================= Function Implementations ========================//

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -76,189 +76,25 @@ COMMON_CODEGEN = """
 #include "api_dump_html.h"
 #include "api_dump_json.h"
 
-//============================= Dump Functions ==============================//
-
-@foreach function where(not '{funcName}' in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr', 'vkDebugMarkerSetObjectNameEXT','vkSetDebugUtilsObjectNameEXT'])
-void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
-{{
-    if (!dump_inst.shouldDumpOutput()) return ;
-    dump_inst.outputMutex()->lock();
-    switch(dump_inst.settings().format())
-    {{
-    case ApiDumpFormat::Text:
-        dump_text_head_{funcName}(dump_inst, {funcNamedParams});
-        break;
-    case ApiDumpFormat::Html:
-        dump_html_head_{funcName}(dump_inst, {funcNamedParams});
-        break;
-    case ApiDumpFormat::Json:
-        dump_json_head_{funcName}(dump_inst, {funcNamedParams});
-        break;
-    }}
-    //Keep lock
-}}
-@end function
-
-@foreach function where('{funcReturn}' != 'void' and not '{funcName}' in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr', 'vkDebugMarkerSetObjectNameEXT','vkSetDebugUtilsObjectNameEXT'])
-void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
-{{
-    if (!dump_inst.shouldDumpOutput()) return;
-
-    //Lock is already held
-    switch(dump_inst.settings().format())
-    {{
-    case ApiDumpFormat::Text:
-        dump_text_body_{funcName}(dump_inst, result, {funcNamedParams});
-        break;
-    case ApiDumpFormat::Html:
-        dump_html_body_{funcName}(dump_inst, result, {funcNamedParams});
-        break;
-    case ApiDumpFormat::Json:
-        dump_json_body_{funcName}(dump_inst, result, {funcNamedParams});
-        break;
-    }}
-    dump_inst.outputMutex()->unlock();
-}}
-@end function
-
-@foreach function where('{funcReturn}' == 'void')
-void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
-{{
-    if (!dump_inst.shouldDumpOutput()) return ;
-    //Lock is already held
-    switch(dump_inst.settings().format())
-    {{
-    case ApiDumpFormat::Text:
-        dump_text_body_{funcName}(dump_inst, {funcNamedParams});
-        break;
-    case ApiDumpFormat::Html:
-        dump_html_body_{funcName}(dump_inst, {funcNamedParams});
-        break;
-    case ApiDumpFormat::Json:
-        dump_json_body_{funcName}(dump_inst, {funcNamedParams});
-        break;
-    }}
-    dump_inst.outputMutex()->unlock();
-}}
-@end function
-
-
-@foreach function where('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
-void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
-{{
-    dump_inst.outputMutex()->lock();
-
-    if (pNameInfo->pObjectName)
-    {{
-        dump_inst.object_name_map.insert(std::make_pair<uint64_t, std::string>((uint64_t &&)pNameInfo->object, pNameInfo->pObjectName));
-    }}
-    else
-    {{
-        dump_inst.object_name_map.erase(pNameInfo->object);
-    }}
-
-    if (dump_inst.shouldDumpOutput()) {{
-        switch(dump_inst.settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_head_{funcName}(dump_inst, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_head_{funcName}(dump_inst, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_head_{funcName}(dump_inst, {funcNamedParams});
-            break;
-        }}
-    }}
-
-    //Keep lock
-}}
-@end function
-
-@foreach function where('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
-void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
-{{
-    //Lock is already held
-    if (dump_inst.shouldDumpOutput()) {{
-        switch(dump_inst.settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_body_{funcName}(dump_inst, result, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_body_{funcName}(dump_inst, result, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_body_{funcName}(dump_inst, result, {funcNamedParams});
-            break;
-        }}
-    }}
-
-    dump_inst.outputMutex()->unlock();
-}}
-@end function
-
-@foreach function where('{funcName}' == 'vkSetDebugUtilsObjectNameEXT')
-void dump_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
-{{
-    dump_inst.outputMutex()->lock();
-    if (pNameInfo->pObjectName)
-    {{
-        dump_inst.object_name_map.insert(std::make_pair<uint64_t, std::string>((uint64_t &&)pNameInfo->objectHandle, pNameInfo->pObjectName));
-    }}
-    else
-    {{
-        dump_inst.object_name_map.erase(pNameInfo->objectHandle);
-    }}
-    if (dump_inst.shouldDumpOutput()) {{
-        switch(dump_inst.settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_head_{funcName}(dump_inst, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_head_{funcName}(dump_inst, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_head_{funcName}(dump_inst, {funcNamedParams});
-            break;
-        }}
-    }}
-    //Keep lock
-}}
-@end function
-
-@foreach function where('{funcName}' == 'vkSetDebugUtilsObjectNameEXT')
-void dump_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
-{{
-    //Lock is already held
-    if (dump_inst.shouldDumpOutput()) {{
-        switch(dump_inst.settings().format())
-        {{
-        case ApiDumpFormat::Text:
-            dump_text_body_{funcName}(dump_inst, result, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Html:
-            dump_html_body_{funcName}(dump_inst, result, {funcNamedParams});
-            break;
-        case ApiDumpFormat::Json:
-            dump_json_body_{funcName}(dump_inst, result, {funcNamedParams});
-            break;
-        }}
-    }}
-    dump_inst.outputMutex()->unlock();
-}}
-@end function
-
-//============================= API EntryPoints =============================//
-
 // Specifically implemented functions
 
-@foreach function where('{funcName}' == 'vkCreateInstance')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance)
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"vkCreateInstance(pCreateInfo, pAllocator, pInstance)\", \"VkResult\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"vkCreateInstance(pCreateInfo, pAllocator, pInstance)\", \"VkResult\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"vkCreateInstance\", \"VkResult\");
+                break;
+        }}
+    }}
 
     // Get the function pointer
     VkLayerInstanceCreateInfo* chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
@@ -272,36 +108,86 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 
     // Call the function and create the dispatch table
     chain_info->u.pLayerInfo = chain_info->u.pLayerInfo->pNext;
-    {funcReturn} result = fpCreateInstance({funcNamedParams});
+    VkResult result = fpCreateInstance(pCreateInfo, pAllocator, pInstance);
     if(result == VK_SUCCESS) {{
         initInstanceTable(*pInstance, fpGetInstanceProcAddr);
     }}
-    {funcStateTrackingCode}
     // Output the API dump
-    dump_body_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_vkCreateInstance(ApiDumpInstance::current(), result, pCreateInfo, pAllocator, pInstance);
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_vkCreateInstance(ApiDumpInstance::current(), result, pCreateInfo, pAllocator, pInstance);
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_vkCreateInstance(ApiDumpInstance::current(), result, pCreateInfo, pAllocator, pInstance);
+                break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
     return result;
 }}
-@end function
 
-@foreach function where('{funcName}' == 'vkDestroyInstance')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator)
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+        case ApiDumpFormat::Text:
+            dump_text_function_head(ApiDumpInstance::current(), \"vkDestroyInstance(instance, pAllocator)\", \"void\");
+            break;
+        case ApiDumpFormat::Html:
+            dump_html_function_head(ApiDumpInstance::current(), \"vkDestroyInstance(instance, pAllocator)\", \"void\");
+            break;
+        case ApiDumpFormat::Json:
+            dump_json_function_head(ApiDumpInstance::current(), \"vkDestroyInstance\", \"void\");
+            break;
+        }}
+    }}
     // Destroy the dispatch table
-    dispatch_key key = get_dispatch_key({funcDispatchParam});
-    instance_dispatch_table({funcDispatchParam})->DestroyInstance({funcNamedParams});
+    dispatch_key key = get_dispatch_key(instance);
+    instance_dispatch_table(instance)->DestroyInstance(instance, pAllocator);
     destroy_instance_dispatch_table(key);
-    {funcStateTrackingCode}
+
     // Output the API dump
-    dump_body_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+        case ApiDumpFormat::Text:
+            dump_text_vkDestroyInstance(ApiDumpInstance::current(), instance, pAllocator);
+            break;
+        case ApiDumpFormat::Html:
+            dump_html_vkDestroyInstance(ApiDumpInstance::current(), instance, pAllocator);
+            break;
+        case ApiDumpFormat::Json:
+            dump_json_vkDestroyInstance(ApiDumpInstance::current(), instance, pAllocator);
+            break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
 }}
-@end function
 
-@foreach function where('{funcName}' == 'vkCreateDevice')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
-
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)\", \"VkResult\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice)\", \"VkResult\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"vkCreateDevice\", \"VkResult\");
+                break;
+        }}
+    }}
     // Get the function pointer
     VkLayerDeviceCreateInfo* chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
     assert(chain_info->u.pLayerInfo != 0);
@@ -315,41 +201,77 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 
     // Call the function and create the dispatch table
     chain_info->u.pLayerInfo = chain_info->u.pLayerInfo->pNext;
-    {funcReturn} result = fpCreateDevice({funcNamedParams});
+    VkResult result = fpCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
     if(result == VK_SUCCESS) {{
         initDeviceTable(*pDevice, fpGetDeviceProcAddr);
     }}
-    {funcStateTrackingCode}
+
     // Output the API dump
-    dump_body_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_vkCreateDevice(ApiDumpInstance::current(), result, physicalDevice, pCreateInfo, pAllocator, pDevice);
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_vkCreateDevice(ApiDumpInstance::current(), result, physicalDevice, pCreateInfo, pAllocator, pDevice);
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_vkCreateDevice(ApiDumpInstance::current(), result, physicalDevice, pCreateInfo, pAllocator, pDevice);
+                break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
     return result;
 }}
-@end function
 
-@foreach function where('{funcName}' == 'vkDestroyDevice')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator)
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"vkDestroyDevice(device, pAllocator)\", \"void\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"vkDestroyDevice(device, pAllocator)\", \"void\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"vkDestroyDevice\", \"void\");
+                break;
+        }}
+    }}
 
     // Destroy the dispatch table
-    dispatch_key key = get_dispatch_key({funcDispatchParam});
-    device_dispatch_table({funcDispatchParam})->DestroyDevice({funcNamedParams});
+    dispatch_key key = get_dispatch_key(device);
+    device_dispatch_table(device)->DestroyDevice(device, pAllocator);
     destroy_device_dispatch_table(key);
-    {funcStateTrackingCode}
-    // Output the API dump
-    dump_body_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
-}}
-@end function
 
-@foreach function where('{funcName}' == 'vkEnumerateInstanceExtensionProperties')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+    // Output the API dump
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_vkDestroyDevice(ApiDumpInstance::current(), device, pAllocator);
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_vkDestroyDevice(ApiDumpInstance::current(), device, pAllocator);
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_vkDestroyDevice(ApiDumpInstance::current(), device, pAllocator);
+                break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
+}}
+
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount, VkExtensionProperties* pProperties)
 {{
     return util_GetExtensionProperties(0, NULL, pPropertyCount, pProperties);
 }}
-@end function
 
-@foreach function where('{funcName}' == 'vkEnumerateInstanceLayerProperties')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties)
 {{
     static const VkLayerProperties layerProperties[] = {{
         {{
@@ -362,10 +284,8 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 
     return util_GetLayerProperties(ARRAY_SIZE(layerProperties), layerProperties, pPropertyCount, pProperties);
 }}
-@end function
 
-@foreach function where('{funcName}' == 'vkEnumerateDeviceLayerProperties')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkLayerProperties* pProperties)
 {{
     static const VkLayerProperties layerProperties[] = {{
         {{
@@ -378,30 +298,65 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 
     return util_GetLayerProperties(ARRAY_SIZE(layerProperties), layerProperties, pPropertyCount, pProperties);
 }}
-@end function
 
-@foreach function where('{funcName}' == 'vkQueuePresentKHR')
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo)
 {{
     ApiDumpInstance::current().outputMutex()->lock();
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"vVkResult\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR(queue, pPresentInfo)\", \"vVkResult\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"vkQueuePresentKHR\", \"vVkResult\");
+                break;
+        }}
+    }}
 
-    {funcReturn} result = device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
-    {funcStateTrackingCode}
-    dump_body_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
-
+    VkResult result = device_dispatch_table(queue)->QueuePresentKHR(queue, pPresentInfo);
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_vkQueuePresentKHR(ApiDumpInstance::current(), result, queue, pPresentInfo);
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_vkQueuePresentKHR(ApiDumpInstance::current(), result, queue, pPresentInfo);
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_vkQueuePresentKHR(ApiDumpInstance::current(), result, queue, pPresentInfo);
+                break;
+        }}
+    }}
     ApiDumpInstance::current().nextFrame();
     ApiDumpInstance::current().outputMutex()->unlock();
     return result;
 }}
-@end function
 
 // Autogen instance functions
 
 @foreach function where('{funcDispatchType}' == 'instance' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkCreateInstance', 'vkDestroyInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties','vkGetPhysicalDeviceToolPropertiesEXT'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"{funcName}\", \"{funcReturn}\");
+                break;
+        }}
+    }}
     {funcReturn} result = instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
     {funcStateTrackingCode}
     @if('{funcName}' == 'vkEnumeratePhysicalDevices')
@@ -411,7 +366,22 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
         }}
     }}
     @end if
-    dump_body_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+                break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
     return result;
 }}
 @end function
@@ -419,10 +389,38 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 @foreach function where('{funcDispatchType}' == 'instance' and '{funcReturn}' == 'void' and '{funcName}' not in ['vkCreateInstance', 'vkDestroyInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+        case ApiDumpFormat::Text:
+            dump_text_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+            break;
+        case ApiDumpFormat::Html:
+            dump_html_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+            break;
+        case ApiDumpFormat::Json:
+            dump_json_function_head(ApiDumpInstance::current(), \"{funcName}\", \"{funcReturn}\");
+            break;
+        }}
+    }}
     instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
     {funcStateTrackingCode}
-    dump_body_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+        case ApiDumpFormat::Text:
+            dump_text_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+            break;
+        case ApiDumpFormat::Html:
+            dump_html_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+            break;
+        case ApiDumpFormat::Json:
+            dump_json_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+            break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
 }}
 @end function
 
@@ -431,10 +429,50 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 @foreach function where('{funcDispatchType}' == 'device' and '{funcReturn}' != 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkQueuePresentKHR', 'vkGetDeviceProcAddr'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    ApiDumpInstance::current().outputMutex()->lock();
+    @if('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
+    if (pNameInfo->pObjectName)
+        ApiDumpInstance::current().object_name_map.insert(std::make_pair<uint64_t, std::string>((uint64_t &&)pNameInfo->object, pNameInfo->pObjectName));
+    else
+        ApiDumpInstance::current().object_name_map.erase(pNameInfo->object);
+    @end if
+    @if('{funcName}' == 'vkSetDebugUtilsObjectNameEXT')
+    if (pNameInfo->pObjectName)
+        ApiDumpInstance::current().object_name_map.insert(std::make_pair<uint64_t, std::string>((uint64_t &&)pNameInfo->objectHandle, pNameInfo->pObjectName));
+    else
+        ApiDumpInstance::current().object_name_map.erase(pNameInfo->objectHandle);
+    @end if
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"{funcName}\", \"{funcReturn}\");
+                break;
+        }}
+    }}
     {funcReturn} result = device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
     {funcStateTrackingCode}
-    dump_body_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_{funcName}(ApiDumpInstance::current(), result, {funcNamedParams});
+                break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
     return result;
 }}
 @end function
@@ -442,16 +480,58 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 @foreach function where('{funcDispatchType}' == 'device' and '{funcReturn}' == 'void' and '{funcName}' not in ['vkDestroyDevice', 'vkEnumerateInstanceExtensionProperties', 'vkEnumerateInstanceLayerProperties', 'vkGetDeviceProcAddr'])
 VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
-    dump_head_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"{funcName}({funcNamedParams})\", \"{funcReturn}\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"{funcName}\", \"{funcReturn}\");
+                break;
+        }}
+    }}
     device_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
     {funcStateTrackingCode}
-    dump_body_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_{funcName}(ApiDumpInstance::current(), {funcNamedParams});
+                break;
+        }}
+    }}
+    ApiDumpInstance::current().outputMutex()->unlock();
 }}
 @end function
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t *pToolCount, VkPhysicalDeviceToolPropertiesEXT *pToolProperties)
 {{
-    dump_head_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), physicalDevice, pToolCount, pToolProperties);
+    ApiDumpInstance::current().outputMutex()->lock();
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_function_head(ApiDumpInstance::current(), \"vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)\", \"VkResult\");
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_function_head(ApiDumpInstance::current(), \"vkGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties)\", \"VkResult\");
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_function_head(ApiDumpInstance::current(), \"vkGetPhysicalDeviceToolPropertiesEXT\", \"VkResult\");
+                break;
+        }}
+    }}
     static const VkPhysicalDeviceToolPropertiesEXT api_dump_layer_tool_props = {{
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
         nullptr,
@@ -476,7 +556,20 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolProperties
     }}
 
     (*pToolCount)++;
-    dump_body_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
+    if (ApiDumpInstance::current().shouldDumpOutput()) {{
+        switch(ApiDumpInstance::current().settings().format())
+        {{
+            case ApiDumpFormat::Text:
+                dump_text_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
+                break;
+            case ApiDumpFormat::Html:
+                dump_html_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
+                break;
+            case ApiDumpFormat::Json:
+                dump_json_vkGetPhysicalDeviceToolPropertiesEXT(ApiDumpInstance::current(), result, physicalDevice, pToolCount, pToolProperties);
+                break;
+        }}
+    }}
     return result;
 }}
 
@@ -890,33 +983,11 @@ std::ostream& dump_text_{unName}(const {unName}& object, const ApiDumpSettings& 
 //========================= Function Implementations ========================//
 
 @foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
-std::ostream& dump_text_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
-{{
-    const ApiDumpSettings& settings(dump_inst.settings());
-    if (settings.showThreadAndFrame()) {{
-        settings.stream() << "Thread " << dump_inst.threadID() << ", Frame " << dump_inst.frameCount();
-    }}
-    if(settings.showTimestamp() && settings.showThreadAndFrame()) {{
-        settings.stream() << ", ";
-    }}
-    if (settings.showTimestamp()) {{
-        settings.stream() << "Time " << dump_inst.current_time_since_start().count() << " us";
-    }}
-    if (settings.showTimestamp() || settings.showThreadAndFrame()) {{
-        settings.stream() << ":\\n";
-    }}
-    settings.stream() << "{funcName}({funcNamedParams}) returns {funcReturn}";
-
-    return settings.shouldFlush() ? settings.stream() << std::flush : settings.stream();
-}}
-@end function
-
-@foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
 @if('{funcReturn}' != 'void')
-std::ostream& dump_text_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
+std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 @end if
 @if('{funcReturn}' == 'void')
-std::ostream& dump_text_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
+std::ostream& dump_text_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @end if
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
@@ -1314,27 +1385,11 @@ std::ostream& dump_html_{unName}(const {unName}& object, const ApiDumpSettings& 
 //========================= Function Implementations ========================//
 
 @foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
-std::ostream& dump_html_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
-{{
-    const ApiDumpSettings& settings(dump_inst.settings());
-    if (settings.showThreadAndFrame()){{
-        settings.stream() << "<div class='thd'>Thread: " << dump_inst.threadID() << "</div>";
-    }}
-    if(settings.showTimestamp())
-        settings.stream() << "<div class='time'>Time: " << dump_inst.current_time_since_start().count() << " us</div>";
-    settings.stream() << "<details class='fn'><summary>";
-    dump_html_nametype(settings.stream(), settings.showType(), "{funcName}({funcNamedParams})", "{funcReturn}");
-
-    return settings.shouldFlush() ? settings.stream() << std::flush : settings.stream();
-}}
-@end function
-
-@foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
 @if('{funcReturn}' != 'void')
-std::ostream& dump_html_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
+std::ostream& dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 @end if
 @if('{funcReturn}' == 'void')
-std::ostream& dump_html_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
+std::ostream& dump_html_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @end if
 {{
     const ApiDumpSettings& settings(dump_inst.settings());
@@ -1758,43 +1813,13 @@ bool is_union(const char *t)
 
 static bool needFuncComma = false;
 
-@foreach function where(not '{funcName}' in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
-std::ostream& dump_json_head_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
-{{
-    const ApiDumpSettings& settings(dump_inst.settings());
-
-    if(dump_inst.firstFunctionCallOnFrame())
-        needFuncComma = false;
-
-    if (needFuncComma) settings.stream() << ",\\n";
-
-    // Display apicall name
-    settings.stream() << settings.indentation(2) << "{{\\n";
-    settings.stream() << settings.indentation(3) << "\\\"name\\\" : \\\"{funcName}\\\",\\n";
-
-    // Display thread info
-    if (settings.showThreadAndFrame()){{
-        settings.stream() << settings.indentation(3) << "\\\"thread\\\" : \\\"Thread " << dump_inst.threadID() << "\\\",\\n";
-    }}
-
-    // Display elapsed time
-    if(settings.showTimestamp()) {{
-        settings.stream() << settings.indentation(3) << "\\\"time\\\" : \\\""<< dump_inst.current_time_since_start().count() << " us\\\",\\n";
-    }}
-
-    // Display return value
-    settings.stream() << settings.indentation(3) << "\\\"returnType\\\" : " << "\\\"{funcReturn}\\\",\\n";
-
-    return settings.shouldFlush() ? settings.stream() << std::flush : settings.stream();
-}}
-@end function
 
 @foreach function where(not '{funcName}' in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
 @if('{funcReturn}' != 'void')
-std::ostream& dump_json_body_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
+std::ostream& dump_json_{funcName}(ApiDumpInstance& dump_inst, {funcReturn} result, {funcTypedParams})
 @end if
 @if('{funcReturn}' == 'void')
-std::ostream& dump_json_body_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
+std::ostream& dump_json_{funcName}(ApiDumpInstance& dump_inst, {funcTypedParams})
 @end if
 {{
     const ApiDumpSettings& settings(dump_inst.settings());


### PR DESCRIPTION
Big refactor to the codebase which cleans up many aspects of the code, to reduce the code generation time and compile time.

Changes include:
* Removing variadic templates, replacing them with explicit storage in the ApiDumpInstance class. There are only two places in the entire API where this is needed, making everything require a variadic template to handle these two cases is a bit much.
* Removing redundant `inline` statements for class member functions
* Removing the return type for many of the api_dump.h functions. Returning the stream operator was used in one place and one place only, and didn't require returning the ostream type to function.
* Factor out the dump_head functions. The actual values printed are easily replaced with a single function that takes the function name & return type as parameters, removing large amounts of generated code.
* Remove runtime JSON comma printing - modify the codegen to put commas where necessary instead of keeping a boolean value to keep track of things.
* Fix unknown structures in the pNext chain being incorrectly quoted in JSON output
* Make the type parsing handle the case where the name of the function parameter/struct member is a substring of the type, causing incorrect printing of the type.
* Drastically improve the performance of the codegen by using dictionaries instead of sets. This is because the codegen previously would linearly search through the entire list when looking for a single element. Now lookups are just a O(1) check into a dictionary.