### PR TITLE
api_dump: Prevent crash in VkDescriptorDataEXT union

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -906,6 +906,8 @@ class ApiDumpInstance {
     bool getIsDynamicViewport() const { return is_dynamic_viewport; }
     void setMemoryHeapCount(uint32_t memory_heap_count) { this->memory_heap_count = memory_heap_count; }
     uint32_t getMemoryHeapCount() { return memory_heap_count; }
+    void setDescriptorType(VkDescriptorType type) { this->descriptor_type = type; }
+    VkDescriptorType getDescriptorType() { return this->descriptor_type; }
 
     std::chrono::microseconds current_time_since_start() {
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
@@ -950,7 +952,7 @@ class ApiDumpInstance {
     std::unordered_map<std::thread::id, uint64_t> thread_map;
 
     std::recursive_mutex cmd_buffer_state_mutex;
-    std::map<std::pair<VkDevice, VkCommandPool>, std::unordered_set<VkCommandBuffer> > cmd_buffer_pools;
+    std::map<std::pair<VkDevice, VkCommandPool>, std::unordered_set<VkCommandBuffer>> cmd_buffer_pools;
     std::unordered_map<VkCommandBuffer, VkCommandBufferLevel> cmd_buffer_level;
 
     bool conditional_initialized = false;
@@ -974,6 +976,9 @@ class ApiDumpInstance {
 
     // Storage for VkPhysicalDeviceMemoryBudgetPropertiesEXT which needs the number of heaps from VkPhysicalDeviceMemoryProperties
     uint32_t memory_heap_count;
+
+    // Storage for the VkDescriptorDataEXT union to know what is the active element
+    VkDescriptorType descriptor_type;
 };
 
 // Utility to output an address.


### PR DESCRIPTION
The VK_EXT_descriptor_buffer extension adds a union with pointer elements. Because API Dumps union logic is naive, it prints the value of every element in the union regardless of whichever the 'active' element is, as it is not always possible to easily get the active element. VkDescriptorDataEXT contains pointers which are dereferenced resulting in a crash. Fixing it is straightforward because the parent structure VkDescriptorGetInfoEXT contains the type to use, so it is just a matter using the PARAMETER_STATE and VALIDITY_CHECKS functionality to set & get the type when printing out the contents of the union.