### PR TITLE
Remove usage of VK_LAYER_EXPORT

### DIFF
--- a/layersvt/monitor.cpp
+++ b/layersvt/monitor.cpp
@@ -84,7 +84,7 @@ static std::unordered_map<void *, monitor_layer_data *> layer_data_map;
 template monitor_layer_data *GetLayerDataPtr<monitor_layer_data>(void *data_key,
                                                                  std::unordered_map<void *, monitor_layer_data *> &data_map);
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo,
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo,
                                                               const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
     VkLayerDeviceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
@@ -132,7 +132,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice g
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
+VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
                                                                           VkPhysicalDevice *pPhysicalDevices) {
     dispatch_key key = get_dispatch_key(instance);
     monitor_layer_data *my_data = GetLayerDataPtr(key, layer_data_map);
@@ -151,7 +151,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInst
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDeviceGroups(
+VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDeviceGroups(
     VkInstance instance, uint32_t *pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties *pPhysicalDeviceGroupProperties) {
     dispatch_key key = get_dispatch_key(instance);
     monitor_layer_data *my_data = GetLayerDataPtr(key, layer_data_map);
@@ -172,7 +172,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDeviceGroups(
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
     dispatch_key key = get_dispatch_key(device);
     monitor_layer_data *my_data = GetLayerDataPtr(key, layer_data_map);
     VkLayerDispatchTable *pTable = my_data->device_dispatch_table;
@@ -182,7 +182,7 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, cons
     layer_data_map.erase(key);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                                                                 const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
     VkLayerInstanceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
@@ -232,7 +232,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstance
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
     dispatch_key key = get_dispatch_key(instance);
     monitor_layer_data *my_data = GetLayerDataPtr(key, layer_data_map);
     VkLayerInstanceDispatchTable *pTable = my_data->instance_dispatch_table;
@@ -241,7 +241,7 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance
     layer_data_map.erase(key);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
+VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
     monitor_layer_data *my_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
 
     time_t now;
@@ -274,7 +274,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, 
     return result;
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolPropertiesEXT(
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolPropertiesEXT(
     VkPhysicalDevice physicalDevice, uint32_t *pToolCount, VkPhysicalDeviceToolPropertiesEXT *pToolProperties) {
     static const VkPhysicalDeviceToolPropertiesEXT monitor_layer_tool_props = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
@@ -306,7 +306,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceToolProperties
 }
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance instance,
                                                                        const VkWin32SurfaceCreateInfoKHR *pCreateInfo,
                                                                        const VkAllocationCallbacks *pAllocator,
                                                                        VkSurfaceKHR *pSurface) {
@@ -318,7 +318,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstanc
     return result;
 }
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance instance,
                                                                      const VkXcbSurfaceCreateInfoKHR *pCreateInfo,
                                                                      const VkAllocationCallbacks *pAllocator,
                                                                      VkSurfaceKHR *pSurface) {
@@ -357,7 +357,15 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance 
 }
 #endif
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#else
+#define EXPORT_FUNCTION
+#endif
+
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
 #define ADD_HOOK(fn) \
     if (!strncmp(#fn, funcName, sizeof(#fn))) return (PFN_vkVoidFunction)fn
 
@@ -376,7 +384,7 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkD
     return pTable->GetDeviceProcAddr(dev, funcName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
 #define ADD_HOOK(fn) \
     if (!strncmp(#fn, funcName, sizeof(#fn))) return (PFN_vkVoidFunction)fn
 

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -1602,26 +1602,35 @@ static PFN_vkVoidFunction intercept_khr_swapchain_command(const char *name, VkDe
 
 }  // namespace screenshot
 
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#else
+#define EXPORT_FUNCTION
+#endif
+
+
 // loader-layer interface v0, just wrappers since there is only a layer
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t *pCount,
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t *pCount,
                                                                                   VkLayerProperties *pProperties) {
     return screenshot::EnumerateInstanceLayerProperties(pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount,
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount,
                                                                                 VkLayerProperties *pProperties) {
     // the layer command handles VK_NULL_HANDLE just fine internally
     assert(physicalDevice == VK_NULL_HANDLE);
     return screenshot::EnumerateDeviceLayerProperties(VK_NULL_HANDLE, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
                                                                                       VkExtensionProperties *pProperties) {
     return screenshot::EnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
                                                                                     const char *pLayerName, uint32_t *pCount,
                                                                                     VkExtensionProperties *pProperties) {
     // the layer command handles VK_NULL_HANDLE just fine internally
@@ -1629,10 +1638,10 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
     return screenshot::EnumerateDeviceExtensionProperties(VK_NULL_HANDLE, pLayerName, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
     return screenshot::GetDeviceProcAddr(dev, funcName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
     return screenshot::GetInstanceProcAddr(instance, funcName);
 }

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -78,7 +78,15 @@ COMMON_CODEGEN = """
 
 // Specifically implemented functions
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance)
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#else
+#define EXPORT_FUNCTION
+#endif
+
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance)
 {{
     ApiDumpInstance::current().outputMutex()->lock();
     if (ApiDumpInstance::current().shouldDumpOutput()) {{
@@ -131,7 +139,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstance
     return result;
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
 {{
     ApiDumpInstance::current().outputMutex()->lock();
     if (ApiDumpInstance::current().shouldDumpOutput()) {{
@@ -185,12 +193,12 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice p
     return result;
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount, VkExtensionProperties* pProperties)
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount, VkExtensionProperties* pProperties)
 {{
     return util_GetExtensionProperties(0, NULL, pPropertyCount, pProperties);
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties)
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties)
 {{
     static const VkLayerProperties layerProperties[] = {{
         {{
@@ -204,7 +212,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerPropertie
     return util_GetLayerProperties(ARRAY_SIZE(layerProperties), layerProperties, pPropertyCount, pProperties);
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkLayerProperties* pProperties)
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkLayerProperties* pProperties)
 {{
     static const VkLayerProperties layerProperties[] = {{
         {{
@@ -221,7 +229,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(
 // Autogen instance functions
 
 @foreach function where('{funcDispatchType}' == 'instance' and '{funcName}' not in ['vkCreateInstance', 'vkCreateDevice', 'vkGetInstanceProcAddr', 'vkEnumerateDeviceExtensionProperties', 'vkEnumerateDeviceLayerProperties'])
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
     ApiDumpInstance::current().outputMutex()->lock();
     if (ApiDumpInstance::current().shouldDumpOutput()) {{
@@ -320,7 +328,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 // Autogen device functions
 
 @foreach function where('{funcDispatchType}' == 'device' and '{funcName}' not in ['vkGetDeviceProcAddr'])
-VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
+VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 {{
     ApiDumpInstance::current().outputMutex()->lock();
     @if('{funcName}' == 'vkDebugMarkerSetObjectNameEXT')
@@ -398,7 +406,7 @@ VK_LAYER_EXPORT VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 }}
 @end function
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName)
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName)
 {{
     @foreach function where('{funcType}' in ['global', 'instance'] and '{funcName}' not in [ 'vkEnumerateDeviceExtensionProperties' ])
     if(strcmp(pName, "{funcName}") == 0)
@@ -411,7 +419,7 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(V
     return instance_dispatch_table(instance)->GetInstanceProcAddr(instance, pName);
 }}
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char* pName)
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char* pName)
 {{
     @foreach function where('{funcType}' == 'device')
     if(strcmp(pName, "{funcName}") == 0)

--- a/scripts/layer_factory_generator.py
+++ b/scripts/layer_factory_generator.py
@@ -448,24 +448,32 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(VkInstance instance, Vk
     inline_custom_source_postamble = """
 // loader-layer interface v0, just wrappers since there is only a layer
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
+#define EXPORT_FUNCTION __attribute__((visibility("default")))
+#else
+#define EXPORT_FUNCTION
+#endif
+
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
                                                                                       VkExtensionProperties *pProperties) {
     return vulkan_layer_factory::EnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t *pCount,
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t *pCount,
                                                                                   VkLayerProperties *pProperties) {
     return vulkan_layer_factory::EnumerateInstanceLayerProperties(pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount,
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t *pCount,
                                                                                 VkLayerProperties *pProperties) {
     // the layer command handles VK_NULL_HANDLE just fine internally
     assert(physicalDevice == VK_NULL_HANDLE);
     return vulkan_layer_factory::EnumerateDeviceLayerProperties(VK_NULL_HANDLE, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
                                                                                     const char *pLayerName, uint32_t *pCount,
                                                                                     VkExtensionProperties *pProperties) {
     // the layer command handles VK_NULL_HANDLE just fine internally
@@ -473,20 +481,20 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropert
     return vulkan_layer_factory::EnumerateDeviceExtensionProperties(VK_NULL_HANDLE, pLayerName, pCount, pProperties);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice dev, const char *funcName) {
     return vulkan_layer_factory::GetDeviceProcAddr(dev, funcName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
+EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
     return vulkan_layer_factory::GetInstanceProcAddr(instance, funcName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance,
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance,
                                                                                            const char *funcName) {
     return vulkan_layer_factory::GetPhysicalDeviceProcAddr(instance, funcName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface *pVersionStruct) {
+EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface *pVersionStruct) {
     assert(pVersionStruct != NULL);
     assert(pVersionStruct->sType == LAYER_NEGOTIATE_INTERFACE_STRUCT);
 

--- a/vku/vk_layer_settings.cpp
+++ b/vku/vk_layer_settings.cpp
@@ -270,12 +270,12 @@ static std::string GetEnvVarKey(const char *layer_key, const char *setting_key, 
     return result.str();
 }
 
-VK_LAYER_EXPORT void InitLayerSettingsLogCallback(LAYER_SETTING_LOG_CALLBACK callback) {
+void InitLayerSettingsLogCallback(LAYER_SETTING_LOG_CALLBACK callback) {
     vk_layer_settings.SetCallback(callback);
     return;
 }
 
-VK_LAYER_EXPORT bool IsLayerSetting(const char *layer_key, const char *setting_key) {
+bool IsLayerSetting(const char *layer_key, const char *setting_key) {
     assert(layer_key);
     assert(!std::string(layer_key).empty());
     assert(setting_key);
@@ -299,7 +299,7 @@ static std::string GetLayerSettingData(const char *layer_key, const char *settin
     return vk_layer_settings.Get(GetSettingKey(layer_key, setting_key).c_str());
 }
 
-VK_LAYER_EXPORT bool GetLayerSettingBool(const char *layer_key, const char *setting_key) {
+bool GetLayerSettingBool(const char *layer_key, const char *setting_key) {
     assert(IsLayerSetting(layer_key, setting_key));
 
     bool result = false;  // default value
@@ -320,7 +320,7 @@ VK_LAYER_EXPORT bool GetLayerSettingBool(const char *layer_key, const char *sett
     return result;
 }
 
-VK_LAYER_EXPORT int GetLayerSettingInt(const char *layer_key, const char *setting_key) {
+int GetLayerSettingInt(const char *layer_key, const char *setting_key) {
     assert(IsLayerSetting(layer_key, setting_key));
 
     int result = 0;  // default value
@@ -339,7 +339,7 @@ VK_LAYER_EXPORT int GetLayerSettingInt(const char *layer_key, const char *settin
     return result;
 }
 
-VK_LAYER_EXPORT double GetLayerSettingFloat(const char *layer_key, const char *setting_key) {
+double GetLayerSettingFloat(const char *layer_key, const char *setting_key) {
     assert(IsLayerSetting(layer_key, setting_key));
 
     double result = 0.0;  // default value
@@ -358,7 +358,7 @@ VK_LAYER_EXPORT double GetLayerSettingFloat(const char *layer_key, const char *s
     return result;
 }
 
-VK_LAYER_EXPORT std::string GetLayerSettingString(const char *layer_key, const char *setting_key) {
+std::string GetLayerSettingString(const char *layer_key, const char *setting_key) {
     assert(IsLayerSetting(layer_key, setting_key));
 
     std::string setting = GetLayerSettingData(layer_key, setting_key);
@@ -370,7 +370,7 @@ VK_LAYER_EXPORT std::string GetLayerSettingString(const char *layer_key, const c
     return setting;
 }
 
-VK_LAYER_EXPORT std::string GetLayerSettingFrames(const char *layer_key, const char *setting_key) {
+std::string GetLayerSettingFrames(const char *layer_key, const char *setting_key) {
     assert(IsLayerSetting(layer_key, setting_key));
 
     std::string setting = GetLayerSettingData(layer_key, setting_key);
@@ -403,7 +403,7 @@ static inline std::vector<std::string> Split(const std::string &value, const std
     return result;
 }
 
-VK_LAYER_EXPORT Strings GetLayerSettingStrings(const char *layer_key, const char *setting_key) {
+Strings GetLayerSettingStrings(const char *layer_key, const char *setting_key) {
     assert(IsLayerSetting(layer_key, setting_key));
 
     std::string setting = GetLayerSettingData(layer_key, setting_key);
@@ -419,7 +419,7 @@ VK_LAYER_EXPORT Strings GetLayerSettingStrings(const char *layer_key, const char
     }
 }
 
-VK_LAYER_EXPORT List GetLayerSettingList(const char *layer_key, const char *setting_key) {
+List GetLayerSettingList(const char *layer_key, const char *setting_key) {
     assert(IsLayerSetting(layer_key, setting_key));
 
     std::vector<std::string> inputs = GetLayerSettingStrings(layer_key, setting_key);

--- a/vku/vk_layer_settings.h
+++ b/vku/vk_layer_settings.h
@@ -35,29 +35,29 @@ typedef void *(*LAYER_SETTING_LOG_CALLBACK)(const char *setting_key, const char 
 
 // Initialize the callback function to get error messages. By default the error messages are outputed to stderr. Use nullptr to
 // return to the default behavior.
-VK_LAYER_EXPORT void InitLayerSettingsLogCallback(LAYER_SETTING_LOG_CALLBACK callback);
+void InitLayerSettingsLogCallback(LAYER_SETTING_LOG_CALLBACK callback);
 
 // Check whether a setting was set either from vk_layer_settings.txt or an environment variable
-VK_LAYER_EXPORT bool IsLayerSetting(const char *layer_key, const char *setting_key);
+bool IsLayerSetting(const char *layer_key, const char *setting_key);
 
 // Query setting data for BOOL setting type in the layer manifest
-VK_LAYER_EXPORT bool GetLayerSettingBool(const char *layer_key, const char *setting_key);
+bool GetLayerSettingBool(const char *layer_key, const char *setting_key);
 
 // Query setting data for INT setting type in the layer manifest
-VK_LAYER_EXPORT int GetLayerSettingInt(const char *layer_key, const char *setting_key);
+int GetLayerSettingInt(const char *layer_key, const char *setting_key);
 
 // Query setting data for FLOAT setting type in the layer manifest
-VK_LAYER_EXPORT double GetLayerSettingFloat(const char *layer_key, const char *setting_key);
+double GetLayerSettingFloat(const char *layer_key, const char *setting_key);
 
 // Query setting data for FRAMES setting type in the layer manifest
-VK_LAYER_EXPORT std::string GetLayerSettingFrames(const char *layer_key, const char *setting_key);
+std::string GetLayerSettingFrames(const char *layer_key, const char *setting_key);
 
 // Query setting data for STRING, ENUM, LOAD_FILE, SAVE_FILE and SAVE_FOLDER setting types in the layer manifest
-VK_LAYER_EXPORT std::string GetLayerSettingString(const char *layer_key, const char *setting_key);
+std::string GetLayerSettingString(const char *layer_key, const char *setting_key);
 
 // Query setting data for FLAGS setting type in the layer manifest
-VK_LAYER_EXPORT Strings GetLayerSettingStrings(const char *layer_key, const char *setting_key);
+Strings GetLayerSettingStrings(const char *layer_key, const char *setting_key);
 
 // Query setting data for LIST setting type in the layer manifest
-VK_LAYER_EXPORT List GetLayerSettingList(const char *layer_key, const char *setting_key);
+List GetLayerSettingList(const char *layer_key, const char *setting_key);
 }  // namespace vku


### PR DESCRIPTION
This PR fixes API Dump, Monitor, Screenshot, and the vk_layer_settings utility to no longer use the VK_LAYER_EXPORT macro which was defined in vk_layer.h. The macro was recently removed thus all the projects using it must be updated.

In addition to defining the macro locally to each file, this commit removes function exporting for functions which do not need it. For Example, it was being added to each and every function in API Dump when only ~7 functions in the entire Vulkan interface need to be exported. Additionally, it was entirely removed from the vk_layer_settings utility due to the utility being a static library thus having no effect.

Fixes #1793 