### PR TITLE
layer_factory: Update debug bit to verbose

### DIFF
--- a/scripts/layer_factory_generator.py
+++ b/scripts/layer_factory_generator.py
@@ -613,7 +613,7 @@ EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
         self.layer_factory += '        }\n'
         self.layer_factory += '\n'
         self.layer_factory += '        bool Error(const std::string &message) {\n'
-        self.layer_factory += '            return log_msg(vlf_report_data, kDebugBit, VK_OBJECT_TYPE_UNKNOWN, 0,\n'
+        self.layer_factory += '            return log_msg(vlf_report_data, kVerboseBit, VK_OBJECT_TYPE_UNKNOWN, 0,\n'
         self.layer_factory += '                           layer_name.c_str(), "%s", message.c_str());\n'
         self.layer_factory += '        }\n'
         self.layer_factory += '\n'


### PR DESCRIPTION
The ValidationLayer repo updated the definition of the debug bit to be 'verbose', so VulkanTools needs to update to reflect that change.