### PR TITLE
Update to latest Vulkan-Utility-Libraries

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -461,20 +461,20 @@ class ApiDumpSettings {
     bool isFrameInRange(uint64_t frame) const { return condFrameOutput.isFrameInRange(frame); }
 
     void init(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator) {
-        VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
-        vlCreateLayerSettingSet("VK_LAYER_LUNARG_api_dump", vlFindLayerSettingsCreateInfo(pCreateInfo), pAllocator, nullptr,
+        VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+        vkuCreateLayerSettingSet("VK_LAYER_LUNARG_api_dump", vkuFindLayerSettingsCreateInfo(pCreateInfo), pAllocator, nullptr,
                                 &layerSettingSet);
 
         // If the layer settings file has a flag indicating to output to a file,
         // do so, to the appropriate filename.
         std::string filename_string = "";
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyFile)) {
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyFile)) {
             bool file = false;
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyFile, file);
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyFile, file);
 
             if (file) {
-                if (vlHasLayerSetting(layerSettingSet, kSettingsKeyLogFilename)) {
-                    vlGetLayerSettingValue(layerSettingSet, kSettingsKeyLogFilename, filename_string);
+                if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyLogFilename)) {
+                    vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyLogFilename, filename_string);
                     if (filename_string.empty()) {
                         filename_string = "vk_apidump.txt";
                     }
@@ -489,9 +489,9 @@ class ApiDumpSettings {
         }
 
         output_format = ApiDumpFormat::Text;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyOutputFormat)) {
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyOutputFormat)) {
             std::string value;
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyOutputFormat, value);
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyOutputFormat, value);
             value = ToLowerString(value);
             if (value == "html") {
                 output_format = ApiDumpFormat::Html;
@@ -503,70 +503,70 @@ class ApiDumpSettings {
         }
 
         show_params = true;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyDetailedOutput)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyDetailedOutput, show_params);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyDetailedOutput)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyDetailedOutput, show_params);
         }
 
         show_address = true;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyNoAddr)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyNoAddr, show_address);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyNoAddr)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyNoAddr, show_address);
             // must invert the setting since the setting is called "no address", which is the logical
             // opposite of show_address
             show_address = !show_address;
         }
 
         should_flush = true;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyFlush)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyFlush, should_flush);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyFlush)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyFlush, should_flush);
         }
 
         show_timestamp = false;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyTimestamp)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyTimestamp, show_timestamp);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyTimestamp)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyTimestamp, show_timestamp);
         }
 
         indent_size = 4;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyIndentSize)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyIndentSize, indent_size);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyIndentSize)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyIndentSize, indent_size);
             indent_size = std::max(indent_size, 0);
         }
         tab_size = indent_size;
 
         show_type = true;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyShowTypes)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyShowTypes, show_type);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyShowTypes)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyShowTypes, show_type);
         }
 
         name_size = 32;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyNameSize)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyNameSize, name_size);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyNameSize)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyNameSize, name_size);
             name_size = std::max(name_size, 0);
         }
 
         type_size = 0;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyTypeSize)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyTypeSize, type_size);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyTypeSize)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyTypeSize, type_size);
             type_size = std::max(type_size, 0);
         }
 
         use_spaces = true;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyUseSpaces)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyUseSpaces, use_spaces);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyUseSpaces)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyUseSpaces, use_spaces);
         }
 
         show_shader = false;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyShowShader)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyShowShader, show_shader);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyShowShader)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyShowShader, show_shader);
         }
 
         show_thread_and_frame = true;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyShowThreadAndFrame)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyShowThreadAndFrame, show_thread_and_frame);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyShowThreadAndFrame)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyShowThreadAndFrame, show_thread_and_frame);
         }
 
         std::string cond_range_string;
