### PR TITLE
API Dump support video extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,15 +213,21 @@ if (WIN32)
                          IMPORTED_LOCATION_DEBUG "${JSONCPP_DLIB}")
 endif()
 
-# Define macro used for building vkxml generated files
-macro(run_vulkantools_vk_xml_generate dependency output)
+# Define macro used for building vk.xml generated files
+function(run_vulkantools_vk_xml_generate dependency output)
     add_custom_command(OUTPUT ${output}
-    COMMAND ${PYTHON_CMD} -B ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py -registry ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/vk.xml -scripts ${VULKAN_HEADERS_REGISTRY_DIRECTORY} ${output}
-        -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264
-        -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265
-    DEPENDS ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/vk.xml ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/generator.py ${VULKANTOOLS_SCRIPTS_DIR}/${dependency} ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/reg.py
+        COMMAND ${PYTHON_CMD} -B ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py -registry ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/vk.xml -scripts ${VULKAN_HEADERS_REGISTRY_DIRECTORY} ${output}
+        DEPENDS ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/vk.xml ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/generator.py ${VULKANTOOLS_SCRIPTS_DIR}/${dependency} ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/reg.py
     )
-endmacro()
+endfunction()
+
+# Define macro used for building video.xml generated files
+function(run_vulkantools_video_xml_generate dependency output)
+    add_custom_command(OUTPUT ${output}
+        COMMAND ${PYTHON_CMD} -B ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py -registry ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/video.xml -scripts ${VULKAN_HEADERS_REGISTRY_DIRECTORY} ${output}
+        DEPENDS ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/video.xml ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/generator.py ${VULKANTOOLS_SCRIPTS_DIR}/${dependency} ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py ${VULKAN_HEADERS_REGISTRY_DIRECTORY}/reg.py
+    )
+endfunction()
 
 if(BUILD_TESTS)
     add_subdirectory(tests)

--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -34,6 +34,7 @@ set LVL_SCRIPTS=%LVL_BASE%\scripts
 set VT_SCRIPTS=..\..\..\scripts
 set REGISTRY_PATH=%~dp0\third_party\Vulkan-Headers\registry
 set REGISTRY=%REGISTRY_PATH%\vk.xml
+set VIDEO_REGISTRY=%REGISTRY_PATH%\video.xml
 
 echo Entering Generated/Include Folder
 echo ********
@@ -49,11 +50,17 @@ py -3 %VT_SCRIPTS%\vlf_makefile_generator.py ..\..\..\layer_factory %REGISTRY_PA
 REM apidump
 echo Generating VT apidump header/source files
 echo ********
-py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump.cpp -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265
-py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump_text.h -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265
-py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump_html.h -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265
-py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump_json.h -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265
- 
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump.cpp
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump_text.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump_html.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %REGISTRY% -scripts %REGISTRY_PATH% api_dump_json.h
+
+
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %VIDEO_REGISTRY% -scripts %REGISTRY_PATH% api_dump_video_text.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %VIDEO_REGISTRY% -scripts %REGISTRY_PATH% api_dump_video_html.h
+py -3 %VT_SCRIPTS%\vt_genvk.py -registry %VIDEO_REGISTRY% -scripts %REGISTRY_PATH% api_dump_video_json.h
+
+
 REM Copy over the built source files to LVL.  Otherwise,
 REM cube won't build.
 echo Entering third_party\Vulkan-ValidationLayers\build-android

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -27,6 +27,7 @@ LVL_GENERATED=${LVL_BASE}/layers/generated
 VT_SCRIPTS=../../../scripts
 REGISTRY_PATH=$dir/third_party/Vulkan-Headers/registry
 REGISTRY=${REGISTRY_PATH}/vk.xml
+VIDEO_REGISTRY=${REGISTRY_PATH}/video.xml
 
 # Check for python 3.6 or greater
 PYTHON_EXECUTABLE=python3
