### PR TITLE
build: Remove xxhash depedency from makefile generator

### DIFF
--- a/scripts/vlf_makefile_generator.py
+++ b/scripts/vlf_makefile_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2015-2017 Valve Corporation
-# Copyright (c) 2015-2017 LunarG, Inc.
+# Copyright (c) 2015-2023 Valve Corporation
+# Copyright (c) 2015-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,7 +76,6 @@ if __name__ == '__main__':
             contents += 'include $(CLEAR_VARS)\n'
             contents += 'LOCAL_MODULE := VkLayer_%s\n' % factory_layer
             contents += 'LOCAL_SRC_FILES += $(LAYER_DIR)/include/layer_factory.cpp\n'
-            contents += 'LOCAL_SRC_FILES += $(LVL_DIR)/layers/xxhash.cpp\n'
             # Add *.cpp files (if any) to makefile dependencies
             for path, subdirs, files in os.walk(factory_layer):
                 for file in files:
@@ -91,7 +90,6 @@ if __name__ == '__main__':
             contents += 'LOCAL_STATIC_LIBRARIES += layer_utils\n'
             contents += 'LOCAL_CPPFLAGS += -std=c++17 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable\n'
             contents += 'LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_ENABLE_BETA_EXTENSIONS -fvisibility=hidden\n'
-            contents += 'LOCAL_CPPFLAGS += -DXXH_NO_LONG_LONG\n'
             contents += 'LOCAL_LDLIBS    := -llog\n'
             contents += 'LOCAL_LDFLAGS   += -Wl,-Bsymbolic\n'
             contents += 'LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL\n'


### PR DESCRIPTION
I think this should have been a part of https://github.com/LunarG/VulkanTools/commit/956fd012dcfc6c3f7384539b500305b030feb66a