### PR TITLE
cmake: Cleanup WSI code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 set(CMAKE_VISIBILITY_INLINES_HIDDEN "YES")
 
-# TODO: Cleanup VK definitions
-if (ANDROID)
-    add_compile_definitions(VK_USE_PLATFORM_ANDROID_KHR)
-endif()
-
 include(GNUInstallDirs)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -23,26 +18,6 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(BUILD_WERROR "Treat compiler warnings as errors")
 if (BUILD_WERROR)
     add_compile_options("$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
-endif()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|DragonFly|GNU")
-    option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
-    option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
-    option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
-
-    find_package(PkgConfig REQUIRED QUIET) # Use PkgConfig to find Linux system libraries
-
-    if (BUILD_WSI_XCB_SUPPORT)
-        pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
-    endif()
-
-    if (BUILD_WSI_XLIB_SUPPORT)
-        pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
-    endif()
-
-    if (BUILD_WSI_WAYLAND_SUPPORT)
-        pkg_check_modules(WAYLAND_CLIENT REQUIRED QUIET IMPORTED_TARGET wayland-client)
-    endif()
 endif()
 
 find_package(VulkanHeaders REQUIRED CONFIG)

--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -7,8 +7,26 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
     set(DisplayServer Win32)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
-    add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES "BSD")
+    add_compile_definitions(VK_USE_PLATFORM_ANDROID_KHR)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|DragonFly|GNU")
+    option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
+    option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
+    option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
+
+    find_package(PkgConfig REQUIRED QUIET) # Use PkgConfig to find Linux system libraries
+
+    if (BUILD_WSI_XCB_SUPPORT)
+        pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
+    endif()
+
+    if (BUILD_WSI_XLIB_SUPPORT)
+        pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
+    endif()
+
+    if (BUILD_WSI_WAYLAND_SUPPORT)
+        pkg_check_modules(WAYLAND_CLIENT REQUIRED QUIET IMPORTED_TARGET wayland-client)
+    endif()
+
     if (BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XCB_KHX)
         set(DisplayServer Xcb)

--- a/via/CMakeLists.txt
+++ b/via/CMakeLists.txt
@@ -88,9 +88,6 @@ target_link_libraries(vkvia PRIVATE
     valijson
     ${CMAKE_DL_LIBS}
     $<TARGET_NAME_IF_EXISTS:Vulkan::Loader>
-    $<TARGET_NAME_IF_EXISTS:PkgConfig::XCB>
-    $<TARGET_NAME_IF_EXISTS:PkgConfig::X11>
-    $<TARGET_NAME_IF_EXISTS:PkgConfig::WAYlAND_CLIENT>
 )
 
 install(TARGETS vkvia)


### PR DESCRIPTION
Neither vkconfig / vkvia currently need/use xcb, x11, or the wayland libraries.

Move the WSI code to the layersvt directory where it is actually used.