### PR TITLE
Update Crash Diagnostic.json

### DIFF
--- a/vkconfig_core/configurations/2.2.2/Crash Diagnostic.json
+++ b/vkconfig_core/configurations/2.2.2/Crash Diagnostic.json
@@ -6,8 +6,7 @@
                 "name": "VK_LAYER_LUNARG_crash_diagnostic",
                 "platforms": [
                     "WINDOWS",
-                    "LINUX",
-                    "MACOS"
+                    "LINUX"
                 ],
                 "rank": 1,
                 "settings": [


### PR DESCRIPTION
macOS is not supported by the diagnostic layer