### PR TITLE
deps: Mark Vulkan-Tools as a test dependency

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -64,6 +64,9 @@
             "build_platforms": [
                 "windows",
                 "linux"
+            ],
+            "optional": [
+                "tests"
             ]
         },
         {


### PR DESCRIPTION
The Vulkan-Tools repo is only used for testing, but known_good.json did not specify that.