### PR TITLE
cmake: Fix constant dirty builds

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,18 +1,6 @@
-
-if (NOT WIN32)
-    # extra setup for out-of-tree builds
-    if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-        add_custom_target(vt_test-dir-symlinks ALL
-            COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/apidump_test.sh
-            VERBATIM
-        )
-    endif()
-else()
-    if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
-        FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/apidump_test.ps1 VKAPIDUMPTEST)
-        add_custom_target(vt_test-dir-symlinks ALL
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VKAPIDUMPTEST} apidump_test.ps1
-            VERBATIM
-            )
-    endif()
+set(apidump_test_script "${CMAKE_CURRENT_LIST_DIR}/apidump_test.sh")
+if (WIN32)
+    set(apidump_test_script "${CMAKE_CURRENT_LIST_DIR}/apidump_test.ps1")
 endif()
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${apidump_test_script} ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Currently these custom targets are always dirty.

It's simpler to just use execute_process and utilize CMake's copy_if_different command during the configuration step.