### PR TITLE
layers: Update to new names in vk_dispatch_table.h

### DIFF
--- a/layersvt/vk_layer_table.cpp
+++ b/layersvt/vk_layer_table.cpp
@@ -25,17 +25,17 @@
 static device_table_map tableMap;
 static instance_table_map tableInstanceMap;
 
-dispatch_key get_dispatch_key(const void *object) { return (dispatch_key) * (VulDeviceDispatchTable **)object; }
+dispatch_key get_dispatch_key(const void *object) { return (dispatch_key) * (VkuDeviceDispatchTable **)object; }
 
 // Map lookup must be thread safe
-VulDeviceDispatchTable *device_dispatch_table(void *object) {
+VkuDeviceDispatchTable *device_dispatch_table(void *object) {
     dispatch_key key = get_dispatch_key(object);
     device_table_map::const_iterator it = tableMap.find((void *)key);
     assert(it != tableMap.end() && "Not able to find device dispatch entry");
     return it->second;
 }
 
-VulInstanceDispatchTable *instance_dispatch_table(void *object) {
+VkuInstanceDispatchTable *instance_dispatch_table(void *object) {
     dispatch_key key = get_dispatch_key(object);
     instance_table_map::const_iterator it = tableInstanceMap.find((void *)key);
     assert(it != tableInstanceMap.end() && "Not able to find instance dispatch entry");
@@ -62,14 +62,14 @@ void destroy_device_dispatch_table(dispatch_key key) { destroy_dispatch_table(ta
 
 void destroy_instance_dispatch_table(dispatch_key key) { destroy_dispatch_table(tableInstanceMap, key); }
 
-VulDeviceDispatchTable *get_dispatch_table(device_table_map &map, void *object) {
+VkuDeviceDispatchTable *get_dispatch_table(device_table_map &map, void *object) {
     dispatch_key key = get_dispatch_key(object);
     device_table_map::const_iterator it = map.find((void *)key);
     assert(it != map.end() && "Not able to find device dispatch entry");
     return it->second;
 }
 
-VulInstanceDispatchTable *get_dispatch_table(instance_table_map &map, void *object) {
+VkuInstanceDispatchTable *get_dispatch_table(instance_table_map &map, void *object) {
     dispatch_key key = get_dispatch_key(object);
     instance_table_map::const_iterator it = map.find((void *)key);
     assert(it != map.end() && "Not able to find instance dispatch entry");
@@ -101,19 +101,19 @@ VkLayerDeviceCreateInfo *get_chain_info(const VkDeviceCreateInfo *pCreateInfo, V
  *    Device -> CommandBuffer or Queue
  * If use the object themselves as key to map then implies Create entrypoints have to be intercepted
  * and a new key inserted into map */
-VulInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa, instance_table_map &map) {
-    VulInstanceDispatchTable *pTable;
+VkuInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa, instance_table_map &map) {
+    VkuInstanceDispatchTable *pTable;
     dispatch_key key = get_dispatch_key(instance);
     instance_table_map::const_iterator it = map.find((void *)key);
 
     if (it == map.end()) {
-        pTable = new VulInstanceDispatchTable;
+        pTable = new VkuInstanceDispatchTable;
         map[(void *)key] = pTable;
     } else {
         return it->second;
     }
 
-    vulInitInstanceDispatchTable(instance, pTable, gpa);
+    vkuInitInstanceDispatchTable(instance, pTable, gpa);
 
     // Setup func pointers that are required but not externally exposed.  These won't be added to the instance dispatch table by
     // default.
@@ -122,27 +122,27 @@ VulInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGet
     return pTable;
 }
 
-VulInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa) {
+VkuInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa) {
     return initInstanceTable(instance, gpa, tableInstanceMap);
 }
 
-VulDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa, device_table_map &map) {
-    VulDeviceDispatchTable *pTable;
+VkuDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa, device_table_map &map) {
+    VkuDeviceDispatchTable *pTable;
     dispatch_key key = get_dispatch_key(device);
     device_table_map::const_iterator it = map.find((void *)key);
 
     if (it == map.end()) {
-        pTable = new VulDeviceDispatchTable;
+        pTable = new VkuDeviceDispatchTable;
         map[(void *)key] = pTable;
     } else {
         return it->second;
     }
 
-    vulInitDeviceDispatchTable(device, pTable, gpa);
+    vkuInitDeviceDispatchTable(device, pTable, gpa);
 
     return pTable;
 }
 
-VulDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa) {
+VkuDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa) {
     return initDeviceTable(device, gpa, tableMap);
 }

--- a/layersvt/vk_layer_table.h
+++ b/layersvt/vk_layer_table.h
@@ -25,24 +25,24 @@
 #include <unordered_map>
 #include <cstring>
 
-typedef std::unordered_map<void *, VulDeviceDispatchTable *> device_table_map;
-typedef std::unordered_map<void *, VulInstanceDispatchTable *> instance_table_map;
-VulDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa, device_table_map &map);
-VulDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa);
-VulInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa, instance_table_map &map);
-VulInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa);
+typedef std::unordered_map<void *, VkuDeviceDispatchTable *> device_table_map;
+typedef std::unordered_map<void *, VkuInstanceDispatchTable *> instance_table_map;
+VkuDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa, device_table_map &map);
+VkuDeviceDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProcAddr gpa);
+VkuInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa, instance_table_map &map);
+VkuInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_vkGetInstanceProcAddr gpa);
 
 typedef void *dispatch_key;
 
 dispatch_key get_dispatch_key(const void *object);
 
-VulDeviceDispatchTable *device_dispatch_table(void *object);
+VkuDeviceDispatchTable *device_dispatch_table(void *object);
 
-VulInstanceDispatchTable *instance_dispatch_table(void *object);
+VkuInstanceDispatchTable *instance_dispatch_table(void *object);
 
-VulDeviceDispatchTable *get_dispatch_table(device_table_map &map, void *object);
+VkuDeviceDispatchTable *get_dispatch_table(device_table_map &map, void *object);
 
-VulInstanceDispatchTable *get_dispatch_table(instance_table_map &map, void *object);
+VkuInstanceDispatchTable *get_dispatch_table(instance_table_map &map, void *object);
 
 VkLayerInstanceCreateInfo *get_chain_info(const VkInstanceCreateInfo *pCreateInfo, VkLayerFunction func);
 VkLayerDeviceCreateInfo *get_chain_info(const VkDeviceCreateInfo *pCreateInfo, VkLayerFunction func);

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -14,7 +14,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "ba0d57a51424de68a86326e393a65b26373e1c1f",
+            "commit": "1c6d92cccfff83d14ed1b5d13ef79514ae379df0",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
The functions and structs in vk_dispatch_table.h have been updated to use a 'vku' prefix instead of 'vul'. Thus, this repo needs to update to it so the next header update goes smoothly.