### PR TITLE
cmake: Raise minimum to 3.17.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.17.2)
 
 enable_testing()
 


### PR DESCRIPTION
The vulkan validation layers update their CMake min to 3.17.2

Raise min accordingly