@@ -49,11 +50,15 @@ echo "Using python: $(which $PYTHON_EXECUTABLE)"
 ( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vlf_makefile_generator.py ../../../layer_factory ${REGISTRY_PATH}/../include)
 
 # apidump
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump.cpp -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265)
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_text.h -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265)
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_html.h -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265)
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_json.h -removeExtensions VK_KHR_video_queue -removeExtensions VK_KHR_video_decode_queue -removeExtensions VK_KHR_video_encode_queue -removeExtensions VK_KHR_video_decode_h264 -removeExtensions VK_KHR_video_decode_h265 -removeExtensions VK_EXT_video_encode_h264 -removeExtensions VK_EXT_video_encode_h265)
- 
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump.cpp)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_text.h)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_html.h)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_json.h)
+
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${VIDEO_REGISTRY} -scripts ${REGISTRY_PATH} api_dump_video_text.h)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${VIDEO_REGISTRY} -scripts ${REGISTRY_PATH} api_dump_video_html.h)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${VIDEO_REGISTRY} -scripts ${REGISTRY_PATH} api_dump_video_json.h)
+
 ( pushd ${LVL_BASE}/build-android; rm -rf generated; mkdir -p generated/include generated/common; popd )
 ( cd generated/include; cp -rf * ${LVL_BASE}/build-android/generated/include )
 

--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -44,11 +44,16 @@ add_definitions(-DVK_ENABLE_BETA_EXTENSIONS)
 
 if (BUILD_APIDUMP)
     add_custom_target( generate_api_cpp DEPENDS api_dump.cpp )
-    add_custom_target( generate_api_h DEPENDS api_dump_text.h )
+    add_custom_target( generate_api_text_h DEPENDS api_dump_text.h )
     add_custom_target( generate_api_html_h DEPENDS api_dump_html.h )
-    set_target_properties(generate_api_cpp generate_api_h generate_api_html_h PROPERTIES FOLDER ${VULKANTOOLS_TARGET_FOLDER})
     add_custom_target( generate_api_json_h DEPENDS api_dump_json.h )
-    set_target_properties(generate_api_cpp generate_api_h generate_api_json_h PROPERTIES FOLDER ${VULKANTOOLS_TARGET_FOLDER})
+    add_custom_target( generate_api_video_text_h DEPENDS api_dump_video_text.h )
+    add_custom_target( generate_api_video_html_h DEPENDS api_dump_video_html.h )
+    add_custom_target( generate_api_video_json_h DEPENDS api_dump_video_json.h )
+
+    set_target_properties(generate_api_cpp generate_api_text_h generate_api_html_h generate_api_json_h
+        generate_api_video_text_h generate_api_video_html_h generate_api_video_json_h
+         PROPERTIES FOLDER ${VULKANTOOLS_TARGET_FOLDER})
 endif()
 
 if (NOT APPLE)
@@ -84,18 +89,12 @@ if (WIN32)
             CXX_STANDARD_REQUIRED ON
             CXX_EXTENSIONS OFF
         )
