### PR TITLE
Revert "vkconfig: Add 'Command Prompt' support with command line mode"

### DIFF
--- a/vkconfig/CHANGELOG.md
+++ b/vkconfig/CHANGELOG.md
@@ -19,7 +19,6 @@
 
 ### Improvements:
 - Add 'status' to give an explicit control to print the Vulkan status log
-- Add support for 'Command Prompt' when using Vulkan Configurator with command lines
 - Add support for using Vulkan Configurator environment variables in the UI
 - Better present implicit layers, showing "Implicitly On" or "Implicitly Off" depending on the environment variable
 - Add double click on configuration name to edit a layers configuration

--- a/vkconfig/CMakeLists.txt
+++ b/vkconfig/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
         endif()
 
         if(WIN32)
-            add_executable(vkconfig ${FILES_ALL} ${CMAKE_CURRENT_SOURCE_DIR}/resourcefiles/vkconfig.rc)
+            add_executable(vkconfig WIN32 ${FILES_ALL} ${CMAKE_CURRENT_SOURCE_DIR}/resourcefiles/vkconfig.rc)
             target_compile_definitions(vkconfig PRIVATE _CRT_SECURE_NO_WARNINGS)
             target_compile_options(vkconfig PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/MP>)
             target_link_libraries(vkconfig Cfgmgr32)

--- a/vkconfig/README.md
+++ b/vkconfig/README.md
@@ -46,6 +46,9 @@ The tool is distributed differently, depending on the platform:
 
 Vulkan Configurator may be used with command line arguments to override layers. Use `vkconfig --help` in the console for more information.
 
+On Windows 10, Vulkan Configurator can't output to 'Command Prompt' without a redirection to a file because it's a win32 application.
+As a workaround, we can run Vulkan Configurator from 'MSYS'.
+
 ![Vulkan Configurator Animated Presentation](https://github.com/LunarG/VulkanTools/blob/main/vkconfig/images/presentation.gif)
 
 

--- a/vkconfig/main.cpp
+++ b/vkconfig/main.cpp
@@ -28,20 +28,10 @@
 
 #include <cassert>
 
-#ifdef _WIN32
-#include <Windows.h>
-#endif
-
 int main(int argc, char* argv[]) {
-#ifdef _WIN32
-    DWORD procId;
-    DWORD count = GetConsoleProcessList(&procId, 1);
-    if (count < 2) {
-        ::ShowWindow(::GetConsoleWindow(), SW_HIDE);  // hide console window
-    }
-#endif
-
     ::vkconfig_version = "vkconfig";
+
+    InitSignals();
 
     const CommandLine command_line(argc, argv);
 
@@ -50,8 +40,6 @@ int main(int argc, char* argv[]) {
         command_line.usage();
         return -1;
     }
-
-    InitSignals();
 
     switch (command_line.command) {
         case COMMAND_SHOW_USAGE: {

--- a/vkconfig/mainwindow.cpp
+++ b/vkconfig/mainwindow.cpp
@@ -186,7 +186,6 @@ void MainWindow::InitTray() {
 
         this->_tray_icon = new QSystemTrayIcon(this);
         this->_tray_icon->setContextMenu(this->_tray_icon_menu);
-        this->UpdateTray();
         this->_tray_icon->show();
 
         this->connect(this->_tray_icon, &QSystemTrayIcon::activated, this, &MainWindow::iconActivated);


### PR DESCRIPTION
This reverts commit a2cfb54fafbadcf67a7dab7305732c9691d300b1.

Windows 11 doesn't support hiding the console so to get text output, the user has to redirect to a file or use a different console than Command Prompt.