### PR TITLE
apple: Add version strings to Frameworks

### DIFF
--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -161,6 +161,8 @@ foreach(layer ${TOOL_LAYERS})
         if(IOS)
             set_target_properties(${layer} PROPERTIES
 		FRAMEWORK			TRUE
+                MACOSX_FRAMEWORK_BUNDLE_VERSION "${VulkanHeaders_VERSION}"
+                MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${VulkanHeaders_VERSION}"
 		MACOSX_FRAMEWORK_IDENTIFIER 	com.khronos.${layer}
             )
         else()


### PR DESCRIPTION
This adds two version field strings to the iOS Framework Info.plist files. These are needed for App store compatibility.