-        if(BUILD_APIDUMP)
-            add_dependencies(VkLayer_${target} generate_api_cpp generate_api_h generate_api_html_h)
-            add_dependencies(VkLayer_${target} generate_api_cpp generate_api_h generate_api_json_h)
-        endif()
         set_target_properties(copy-${target}-def-file PROPERTIES FOLDER ${VULKANTOOLS_TARGET_FOLDER})
     endmacro()
 else()
     macro(add_vk_layer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
         target_link_Libraries(VkLayer_${target} Vulkan::Headers ${VkLayer_utils_LIBRARY})
-        add_dependencies(VkLayer_${target} generate_api_cpp generate_api_h generate_api_html_h)
-        add_dependencies(VkLayer_${target} generate_api_cpp generate_api_h generate_api_json_h)
         if (NOT APPLE)
             set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
         endif ()
@@ -136,6 +135,13 @@ if(BUILD_APIDUMP)
     run_vulkantools_vk_xml_generate(api_dump_generator.py api_dump_text.h)
     run_vulkantools_vk_xml_generate(api_dump_generator.py api_dump_html.h)
     run_vulkantools_vk_xml_generate(api_dump_generator.py api_dump_json.h)
+    run_vulkantools_video_xml_generate(api_dump_generator.py api_dump_video_text.h)
+    run_vulkantools_video_xml_generate(api_dump_generator.py api_dump_video_html.h)
+    run_vulkantools_video_xml_generate(api_dump_generator.py api_dump_video_json.h)
+
+    add_vk_layer(api_dump api_dump.cpp vk_layer_table.cpp ../vku/vk_layer_settings.cpp ../vku/vk_layer_settings.h)
+    add_dependencies(VkLayer_api_dump generate_api_cpp generate_api_text_h generate_api_html_h generate_api_json_h
+        generate_api_video_text_h generate_api_video_html_h generate_api_video_json_h)
 endif ()
 
 if (NOT APPLE)
@@ -145,10 +151,6 @@ if (NOT APPLE)
     if(BUILD_SCREENSHOT)
         add_vk_layer(screenshot screenshot.cpp screenshot_parsing.h screenshot_parsing.cpp vk_layer_table.cpp ../vku/vk_layer_settings.cpp ../vku/vk_layer_settings.h)
     endif ()
-endif ()
-
-if(BUILD_APIDUMP)
-    add_vk_layer(api_dump api_dump.cpp vk_layer_table.cpp ../vku/vk_layer_settings.cpp ../vku/vk_layer_settings.h)
 endif ()
 
 # json file creation

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -33,6 +33,15 @@
 #include "vk_layer_extension_utils.h"
 #include "vk_layer_utils.h"
 
+// Include the video headers so we can print types that come from them
+#include "vk_video/vulkan_video_codecs_common.h"
+#include "vk_video/vulkan_video_codec_h264std.h"
+#include "vk_video/vulkan_video_codec_h264std_decode.h"
+#include "vk_video/vulkan_video_codec_h264std_encode.h"
+#include "vk_video/vulkan_video_codec_h265std.h"
+#include "vk_video/vulkan_video_codec_h265std_decode.h"
+#include "vk_video/vulkan_video_codec_h265std_encode.h"
+
 #include <algorithm>
 #include <chrono>
 #include <fstream>

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -420,16 +420,18 @@ TEXT_CODEGEN = """
 #pragma once
 
 #include "api_dump.h"
-
+#include "api_dump_video_text.h"
+@if(not {isVideoGeneration})
 void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents, const char* pnext_type);
 void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents);
-
+@end if
 @foreach union
 void dump_text_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
 @end union
 
 //============================= typedefs ==============================//
 
+@if(not {isVideoGeneration})
 // Functions for dumping typedef types that the codegen scripting can't handle
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_text_VkAccelerationStructureTypeKHR(VkAccelerationStructureTypeKHR object, const ApiDumpSettings& settings, int indents);
@@ -443,17 +445,20 @@ void dump_text_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
     dump_text_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
 #endif // VK_ENABLE_BETA_EXTENSIONS
-
+@end if
 //=========================== Type Implementations ==========================//
 
 @foreach type where('{etyName}' != 'void')
 void dump_text_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
 {{
-    @if('{etyName}' != 'uint8_t')
+    @if('{etyName}' != 'uint8_t' and '{etyName}' != 'int8_t')
     settings.stream() << object;
     @end if
     @if('{etyName}' == 'uint8_t')
     settings.stream() << (uint32_t) object;
+    @end if
+    @if('{etyName}' == 'int8_t')
+    settings.stream() << (int32_t) object;
     @end if
 }}
 @end type
@@ -700,7 +705,7 @@ void dump_text_{unName}(const {unName}& object, const ApiDumpSettings& settings,
 @end union
 
 //======================== pNext Chain Implementation =======================//
-
+@if(not {isVideoGeneration})
 void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& settings, int indents, const char* pnext_type)
 {{
     if (object == nullptr) {{
@@ -751,7 +756,7 @@ void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         settings.stream() << "UNKNOWN (" << (int64_t) (base_struct->sType) << ")\\n";
     }}
 }}
-
+@end if
 //========================= Function Implementations ========================//
 
 @foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
@@ -826,15 +831,17 @@ HTML_CODEGEN = """
 #pragma once
 
 #include "api_dump.h"
-
+#include "api_dump_video_html.h"
+@if(not {isVideoGeneration})
 void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents);
-
+@end if
 @foreach union
 void dump_html_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
 @end union
 
 //============================= typedefs ==============================//
 
+@if(not {isVideoGeneration})
 // Functions for dumping typedef types that the codegen scripting can't handle
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_html_VkAccelerationStructureTypeKHR(VkAccelerationStructureTypeKHR object, const ApiDumpSettings& settings, int indents);
@@ -848,7 +855,7 @@ void dump_html_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
     dump_html_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
 #endif // VK_ENABLE_BETA_EXTENSIONS
-
+@end if
 
 //=========================== Type Implementations ==========================//
 
