### PR TITLE
Build API Dump as a framework for iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         - run: cmake --build build
         - run: cmake --install build --prefix /tmp
         # Helps verify useful details about the dylib (platform, minos, sdk)
-        - run: vtool -show-build /tmp/lib/libVkLayer_api_dump.dylib
+        - run: vtool -show-build /tmp/lib/VkLayer_api_dump.framework/VkLayer_api_dump
 
   mingw:
     runs-on: windows-latest

--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -75,7 +75,12 @@ if(BUILD_APIDUMP)
     run_vulkantools_video_xml_generate(api_dump_generator.py api_dump_video_html.h)
     run_vulkantools_video_xml_generate(api_dump_generator.py api_dump_video_json.h)
 
-    add_library(VkLayer_api_dump MODULE)
+    if(IOS)
+        add_library(VkLayer_api_dump SHARED)
+    else()
+        add_library(VkLayer_api_dump MODULE)
+    endif()
+
     target_sources(VkLayer_api_dump PRIVATE
         api_dump.cpp
         api_dump.h
@@ -160,7 +165,15 @@ foreach(layer ${TOOL_LAYERS})
     endif()
 
     if (APPLE)
-        set_target_properties(${layer} PROPERTIES SUFFIX ".dylib")
+        # IOS and APPLE can both be true (FYI)
+        if(IOS)
+            set_target_properties(${layer} PROPERTIES
+		FRAMEWORK			TRUE
+		MACOSX_FRAMEWORK_IDENTIFIER 	com.khronos.${layer}
+            )
+        else()
+            set_target_properties(${layer} PROPERTIES SUFFIX ".dylib")
+        endif()
     endif()
 
     if (ANDROID)


### PR DESCRIPTION
Apples App store rules require dynamic libraries be packaged as Frameworks for iOS. This requirement is not applied for macOS, so all iOS libraries should be packaged as Frameworks moving forward to comply with Apples policy. Although this layer in particular is not likely to be shipped in an application bundle, it is being made a Framework as well to be consistent with all the other layers.
  