### PR TITLE
cmake: Only require the CXX compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.17.2)
 
-project(VULKAN_TOOLS)
+project(VULKAN_TOOLS LANGUAGES CXX)
 
 add_subdirectory(scripts)
 


### PR DESCRIPTION
Allows simplifying the rest of the CMake code