### PR TITLE
Enable VK_QNX_external_memory_screen_buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif()
 # Define macro used for building vk.xml generated files
 function(run_vulkantools_vk_xml_generate dependency output)
     add_custom_command(OUTPUT ${output}
-        COMMAND ${PYTHON_CMD} -B ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py -registry ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml -scripts ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry ${output} -removeExtensions VK_QNX_external_memory_screen_buffer
+        COMMAND ${PYTHON_CMD} -B ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py -registry ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml -scripts ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry ${output}
         DEPENDS ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/generator.py ${VULKANTOOLS_SCRIPTS_DIR}/${dependency} ${VULKANTOOLS_SCRIPTS_DIR}/vt_genvk.py ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/reg.py
     )
 endfunction()

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -46,10 +46,10 @@ echo "Using python: $(which $PYTHON_EXECUTABLE)"
 
 
 # apidump
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump.cpp -removeExtensions VK_QNX_external_memory_screen_buffer)
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_text.h -removeExtensions VK_QNX_external_memory_screen_buffer)
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_html.h -removeExtensions VK_QNX_external_memory_screen_buffer)
-( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_json.h -removeExtensions VK_QNX_external_memory_screen_buffer)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump.cpp)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_text.h)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_html.h)
+( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${REGISTRY} -scripts ${REGISTRY_PATH} api_dump_json.h)
 
 ( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${VIDEO_REGISTRY} -scripts ${REGISTRY_PATH} api_dump_video_text.h)
 ( cd generated/include; ${PYTHON_EXECUTABLE} ${VT_SCRIPTS}/vt_genvk.py -registry ${VIDEO_REGISTRY} -scripts ${REGISTRY_PATH} api_dump_video_html.h)

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -1787,7 +1787,7 @@ class ApiDumpOutputGenerator(OutputGenerator):
             root = self.registry.reg
 
         for node in root.find('extensions').findall('extension'):
-            if node.get('supported') == 'vulkan': # dont print unsupported extensions
+            if 'vulkan' in node.get('supported'): # dont print unsupported extensions
                 ext = VulkanExtension(node)
                 self.extensions[ext.name] = ext
                 for item in ext.vktypes:

--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -50,10 +50,11 @@ prefixStrings = [
 platform_dict = {
     'android' : 'VK_USE_PLATFORM_ANDROID_KHR',
     'fuchsia' : 'VK_USE_PLATFORM_FUCHSIA',
-    'ggp': 'VK_USE_PLATFORM_GGP',
+    'ggp' : 'VK_USE_PLATFORM_GGP',
     'ios' : 'VK_USE_PLATFORM_IOS_MVK',
     'macos' : 'VK_USE_PLATFORM_MACOS_MVK',
     'metal' : 'VK_USE_PLATFORM_METAL_EXT',
+    'sci' : 'VK_USE_PLATFORM_SCI',
     'vi' : 'VK_USE_PLATFORM_VI_NN',
     'wayland' : 'VK_USE_PLATFORM_WAYLAND_KHR',
     'win32' : 'VK_USE_PLATFORM_WIN32_KHR',


### PR DESCRIPTION
This extension was disabled due to not working with API dump, to which this commit fixes. The souce of the error was that vulkan safety critical modified vk.xml to change the supported="vulkan" to allow supported="vulkan,vulkansc". ApiDump's generator was only looking for vulkan, causing any extension that worked with both API's to be missed, causing the extension guard to not be added where required.

This commit also adds the SCI platform define to the hardcoded list.

Fixes #1840 