### PR TITLE
vkconfig: Only display setting are not change dynamically in context

### DIFF
--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -1704,6 +1704,8 @@ void MainWindow::ResetLaunchApplication() {
         _launch_application.reset();
 
         ui->push_button_launcher->setText("Launch");
+
+        _settings_tree_manager.launched_application = false;
     }
 }
 
@@ -1813,6 +1815,8 @@ void MainWindow::on_push_button_launcher_clicked() {
         const std::string failed_log =
             std::string("Failed to launch ") + ReplaceBuiltInVariable(_launcher_executable->text().toStdString()).c_str() + "!\n";
         Log(failed_log);
+    } else {
+        _settings_tree_manager.launched_application = false;
     }
 }
 

--- a/vkconfig/settings_tree.cpp
+++ b/vkconfig/settings_tree.cpp
@@ -50,7 +50,7 @@
 static const char *TOOLTIP_ORDER =
     "Layers are executed between the Vulkan application and driver in the specific order represented here";
 
-SettingsTreeManager::SettingsTreeManager() : tree(nullptr) {}
+SettingsTreeManager::SettingsTreeManager() : launched_application(false), tree(nullptr) {}
 
 void SettingsTreeManager::CreateGUI(QTreeWidget *build_tree) {
     assert(build_tree);
@@ -470,11 +470,13 @@ void SettingsTreeManager::Refresh(RefreshAreas refresh_areas) {
 
     this->tree->blockSignals(false);
 
-    QSettings settings;
-    if (!settings.value("vkconfig_restart", false).toBool()) {
-        settings.setValue("vkconfig_restart", true);
+    if (this->launched_application) {
+        QSettings settings;
+        if (!settings.value("vkconfig_restart", false).toBool()) {
+            settings.setValue("vkconfig_restart", true);
 
-        Alert::ConfiguratorRestart();
+            Alert::ConfiguratorRestart();
+        }
     }
 
     // Refresh layer configuration

--- a/vkconfig/settings_tree.h
+++ b/vkconfig/settings_tree.h
@@ -39,6 +39,8 @@ class SettingsTreeManager : QObject {
    public:
     SettingsTreeManager();
 
+    bool launched_application;
+
     void CreateGUI(QTreeWidget *build_tree);
     void CleanupGUI();
 


### PR DESCRIPTION
I made and tweak for when the message is displayed based on your feedback in here:
https://gitlab.khronos.org/vulkan/Vulkan-SDK-Packaging/-/issues/1491

Now, the message is displyed only is the user is changing setting while an application is launched. The first time.