### PR TITLE
vkconfig: Better handle implicit layer

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Better present implicit layers, showing "Implicitly On" or "Implicitly Off" depending on the environment variable
 
 ### Fixes:
-- Fix clear log when changing `Vulkan Kiader Messages` type when `Clear log on action` is unchecked
+- Fix clear log when changing `Vulkan Loader Messages` type when `Clear log on action` is unchecked
 - Fix spaces in application launcher command-line 'path' arguments
 - Fix 'Use of application list' check box not being saved
 - Clean up UI update

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add 'status' to give an explicit control to print the Vulkan status log
 - Add support for command line outputs on Windows when using 'Command Prompt'
 - Add support for using Vulkan Configurator environment variables in the UI
+- Better present implicit layers, showing "Implicitly On" or "Implicitly Off" depending on the environment variable
 
 ### Fixes:
 - Fix clear log when changing `Vulkan Kiader Messages` type when `Clear log on action` is unchecked

--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add support for command line outputs on Windows when using 'Command Prompt'
 - Add support for using Vulkan Configurator environment variables in the UI
 - Better present implicit layers, showing "Implicitly On" or "Implicitly Off" depending on the environment variable
+- Add double click on configuration name to edit a layers configuration
 
 ### Fixes:
 - Fix clear log when changing `Vulkan Loader Messages` type when `Clear log on action` is unchecked

