### PR TITLE
layer: Update Android layer settings doc

### DIFF
--- a/layersvt/api_dump_layer.md
+++ b/layersvt/api_dump_layer.md
@@ -111,14 +111,14 @@ The easiest way to set a property is from the ADB shell:
 
 **For example:**
 
-To set the API Dump output log filename, which on desktop uses `VK_APIDUMP_LOG_FILENAME`
+To set the API Dump output log filename, which on desktop uses `VK_API_DUMP_LOG_FILENAME`
 set the following property:
 
-    debug.apidump_log_filename
+    debug.vulkan.api_dump.log_filename
 
 Which you can set in the following way:
 
-    adb shell "setprop debug.apidump_log_filename '/sdcard/Android/vk_apidump.txt'"
+    adb shell "setprop debug.vulkan.api_dump.log_filename '/sdcard/Android/vk_apidump.txt'"
 
 <br></br>
 

--- a/layersvt/screenshot_layer.md
+++ b/layersvt/screenshot_layer.md
@@ -49,6 +49,6 @@ Vulkan Cube demo from [Khronos/Vulkan-Tools](https://github.com/KhronosGroup/Vul
 adb shell pm grant com.example.VkCube android.permission.READ_EXTERNAL_STORAGE
 adb shell pm grant com.example.VkCube android.permission.WRITE_EXTERNAL_STORAGE
 ```
-## Layer Options
+## Layer Settings
 
 The options for this layer are specified in VK_LAYER_LUNARG_screenshot.json. The layer option details are documented in the [screenshot layer documentation](https://vulkan.lunarg.com/doc/sdk/latest/windows/screenshot_layer.html#user-content-layer-details).


### PR DESCRIPTION
Note that `VK_APIDUMP_LOG_FILENAME` is still supported for backward compatibility reason but `VK_API_DUMP_LOG_FILENAME` is the expect name.

Environment variable layer settings names are built this way:
`VK_[VENDOR_][LAYER_NAME_POSTFIX_]SETTING_NAME`

For Android, the name are build similarly:
`debug.vulkan.[VENDOR.][LAYER_NAME_POSTFIX.]setting_name`

The layer settings library will first search the full name :
`debug.vulkan.lunarg.api_dump.setting_name`

And then trim the vendor name:
`debug.vulkan.api_dump.setting_name`

And then trim the layer name:
`debug.vulkan.setting_name`

Enabling using the same setting for multiple layers and also as a trick to be more backward compatible with the previous layer setting system and each layer implementation that were quite inconsistent.

An inconsistency with API Dump is that in the environment name the `_` was remove... There is a workaround in API dump to support both `API_DUMP` and `APIDUMP`.



Unfortunately using a `_` in `apidump_log_filename` as a separator between the layer name and the setting name is a case that was not covered by the layer setting library... Should we add backward compatbility for that? That will be a pretty hacky thing to do, sadly not the only thing hacky in the layer settings library as the layer settings across layers were badly inconsistent with details like this...
