### PR TITLE
Update version.h

### DIFF
--- a/vkconfig_core/version.h
+++ b/vkconfig_core/version.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 #define SUPPORT_LAYER_CONFIG_2_2_0 1


### PR DESCRIPTION
Fix for multiple compilation errors on Fedora 38 g++ (GCC) 13.0.1 due to the lack of cstdint include