### PR TITLE
apidump: Fix tests looking in wrong output folder

### DIFF
--- a/layersvt/test/CMakeLists.txt
+++ b/layersvt/test/CMakeLists.txt
@@ -33,7 +33,8 @@ function(LayerTest NAME)
                    layer_test_framework.h)
     add_dependencies(${TEST_NAME} VkLayer_${NAME})
     target_link_libraries(${TEST_NAME} Vulkan::Headers Vulkan::Loader GTest::gtest GTest::gtest_main Vulkan::LayerSettings)
-    target_compile_definitions(${TEST_NAME} PUBLIC TEST_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_${NAME}>")
+    target_compile_definitions(${TEST_NAME} PUBLIC LAYER_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_${NAME}>")
+    target_compile_definitions(${TEST_NAME} PUBLIC TEST_EXECUTABLE_PATH="$<TARGET_FILE_DIR:${TEST_NAME}>")
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT

--- a/layersvt/test/layer_test_helper.cpp
+++ b/layersvt/test/layer_test_helper.cpp
@@ -96,7 +96,7 @@ VkResult layer_test::VulkanInstanceBuilder::Init(const std::vector<VkLayerSettin
         }
     }
 
-    layer_test::SetEnvironmentSetting("VK_LAYER_PATH", TEST_BINARY_PATH);
+    layer_test::SetEnvironmentSetting("VK_LAYER_PATH", LAYER_BINARY_PATH);
 
     VkApplicationInfo app_info{GetDefaultApplicationInfo()};
 

--- a/layersvt/test/test_api_dump.cpp
+++ b/layersvt/test/test_api_dump.cpp
@@ -50,7 +50,7 @@ TEST_F(ApiDumpTests, init_layer) {
     EXPECT_EQ(err, VK_SUCCESS);
 
     // check the output file is generated
-    const std::string path = std::string(TEST_BINARY_PATH) + "/test/" + filename_string;
+    const std::string path = std::string(TEST_EXECUTABLE_PATH) + "/" + filename_string;
     FILE* file = fopen(path.c_str(), "r");
     ASSERT_TRUE(file != NULL);
 


### PR DESCRIPTION
The CMake code mixed up the layer binary directory with the test executable directory, causing tests to look in the layer binary directory by mistake.