### PR TITLE
cmake: move jsoncpp to knowngood to simply build steps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,6 @@ endif()
 
 set (VULKAN_SDK $ENV{VULKAN_SDK})
 
-# NOTE: jsoncpp is located in SUBPROJECTS_DIR.
-set (SUBPROJECTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/submodules)
-
 set(VULKANTOOLS_SCRIPTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/scripts)
 
 find_package(VulkanHeaders REQUIRED CONFIG)
@@ -157,8 +154,10 @@ if (VULKAN_LOADER_INSTALL_DIR)
 elseif(ENV{VULKAN_LOADER_INSTALL_DIR})
     message(STATUS "VULKAN_LOADER_INSTALL_DIR environment variable specified, using find_package to locate Vulkan")
 endif()
-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR})
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH};${VULKAN_LOADER_INSTALL_DIR};${VULKAN_HEADERS_INSTALL_DIR};${JSONCPP_INSTALL_DIR};$ENV{VULKAN_LOADER_INSTALL_DIR};$ENV{VULKAN_HEADERS_INSTALL_DIR};$ENV{JSONCPP_INSTALL_DIR})
 find_package(Vulkan)
+
+find_package(jsoncpp REQUIRED CONFIG)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows" OR
     CMAKE_SYSTEM_NAME STREQUAL "Linux" OR
@@ -186,31 +185,6 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     option(BUILD_VIA "Build VIA" ON)
     option(BUILD_LAYERMGR "Build Vulkan Configurator" ON)
 
-endif()
-
-find_path(JSONCPP_INCLUDE_DIR json/json.h HINTS "${SUBPROJECTS_DIR}/jsoncpp/dist"
-                                                   "${SUBPROJECTS_DIR}/JsonCpp/dist"
-                                                   "${SUBPROJECTS_DIR}/JsonCPP/dist"
-                                                   "${SUBPROJECTS_DIR}/JSONCPP/dist"
-                                                   "${CMAKE_SOURCE_DIR}/../jsoncpp/dist"
-                                             DOC "Path to jsoncpp/dist/json/json.h")
-
-find_path(JSONCPP_SOURCE_DIR jsoncpp.cpp HINTS "${SUBPROJECTS_DIR}/jsoncpp/dist"
-                                                   "${SUBPROJECTS_DIR}/JsonCpp/dist"
-                                                   "${SUBPROJECTS_DIR}/JsonCPP/dist"
-                                                   "${SUBPROJECTS_DIR}/JSONCPP/dist"
-                                                   "${CMAKE_SOURCE_DIR}/../jsoncpp/dist"
-                                             DOC "Path to jsoncpp/dist/jsoncpp.cpp")
-
-find_library(JSONCPP_LIB NAMES jsoncpp HINTS ${JSONCPP_SEARCH_PATH} )
-
-if (WIN32)
-    add_library(jsoncpp         STATIC IMPORTED)
-    find_library(JSONCPP_DLIB NAMES jsoncpp
-                 HINTS ${JSONCPP_DEBUG_SEARCH_PATH} )
-    set_target_properties(jsoncpp PROPERTIES
-                         IMPORTED_LOCATION       "${JSONCPP_LIB}"
-                         IMPORTED_LOCATION_DEBUG "${JSONCPP_DLIB}")
 endif()
 
 # Define macro used for building vk.xml generated files

--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -108,7 +108,6 @@ if (APPLE)
         ${CMAKE_CURRENT_BINARY_DIR}
         ${CMAKE_BINARY_DIR}
         ${Vulkan-ValidationLayers_INCLUDE_DIR}
