### PR TITLE
apidump: Fix file setting being ignored

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -526,12 +526,14 @@ class ApiDumpSettings {
             bool file = false;
             vkuGetLayerSettingValue(layerSettingSet, kSettingsKeyFile, file);
 
-            if (output_format == ApiDumpFormat::Html) {
-                filename_string = "vk_apidump.html";
-            } else if (output_format == ApiDumpFormat::Json) {
-                filename_string = "vk_apidump.json";
-            } else {
-                filename_string = "vk_apidump.txt";
+            if (file) {
+                if (output_format == ApiDumpFormat::Html) {
+                    filename_string = "vk_apidump.html";
+                } else if (output_format == ApiDumpFormat::Json) {
+                    filename_string = "vk_apidump.json";
+                } else {
+                    filename_string = "vk_apidump.txt";
+                }
             }
         }
 


### PR DESCRIPTION
If the 'file' option is set in the settings file, it will now be used to determine whether to write to a file output or not. Previously it was being ignored entirely, resulting in all output heading to a file.