### PR TITLE
Add VulkanTools apidump GN build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,10 @@ jobs:
           CMAKE_GENERATOR: Ninja
       - run: cmake --build build
       - run: cmake --install build --prefix build/install
+
+  chromium:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
+      - run: python scripts/gn/gn.py

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,174 @@
+# Copyright (C) 2018-2024 The ANGLE Project Authors.
+# Copyright (C) 2019-2024 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/lunarg_vulkantools.gni")
+
+# This is not currently implemented for Fuchsia
+assert(!is_fuchsia)
+
+vulkan_undefine_configs = []
+if (is_win) {
+  vulkan_undefine_configs += [ "//build/config/win:unicode" ]
+}
+
+config("generated_layers_config") {
+  if (is_clang) {
+    cflags = [
+      "-Wno-conversion",
+      "-Wno-deprecated-copy",
+      "-Wno-extra-semi",
+      "-Wno-implicit-fallthrough",
+      "-Wno-missing-field-initializers",
+      "-Wno-newline-eof",
+      "-Wno-sign-compare",
+      "-Wno-unused-const-variable",
+    ]
+  }
+}
+
+config("vulkan_internal_config") {
+  defines = [ "VK_ENABLE_BETA_EXTENSIONS" ]
+
+  cflags = []
+  if (is_clang || !is_win) {
+    cflags += [ "-Wno-unused-function" ]
+  }
+  if (is_clang && is_mac) {
+    cflags += [ "-Wno-unguarded-availability-new" ]
+  }
+
+  # Suppress warnings the vulkan code doesn't comply with.
+  if (is_clang) {
+    cflags += [ "-Wno-extra-semi" ]
+  }
+}
+
+# The vulkantools layers
+# ----------------------
+
+config("vulkan_layer_config") {
+  include_dirs = [
+    "layersvt",
+    "layersvt/generated",
+  ]
+  if (is_clang) {
+    cflags = [ "-Wno-extra-semi" ]
+  }
+}
+
+vt_sources = [
+  "layersvt/generated/api_dump.cpp",
+  "layersvt/generated/api_dump_html.h",
+  "layersvt/generated/api_dump_json.h",
+  "layersvt/generated/api_dump_text.h",
+  "layersvt/generated/api_dump_video_html.h",
+  "layersvt/generated/api_dump_video_json.h",
+  "layersvt/generated/api_dump_video_text.h",
+  "layersvt/api_dump.h",
+  "layersvt/vk_layer_table.cpp",
+  "layersvt/vk_layer_table.h",
+]
+
+if (!is_android) {
+  vulkan_data_dir = "$root_out_dir/$vulkan_data_subdir"
+  action("vulkan_gen_json_files") {
+    script = "scripts/gn/generate_vulkantools_layers_json.py"
+
+    deps = [ "$vulkan_headers_dir:vulkan_headers" ]
+
+    sources = [ "layersvt/json/VkLayer_api_dump.json.in" ]
+    outputs = [ "$vulkan_data_dir/VkLayer_lunarg_api_dump.json" ]
+
+    if (is_linux) {
+      _platform = "Linux"
+    } else if (is_win) {
+      _platform = "Windows"
+    } else if (is_mac) {
+      _platform = "Darwin"
+    } else {
+      _platform = "Other"
+    }
+
+    args = [
+             "--platform",
+             _platform,
+             rebase_path("layersvt/json/", root_build_dir),
+             rebase_path(vulkan_data_dir, root_build_dir),
+           ] + rebase_path(sources, root_build_dir)
+
+    # The layer JSON files are part of the necessary data deps.
+    data = outputs
+  }
+}
+
+source_set("vulkan_layer_utils") {
+  include_dirs = [
+    "layers",
+    "layers/external",
+    "layers/vulkan",
+  ]
+  sources = [
+    "$vulkan_headers_dir/include/vulkan/vk_layer.h",
+    "$vulkan_headers_dir/include/vulkan/vulkan.h",
+  ]
+  public_configs = [
+    ":vulkan_internal_config",
+  ]
+  public_deps = [
+    "$vulkan_headers_dir:vulkan_headers",
+    "$vulkan_utility_libraries_dir:vulkan_layer_settings",
+  ]
+
+  configs -= vulkan_undefine_configs
+}
+
+library_type = "shared_library"
+
+target(library_type, "VkLayer_lunarg_api_dump") {
+  defines = []
+  ldflags = []
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs -= [ "//build/config/compiler:no_rtti" ]
+  configs += [ "//build/config/compiler:rtti" ]
+  configs -= vulkan_undefine_configs
+  configs += [ ":generated_layers_config" ]
+  public_configs = [ ":vulkan_layer_config" ]
+  deps = [
+    ":vulkan_layer_utils",
+    "$vulkan_utility_libraries_dir:vulkan_layer_settings",
+  ]
+  sources = vt_sources
+  if (is_win) {
+    defines += [ "NOMINMAX" ]
+    sources += [ "layers/VkLayer_lunarg_api_dump.def" ]
+  }
+  if (defined(ozone_platform_x11) && ozone_platform_x11) {
+    defines += [ "VK_USE_PLATFORM_XLIB_KHR" ]
+  }
+  if (is_android) {
+    libs = [
+      "log",
+      "nativewindow",
+    ]
+    configs -= [ "//build/config/android:hide_all_but_jni_onload" ]
+  }
+}
+
+group("lunarg_vulkantools") {
+  public_deps = []
+  data_deps = []
+  data_deps += [ ":VkLayer_lunarg_api_dump" ]
+}