-        ${JSONCPP_INCLUDE_DIR}
     )
 else ()
     include_directories(
@@ -116,7 +115,6 @@ else ()
         ${CMAKE_CURRENT_BINARY_DIR}
         ${CMAKE_BINARY_DIR}
         ${Vulkan-ValidationLayers_INCLUDE_DIR}
-        ${JSONCPP_INCLUDE_DIR}
     )
 endif()
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -1,100 +1,118 @@
 {
-  "repos" : [
-    {
-      "name" : "Vulkan-Headers",
-      "url" : "https://github.com/KhronosGroup/Vulkan-Headers.git",
-      "sub_dir" : "Vulkan-Headers",
-      "build_dir" : "Vulkan-Headers/build",
-      "install_dir" : "Vulkan-Headers/build/install",
-      "commit": "v1.3.250"
-    },
-    {
-      "name" : "Vulkan-Loader",
-      "url" : "https://github.com/KhronosGroup/Vulkan-Loader.git",
-      "sub_dir" : "Vulkan-Loader",
-      "build_dir" : "Vulkan-Loader/build",
-      "install_dir" : "Vulkan-Loader/build/install",
-      "commit": "v1.3.250",
-      "deps" : [
+    "repos": [
         {
-          "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
-          "repo_name" : "Vulkan-Headers"
-        }
-      ],
-      "cmake_options" : [
-        "-DBUILD_TESTS=OFF"
-      ],
-      "build_platforms" : [
-        "linux",
-        "darwin"
-      ]
-    },
-    {
-      "name" : "Vulkan-Tools",
-      "url" : "https://github.com/KhronosGroup/Vulkan-Tools.git",
-      "sub_dir" : "Vulkan-Tools",
-      "build_dir" : "Vulkan-Tools/build",
-      "install_dir" : "Vulkan-Tools/build/install",
-      "commit": "v1.3.250",
-      "deps" : [
-        {
-          "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
-          "repo_name" : "Vulkan-Headers"
+            "name": "Vulkan-Headers",
+            "url": "https://github.com/KhronosGroup/Vulkan-Headers.git",
+            "sub_dir": "Vulkan-Headers",
+            "build_dir": "Vulkan-Headers/build",
+            "install_dir": "Vulkan-Headers/build/install",
+            "commit": "v1.3.250"
         },
         {
-          "var_name" : "VULKAN_LOADER_INSTALL_DIR",
-          "repo_name" : "Vulkan-Loader"
-        }
-      ],
-      "cmake_options" : [
-        "-DBUILD_CUBE=OFF"
-      ],
-      "build_platforms" : [
-        "windows",
-        "linux"
-      ]
-    },
-    {
-      "name" : "Vulkan-ValidationLayers",
-      "url" : "https://github.com/KhronosGroup/Vulkan-ValidationLayers.git",
-      "sub_dir" : "Vulkan-ValidationLayers",
-      "build_dir" : "Vulkan-ValidationLayers/build",
-      "install_dir" : "Vulkan-ValidationLayers/build/install",
-      "commit": "v1.3.250",
-      "deps" : [
-        {
-          "var_name" : "VULKAN_HEADERS_INSTALL_DIR",
-          "repo_name" : "Vulkan-Headers"
+            "name": "Vulkan-Utility-Libraries",
+            "url": "https://github.com/KhronosGroup/Vulkan-Utility-Libraries.git",
+            "sub_dir": "Vulkan-Utility-Libraries",
+            "build_dir": "Vulkan-Utility-Libraries/build",
+            "install_dir": "Vulkan-Utility-Libraries/build/install",
+            "commit": "main",
+            "deps": [
+                {
+                    "var_name": "VULKAN_HEADERS_INSTALL_DIR",
+                    "repo_name": "Vulkan-Headers"
+                }
+            ]
         },
         {
-          "var_name" : "VULKAN_LOADER_INSTALL_DIR",
-          "repo_name" : "Vulkan-Loader"
+            "name": "Vulkan-Loader",
+            "url": "https://github.com/KhronosGroup/Vulkan-Loader.git",
+            "sub_dir": "Vulkan-Loader",
+            "build_dir": "Vulkan-Loader/build",
+            "install_dir": "Vulkan-Loader/build/install",
+            "commit": "v1.3.250",
+            "deps": [
+                {
+                    "var_name": "VULKAN_HEADERS_INSTALL_DIR",
+                    "repo_name": "Vulkan-Headers"
+                }
+            ],
+            "cmake_options": [
+                "-DBUILD_TESTS=OFF"
+            ],
+            "build_platforms": [
+                "linux",
+                "darwin"
+            ]
+        },
+        {
+            "name": "Vulkan-Tools",
+            "url": "https://github.com/KhronosGroup/Vulkan-Tools.git",
+            "sub_dir": "Vulkan-Tools",
+            "build_dir": "Vulkan-Tools/build",
+            "install_dir": "Vulkan-Tools/build/install",
+            "commit": "v1.3.250",
+            "deps": [
+                {
+                    "var_name": "VULKAN_HEADERS_INSTALL_DIR",
+                    "repo_name": "Vulkan-Headers"
+                },
+                {
+                    "var_name": "VULKAN_LOADER_INSTALL_DIR",
+                    "repo_name": "Vulkan-Loader"
+                }
+            ],
+            "cmake_options": [
+                "-DBUILD_CUBE=OFF"
+            ],
+            "build_platforms": [
+                "windows",
+                "linux"
+            ]
+        },
+        {
+            "name": "Vulkan-ValidationLayers",
+            "url": "https://github.com/KhronosGroup/Vulkan-ValidationLayers.git",
+            "sub_dir": "Vulkan-ValidationLayers",
+            "build_dir": "Vulkan-ValidationLayers/build",
+            "install_dir": "Vulkan-ValidationLayers/build/install",
+            "commit": "v1.3.250",
+            "deps": [
+                {
+                    "var_name": "VULKAN_HEADERS_INSTALL_DIR",
+                    "repo_name": "Vulkan-Headers"
+                },
+                {
+                    "var_name": "VULKAN_LOADER_INSTALL_DIR",
+                    "repo_name": "Vulkan-Loader"
+                }
+            ],
+            "cmake_options": [
+                "-DBUILD_TESTS=FALSE",
+                "-DBUILD_LAYERS=OFF",
+                "-DBUILD_LAYER_SUPPORT_FILES=ON",
+                "-DUSE_ROBIN_HOOD_HASHING=OFF"
+            ]
+        },
+        {
+            "name": "jsoncpp",
+            "url": "https://github.com/open-source-parsers/jsoncpp.git",
+            "sub_dir": "jsoncpp",
+            "build_dir": "jsoncpp/build",
+            "install_dir": "jsoncpp/build/install",
+            "commit": "1.9.5",
+            "cmake_options": [
+                "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+                "-DJSONCPP_WITH_TESTS=OFF",
+                "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF",
+                "-DJSONCPP_WITH_WARNING_AS_ERROR=OFF",
+                "-DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF"
+            ]
         }
-      ],
-      "cmake_options" : [
-        "-DBUILD_TESTS=FALSE","-DBUILD_LAYERS=OFF","-DBUILD_LAYER_SUPPORT_FILES=ON","-DUSE_ROBIN_HOOD_HASHING=OFF"
-      ]
-    },
-    {
-        "name": "jsoncpp",
-        "url": "https://github.com/open-source-parsers/jsoncpp.git",
-        "sub_dir": "jsoncpp",
-        "build_dir": "jsoncpp/build",
-        "install_dir": "jsoncpp/build/install",
-        "commit": "1.9.5",
-        "cmake_options": [
-            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
-            "-DJSONCPP_WITH_TESTS=OFF",
-            "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF",
-            "-DJSONCPP_WITH_WARNING_AS_ERROR=OFF",
-            "-DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF"
-        ]
-    }
-  ],
-  "install_names" : {
-      "Vulkan-Headers" : "VULKAN_HEADERS_INSTALL_DIR",
-      "Vulkan-Loader" : "VULKAN_LOADER_INSTALL_DIR",
-      "Vulkan-ValidationLayers" : "VULKAN_VALIDATIONLAYERS_INSTALL_DIR",
-      "jsoncpp": "JSONCPP_INSTALL_DIR"
+    ],
+    "install_names": {
+        "Vulkan-Headers": "VULKAN_HEADERS_INSTALL_DIR",
+        "Vulkan-Utility-Libraries": "VULKAN_UTILITY_LIBRARIES_INSTALL_DIR",
+        "Vulkan-Loader": "VULKAN_LOADER_INSTALL_DIR",
+        "Vulkan-ValidationLayers": "VULKAN_VALIDATIONLAYERS_INSTALL_DIR",
+        "jsoncpp": "JSONCPP_INSTALL_DIR"
     }
 }

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -74,11 +74,27 @@
       "cmake_options" : [
         "-DBUILD_TESTS=FALSE","-DBUILD_LAYERS=OFF","-DBUILD_LAYER_SUPPORT_FILES=ON","-DUSE_ROBIN_HOOD_HASHING=OFF"
       ]
+    },
+    {
+        "name": "jsoncpp",
+        "url": "https://github.com/open-source-parsers/jsoncpp.git",
+        "sub_dir": "jsoncpp",
+        "build_dir": "jsoncpp/build",
+        "install_dir": "jsoncpp/build/install",
+        "commit": "1.9.5",
+        "cmake_options": [
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+            "-DJSONCPP_WITH_TESTS=OFF",
+            "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF",
+            "-DJSONCPP_WITH_WARNING_AS_ERROR=OFF",
+            "-DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF"
+        ]
     }
   ],
   "install_names" : {
       "Vulkan-Headers" : "VULKAN_HEADERS_INSTALL_DIR",
       "Vulkan-Loader" : "VULKAN_LOADER_INSTALL_DIR",
-      "Vulkan-ValidationLayers" : "VULKAN_VALIDATIONLAYERS_INSTALL_DIR"
+      "Vulkan-ValidationLayers" : "VULKAN_VALIDATIONLAYERS_INSTALL_DIR",
+      "jsoncpp": "JSONCPP_INSTALL_DIR"
     }
 }

