### PR TITLE
Make update_object_name_map() update on name re-assignment

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -837,13 +837,13 @@ class ApiDumpInstance {
 
     void update_object_name_map(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
         if (pNameInfo->pObjectName)
-            object_name_map.emplace(pNameInfo->object, pNameInfo->pObjectName);
+            object_name_map[pNameInfo->object] = pNameInfo->pObjectName;
         else
             object_name_map.erase(pNameInfo->object);
     }
     void update_object_name_map(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
         if (pNameInfo->pObjectName)
-            object_name_map.emplace(pNameInfo->objectHandle, pNameInfo->pObjectName);
+            object_name_map[pNameInfo->objectHandle] = pNameInfo->pObjectName;
         else
             object_name_map.erase(pNameInfo->objectHandle);
     }


### PR DESCRIPTION
The emplace() function will not update the value in the map if it is already present.

This is useful if you are labelling objects which get recycled. For examples, you might label a fence "Frame 1 Complete Fence" and then again "Frame 4 Complete Fence". 