### PR TITLE
apidump: Return NULL in Get*ProcAddr for disabled extensions

### DIFF
--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -379,10 +379,10 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL api_dump_known_instance_functions(const
     return nullptr;
 }}
 
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL api_dump_known_device_functions(const char* pName)
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL api_dump_known_device_functions(VkDevice device, const char* pName)
 {{
     @foreach function where('{funcType}' == 'device')
-    if(strcmp(pName, "{funcName}") == 0)
+    if(strcmp(pName, "{funcName}") == 0 && (!device || device_dispatch_table(device)->{funcShortName}))
         return reinterpret_cast<PFN_vkVoidFunction>({funcName});
     @end function
 
@@ -395,7 +395,7 @@ EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(V
     if (instance_func) return instance_func;
 
     // Make sure that device functions queried through GIPA works
-    auto device_func = api_dump_known_device_functions(pName);
+    auto device_func = api_dump_known_device_functions(NULL, pName);
     if (device_func) return device_func;
 
     // Haven't created an instance yet, exit now since there is no instance_dispatch_table
@@ -406,7 +406,7 @@ EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(V
 
 EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char* pName)
 {{
-    auto device_func = api_dump_known_device_functions(pName);
+    auto device_func = api_dump_known_device_functions(device, pName);
     if (device_func) return device_func;
 
     // Haven't created a device yet, exit now since there is no device_dispatch_table

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -369,10 +369,15 @@ VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
 }}
 @end function
 
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL api_dump_known_instance_functions(const char* pName)
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL api_dump_known_instance_functions(VkInstance instance, const char* pName)
 {{
     @foreach function where('{funcType}' in ['global', 'instance'] and '{funcName}' not in [ 'vkEnumerateDeviceExtensionProperties' ])
+    @if('${funcDispatchType}' == 'instance')
+    if(strcmp(pName, "{funcName}") == 0 && (!instance || instance_dispatch_table(instance)->{funcShortName}))
+    @end if
+    @if('${funcDispatchType}' != 'instance')
     if(strcmp(pName, "{funcName}") == 0)
+    @end if
         return reinterpret_cast<PFN_vkVoidFunction>({funcName});
     @end function
 
@@ -391,7 +396,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL api_dump_known_device_functions(VkDevic
 
 EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName)
 {{
-    auto instance_func = api_dump_known_instance_functions(pName);
+    auto instance_func = api_dump_known_instance_functions(instance, pName);
     if (instance_func) return instance_func;
 
     // Make sure that device functions queried through GIPA works


### PR DESCRIPTION
vkGetDeviceProcAddr specifies that only function pointers of enabled extensions should be exposed. If an extension is not enabled, vkGetDeviceProcAddr should return NULL. The same goes for vkGetInstanceProcAddr, except that the extension only needs to be available. Some users like winevulkan rely on this behaviour and break when used with the current API dump layer.

Assuming that drivers and other layers act accordingly and return NULL for non-enabled entrypoints, we can mirror this by simply returning NULL when the corresponding dispatch table entry is NULL.