### PR TITLE
vkconfig: Add support for command line outputs on Windows when using 'Command Prompt'

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Improvements:
 - Add 'status' to give an explicit control to print the Vulkan status log
+- Add support for command line outputs on Windows when using 'Command Prompt'
+- Add support for using Vulkan Configurator environment variables in the UI
 
 ### Fixes:
 - Fix clear log when changing `Vulkan Kiader Messages` type when `Clear log on action` is unchecked

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -28,6 +28,10 @@
 
 #include <cassert>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 int main(int argc, char* argv[]) {
     ::vkconfig_version = "vkconfig";
 
@@ -40,6 +44,15 @@ int main(int argc, char* argv[]) {
         command_line.usage();
         return -1;
     }
+
+#ifdef _WIN32
+    if (command_line.command != COMMAND_GUI || command_line.command != COMMAND_VULKAN_SDK) {
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+            freopen("CONOUT$", "w", stdout);
+            freopen("CONOUT$", "w", stderr);
+        }
+    }
+#endif
 
     switch (command_line.command) {
         case COMMAND_SHOW_USAGE: {

--- a/vkconfig3/main.cpp
+++ b/vkconfig3/main.cpp
@@ -28,6 +28,10 @@
 
 #include <cassert>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 int main(int argc, char* argv[]) {
     ::vkconfig_version = "vkconfig3";
 
@@ -40,6 +44,15 @@ int main(int argc, char* argv[]) {
         command_line.usage();
         return -1;
     }
+
+#ifdef _WIN32
+    if (command_line.command != COMMAND_GUI || command_line.command != COMMAND_VULKAN_SDK) {
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+            freopen("CONOUT$", "w", stdout);
+            freopen("CONOUT$", "w", stderr);
+        }
+    }
+#endif
 
     switch (command_line.command) {
         case COMMAND_SHOW_USAGE: {


### PR DESCRIPTION
Note that here I copied my test built executable into my SDK 1.3.280.beta2 directory but this is going to be available in next SDK

![image](https://github.com/LunarG/VulkanTools/assets/62888873/ef8d9819-3001-4a26-9288-b3d5ef301994)