@@ -856,11 +863,14 @@ void dump_html_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
 void dump_html_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
 {{
     settings.stream() << "<div class='val'>";
-    @if('{etyName}' != 'uint8_t')
+    @if('{etyName}' != 'uint8_t' and '{etyName}' != 'int8_t')
     settings.stream() << object;
     @end if
     @if('{etyName}' == 'uint8_t')
     settings.stream() << (uint32_t) object;
+    @end if
+    @if('{etyName}' == 'int8_t')
+    settings.stream() << (int32_t) object;
     @end if
     settings.stream() << "</div></summary>";
 }}
@@ -1105,7 +1115,7 @@ void dump_html_{unName}(const {unName}& object, const ApiDumpSettings& settings,
 @end union
 
 //======================== pNext Chain Implementation =======================//
-
+@if(not {isVideoGeneration})
 void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
 {{
     switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
@@ -1133,7 +1143,7 @@ void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         settings.stream() << "<div class='val'>UNKNOWN (" << (int64_t) (static_cast<const VkBaseInStructure*>(object)->sType) <<")</div></summary></details>";
     }}
 }}
-
+@end if
 //========================= Function Implementations ========================//
 
 @foreach function where('{funcName}' not in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
@@ -1208,15 +1218,17 @@ JSON_CODEGEN = """
 #pragma once
 
 #include "api_dump.h"
-
+#include "api_dump_video_json.h"
+@if(not {isVideoGeneration})
 void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents);
-
+@end if
 @foreach union
 void dump_json_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents);
 @end union
 
 //============================= typedefs ==============================//
 
+@if(not {isVideoGeneration})
 // Functions for dumping typedef types that the codegen scripting can't handle
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_json_VkAccelerationStructureTypeKHR(VkAccelerationStructureTypeKHR object, const ApiDumpSettings& settings, int indents);
@@ -1230,6 +1242,7 @@ void dump_json_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
     dump_json_VkBuildAccelerationStructureFlagsKHR(object, settings, indents);
 }}
 #endif // VK_ENABLE_BETA_EXTENSIONS
+@end if
 
 //=========================== Type Implementations ==========================//
 
@@ -1237,12 +1250,14 @@ void dump_json_VkBuildAccelerationStructureFlagsNV(VkBuildAccelerationStructureF
 void dump_json_{etyName}({etyName} object, const ApiDumpSettings& settings, int indents)
 {{
 
-    //settings.stream() << settings.indentation(indents);
-    @if('{etyName}' != 'uint8_t')
+    @if('{etyName}' != 'uint8_t' and '{etyName}' != 'int8_t')
     settings.stream() << "\\"" << object << "\\"";
     @end if
     @if('{etyName}' == 'uint8_t')
     settings.stream() << "\\"" << (uint32_t) object << "\\"";
+    @end if
+    @if('{etyName}' == 'int8_t')
+    settings.stream() << "\\"" << (int32_t) object << "\\"";
     @end if
 }}
 @end type
@@ -1443,7 +1458,7 @@ void dump_json_{sctName}(const {sctName}& object, const ApiDumpSettings& setting
     settings.stream() << "\\n" << settings.indentation(indents) << "]";
 }}
 @end struct
-
+@if({isVideoGeneration})
 bool is_struct(const char *t)
 {{
     char *tm = (char*)t;
@@ -1455,7 +1470,7 @@ bool is_struct(const char *t)
 @end struct
     return false;
 }}
-
+@end if
 //========================== Union Implementations ==========================//
 @foreach union
 void dump_json_{unName}(const {unName}& object, const ApiDumpSettings& settings, int indents)
@@ -1480,7 +1495,7 @@ void dump_json_{unName}(const {unName}& object, const ApiDumpSettings& settings,
     settings.stream() << "\\n" << settings.indentation(indents) << "]";
 }}
 @end union
-
+@if({isVideoGeneration})
 bool is_union(const char *t)
 {{
     char *tm = (char*)t;
@@ -1492,9 +1507,9 @@ bool is_union(const char *t)
 @end union
     return false;
 }}
-
+@end if
 //======================== pNext Chain Implementation =======================//
-
+@if(not {isVideoGeneration})
 void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& settings, int indents)
 {{
     switch((int64_t) (static_cast<const VkBaseInStructure*>(object)->sType)) {{
@@ -1526,7 +1541,7 @@ void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         settings.stream() << settings.indentation(indents) << "}}";
     }}
 }}
-
+@end if
 //========================= Function Implementations ========================//
 
 @foreach function where(not '{funcName}' in ['vkGetDeviceProcAddr', 'vkGetInstanceProcAddr'])
@@ -1688,6 +1703,11 @@ VALIDITY_CHECKS = {
     },
 }
 
+# These types are defined in both video.xml and vk.xml. Because duplicate functions aren't allowed,
+# we have to prevent these from generating twice. This is done by removing the types from the non-video
+# outputs
+DUPLICATE_TYPES_IN_VIDEO_HEADER = ['uint32_t', 'uint16_t', 'uint8_t', 'int32_t', 'int8_t']
+
 class ApiDumpGeneratorOptions(GeneratorOptions):
     def __init__(self,
                  conventions = None,
@@ -1717,6 +1737,7 @@ class ApiDumpGeneratorOptions(GeneratorOptions):
                  indentFuncPointer = False,
                  alignFuncParam = 0,
                  expandEnumerants = True,
+                 isVideoGeneration = False,
                  ):
         GeneratorOptions.__init__(self,
                  conventions = conventions,
@@ -1745,6 +1766,7 @@ class ApiDumpGeneratorOptions(GeneratorOptions):
         self.indentFuncProto = indentFuncProto
         self.indentFuncPointer = indentFuncPointer
         self.alignFuncParam  = alignFuncParam
+        self.isVideoGeneration = isVideoGeneration
 
 
 class ApiDumpOutputGenerator(OutputGenerator):
@@ -1756,6 +1778,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
                  registryFile = None):
         gen.OutputGenerator.__init__(self, errFile, warnFile, diagFile)
         self.format = None
+        self.isVideoGeneration = False
 
         self.constants = {}
         self.extensions = {}
@@ -1763,6 +1786,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
         self.extTypes = {}
         self.includes = {}
 
+        self.sysTypes = {}
         self.basetypes = {}
         self.bitmasks = {}
         self.enums = {}
@@ -1783,6 +1807,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
     def beginFile(self, genOpts):
         gen.OutputGenerator.beginFile(self, genOpts)
         self.format = genOpts.input
+        self.isVideoGeneration = genOpts.isVideoGeneration
 
         if self.registryFile is not None:
             root = xml.etree.ElementTree.parse(self.registryFile)
@@ -1812,7 +1837,8 @@ class ApiDumpOutputGenerator(OutputGenerator):
         # Find all 'system' types and put it in a set
         sysTypeNames = set()
         for node in self.registry.reg.find('types').findall('type'):
-            if node.get('category') is None and node.get('requires') in self.includes and node.get('requires') != 'vk_platform':
+            if node.get('category') is None and node.get('requires') in self.includes and node.get('requires') not in ['vk_platform', 'stdint'] \
+                and "vk_video" not in node.get('requires'):
                 sysTypeNames.add(node.get('name'))
 
         # Look through the set of sysTypeName to find all of the extensions that use the system types, then add it to sysTypes
@@ -1957,8 +1983,13 @@ class ApiDumpOutputGenerator(OutputGenerator):
             self.structs[typeinfo.elem.get('name')] = VulkanStruct(typeinfo.elem, self.constants, self.enums)
         elif typeinfo.elem.get('category') == 'basetype':
             self.basetypes[typeinfo.elem.get('name')] = VulkanBasetype(typeinfo.elem)
-        elif typeinfo.elem.get('category') is None and typeinfo.elem.get('requires') == 'vk_platform':
-            self.externalTypes[typeinfo.elem.get('name')] = VulkanExternalType(typeinfo.elem)
+        elif typeinfo.elem.get('category') is None and typeinfo.elem.get('requires') in ['vk_platform', 'stdint']:
+            # only add these types if we are generating the video headers
+            if typeinfo.elem.get('name') in DUPLICATE_TYPES_IN_VIDEO_HEADER:
+                if self.isVideoGeneration:
+                    self.externalTypes[typeinfo.elem.get('name')] = VulkanExternalType(typeinfo.elem)
+            else:
+                self.externalTypes[typeinfo.elem.get('name')] = VulkanExternalType(typeinfo.elem)
         elif typeinfo.elem.get('category') == 'handle':
             self.handles[typeinfo.elem.get('name')] = VulkanHandle(typeinfo.elem)
         elif typeinfo.elem.get('category') == 'union':
@@ -2018,6 +2049,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
 
             # Merge the values and the parent values
             values = item.values().copy()
+            values.update({'isVideoGeneration' : str(self.isVideoGeneration)})
             for parent in parents:
                 values.update(parent.values())
 
@@ -2302,7 +2334,8 @@ class VulkanExtension:
 
     def __init__(self, rootNode):
         self.name = rootNode.get('name')
-        self.number = int(rootNode.get('number'))
+        # video.xml extensions dont have numbers - just use None in that case
+        self.number = int(rootNode.get('number')) if rootNode.get('number') else None
         self.type = rootNode.get('type')
         self.dependency = rootNode.get('requires')
         self.guard = GetFeatureProtect(rootNode)

--- a/scripts/vt_genvk.py
+++ b/scripts/vt_genvk.py
@@ -232,6 +232,36 @@ def makeGenOpts(args):
             expandEnumerants  = False)
     ]
 
+    # API dump generator options for api_dump_video_text.h
+    genOpts['api_dump_video_text.h'] = [
+        ApiDumpOutputGenerator,
+        ApiDumpGeneratorOptions(
+            conventions       = conventions,
+            input             = TEXT_CODEGEN,
+            filename          = 'api_dump_video_text.h',
+            apiname           = 'vulkan',
+            genpath           = None,
+            profile           = None,
+            versions          = featuresPat,
+            emitversions      = featuresPat,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensionsPat,
+            removeExtensions  = removeExtensionsPat,
+            emitExtensions    = emitExtensionsPat,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            genFuncPointers   = True,
+            protectFile       = protect,
+            protectFeature    = False,
+            protectProto      = None,
+            protectProtoStr   = 'VK_NO_PROTOTYPES',
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            expandEnumerants  = False,
+            isVideoGeneration = True)
+    ]
+
     # API dump generator options for api_dump_html.h
     genOpts['api_dump_html.h'] = [
         ApiDumpOutputGenerator,
@@ -259,6 +289,36 @@ def makeGenOpts(args):
             apientryp         = 'VKAPI_PTR *',
             alignFuncParam    = 48,
             expandEnumerants  = False)
+    ]
+
+     # API dump generator options for api_dump_video_html.h
+    genOpts['api_dump_video_html.h'] = [
+        ApiDumpOutputGenerator,
+        ApiDumpGeneratorOptions(
+            conventions       = conventions,
+            input             = HTML_CODEGEN,
+            filename          = 'api_dump_video_html.h',
+            apiname           = 'vulkan',
+            genpath           = None,
+            profile           = None,
+            versions          = featuresPat,
+            emitversions      = featuresPat,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensionsPat,
+            removeExtensions  = removeExtensionsPat,
+            emitExtensions    = emitExtensionsPat,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            genFuncPointers   = True,
+            protectFile       = protect,
+            protectFeature    = False,
+            protectProto      = None,
+            protectProtoStr   = 'VK_NO_PROTOTYPES',
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            expandEnumerants  = False,
+            isVideoGeneration = True)
     ]
 
     # API dump generator options for api_dump_json.h
@@ -289,6 +349,37 @@ def makeGenOpts(args):
             alignFuncParam    = 48,
             expandEnumerants  = False)
     ]
+
+    # API dump generator options for api_dump_video_json.h
+    genOpts['api_dump_video_json.h'] = [
+        ApiDumpOutputGenerator,
+        ApiDumpGeneratorOptions(
+            conventions       = conventions,
+            input             = JSON_CODEGEN,
+            filename          = 'api_dump_video_json.h',
+            apiname           = 'vulkan',
+            genpath           = None,
+            profile           = None,
+            versions          = featuresPat,
+            emitversions      = featuresPat,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensionsPat,
+            removeExtensions  = removeExtensionsPat,
+            emitExtensions    = emitExtensionsPat,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            genFuncPointers   = True,
+            protectFile       = protect,
+            protectFeature    = False,
+            protectProto      = None,
+            protectProtoStr   = 'VK_NO_PROTOTYPES',
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            expandEnumerants  = False,
+            isVideoGeneration = True)
+    ]
+
 
     # Helper file generator options for vk_struct_size_helper.h
     genOpts['vk_struct_size_helper.h'] = [


### PR DESCRIPTION
NOTE: This uses the currently in progress #1771 PR as a base, and therefore is not ready for primetime. Expect a rebase on main when the refactor PR is complete. Until then, this PR contains commits of both

This PR adds support for the video extensions in API Dump. The video extensions were not supported initially because they required definitions for the various external types that were defined in video.xml but because these definitions live in a different xml file, they weren't generated. This PR fixes it by running the generator script over the video.xml files to produce text, html, and json header files that are then used by the existing API Dump code.