### PR TITLE
Look for api dump test output in current directory

### DIFF
--- a/layersvt/test/CMakeLists.txt
+++ b/layersvt/test/CMakeLists.txt
@@ -34,7 +34,6 @@ function(LayerTest NAME)
     add_dependencies(${TEST_NAME} VkLayer_${NAME})
     target_link_libraries(${TEST_NAME} Vulkan::Headers Vulkan::Loader GTest::gtest GTest::gtest_main Vulkan::LayerSettings)
     target_compile_definitions(${TEST_NAME} PUBLIC LAYER_BINARY_PATH="$<TARGET_FILE_DIR:VkLayer_${NAME}>")
-    target_compile_definitions(${TEST_NAME} PUBLIC TEST_EXECUTABLE_PATH="$<TARGET_FILE_DIR:${TEST_NAME}>")
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT

--- a/layersvt/test/test_api_dump.cpp
+++ b/layersvt/test/test_api_dump.cpp
@@ -23,6 +23,8 @@
 #include <cstdio>
 #include <cstring>
 
+#include <filesystem>
+
 static const char* kLayerName = "VK_LAYER_LUNARG_api_dump";
 
 class ApiDumpTests : public VkTestFramework {
@@ -50,8 +52,8 @@ TEST_F(ApiDumpTests, init_layer) {
     EXPECT_EQ(err, VK_SUCCESS);
 
     // check the output file is generated
-    const std::string path = std::string(TEST_EXECUTABLE_PATH) + "/" + filename_string;
-    FILE* file = fopen(path.c_str(), "r");
+    const std::filesystem::path path = std::filesystem::current_path() / std::filesystem::path(filename_string);
+    FILE* file = fopen(path.string().c_str(), "r");
     ASSERT_TRUE(file != NULL);
 
     const char* file_start_content_expected = "<!doctype html>";


### PR DESCRIPTION
The tests are failing on windows due to a mismatch in the working directory that the executable is being run and the directory that is assumed to be where Api Dump will output. By querying where the current directory is, the tests can always find the output of Api Dump.