### PR TITLE
vkconfig: Refactor system tray, extended menu

### DIFF
--- a/vkconfig/mainwindow.h
+++ b/vkconfig/mainwindow.h
@@ -98,6 +98,9 @@ class MainWindow : public QMainWindow {
     QSystemTrayIcon *_tray_icon;
     QMenu *_tray_icon_menu;
     QAction *_tray_restore_action;
+    QAction *_tray_layers_controlled_by_applications;
+    QAction *_tray_layers_controlled_by_configurator;
+    QAction *_tray_layers_disabled_by_configurator;
     QAction *_tray_quit_action;
 
     void RemoveClicked(ConfigurationListItem *item);
@@ -111,6 +114,10 @@ class MainWindow : public QMainWindow {
     void ReloadDefaultClicked(ConfigurationListItem *item);
 
    private slots:
+    void trayActionRestore();
+    void trayActionControlledByApplications();
+    void trayActionControlledByConfigurator();
+    void trayActionDisabledByApplications();
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
 
    public Q_SLOTS:

--- a/vkconfig/mainwindow.ui
+++ b/vkconfig/mainwindow.ui
@@ -118,7 +118,7 @@
               </item>
               <item>
                <property name="text">
-                <string>All Layers Disabled by the Vulkan Configurator</string>
+                <string>Layers Disabled by the Vulkan Configurator</string>
                </property>
               </item>
              </widget>


### PR DESCRIPTION
New system tray menu:
![image](https://github.com/LunarG/VulkanTools/assets/62888873/9344bf89-1e95-4c43-9975-3a8d7fcd580f)

Double clicking on the icon will show the main window.