-        if (vlHasLayerSetting(layerSettingSet, kSettingsKeyOutputRange)) {
-            vlGetLayerSettingValue(layerSettingSet, kSettingsKeyOutputRange, cond_range_string);
+        if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyOutputRange)) {
+            vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyOutputRange, cond_range_string);
         }
 
         if (cond_range_string == "" || cond_range_string == "0-0") {  //"0-0" is every frame, no need to check
@@ -697,7 +697,7 @@ class ApiDumpSettings {
             setupInterFrameOutputFormatting(0);
         }
 
-        vlDestroyLayerSettingSet(layerSettingSet, pAllocator);
+        vkuDestroyLayerSettingSet(layerSettingSet, pAllocator);
     }
 
    private:

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -336,6 +336,14 @@ class AndroidLogcatWriter final : public AndroidLogcatBuf<>::LogWriter {
 };
 #endif
 
+static const char *GetDefaultPrefix() {
+#ifdef __ANDROID__
+    return "apidump";
+#else
+    return "APIDUMP";
+#endif
+}
+
 class ApiDumpSettings {
    public:
     ApiDumpSettings() : output_stream(std::cout.rdbuf()) {
@@ -463,7 +471,9 @@ class ApiDumpSettings {
     void init(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator) {
         VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
         vkuCreateLayerSettingSet("VK_LAYER_LUNARG_api_dump", vkuFindLayerSettingsCreateInfo(pCreateInfo), pAllocator, nullptr,
-                                &layerSettingSet);
+                                 &layerSettingSet);
+
+        vkuSetLayerSettingCompatibilityNamespace(layerSettingSet, GetDefaultPrefix());
 
         // If the layer settings file has a flag indicating to output to a file,
         // do so, to the appropriate filename.

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -310,19 +310,19 @@ static DeviceMapStruct *get_device_info(VkDevice dev) {
 }
 
 static void init_screenshot(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator) {
-    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
-    vlCreateLayerSettingSet("VK_LAYER_LUNARG_screenshot", vlFindLayerSettingsCreateInfo(pCreateInfo), pAllocator, nullptr,
-                            &layerSettingSet);
+    VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet("VK_LAYER_LUNARG_screenshot", vkuFindLayerSettingsCreateInfo(pCreateInfo), pAllocator, nullptr,
+                             &layerSettingSet);
 
-    if (vlHasLayerSetting(layerSettingSet, kSettingsKeyFrames)) {
+    if (vkuHasLayerSetting(layerSettingSet, kSettingsKeyFrames)) {
         std::string value;
-        vlGetLayerSettingValue(layerSettingSet, kSettingsKeyFrames, value);
+        vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyFrames, value);
         populate_frame_list(value.c_str());
     }
 
-    if (vlHasLayerSetting(layerSettingSet, kSettingKeyFormat)) {
+    if (vkuHasLayerSetting(layerSettingSet, kSettingKeyFormat)) {
         std::string value;
-        vlGetLayerSettingValue(layerSettingSet, kSettingKeyFormat, value);
+        vkuGetLayerSettingValue(layerSettingSet, kSettingKeyFormat, value);
 
         if (value == "UNORM") {
             userColorSpaceFormat = UNORM;
@@ -353,8 +353,8 @@ static void init_screenshot(const VkInstanceCreateInfo *pCreateInfo, const VkAll
         }
     }
 
-    if (vlHasLayerSetting(layerSettingSet, kSettingKeyDir)) {
-        vlGetLayerSettingValue(layerSettingSet, kSettingKeyDir, vk_screenshot_dir);
+    if (vkuHasLayerSetting(layerSettingSet, kSettingKeyDir)) {
+        vkuGetLayerSettingValue(layerSettingSet, kSettingKeyDir, vk_screenshot_dir);
     }
 #ifdef ANDROID
     if (vk_screenshot_dir.empty()) {
@@ -362,7 +362,7 @@ static void init_screenshot(const VkInstanceCreateInfo *pCreateInfo, const VkAll
     }
 #endif
 
-    vlDestroyLayerSettingSet(layerSettingSet, pAllocator);
+    vkuDestroyLayerSettingSet(layerSettingSet, pAllocator);
 }
 
 VkQueue getQueueForScreenshot(VkDevice device) {

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -97,6 +97,7 @@ COMMON_CODEGEN = """
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance)
 {{
     ApiDumpInstance::current().outputMutex()->lock();
+    ApiDumpInstance::current().initLayerSettings(pCreateInfo, pAllocator);
     dump_function_head(ApiDumpInstance::current(), "vkCreateInstance", "pCreateInfo, pAllocator, pInstance", "VkResult");
 
     // Get the function pointer
@@ -115,8 +116,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCre
     if(result == VK_SUCCESS) {{
         initInstanceTable(*pInstance, fpGetInstanceProcAddr);
     }}
-
-    ApiDumpInstance::current().initLayerSettings(pCreateInfo, pAllocator);
 
     // Output the API dump
     if (ApiDumpInstance::current().shouldDumpOutput()) {{

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -14,7 +14,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "1c6d92cccfff83d14ed1b5d13ef79514ae379df0",
+            "commit": "08576356d65f0e7a5ae3bd407bb1103e0ab94db4",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",

--- a/vkconfig_core/test/test_override.cpp
+++ b/vkconfig_core/test/test_override.cpp
@@ -115,140 +115,140 @@ TEST(test_override, vk_layer_settings_txt) {
 
     EXPECT_EQ(true, OverrideConfiguration(env, layer_manager.available_layers, configuration));
 
-    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
-    vlCreateLayerSettingSet(LAYER, nullptr, nullptr, nullptr, &layerSettingSet);
+    VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet(LAYER, nullptr, nullptr, nullptr, &layerSettingSet);
 
-    EXPECT_EQ(false, vlHasLayerSetting(layerSettingSet, "not_found"));
+    EXPECT_EQ(false, vkuHasLayerSetting(layerSettingSet, "not_found"));
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "toogle"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "toogle"));
     bool setting_toogle = false;
-    vlGetLayerSettingValue(layerSettingSet, "toogle", setting_toogle);
+    vkuGetLayerSettingValue(layerSettingSet, "toogle", setting_toogle);
     EXPECT_EQ(true, setting_toogle);
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "enum_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "enum_required_only"));
     std::string setting_enum_required_only;
-    vlGetLayerSettingValue(layerSettingSet, "enum_required_only", setting_enum_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "enum_required_only", setting_enum_required_only);
     EXPECT_STREQ("value2", setting_enum_required_only.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "enum_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "enum_with_optional"));
     std::string setting_enum_with_optional;
-    vlGetLayerSettingValue(layerSettingSet, "enum_with_optional", setting_enum_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "enum_with_optional", setting_enum_with_optional);
     EXPECT_STREQ("value1", setting_enum_with_optional.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "flags_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "flags_required_only"));
     std::vector<std::string> setting_flags_required_only;
-    vlGetLayerSettingValues(layerSettingSet, "flags_required_only", setting_flags_required_only);
+    vkuGetLayerSettingValues(layerSettingSet, "flags_required_only", setting_flags_required_only);
     EXPECT_STREQ("flag0", setting_flags_required_only[0].c_str());
     EXPECT_STREQ("flag2", setting_flags_required_only[1].c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "flags_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "flags_with_optional"));
     std::vector<std::string> setting_flags_with_optional;
-    vlGetLayerSettingValues(layerSettingSet, "flags_with_optional", setting_flags_with_optional);
+    vkuGetLayerSettingValues(layerSettingSet, "flags_with_optional", setting_flags_with_optional);
     EXPECT_STREQ("flag0", setting_flags_with_optional[0].c_str());
     EXPECT_STREQ("flag2", setting_flags_with_optional[1].c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "string_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "string_required_only"));
     std::string setting_string_required_only;
-    vlGetLayerSettingValue(layerSettingSet, "string_required_only", setting_string_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "string_required_only", setting_string_required_only);
     EXPECT_STREQ("My string", setting_string_required_only.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "string_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "string_with_optional"));
     std::string setting_string_with_optional;
-    vlGetLayerSettingValue(layerSettingSet, "string_required_only", setting_string_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "string_required_only", setting_string_with_optional);
     EXPECT_STREQ("My string", setting_string_with_optional.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "bool_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "bool_required_only"));
     bool setting_bool_required_only = false;
-    vlGetLayerSettingValue(layerSettingSet, "bool_required_only", setting_bool_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "bool_required_only", setting_bool_required_only);
     EXPECT_EQ(true, setting_bool_required_only);
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "bool_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "bool_with_optional"));
     bool setting_bool_with_optional = false;
-    vlGetLayerSettingValue(layerSettingSet, "bool_with_optional", setting_bool_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "bool_with_optional", setting_bool_with_optional);
     EXPECT_EQ(true, setting_bool_with_optional);
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "load_file_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "load_file_required_only"));
     std::string setting_load_file_required_only;
-    vlGetLayerSettingValue(layerSettingSet, "load_file_required_only", setting_load_file_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "load_file_required_only", setting_load_file_required_only);
     EXPECT_STREQ("./my_test.txt", setting_load_file_required_only.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "load_file_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "load_file_with_optional"));
     std::string setting_load_file_with_optional;
-    vlGetLayerSettingValue(layerSettingSet, "load_file_with_optional", setting_load_file_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "load_file_with_optional", setting_load_file_with_optional);
     EXPECT_STREQ("./my_test.txt", setting_load_file_with_optional.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "save_file_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "save_file_required_only"));
     std::string setting_save_file_required_only;
-    vlGetLayerSettingValue(layerSettingSet, "load_file_with_optional", setting_save_file_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "load_file_with_optional", setting_save_file_required_only);
     EXPECT_STREQ("./my_test.txt", setting_save_file_required_only.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "save_file_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "save_file_with_optional"));
     std::string setting_save_file_with_optional;
-    vlGetLayerSettingValue(layerSettingSet, "load_file_with_optional", setting_save_file_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "load_file_with_optional", setting_save_file_with_optional);
     EXPECT_STREQ("./my_test.txt", setting_save_file_with_optional.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "save_folder_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "save_folder_required_only"));
     std::string setting_save_folder_required_only;
-    vlGetLayerSettingValue(layerSettingSet, "save_folder_required_only", setting_save_folder_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "save_folder_required_only", setting_save_folder_required_only);
     EXPECT_STREQ("./my_test", setting_save_folder_required_only.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "save_folder_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "save_folder_with_optional"));
     std::string setting_save_folder_with_optional;
-    vlGetLayerSettingValue(layerSettingSet, "save_folder_with_optional", setting_save_folder_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "save_folder_with_optional", setting_save_folder_with_optional);
     EXPECT_STREQ("./my_test", setting_save_folder_with_optional.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "int_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "int_required_only"));
     int setting_int_required_only = 0;
-    vlGetLayerSettingValue(layerSettingSet, "int_required_only", setting_int_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "int_required_only", setting_int_required_only);
     EXPECT_EQ(76, setting_int_required_only);
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "int_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "int_with_optional"));
     int setting_int_with_optional = 0;
-    vlGetLayerSettingValue(layerSettingSet, "int_with_optional", setting_int_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "int_with_optional", setting_int_with_optional);
     EXPECT_EQ(82, setting_int_with_optional);
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "float_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "float_required_only"));
     float setting_float_required_only = 0.0f;
-    vlGetLayerSettingValue(layerSettingSet, "float_required_only", setting_float_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "float_required_only", setting_float_required_only);
     EXPECT_EQ(76.500000, setting_float_required_only);
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "float_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "float_with_optional"));
     float setting_float_with_optional = 0.0f;
-    vlGetLayerSettingValue(layerSettingSet, "float_with_optional", setting_float_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "float_with_optional", setting_float_with_optional);
     EXPECT_EQ(76.500000, setting_float_with_optional);
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "frames_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "frames_required_only"));
     std::string setting_frames_required_only;
-    vlGetLayerSettingValue(layerSettingSet, "frames_required_only", setting_frames_required_only);
+    vkuGetLayerSettingValue(layerSettingSet, "frames_required_only", setting_frames_required_only);
     EXPECT_STREQ("76-82,75", setting_frames_required_only.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "frames_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "frames_with_optional"));
     std::string setting_frames_with_optional;
-    vlGetLayerSettingValue(layerSettingSet, "frames_with_optional", setting_frames_with_optional);
+    vkuGetLayerSettingValue(layerSettingSet, "frames_with_optional", setting_frames_with_optional);
     EXPECT_STREQ("79-82,75", setting_frames_with_optional.c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "list_required_only"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "list_required_only"));
     std::vector<std::string> setting_list_required_only;
-    vlGetLayerSettingValues(layerSettingSet, "list_required_only", setting_list_required_only);
+    vkuGetLayerSettingValues(layerSettingSet, "list_required_only", setting_list_required_only);
     EXPECT_STREQ("76", setting_list_required_only[0].c_str());
     EXPECT_STREQ("82", setting_list_required_only[1].c_str());
     EXPECT_STREQ("stringB", setting_list_required_only[2].c_str());
     EXPECT_STREQ("stringD", setting_list_required_only[3].c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "list_with_optional"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "list_with_optional"));
     std::vector<std::string> setting_list_with_optional;
-    vlGetLayerSettingValues(layerSettingSet, "list_with_optional", setting_list_with_optional);
+    vkuGetLayerSettingValues(layerSettingSet, "list_with_optional", setting_list_with_optional);
     EXPECT_STREQ("76", setting_list_with_optional[0].c_str());
     EXPECT_STREQ("stringA", setting_list_with_optional[1].c_str());
 
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "list_empty"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "list_empty"));
     std::vector<std::string> setting_list_empty;
-    vlGetLayerSettingValues(layerSettingSet, "list_empty", setting_list_empty);
+    vkuGetLayerSettingValues(layerSettingSet, "list_empty", setting_list_empty);
     EXPECT_EQ(true, setting_list_empty.empty());
 
     EXPECT_EQ(true, SurrenderConfiguration(env));
 
-    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
+    vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 
     env.Reset(Environment::SYSTEM);  // Don't change the system settings on exit
 }
@@ -272,32 +272,32 @@ TEST(test_override, env_var) {
 
     EXPECT_EQ(true, OverrideConfiguration(env, layer_manager.available_layers, configuration));
 
-    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
-    vlCreateLayerSettingSet(LAYER, nullptr, nullptr, nullptr, &layerSettingSet);
+    VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet(LAYER, nullptr, nullptr, nullptr, &layerSettingSet);
 
-    EXPECT_EQ(false, vlHasLayerSetting(layerSettingSet, "env_o"));
+    EXPECT_EQ(false, vkuHasLayerSetting(layerSettingSet, "env_o"));
 
     qputenv("VK_LUNARG_REFERENCE_1_2_1_ENV_A", "pouet");
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "env_a"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "env_a"));
     std::string setting_env_a;
-    vlGetLayerSettingValue(layerSettingSet, "env_a", setting_env_a);
+    vkuGetLayerSettingValue(layerSettingSet, "env_a", setting_env_a);
     EXPECT_STREQ("pouet", setting_env_a.c_str());
 
     // Check support of environment variable without vendor namespace
     qputenv("VK_REFERENCE_1_2_1_ENV_B", "pouet");
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "env_b"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "env_b"));
     std::string setting_env_b;
-    vlGetLayerSettingValue(layerSettingSet, "env_b", setting_env_b);
+    vkuGetLayerSettingValue(layerSettingSet, "env_b", setting_env_b);
     EXPECT_STREQ("pouet", setting_env_b.c_str());
 
     // Check support of environment variable without full namespace
     qputenv("VK_ENV_C", "pouet");
-    EXPECT_EQ(true, vlHasLayerSetting(layerSettingSet, "env_c"));
+    EXPECT_EQ(true, vkuHasLayerSetting(layerSettingSet, "env_c"));
     std::string setting_env_c;
-    vlGetLayerSettingValue(layerSettingSet, "env_c", setting_env_c);
+    vkuGetLayerSettingValue(layerSettingSet, "env_c", setting_env_c);
     EXPECT_STREQ("pouet", setting_env_c.c_str());
 
-    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
+    vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 
     EXPECT_EQ(true, SurrenderConfiguration(env));
 


### PR DESCRIPTION
Also fix regression in Environment Variable naming: 

The use of the layer settings library changed the established names for
the settings set through environment variables. This commit addresses
this by using the compatibility namespace feature to ensure existing
users aren't affected.