### PR TITLE
build: Use Vulkan-Loader find_package support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,9 @@ endif()
 
 find_package(VulkanHeaders REQUIRED CONFIG)
 
-find_library(Vulkan_LIBRARY NAMES vulkan vulkan-1)
-add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
-set_target_properties(Vulkan::Vulkan PROPERTIES
-    IMPORTED_LOCATION ${Vulkan_LIBRARY})
-target_link_libraries(Vulkan::Vulkan INTERFACE Vulkan::Headers)
+if(NOT ANDROID)
+    find_package(VulkanLoader REQUIRED CONFIG)
+endif()
 
 find_package(VulkanUtilityLibraries REQUIRED CONFIG)
 

--- a/layersvt/test/CMakeLists.txt
+++ b/layersvt/test/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 function(LayerTest NAME)
 	set(TEST_FILENAME ./test_${NAME}.cpp)
     set(TEST_NAME test_${NAME}_layer)
-    
+
     file(GLOB TEST_JSON_FILES ${CMAKE_SOURCE_DIR}/profiles/test/data/)
 
     add_executable(${TEST_NAME}
@@ -41,7 +41,10 @@ function(LayerTest NAME)
                    layer_test_framework.cpp
                    layer_test_framework.h)
     add_dependencies(${TEST_NAME} VkLayer_${NAME})
-    target_link_libraries(${TEST_NAME} Vulkan::Headers Vulkan::Vulkan GTest::gtest GTest::gtest_main Vulkan::LayerSettings)
+    target_link_libraries(${TEST_NAME} Vulkan::Headers GTest::gtest GTest::gtest_main Vulkan::LayerSettings)
+    if (NOT ANDROID)
+        target_link_libraries(${TEST_NAME} Vulkan::Loader)
+    endif()
     target_compile_definitions(${TEST_NAME} PUBLIC TEST_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_${NAME}>")
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -28,7 +28,7 @@
             "sub_dir": "Vulkan-Loader",
             "build_dir": "Vulkan-Loader/build",
             "install_dir": "Vulkan-Loader/build/install",
-            "commit": "v1.3.264",
+            "commit": "d40385b1748ae5270fcab18c5aae1a2e5a301465",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",

--- a/via/CMakeLists.txt
+++ b/via/CMakeLists.txt
@@ -58,7 +58,6 @@ endif()
 
 target_link_libraries(vkvia PRIVATE
     Vulkan::Headers
-    Vulkan::Vulkan
     jsoncpp_static
     valijson
     ${CMAKE_DL_LIBS}
@@ -66,5 +65,9 @@ target_link_libraries(vkvia PRIVATE
     $<TARGET_NAME_IF_EXISTS:PkgConfig::X11>
     $<TARGET_NAME_IF_EXISTS:PkgConfig::WAYlAND_CLIENT>
 )
+
+if (NOT ANDROID)
+    target_link_libraries(vkvia PRIVATE Vulkan::Loader)
+endif()
 
 install(TARGETS vkvia)


### PR DESCRIPTION
Simplifies the CMake code since Vulkan-Loader now exports itself in an easy to consume format. No need to create our own target, just use the provided one.