### PR TITLE
Use pkg-config for jsoncpp if possible

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -81,7 +81,10 @@
                 "-DJSONCPP_WITH_TESTS=OFF",
                 "-DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF",
                 "-DJSONCPP_WITH_WARNING_AS_ERROR=OFF",
-                "-DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF"
+                "-DJSONCPP_WITH_PKGCONFIG_SUPPORT=ON",
+                "-DBUILD_SHARED_LIBS=OFF",
+                "-DBUILD_STATIC_LIBS=ON",
+                "-DBUILD_OBJECT_LIBS=OFF"
             ]
         },
         {

--- a/via/CMakeLists.txt
+++ b/via/CMakeLists.txt
@@ -66,21 +66,14 @@ elseif (MSVC)
     target_compile_definitions(vkvia PRIVATE _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES)
 endif()
 
-find_package(jsoncpp CONFIG)
-
-if (TARGET jsoncpp_static)
-    # RPATH causes issues for the Linux SDK tarball due to absolute paths.
-    # This can be worked around with relative RPATHS but the tarball doesn't ship jsoncpp.
-    # So the easiest solution is to just the static version of jsoncpp.
-    target_link_libraries(vkvia PRIVATE jsoncpp_static)
-    set_target_properties(vkvia PROPERTIES SKIP_BUILD_RPATH TRUE)
-elseif(UNIX)
-    # https://github.com/LunarG/VulkanTools/issues/1908
-    find_package(PkgConfig REQUIRED)
+# https://github.com/LunarG/VulkanTools/issues/1908
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
     pkg_check_modules(jsoncpp REQUIRED IMPORTED_TARGET jsoncpp)
     target_link_libraries(vkvia PRIVATE PkgConfig::jsoncpp)
 else()
-    message(FATAL_ERROR "Unable to find jsoncpp!")
+    find_package(jsoncpp CONFIG REQUIRED)
+    target_link_libraries(vkvia PRIVATE jsoncpp_static)
 endif()
 
 target_link_libraries(vkvia PRIVATE


### PR DESCRIPTION
The main thing to note is we want to use the STATIC version of jsoncpp

By default pkg-config was pointing to the SHARED version

I explicitly turn this off in the known_good.json now so now the pkg-config path will work for us for the linux tarball.