### PR TITLE
VIA: Fix SDK detection

### DIFF
--- a/via/via_system_linux.cpp
+++ b/via/via_system_linux.cpp
@@ -1133,7 +1133,8 @@ ViaSystem::ViaResults ViaSystemLinux::PrintSystemSdkInfo() {
         PrintTableElement("");
         PrintEndTableRow();
 
-        const std::vector<const char *> explicit_layer_path_suffixes{"/etc/explicit_layer.d", "/etc/vulkan/explicit_layer.d"};
+        const std::vector<const char *> explicit_layer_path_suffixes{"/etc/explicit_layer.d", "/etc/vulkan/explicit_layer.d",
+                                                                     "/share/explicit_layer.d", "/share/vulkan/explicit_layer.d"};
 
         for (auto &explicit_layer_path_suffix : explicit_layer_path_suffixes) {
             std::string explicit_layer_path = sdk_path + explicit_layer_path_suffix;


### PR DESCRIPTION
Fix the SDK detection based on Explicit layer location which was recently updated in the SDK setup scripts.