### PR TITLE
Unit test on macOS potential fix

### DIFF
--- a/vkconfig_core/test/test_path.cpp
+++ b/vkconfig_core/test/test_path.cpp
@@ -160,9 +160,15 @@ TEST(test_path, get_path_vulkan_sdk) {
     }
 
     {
+#ifdef __APPLE__
+        qputenv("VULKAN_SDK", "~/VulkanSDK");
+        const std::string value = ::GetPath(BUILTIN_PATH_VULKAN_SDK);
+        EXPECT_STREQ(ConvertNativeSeparators("~/VulkanSDK/share/vulkan").c_str(), value.c_str());
+#else
         qputenv("VULKAN_SDK", "~/VulkanSDK");
         const std::string value = ::GetPath(BUILTIN_PATH_VULKAN_SDK);
         EXPECT_STREQ(ConvertNativeSeparators("~/VulkanSDK").c_str(), value.c_str());
+#endif
     }
 }
 


### PR DESCRIPTION
@christophe-lunarg 
This is a 'possible' fix for this issue:
https://github.com/LunarG/VulkanTools/issues/1897

We need this test corrected so we can get VulkanTools into CI for macOS. I took a look at the test, but I don't know why it's failing only on macOS, other than the relative paths isn't setup correctly. There may be a better way to fix this than my hack, if so, please chime in, as the issue is about a month old now.