--- a/vkconfig/dialog_layers.cpp
+++ b/vkconfig/dialog_layers.cpp
@@ -305,7 +305,20 @@ void LayersDialog::AddLayerItem(const Parameter &parameter) {
     const QSize combo_size = fm.size(Qt::TextSingleLine, "Application-Controlled") * 1.6;
     item->setSizeHint(1, combo_size);
 
-    widget->addItem(is_implicit_layer ? "Implicitly On" : "Application-Controlled");
+    bool disable_value = false;
+    if (!layer->disable_env.empty()) {
+        disable_value = !qgetenv(layer->disable_env.c_str()).isEmpty();
+    }
+
+    bool enable_value = false;
+    if (!layer->enable_env.empty()) {
+        enable_value = qgetenv(layer->enable_env.c_str()).toStdString() == layer->enable_value;
+    }
+
+    const std::string implicit_string =
+        !disable_value || (!layer->enable_env.empty() && enable_value) ? "Implicitly On" : "Implicitly Off";
+
+    widget->addItem(is_implicit_layer ? implicit_string.c_str() : "Application-Controlled");
     widget->addItem("Overridden / Forced On");
     widget->addItem("Excluded / Forced Off");
     widget->setCurrentIndex(parameter.state);

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -297,7 +297,7 @@ void MainWindow::UpdateUI() {
     ui->push_button_remove->setEnabled(use_override && has_select_configuration);
     ui->push_button_duplicate->setEnabled(use_override && has_select_configuration);
     ui->push_button_new->setEnabled(use_override);
-    ui->settings_tree->setEnabled(use_override && has_select_configuration);
+    ui->settings_tree->setEnabled(environment.GetMode() == LAYERS_MODE_BY_CONFIGURATOR_RUNNING);
     ui->group_box_settings->setTitle(active_contiguration_name.empty() ? "Configuration Settings"
                                                                        : (active_contiguration_name + " Settings").c_str());
 
@@ -862,6 +862,7 @@ void MainWindow::NewClicked() {
     LayersDialog dlg(this, new_configuration);
     switch (dlg.exec()) {
         case QDialog::Accepted:
+            configurator.configurations.SetActiveConfiguration(configurator.layers.available_layers, new_configuration.key);
             break;
         case QDialog::Rejected:
             configurator.configurations.RemoveConfiguration(configurator.layers.available_layers, new_configuration.key);

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -103,6 +103,8 @@ MainWindow::MainWindow(QWidget *parent)
 
     connect(ui->configuration_tree, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this,
             SLOT(OnConfigurationItemChanged(QTreeWidgetItem *, int)));
+    connect(ui->configuration_tree, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), this,
+            SLOT(OnConfigurationItemDoubleClicked(QTreeWidgetItem *, int)));
     connect(ui->configuration_tree, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this,
             SLOT(OnConfigurationTreeChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
     connect(ui->configuration_tree, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this,
@@ -535,6 +537,13 @@ void MainWindow::OnConfigurationTreeClicked(QTreeWidgetItem *item, int column) {
 
     this->UpdateUI();
     this->UpdateStatus();
+}
+
+void MainWindow::OnConfigurationItemDoubleClicked(QTreeWidgetItem *item, int column) {
+    ConfigurationListItem *configuration_item = dynamic_cast<ConfigurationListItem *>(item);
+    if (configuration_item == nullptr) return;
+
+    EditClicked(configuration_item);
 }
 
 /// An item has been changed. Check for edit of the items name (configuration name)

--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -156,6 +156,7 @@ class MainWindow : public QMainWindow {
     void OnConfigurationItemClicked(bool checked);
     void OnConfigurationTreeChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
     void OnConfigurationItemChanged(QTreeWidgetItem *item, int column);
+    void OnConfigurationItemDoubleClicked(QTreeWidgetItem *item, int column);
     void OnConfigurationTreeClicked(QTreeWidgetItem *item, int column);
     void OnSettingsTreeClicked(QTreeWidgetItem *item, int column);
     void OnLauncherLoaderMessageChanged(int level);

--- a/vkconfig_core/configuration_manager.cpp
+++ b/vkconfig_core/configuration_manager.cpp
@@ -53,6 +53,8 @@ void ConfigurationManager::LoadAllConfigurations(const std::vector<Layer> &avail
         LoadConfigurationsPath(available_layers, path.c_str());
     }
 
+    this->SortConfigurations();
+
     RefreshConfiguration(available_layers);
 }
 
@@ -213,6 +215,7 @@ void ConfigurationManager::RemoveConfiguration(const std::vector<Layer> &availab
     }
 
     std::swap(updated_configurations, available_configurations);
+    this->SortConfigurations();
 
     SetActiveConfiguration(available_layers, nullptr);
     this->active_configuration = nullptr;
@@ -235,7 +238,7 @@ void ConfigurationManager::SetActiveConfiguration(const std::vector<Layer> &avai
         if (active_configuration != nullptr) {
             assert(!active_configuration->key.empty());
             environment.Set(ACTIVE_CONFIGURATION, active_configuration->key.c_str());
-            surrender = !active_configuration->HasOverride();
+            surrender = false;  //! active_configuration->HasOverride();
         } else {
             surrender = true;
         }

--- a/vkconfig_core/environment.h
+++ b/vkconfig_core/environment.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2022 Valve Corporation
- * Copyright (c) 2020-2022 LunarG, Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -253,6 +253,19 @@ bool Layer::Load(const std::vector<Layer>& available_layers, const std::string& 
         this->url = ReadStringValue(json_layer_object, "url");
     }
 
+    if (json_layer_object.value("disable_environment") != QJsonValue::Undefined) {
+        const QJsonObject& json_env_object = json_layer_object.value("disable_environment").toObject();
+        const QStringList keys = json_env_object.keys();
+        this->disable_env = keys[0].toStdString();
+        this->disable_value = ReadStringValue(json_env_object, this->disable_env.c_str()) == "1";
+    }
+    if (json_layer_object.value("enable_environment") != QJsonValue::Undefined) {
+        const QJsonObject& json_env_object = json_layer_object.value("enable_environment").toObject();
+        const QStringList keys = json_env_object.keys();
+        this->enable_env = keys[0].toStdString();
+        this->enable_value = ReadStringValue(json_env_object, this->enable_env.c_str()) == "1";
+    }
+
     if (!is_valid && this->key != "VK_LAYER_LUNARG_override") {
         if (!is_builtin_layer_file || (is_builtin_layer_file && this->api_version >= Version(1, 2, 170))) {
             Alert::LayerInvalid(full_path_to_file.c_str(), validator.message.toStdString().c_str());

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -66,6 +66,10 @@ class Layer {
     std::string manifest_path;
     LayerType type;
     QJsonDocument profile;
+    std::string disable_env;
+    std::string enable_env;
+    bool disable_value;
+    bool enable_value;
 
     std::vector<SettingMeta*> settings;
     std::vector<LayerPreset> presets;

--- a/vkconfig_core/parameter.cpp
+++ b/vkconfig_core/parameter.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
1. All implicit layers must have disable_environment in their manifest
2. If disable_environment is set (to anything) in the environment, the layer will not be enabled
3. If enable_environment is in the layer's manifest, then the layer wont be enabled UNLESS the exact string in enable_environment is set in the environment.

![image](https://github.com/LunarG/VulkanTools/assets/62888873/32b83473-6398-437d-a0ce-6154acacf0d9)