--- a/via/CMakeLists.txt
+++ b/via/CMakeLists.txt
@@ -48,16 +48,14 @@ add_executable(vkvia
                   via_system.hpp
                   via_system.cpp
                   via_system_windows.hpp
-                  via_system_windows.cpp
-                  ${JSONCPP_SOURCE_DIR}/jsoncpp.cpp)
+                  via_system_windows.cpp)
 elseif(APPLE)
 add_executable(vkvia
                   via.cpp
                   via_system.hpp
                   via_system.cpp
                   via_system_macos.hpp
-                  via_system_macos.cpp
-                  ${JSONCPP_SOURCE_DIR}/jsoncpp.cpp)
+                  via_system_macos.cpp)
 elseif(UNIX)
 add_executable(vkvia
                   via.cpp
@@ -66,12 +64,10 @@ add_executable(vkvia
                   via_system_linux.hpp
                   via_system_linux.cpp
                   via_system_bsd.hpp
-                  via_system_bsd.cpp
-                  ${JSONCPP_SOURCE_DIR}/jsoncpp.cpp)
+                  via_system_bsd.cpp)
 endif()
 
-target_include_directories(vkvia PUBLIC ${JSONCPP_INCLUDE_DIR})
-target_link_libraries(vkvia Vulkan::Headers Vulkan::Vulkan ${CMAKE_DL_LIBS})
+target_link_libraries(vkvia Vulkan::Headers Vulkan::Vulkan jsoncpp_static ${CMAKE_DL_LIBS})
 if(WIN32)
     target_link_libraries(vkvia version shlwapi Cfgmgr32)
 endif()


### PR DESCRIPTION
This will also removing the submodule and the update_external_sources steps...

I might follow this with adding the external libraries into the update_deps/known_good stuff. 

This repository is a huge build system mess \o/

I am a bit concerned with Android build, it's not clear how it works but it doesn't seem to use CMake...