### PR TITLE
apidump: Fix regression in the NoAddr setting

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -507,9 +507,12 @@ class ApiDumpSettings {
             vlGetLayerSettingValue(layerSettingSet, kSettingsKeyDetailedOutput, show_params);
         }
 
-        show_address = false;
+        show_address = true;
         if (vlHasLayerSetting(layerSettingSet, kSettingsKeyNoAddr)) {
             vlGetLayerSettingValue(layerSettingSet, kSettingsKeyNoAddr, show_address);
+            // must invert the setting since the setting is called "no address", which is the logical
+            // opposite of show_address
+            show_address = !show_address;
         }
 
         should_flush = true;


### PR DESCRIPTION
api_dump.h stores the no-address setting in a variable called show_address. This requires inverting the setting to match what the rest of the api_dump code expects it to mean. This fixes a regression introduced by the transition to using the Layer Settings library from Vulkan-Utility-Libraries.