--- a/scripts/gn/DEPS
+++ b/scripts/gn/DEPS
@@ -1,0 +1,66 @@
+# This file is subset of DEPS file from https://chromium.googlesource.com/angle/angle
+# with the minimum toolchain necessary to build Vulkan-ValidationLayers
+
+gclient_gn_args_file = 'build/config/gclient_args.gni'
+
+vars = {
+  'chromium_git': 'https://chromium.googlesource.com',
+  'ninja_version': 'version:2@1.11.1.chromium.6',
+}
+
+deps = {
+
+  'build': {
+    'url': '{chromium_git}/chromium/src/build.git@1015724d82945f9ef7e51c6f804034ccf5f79951',
+  },
+
+  'buildtools': {
+    'url': '{chromium_git}/chromium/src/buildtools.git@3c7e3f1b8b1e4c0b6ec693430379cea682de78d6',
+  },
+
+  'buildtools/linux64': {
+    'packages': [
+      {
+        'package': 'gn/gn/linux-${{arch}}',
+        'version': 'git_revision:5e19d2fb166fbd4f6f32147fbb2f497091a54ad8',
+      }
+    ],
+    'dep_type': 'cipd',
+    'condition': 'host_os == "linux"',
+  },
+
+  'testing': {
+    'url': '{chromium_git}/chromium/src/testing@949b2864b6bd27656753b917c9aa7731dc7a06f6',
+  },
+
+   'tools/clang': {
+     'url': '{chromium_git}/chromium/src/tools/clang.git@566877f1ff1a5fa6beaca3ab4b47bd0b92eb614f',
+   },
+
+  'third_party/ninja': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/ninja/${{platform}}',
+        'version': Var('ninja_version'),
+      }
+    ],
+    'dep_type': 'cipd',
+  },
+
+}
+
+hooks = [
+  {
+    'name': 'sysroot_x64',
+    'pattern': '.',
+    'condition': 'checkout_linux and checkout_x64',
+    'action': ['python3', 'build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x64'],
+  },
+  {
+    # Note: On Win, this should run after win_toolchain, as it may use it.
+    'name': 'clang',
+    'pattern': '.',
+    'action': ['python3', 'tools/clang/scripts/update.py'],
+  },
+]

