### PR TITLE
Add case for iOS builds with cmake

### DIFF
--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -34,6 +34,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
        # TODO Add Metal Support
        add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
     endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    if (BUILD_METAL_SUPPORT)
+       # TODO Add Metal Support
+       add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
+    endif()
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()


### PR DESCRIPTION
A minor tweak to allow for building with iOS as a target.
Note I left out the case for VK_USE_PLATFORM_MACOS_MVK on purpose as it is deprecated. While there are probably people using this still for macOS, I thought it best not to encourage it moving forward, such as on iOS.