### PR TITLE
Replace "implem" with "driver" loader log level

### DIFF
--- a/vkconfig_core/type_log.cpp
+++ b/vkconfig_core/type_log.cpp
@@ -33,7 +33,7 @@ const char* GetToken(LogType value) {
         "debug",   // LOG_DEBUG
         "perf",    // LOG_PERF
         "layer",   // LOG_LAYER
-        "implem",  // LOG_IMPLEM
+        "driver",  // LOG_DRIVER
     };
     static_assert(std::size(TOKENS) == LOG_COUNT);
 

--- a/vkconfig_core/type_log.h
+++ b/vkconfig_core/type_log.h
@@ -31,10 +31,10 @@ enum LogType {
     LOG_DEBUG,
     LOG_PERF,
     LOG_LAYER,
-    LOG_IMPLEM,
+    LOG_DRIVER,
 
     LOG_FIRST = LOG_ERROR,
-    LOG_LAST = LOG_IMPLEM,
+    LOG_LAST = LOG_DRIVER,
 
     LOG_MESSAGE_INVALID = ~0,
 };

--- a/vkconfig_gui/tab_configurations.cpp
+++ b/vkconfig_gui/tab_configurations.cpp
@@ -193,7 +193,7 @@ void TabConfigurations::UpdateUI_LoaderMessages() {
         ui->configuration_loader_layers_checkBox->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_LAYER));
         ui->configuration_loader_layers_checkBox->blockSignals(false);
         ui->configuration_loader_drivers_checkBox->blockSignals(true);
-        ui->configuration_loader_drivers_checkBox->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_IMPLEM));
+        ui->configuration_loader_drivers_checkBox->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_DRIVER));
         ui->configuration_loader_drivers_checkBox->blockSignals(false);
     }
 }
@@ -572,7 +572,7 @@ void TabConfigurations::OnCheckedLoaderMessageTypes(bool checked) {
         loader_log_messages_bits |= ui->configuration_loader_infos_checkBox->isChecked() ? GetBit(LOG_INFO) : 0;
         loader_log_messages_bits |= ui->configuration_loader_debug_checkBox->isChecked() ? GetBit(LOG_DEBUG) : 0;
         loader_log_messages_bits |= ui->configuration_loader_layers_checkBox->isChecked() ? GetBit(LOG_LAYER) : 0;
-        loader_log_messages_bits |= ui->configuration_loader_drivers_checkBox->isChecked() ? GetBit(LOG_IMPLEM) : 0;
+        loader_log_messages_bits |= ui->configuration_loader_drivers_checkBox->isChecked() ? GetBit(LOG_DRIVER) : 0;
 
         active_configuration->loader_log_messages_flags = loader_log_messages_bits;
     }


### PR DESCRIPTION
Matches the Vulkan-Loader's own log levels.