--- a/scripts/gn/generate_vulkantools_layers_json.py
+++ b/scripts/gn/generate_vulkantools_layers_json.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2016 The ANGLE Project Authors.
+# Copyright (c) 2022-2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate copies of the Vulkan layers JSON files, with no paths, forcing
+Vulkan to use the default search path to look for layers."""
+
+from __future__ import print_function
+
+import argparse
+import glob
+import json
+import os
+import platform
+import sys
+
+def glob_slash(dirname):
+    r"""Like regular glob but replaces \ with / in returned paths."""
+    return [s.replace('\\', '/') for s in glob.glob(dirname)]
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--icd', action='store_true')
+    parser.add_argument('--no-path-prefix', action='store_true')
+    parser.add_argument('--platform', type=str, default=platform.system(),
+        help='Target platform to build vulkantools layers for: '
+             'Linux|Darwin|Windows|Fuchsia|...')
+    parser.add_argument('source_dir')
+    parser.add_argument('target_dir')
+    parser.add_argument('json_files', nargs='*')
+    args = parser.parse_args()
+
+    source_dir = args.source_dir
+    target_dir = args.target_dir
+
+    json_files = [j for j in args.json_files if j.endswith('.json')]
+    json_in_files = [j for j in args.json_files if j.endswith('.json.in')]
+
+    data_key = 'ICD' if args.icd else 'layer'
+
+    if not os.path.isdir(source_dir):
+        print(source_dir + ' is not a directory.', file=sys.stderr)
+        return 1
+
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    for json_fname in json_files:
+        if not json_fname.endswith('.json'):
+            continue
+        with open(json_fname) as infile:
+            data = json.load(infile)
+
+        # Update the path.
+        if not data_key in data:
+            raise Exception(
+                "Could not find '%s' key in %s" % (data_key, json_fname))
+
+        # If layer has no library path
+        if 'library_path' in data[data_key]:
+            prev_name = os.path.basename(data[data_key]['library_path'])
+            data[data_key]['library_path'] = prev_name
+
+        target_fname = os.path.join(target_dir, os.path.basename(json_fname))
+        with open(target_fname, 'w') as outfile:
+            json.dump(data, outfile)
+
+    # Set json file prefix and suffix for generating files, default to Linux.
+    if args.no_path_prefix:
+        relative_path_prefix = ''
+    elif args.platform == 'Windows':
+        relative_path_prefix = r'..\\'  # json-escaped, hence two backslashes.
+    else:
+        relative_path_prefix = '../lib'
+    file_type_suffix = '.so'
+    if args.platform == 'Windows':
+        file_type_suffix = '.dll'
+    elif args.platform == 'Darwin':
+        file_type_suffix = '.dylib'
+
+    for json_in_name in json_in_files:
+        if not json_in_name.endswith('.json.in'):
+            continue
+        json_in_fname = os.path.basename(json_in_name)
+        layer_name = json_in_fname[:-len('.json.in')]
+        layer_lib_name = layer_name + file_type_suffix
+        json_out_fname = os.path.join(target_dir, json_in_fname[:-len('.in')])
+        with open(json_out_fname,'w') as json_out_file, \
+             open(json_in_name) as infile:
+            for line in infile:
+                line = line.replace('@JSON_LIBRARY_PATH@', relative_path_prefix + layer_lib_name)
+                json_out_file.write(line)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/gn/gn.py
+++ b/scripts/gn/gn.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2023-2024 The Khronos Group Inc.
+# Copyright 2023-2024 Valve Corporation
+# Copyright 2023-2024 LunarG, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+
+# helper to define paths relative to the repo root
+def RepoRelative(path):
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '../../', path))
+
+def BuildGn():
+    if not os.path.exists(RepoRelative("depot_tools")):
+        clone_cmd = 'git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools'.split(" ")
+        subprocess.check_call(clone_cmd)
+
+    os.environ['PATH'] = os.environ.get('PATH') + ":" + RepoRelative("depot_tools")
+
+    # Updating Repo Dependencies and GN Toolchain
+    update_cmd = './scripts/gn/update_deps.sh'
+    subprocess.check_call(update_cmd)
+
+    gn_check_cmd = 'gn gen --check out/Debug'.split(" ")
+    subprocess.check_call(gn_check_cmd)
+
+    # Generating Ninja Files
+    gn_gen_cmd = 'gn gen out/Debug'.split(" ")
+    subprocess.check_call(gn_gen_cmd)
+
+    # Running Ninja Build
+    ninja_build_cmd = 'ninja -C out/Debug'.split(" ")
+    subprocess.check_call(ninja_build_cmd)
+
+#
+# Module Entrypoint
+def main():
+    try:
+        BuildGn()
+    except subprocess.CalledProcessError as proc_error:
+        print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
+        sys.exit(proc_error.returncode)
+    except Exception as unknown_error:
+        print('An unkown error occured: %s', unknown_error)
+        sys.exit(1)
+
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/gn/secondary/build_overrides/build.gni
+++ b/scripts/gn/secondary/build_overrides/build.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2019-2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_with_chromium = false
+ignore_elf32_limitations = true
+linux_use_bundled_binutils_override = false
+use_system_xcode = true

--- a/scripts/gn/secondary/build_overrides/lunarg_vulkantools.gni
+++ b/scripts/gn/secondary/build_overrides/lunarg_vulkantools.gni
@@ -1,0 +1,24 @@
+# Copyright (c) 2019-2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Paths to validation layer dependencies
+vulkan_headers_dir = "//external/Vulkan-Headers"
+vulkan_utility_libraries_dir = "//external/Vulkan-Utility-Libraries"
+
+# Subdirectories for generated files
+vulkan_data_subdir = ""
+vulkan_gen_subdir = ""
+
+# Build options
+ozone_platform_x11 = true

--- a/scripts/gn/secondary/build_overrides/vulkan_headers.gni
+++ b/scripts/gn/secondary/build_overrides/vulkan_headers.gni
@@ -1,0 +1,15 @@
+# Copyright (c) 2020-2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+vulkan_use_x11 = true

--- a/scripts/gn/secondary/build_overrides/vulkan_utility_libraries.gni
+++ b/scripts/gn/secondary/build_overrides/vulkan_utility_libraries.gni
@@ -1,0 +1,5 @@
+# Copyright 2023-2023 LunarG, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+vulkan_headers_dir = "//external/Vulkan-Headers"

--- a/scripts/gn/update_deps.sh
+++ b/scripts/gn/update_deps.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Copyright (c) 2019-2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Execute at repo root
+cd "$(dirname $0)/../../"
+
+# Use update_deps.py to update source dependencies from /scripts/known_good.json
+scripts/update_deps.py --dir="external" --no-build
+
+cat << EOF > .gn
+buildconfig = "//build/config/BUILDCONFIG.gn"
+secondary_source = "//scripts/gn/secondary/"
+
+default_args = {
+    clang_use_chrome_plugins = false
+    use_custom_libcxx = false
+}
+EOF
+
+# Use gclient to update toolchain dependencies from /scripts/gn/DEPS (from chromium)
+cat << EOF > .gclient
+solutions = [
+  { "name"        : ".",
+    "url"         : "https://github.com/LunarG/VulkanToolss",
+    "deps_file"   : "scripts/gn/DEPS",
+    "managed"     : False,
+    "custom_deps" : {
+    },
+    "custom_vars": {},
+  },
+]
+EOF
+gclient sync
+


### PR DESCRIPTION
Add GN build support for the api dump layer only. 

This is needed by Google for Chromium ANGLE builds so that apidump can be built in-tree and loaded as an ANGLE debugging output option.

Very closely based on the GN build infrastructure found in the VVL repo.