### PR TITLE
vkconfig3: BETA fixes

### DIFF
--- a/vkconfig_cmd/main.cpp
+++ b/vkconfig_cmd/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
 
     if (vulkan_info.loaderVersion < Version::REQUIRED_LOADER_VERSION) {
         fprintf(stderr,
-                "%s: [ERROR] The system has Vulkan Loader version %s but version %s is requered. Please update the Vulkan Runtime "
+                "%s: [ERROR] The system has Vulkan Loader version %s but version %s is required. Please update the Vulkan Runtime "
                 "at https://vulkan.lunarg.com/sdk/home",
                 VKCONFIG_SHORT_NAME, vulkan_info.loaderVersion.str().c_str(), Version::REQUIRED_LOADER_VERSION.str().c_str());
         return -1;

--- a/vkconfig_cmd/main_layers.cpp
+++ b/vkconfig_cmd/main_layers.cpp
@@ -27,14 +27,16 @@
 #include <cassert>
 
 static int RunLayersOverride(Configurator& configurator, const CommandLine& command_line) {
-    const bool load_result =
-        configurator.configurations.ImportConfiguration(configurator.layers, command_line.layers_configuration_path);
+    std::string configuration_name;
+    const bool load_result = configurator.configurations.ImportConfiguration(
+        configurator.layers, command_line.layers_configuration_path, configuration_name);
     if (!load_result) {
         fprintf(stderr, "vkconfig: Failed to load %s layers configuration file...\n",
                 command_line.layers_configuration_path.c_str());
         return -1;
     }
 
+    configurator.SetActiveConfigurationName(configuration_name);
     const bool override_result = configurator.Override(OVERRIDE_AREA_ALL);
     if (override_result) {
         printf("vkconfig: Layers configuration \"%s\" applied to all Vulkan Applications, including Vulkan layers:\n",
@@ -78,10 +80,10 @@ static int RunLayersList(Configurator& configurator, const CommandLine& command_
     if (configurator.layers.selected_layers.empty()) {
         printf("vkconfig: No Vulkan layer found\n");
     } else {
-        for (std::size_t i = 0, n = configurator.layers.selected_layers.size(); i < n; ++i) {
-            const Layer& layer = configurator.layers.selected_layers[i];
+        const std::vector<std::string>& layer_names = configurator.layers.GatherLayerNames();
 
-            printf("%s\n", layer.key.c_str());
+        for (std::size_t i = 0, n = layer_names.size(); i < n; ++i) {
+            printf("%s\n", layer_names[i].c_str());
         }
     }
 
@@ -89,20 +91,7 @@ static int RunLayersList(Configurator& configurator, const CommandLine& command_
 }
 
 static int RunLayersVerbose(Configurator& configurator, const CommandLine& command_line) {
-    for (std::size_t i = 0, n = configurator.layers.selected_layers.size(); i < n; ++i) {
-        const Layer& layer = configurator.layers.selected_layers[i];
-
-        printf("%s %s-%s\n", layer.key.c_str(), layer.api_version.str().c_str(), layer.implementation_version.c_str());
-        printf("- %s\n", layer.description.c_str());
-        printf("- %s\n", layer.manifest_path.AbsolutePath().c_str());
-        printf("- %s\n", layer.binary_path.AbsolutePath().c_str());
-        printf("- %s layer\n", GetToken(layer.type));
-
-        if (i < (n - 1)) {
-            printf("\n");
-        }
-    }
-
+    printf("%s", configurator.layers.Log().c_str());
     return 0;
 }
 

--- a/vkconfig_core/alert.cpp
+++ b/vkconfig_core/alert.cpp
@@ -48,7 +48,7 @@ void Alert::StartLoaderFailure() {
 void Alert::StartLoaderIncompatibleVersions(const Version& system_loader_version, const Version& required_loader_version) {
     QMessageBox alert;
     alert.setWindowTitle("Vulkan Configurator failed to start...");
-    alert.setText(format("The system has Vulkan Loader version % s but version %s is requered. Please update the Vulkan Runtime.",
+    alert.setText(format("The system has Vulkan Loader version % s but version %s is required. Please update the Vulkan Runtime.",
                          system_loader_version.str().c_str(), required_loader_version.str().c_str())
                       .c_str());
     alert.setInformativeText("<a href=\"https://vulkan.lunarg.com/sdk/home\">https://vulkan.lunarg.com/sdk/home</a>");

--- a/vkconfig_core/configuration.h
+++ b/vkconfig_core/configuration.h
@@ -37,7 +37,7 @@ class Configuration {
     static Configuration Create(const LayerManager& layers, const std::string& configuration_key);
 
     bool Load(const Path& full_path, const LayerManager& layers);
-    bool Save(const Path& full_path, bool exporter = false) const;
+    bool Save(const Path& full_path) const;
     void Reset(const LayerManager& layers);
 
     Parameter* Find(const std::string& layer_key);

--- a/vkconfig_core/configuration_manager.cpp
+++ b/vkconfig_core/configuration_manager.cpp
@@ -156,14 +156,6 @@ void ConfigurationManager::SortConfigurations() {
     std::sort(this->available_configurations.begin(), this->available_configurations.end(), Compare());
 }
 
-std::vector<ReferencedLayer> ConfigurationManager::BuildReferencedLayers(const LayerManager &layers, const Path &path) {
-    std::vector<ReferencedLayer> result;
-
-    layers.GatherLayerNames();
-
-    return result;
-}
-
 void ConfigurationManager::LoadConfigurationsPath(const LayerManager &layers) {
     const std::vector<Path> &configuration_files = CollectFilePaths(Get(Path::CONFIGS));
     for (std::size_t i = 0, n = configuration_files.size(); i < n; ++i) {
@@ -350,7 +342,8 @@ void ConfigurationManager::RenameConfiguration(const std::string &old_configurat
     this->SortConfigurations();
 }
 
-bool ConfigurationManager::ImportConfiguration(const LayerManager &layers, const Path &full_import_path) {
+bool ConfigurationManager::ImportConfiguration(const LayerManager &layers, const Path &full_import_path,
+                                               std::string &configuration_name) {
     assert(!full_import_path.Empty());
 
     this->last_path_import_config = full_import_path.AbsoluteDir();
@@ -360,17 +353,18 @@ bool ConfigurationManager::ImportConfiguration(const LayerManager &layers, const
         return false;
     }
 
-    configuration.key = MakeConfigurationName(this->available_configurations, configuration.key + " (Imported)");
+    configuration_name = configuration.key =
+        MakeConfigurationName(this->available_configurations, configuration.key + " (Imported)");
     this->available_configurations.push_back(configuration);
     this->SortConfigurations();
-
-    // this->GetActiveConfigurationInfo()->name = configuration.key;
 
     return true;
 }
 
 bool ConfigurationManager::ExportConfiguration(const LayerManager &layers, const Path &full_export_path,
                                                const std::string &configuration_name) {
+    (void)layers;
+
     assert(!configuration_name.empty());
     assert(!full_export_path.Empty());
 
@@ -379,5 +373,5 @@ bool ConfigurationManager::ExportConfiguration(const LayerManager &layers, const
     Configuration *configuration = this->FindConfiguration(configuration_name);
     assert(configuration);
 
-    return configuration->Save(full_export_path, true);
+    return configuration->Save(full_export_path);
 }

--- a/vkconfig_core/configuration_manager.h
+++ b/vkconfig_core/configuration_manager.h
@@ -51,7 +51,7 @@ class ConfigurationManager : public Serialize {
     int GetConfigurationIndex(const std::string& configuration_name) const;
 
     void RenameConfiguration(const std::string& old_configuration_name, const std::string& new_configuration_name);
-    bool ImportConfiguration(const LayerManager& layers, const Path& full_import_path);
+    bool ImportConfiguration(const LayerManager& layers, const Path& full_import_path, std::string& configuration_name);
     bool ExportConfiguration(const LayerManager& layers, const Path& full_export_path, const std::string& configuration_name);
 
     const Configuration* FindConfiguration(const std::string& configuration_name) const;
@@ -61,8 +61,6 @@ class ConfigurationManager : public Serialize {
 
     bool IsDefaultConfiguration(const std::string& configuration_key) const;
     void ResetDefaultConfigurations(const LayerManager& layers);
-
-    std::vector<ReferencedLayer> BuildReferencedLayers(const LayerManager& layers, const Path& path);
 
     bool Empty() const { return this->available_configurations.empty(); }
 

--- a/vkconfig_core/configurator.h
+++ b/vkconfig_core/configurator.h
@@ -107,9 +107,6 @@ class Configurator : public Serialize {
     bool GetUseSystemTray() const;
     void SetUseSystemTray(bool enabled);
 
-    Path GetHomeSDK() const;
-    void SetHomeSDK(const Path& path);
-
     bool HasActiveSettings() const;
     bool HasEnabledUI(EnabledUI enabled_ui) const;
 
@@ -139,7 +136,6 @@ class Configurator : public Serialize {
     Path last_path_status = ::Get(Path::HOME) + "/vkconfig.txt";
 
    private:
-    Path home_sdk_path = ::Get(Path::HOME);
     int hide_message_boxes_flags = 0;
     bool use_system_tray = false;
     ExecutableScope executable_scope = EXECUTABLE_ANY;

--- a/vkconfig_core/executable_manager.cpp
+++ b/vkconfig_core/executable_manager.cpp
@@ -74,6 +74,10 @@ bool ExecutableManager::Load(const QJsonObject& json_root_object) {
         this->last_path_executable = json_executables_object.value("last_path_executable").toString().toStdString();
     }
 
+    if (json_executables_object.value("clear_on_launch") != QJsonValue::Undefined) {
+        this->launcher_clear_on_launch = json_executables_object.value("clear_on_launch").toBool();
+    }
+
     const QJsonObject& json_list_object = json_executables_object.value("list").toObject();
 
     const QStringList& json_list_keys = json_list_object.keys();
@@ -130,6 +134,7 @@ bool ExecutableManager::Save(QJsonObject& json_root_object) const {
     QJsonObject json_executables_object;
     json_executables_object.insert("active_executable", this->active_executable.RelativePath().c_str());
     json_executables_object.insert("last_path_executable", this->last_path_executable.RelativePath().c_str());
+    json_executables_object.insert("clear_on_launch", this->launcher_clear_on_launch);
 
     QJsonObject json_executables_list_object;
     for (std::size_t i = 0, n = this->data.size(); i < n; ++i) {
@@ -238,6 +243,18 @@ bool ExecutableManager::RemoveExecutable() {
     } else {
         this->active_executable = this->data[0].path;
     }
+
+    return true;
+}
+
+bool ExecutableManager::RenameActiveExecutable(const Path& executable_path) {
+    if (this->GetActiveExecutable() == nullptr) {
+        return false;
+    }
+
+    this->GetActiveExecutable()->path = executable_path;
+    this->last_path_executable = executable_path;
+    this->active_executable = executable_path;
 
     return true;
 }

--- a/vkconfig_core/executable_manager.h
+++ b/vkconfig_core/executable_manager.h
@@ -42,6 +42,7 @@ class ExecutableManager : public Serialize {
     bool AppendExecutable(const Executable& executable);
     bool AppendExecutable(const Path& executable_path);
     bool RemoveExecutable();
+    bool RenameActiveExecutable(const Path& executable_path);
     bool UpdateConfigurations(std::vector<Path>& updated_executable_paths);
 
     const std::vector<Executable>& GetExecutables() const { return this->data; }

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -106,7 +106,6 @@ LayerControl Layer::GetActualControl() const {
 std::string Layer::GetActualControlTooltip() const {
     if (this->type == LAYER_TYPE_IMPLICIT) {
         if (!this->disable_env.empty()) {
-            const std::string& value = qgetenv(this->disable_env.c_str()).toStdString();
             if (qEnvironmentVariableIsSet(this->disable_env.c_str())) {
                 return format("'%s' is set", this->disable_env.c_str());
             }
@@ -469,6 +468,9 @@ void Layer::AddSettingData(SettingDataSet& settings_data, const QJsonValue& json
     const std::string& key = ReadStringValue(json_setting_object, "key");
 
     SettingMeta* setting_meta = FindSetting(this->settings, key.c_str());
+    if (setting_meta == nullptr) {
+        return;
+    }
     assert(setting_meta);
 
     SettingData* setting_data = setting_meta->Instantiate();

--- a/vkconfig_core/layer_manager.h
+++ b/vkconfig_core/layer_manager.h
@@ -51,9 +51,10 @@ class LayerManager : public Serialize {
     void LoadLayersFromPath(const Path& layers_path, LayerType type = LAYER_TYPE_EXPLICIT);
     LayerLoadStatus LoadLayer(const Path& layer_path, LayerType type = LAYER_TYPE_EXPLICIT);
 
+    bool AreLayersEnabled(const LayersPathInfo& path_info) const;
     void AppendPath(const LayersPathInfo& path_info);
     void RemovePath(const LayersPathInfo& path_info);
-    void UpdatePathEnabled(const LayersPathInfo& path_info);
+    void UpdatePathEnabled(const LayersPathInfo& path_info, LayersPaths layers_paths);
     std::vector<Path> CollectManifestPaths() const;
 
     std::vector<std::string> GatherLayerNames() const;
@@ -66,6 +67,7 @@ class LayerManager : public Serialize {
 
    private:
     void InitSystemPaths();
+    void UpdateLayersEnabled(const LayersPathInfo& path_info);
 
     std::map<Path, std::string> layers_validated;
 };

--- a/vkconfig_core/path.cpp
+++ b/vkconfig_core/path.cpp
@@ -221,14 +221,17 @@ Path operator+(const Path& path, const std::string& extend) { return Path(path.d
 
 bool operator<(const Path& a, const Path& b) { return a.RelativePath() < b.RelativePath(); }
 
-static const Path GetHomePath() {
-    std::string result = qgetenv("VK_HOME").toStdString();
+static Path VK_HOME_PATH = QDir().homePath().toStdString() + "/VulkanSDK";
 
-    if (result.empty()) {  // Defaukt path
-        result = QDir().homePath().toStdString() + "/VulkanSDK";
+void SetHomePath(const Path& path) { ::VK_HOME_PATH = path; }
+
+static const Path GetHomePath() {
+    Path path = qgetenv("VK_HOME").toStdString();
+
+    if (path.Empty()) {  // Default path
+        path = VK_HOME_PATH;
     }
 
-    Path path(result);
     if (!path.Exists()) {
         path.Create();
     }

--- a/vkconfig_core/path.h
+++ b/vkconfig_core/path.h
@@ -84,6 +84,8 @@ bool operator!=(const Path& a, const Path& b);
 Path operator+(const Path& path, const std::string& extend);
 bool operator<(const Path& a, const Path& b);
 
+void SetHomePath(const Path& path);
+
 std::vector<Path> CollectFilePaths(const Path& directory, const char* filter = "*json");
 
 std::vector<std::string> CollectProfileNamesFromFile(const Path& profile_path);

--- a/vkconfig_core/setting_flags.h
+++ b/vkconfig_core/setting_flags.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_07.json
+++ b/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_07.json
@@ -1,0 +1,39 @@
+{
+    "file_format_version": "1.2.0",
+    "layer": {
+        "name": "VK_LAYER_LUNARG_test_07",
+        "library_path": ".\\VkLayer_test.dll",
+        "api_version": "1.2.170",
+        "implementation_version": "Build 76",
+        "description": "Missing setting",
+        "platforms": [ "WINDOWS", "LINUX" ],
+        "status": "BETA",
+        "features": {
+            "presets": [
+                {
+                    "label": "Preset Inherit",
+                    "description": "Description Inherit",
+                    "settings": [
+                        {
+                            "key": "int_required_only",
+                            "value": 75
+                        },
+                        {
+                            "key": "int_missing",
+                            "value": 76
+                        }
+                    ]
+                }
+            ],
+            "settings": [
+                {
+                    "key": "int_required_only",
+                    "type": "INT",
+                    "label": "Integer",
+                    "description": "Integer Description",
+                    "default": 82
+                }
+            ]
+        }
+    }
+}

--- a/vkconfig_core/test/resources.qrc
+++ b/vkconfig_core/test/resources.qrc
@@ -34,6 +34,7 @@
         <file alias="VK_LAYER_LUNARG_test_04.json">./layers/VK_LAYER_LUNARG_test_04.json</file>
         <file alias="VK_LAYER_LUNARG_test_05.json">./layers/VK_LAYER_LUNARG_test_05.json</file>
         <file alias="VK_LAYER_LUNARG_test_06.json">./layers/VK_LAYER_LUNARG_test_06.json</file>
+        <file alias="VK_LAYER_LUNARG_test_07.json">./layers/VK_LAYER_LUNARG_test_07.json</file>
 
         <file alias="VK_LAYER_LUNARG_version_135.json">./layers/VK_LAYER_LUNARG_version_135.json</file>
         <file alias="VK_LAYER_LUNARG_version_193.json">./layers/VK_LAYER_LUNARG_version_193.json</file>

--- a/vkconfig_core/test/test_configuration.cpp
+++ b/vkconfig_core/test/test_configuration.cpp
@@ -281,8 +281,9 @@ TEST(test_configuration, gather_parameters_exist) {
     EXPECT_STREQ(configuration.parameters[8].key.c_str(), "VK_LAYER_LUNARG_test_04");
     EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_05");
     EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_06");
+    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_test_07");
 
-    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_version");
+    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_version");
 
     std::string missing_layer;
     EXPECT_FALSE(HasMissingLayer(configuration.parameters, layer_manager, missing_layer));
@@ -312,8 +313,9 @@ TEST(test_configuration, gather_parameters_repeat) {
     EXPECT_STREQ(configuration.parameters[8].key.c_str(), "VK_LAYER_LUNARG_test_04");
     EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_05");
     EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_06");
+    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_test_07");
 
-    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_version");
+    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_version");
 }
 
 TEST(test_configuration, gather_parameters_missing) {
@@ -340,11 +342,12 @@ TEST(test_configuration, gather_parameters_missing) {
     EXPECT_STREQ(configuration.parameters[7].key.c_str(), "VK_LAYER_LUNARG_test_04");
     EXPECT_STREQ(configuration.parameters[8].key.c_str(), "VK_LAYER_LUNARG_test_05");
     EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_06");
+    EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_07");
 
-    EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_version");
+    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_version");
 
     // Unordered are never missing so end up last
-    EXPECT_STREQ(configuration.parameters[11].key.c_str(), ::GetLabel(LAYER_BUILTIN_UNORDERED));
+    EXPECT_STREQ(configuration.parameters[12].key.c_str(), ::GetLabel(LAYER_BUILTIN_UNORDERED));
 
     std::string missing_layer;
     EXPECT_TRUE(HasMissingLayer(configuration.parameters, layer_manager, missing_layer));

--- a/vkconfig_core/test/test_executable.cpp
+++ b/vkconfig_core/test/test_executable.cpp
@@ -45,7 +45,7 @@ TEST(test_executable, ctor_path) {
 
     EXPECT_STREQ(Path("./vkcube").AbsolutePath().c_str(), executable.path.AbsolutePath().c_str());
     EXPECT_TRUE(executable.enabled);
-    EXPECT_TRUE(!executable.GetActiveOptionsName().empty());
+    EXPECT_STREQ("Default Options", executable.GetActiveOptionsName().c_str());
     EXPECT_EQ(1, executable.GetOptions().size());
 
     EXPECT_EQ(0, executable.GetActiveOptionsIndex());
@@ -89,4 +89,29 @@ TEST(test_executable, duplicate) {
     EXPECT_EQ(false, executable.DuplicateActiveOptions());
     EXPECT_EQ(0, executable.GetOptions().size());
     EXPECT_EQ(Executable::INVALID_OPTIONS, executable.GetActiveOptionsIndex());
+}
+
+TEST(test_executable, rename) {
+    Executable executable("./vkcube");
+    EXPECT_EQ(1, executable.GetOptions().size());
+    EXPECT_STREQ("Default Options", executable.GetActiveOptionsName().c_str());
+
+    executable.RenameActiveOptions("Pouet");
+    EXPECT_STREQ("Pouet", executable.GetActiveOptionsName().c_str());
+}
+
+TEST(test_executable, add) {
+    Executable executable("./vkcube");
+    EXPECT_EQ(1, executable.GetOptions().size());
+    EXPECT_STREQ("Default Options", executable.GetActiveOptionsName().c_str());
+
+    ExecutableOptions executable_options;
+    executable_options.label = "Pouet Options";
+    executable.AddOptions(executable_options);
+    EXPECT_EQ(2, executable.GetOptions().size());
+
+    EXPECT_STREQ("Default Options", executable.GetActiveOptionsName().c_str());
+
+    executable.SetActiveOptions("Pouet Options");
+    EXPECT_STREQ("Pouet Options", executable.GetActiveOptionsName().c_str());
 }

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -213,6 +213,18 @@ TEST(test_layer, load_setting_enum_interit) {
     EXPECT_EQ(SETTING_VIEW_HIDDEN, setting_override->enum_values[1].view);
 }
 
+TEST(test_layer, load_setting_missing) {
+    Layer layer;
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_07.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
+
+    EXPECT_EQ(Version(1, 2, 0), layer.file_format_version);
+    EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_LINUX_BIT, layer.platforms);
+    EXPECT_EQ(STATUS_BETA, layer.status);
+    EXPECT_EQ(1, layer.settings.size());
+    EXPECT_EQ(1, layer.presets.size());
+}
+
 TEST(test_layer, load_1_1_0_header) {
     Layer layer;
     const LayerLoadStatus load_loaded =

--- a/vkconfig_core/test/test_layer_manager.cpp
+++ b/vkconfig_core/test/test_layer_manager.cpp
@@ -60,7 +60,7 @@ TEST(test_layer_manager, load_all) {
     LayerManager layer_manager;
     layer_manager.LoadLayersFromPath(":/layers");
 
-    EXPECT_EQ(14, layer_manager.Size());
+    EXPECT_EQ(15, layer_manager.Size());
     EXPECT_TRUE(!layer_manager.Empty());
 
     layer_manager.Clear();
@@ -204,7 +204,7 @@ TEST(test_layer_manager, BuildLayerNameList) {
     LayerManager layer_manager;
     layer_manager.LoadLayersFromPath(":/layers");
 
-    EXPECT_EQ(layer_manager.GatherLayerNames().size(), 11);
+    EXPECT_EQ(layer_manager.GatherLayerNames().size(), 12);
 }
 
 TEST(test_layer_manager, avoid_duplicate) {
@@ -275,14 +275,14 @@ TEST(test_layer_manager, custom_path_update_layers) {
     }
 
     info.enabled = false;
-    layer_manager.UpdatePathEnabled(info);
+    layer_manager.UpdatePathEnabled(info, LAYERS_PATHS_GUI);
     EXPECT_EQ(layer_manager.paths[LAYERS_PATHS_GUI][0].enabled, false);
     for (std::size_t i = 0, n = layer_manager.selected_layers.size(); i < n; ++i) {
         EXPECT_FALSE(layer_manager.selected_layers[i].enabled);
     }
 
     info.enabled = true;
-    layer_manager.UpdatePathEnabled(info);
+    layer_manager.UpdatePathEnabled(info, LAYERS_PATHS_GUI);
     EXPECT_EQ(layer_manager.paths[LAYERS_PATHS_GUI][0].enabled, true);
     for (std::size_t i = 0, n = layer_manager.selected_layers.size(); i < n; ++i) {
         EXPECT_TRUE(layer_manager.selected_layers[i].enabled);

--- a/vkconfig_core/test/test_path.cpp
+++ b/vkconfig_core/test/test_path.cpp
@@ -276,7 +276,7 @@ TEST(test_path, collect_file_paths_success_set1) {
 TEST(test_path, collect_file_paths_success_set2) {
     const std::vector<Path>& paths = CollectFilePaths(":/layers/");
 
-    EXPECT_EQ(paths.size(), 14);
+    EXPECT_EQ(paths.size(), 15);
     EXPECT_STREQ(Path(":/layers/VK_LAYER_LUNARG_reference_1_1_0.json").AbsolutePath().c_str(), paths[0].AbsolutePath().c_str());
 }
 

--- a/vkconfig_core/type_layers_paths.cpp
+++ b/vkconfig_core/type_layers_paths.cpp
@@ -24,14 +24,14 @@
 
 const char* GetLabel(LayersPaths Layers_paths_type) {
     static const char* TABLE[] = {
-        "System Implicit Layers",                // LAYERS_PATHS_IMPLICIT_SYSTEM
-        "${VK_IMPLICIT_LAYER_PATH} Layers",      // LAYERS_PATHS_IMPLICIT_ENV_SET
-        "${VK_ADD_IMPLICIT_LAYER_PATH} Layers",  // LAYERS_PATHS_IMPLICIT_ENV_ADD
-        "System Explicit Layers",                // LAYERS_PATHS_EXPLICIT_SYSTEM
-        "${VK_LAYER_PATH} Layers",               // LAYERS_PATHS_EXPLICIT_ENV_SET
-        "${VK_ADD_LAYER_PATH} Layers",           // LAYERS_PATHS_EXPLICIT_ENV_ADD
-        "Vulkan Configurator Layers",            // LAYERS_PATHS_GUI
-        "${VULKAN_SDK} Layers",                  // LAYERS_PATHS_SDK
+        "System Implicit Path",           // LAYERS_PATHS_IMPLICIT_SYSTEM
+        "${VK_IMPLICIT_LAYER_PATH}",      // LAYERS_PATHS_IMPLICIT_ENV_SET
+        "${VK_ADD_IMPLICIT_LAYER_PATH}",  // LAYERS_PATHS_IMPLICIT_ENV_ADD
+        "System Explicit Path",           // LAYERS_PATHS_EXPLICIT_SYSTEM
+        "${VK_LAYER_PATH}",               // LAYERS_PATHS_EXPLICIT_ENV_SET
+        "${VK_ADD_LAYER_PATH}",           // LAYERS_PATHS_EXPLICIT_ENV_ADD
+        "Vulkan Configurator",            // LAYERS_PATHS_GUI
+        "${VULKAN_SDK}",                  // LAYERS_PATHS_SDK
     };
     static_assert(std::size(TABLE) == LAYERS_PATHS_COUNT, "The tranlation table size doesn't match the enum number of elements");
 

--- a/vkconfig_core/version.cpp
+++ b/vkconfig_core/version.cpp
@@ -32,7 +32,7 @@ const Version Version::VKCONFIG(3, 0, 0);
 const Version Version::VKHEADER(VK_HEADER_VERSION_COMPLETE);
 const Version Version::NONE(0, 0, 0);
 const Version Version::LATEST(~0, ~0, ~0);
-const Version Version::REQUIRED_LOADER_VERSION(1, 3, 298);
+const Version Version::REQUIRED_LOADER_VERSION(1, 3, 301);
 
 const char *VKCONFIG_NAME = "Vulkan Configurator";
 const char *VKCONFIG_SHORT_NAME = "vkconfig";

--- a/vkconfig_gui/mainwindow.ui
+++ b/vkconfig_gui/mainwindow.ui
@@ -83,7 +83,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>3</number>
       </property>
       <widget class="QWidget" name="tab_configurations">
        <attribute name="title">

--- a/vkconfig_gui/settings_tree.cpp
+++ b/vkconfig_gui/settings_tree.cpp
@@ -48,9 +48,6 @@
 
 #include <cassert>
 
-static const char *TOOLTIP_ORDER =
-    "Layers are executed between the Vulkan application and driver in the specific order represented here";
-
 SettingsTreeManager::SettingsTreeManager(std::shared_ptr<Ui::MainWindow> ui) : ui(ui) {
     assert(ui.get() != nullptr);
 

--- a/vkconfig_gui/tab_about.cpp
+++ b/vkconfig_gui/tab_about.cpp
@@ -41,11 +41,16 @@ TabAbout::TabAbout(MainWindow &window, std::shared_ptr<Ui::MainWindow> ui) : Tab
 
 TabAbout::~TabAbout() {}
 
-void TabAbout::UpdateUI(UpdateUIMode mode) {}
+void TabAbout::UpdateUI(UpdateUIMode mode) { (void)mode; }
 
 void TabAbout::CleanUI() {}
 
-bool TabAbout::EventFilter(QObject *target, QEvent *event) { return false; }
+bool TabAbout::EventFilter(QObject *target, QEvent *event) {
+    (void)target;
+    (void)event;
+
+    return false;
+}
 
 void TabAbout::on_about_lunarg_pushButton_pressed() {
     QDesktopServices::openUrl(QUrl("https://www.lunarg.com/", QUrl::TolerantMode));

--- a/vkconfig_gui/tab_applications.cpp
+++ b/vkconfig_gui/tab_applications.cpp
@@ -32,31 +32,31 @@ TabApplications::TabApplications(MainWindow &window, std::shared_ptr<Ui::MainWin
                   SLOT(on_launch_executable_list_activated(int)));
     this->connect(this->ui->launch_executable_list->lineEdit(), SIGNAL(textEdited(QString)), this,
                   SLOT(on_launch_executable_list_textEdited(QString)));
-    this->connect(this->ui->launch_executable_search, SIGNAL(pressed()), this, SLOT(on_launch_executable_search_pressed()));
-    this->connect(this->ui->launch_executable_append, SIGNAL(pressed()), this, SLOT(on_launch_executable_append_pressed()));
-    this->connect(this->ui->launch_executable_remove, SIGNAL(pressed()), this, SLOT(on_launch_executable_remove_pressed()));
+    this->connect(this->ui->launch_executable_search, SIGNAL(clicked()), this, SLOT(on_launch_executable_search_pressed()));
+    this->connect(this->ui->launch_executable_append, SIGNAL(clicked()), this, SLOT(on_launch_executable_append_pressed()));
+    this->connect(this->ui->launch_executable_remove, SIGNAL(clicked()), this, SLOT(on_launch_executable_remove_pressed()));
 
     this->connect(this->ui->launch_options_list, SIGNAL(currentIndexChanged(int)), this,
                   SLOT(on_launch_options_list_activated(int)));
     this->connect(this->ui->launch_options_list->lineEdit(), SIGNAL(textEdited(QString)), this,
                   SLOT(on_launch_options_list_textEdited(QString)));
-    this->connect(this->ui->launch_options_append, SIGNAL(pressed()), this, SLOT(on_launch_options_append_pressed()));
-    this->connect(this->ui->launch_options_remove, SIGNAL(pressed()), this, SLOT(on_launch_options_remove_pressed()));
+    this->connect(this->ui->launch_options_append, SIGNAL(clicked()), this, SLOT(on_launch_options_append_pressed()));
+    this->connect(this->ui->launch_options_remove, SIGNAL(clicked()), this, SLOT(on_launch_options_remove_pressed()));
 
     this->connect(this->ui->launch_options_dir_edit, SIGNAL(textEdited(QString)), this,
                   SLOT(on_launch_options_dir_textEdited(QString)));
-    this->connect(this->ui->launch_options_dir_button, SIGNAL(pressed()), this, SLOT(on_launch_options_dir_pressed()));
+    this->connect(this->ui->launch_options_dir_button, SIGNAL(clicked()), this, SLOT(on_launch_options_dir_pressed()));
     this->connect(this->ui->launch_options_args_edit, SIGNAL(textEdited(QString)), this,
                   SLOT(on_launch_options_args_textEdited(QString)));
     this->connect(this->ui->launch_options_envs_edit, SIGNAL(textEdited(QString)), this,
                   SLOT(on_launch_options_envs_textEdited(QString)));
     this->connect(this->ui->launch_options_log_edit, SIGNAL(textEdited(QString)), this,
                   SLOT(on_launch_options_log_textEdited(QString)));
-    this->connect(this->ui->launch_options_log_button, SIGNAL(pressed()), this, SLOT(on_launch_options_log_pressed()));
+    this->connect(this->ui->launch_options_log_button, SIGNAL(clicked()), this, SLOT(on_launch_options_log_pressed()));
 
-    this->connect(this->ui->launch_clear_at_launch, SIGNAL(pressed()), this, SLOT(on_launch_clear_at_launch_pressed()));
-    this->connect(this->ui->launch_clear_log, SIGNAL(pressed()), this, SLOT(on_launch_clear_log_pressed()));
-    this->connect(this->ui->launch_button, SIGNAL(pressed()), this, SLOT(on_launch_button_pressed()));
+    this->connect(this->ui->launch_clear_at_launch, SIGNAL(toggled(bool)), this, SLOT(on_launch_clear_at_launch_toggled(bool)));
+    this->connect(this->ui->launch_clear_log, SIGNAL(clicked()), this, SLOT(on_launch_clear_log_pressed()));
+    this->connect(this->ui->launch_button, SIGNAL(clicked()), this, SLOT(on_launch_button_pressed()));
 
     const Configurator &configurator = Configurator::Get();
 
@@ -64,7 +64,7 @@ TabApplications::TabApplications(MainWindow &window, std::shared_ptr<Ui::MainWin
     // Whenever the control surpasses this block count, old blocks are discarded.
     // Note: We could make this a user configurable setting down the road should this be
     // insufficinet.
-    this->ui->launch_log_text->document()->setMaximumBlockCount(2048);
+    this->ui->launch_log_text->document()->setMaximumBlockCount(65536);
 
     this->ui->launch_button->setEnabled(!configurator.executables.Empty());
 
@@ -98,7 +98,12 @@ void TabApplications::UpdateUI(UpdateUIMode mode) {
 
 void TabApplications::CleanUI() { this->ResetLaunchApplication(); }
 
-bool TabApplications::EventFilter(QObject *target, QEvent *event) { return false; }
+bool TabApplications::EventFilter(QObject *target, QEvent *event) {
+    (void)target;
+    (void)event;
+
+    return false;
+}
 
 void TabApplications::on_launch_executable_search_pressed() {
     Configurator &configurator = Configurator::Get();
@@ -112,6 +117,7 @@ void TabApplications::on_launch_executable_search_pressed() {
         return;
     }
 
+    configurator.executables.RenameActiveExecutable(selected_path.toStdString());
     configurator.executables.GetActiveExecutable()->path = selected_path.toStdString();
 
     this->UpdateUI(UPDATE_REBUILD_UI);
@@ -341,8 +347,8 @@ void TabApplications::on_launch_options_log_pressed() {
     }
 }
 
-void TabApplications::on_launch_clear_at_launch_pressed() {
-    Configurator::Get().executables.launcher_clear_on_launch = ui->launch_clear_at_launch->isChecked();
+void TabApplications::on_launch_clear_at_launch_toggled(bool checked) {
+    Configurator::Get().executables.launcher_clear_on_launch = checked;
 }
 
 void TabApplications::on_launch_clear_log_pressed() {

--- a/vkconfig_gui/tab_applications.h
+++ b/vkconfig_gui/tab_applications.h
@@ -59,7 +59,7 @@ class TabApplications : public Tab {
     void on_launch_options_log_textEdited(const QString& text);
     void on_launch_options_log_pressed();
 
-    void on_launch_clear_at_launch_pressed();
+    void on_launch_clear_at_launch_toggled(bool checked);
     void on_launch_clear_log_pressed();
     void on_launch_button_pressed();
 

--- a/vkconfig_gui/tab_configurations.cpp
+++ b/vkconfig_gui/tab_configurations.cpp
@@ -44,7 +44,7 @@ TabConfigurations::TabConfigurations(MainWindow &window, std::shared_ptr<Ui::Mai
                   SLOT(on_configurations_executable_scope_currentIndexChanged(int)));
     this->connect(this->ui->configurations_executable_list, SIGNAL(currentIndexChanged(int)), this,
                   SLOT(on_configurations_executable_list_currentIndexChanged(int)));
-    this->connect(this->ui->configurations_executable_append, SIGNAL(pressed()), this,
+    this->connect(this->ui->configurations_executable_append, SIGNAL(clicked()), this,
                   SLOT(on_configurations_executable_append_pressed()));
 
     this->connect(this->ui->configurations_group_box_list, SIGNAL(toggled(bool)), this, SLOT(on_configurations_list_toggled(bool)));
@@ -116,7 +116,9 @@ TabConfigurations::~TabConfigurations() {
     settings.setValue("vkconfig3/mainwindow/splitter_settings_state", ui->splitter_settings->saveState());
 }
 
-void TabConfigurations::UpdateUI_Configurations(UpdateUIMode ui_update_mode) {
+void TabConfigurations::UpdateUI_Configurations(UpdateUIMode mode) {
+    (void)mode;
+
     Configurator &configurator = Configurator::Get();
 
     ui->configurations_executable_scope->blockSignals(true);
@@ -220,6 +222,8 @@ void TabConfigurations::UpdateUI_LoaderMessages() {
 }
 
 void TabConfigurations::UpdateUI_Layers(UpdateUIMode mode) {
+    (void)mode;
+
     ui->configurations_layers_list->blockSignals(true);
     ui->configurations_layers_list->clear();
 
@@ -272,6 +276,8 @@ void TabConfigurations::UpdateUI_Layers(UpdateUIMode mode) {
 }
 
 void TabConfigurations::UpdateUI_Settings(UpdateUIMode mode) {
+    (void)mode;
+
     Configurator &configurator = Configurator::Get();
 
     if (configurator.GetActiveConfiguration() == nullptr) {
@@ -582,10 +588,13 @@ void TabConfigurations::OnContextMenuImportClicked(ListItem *item) {
         return;
     }
 
-    const bool result = configurator.configurations.ImportConfiguration(configurator.layers, selected_path);
+    std::string configuration_name;
+    const bool result = configurator.configurations.ImportConfiguration(configurator.layers, selected_path, configuration_name);
 
     if (result) {
+        configurator.SetActiveConfigurationName(configuration_name);
         configurator.Override(OVERRIDE_AREA_ALL);
+
         this->UpdateUI_Configurations(UPDATE_REBUILD_UI);
         this->UpdateUI_LoaderMessages();
         this->UpdateUI_Layers(UPDATE_REBUILD_UI);

--- a/vkconfig_gui/tab_diagnostics.cpp
+++ b/vkconfig_gui/tab_diagnostics.cpp
@@ -30,7 +30,7 @@
 TabDiagnostics::TabDiagnostics(MainWindow &window, std::shared_ptr<Ui::MainWindow> ui) : Tab(TAB_DIAGNOSTIC, window, ui) {
     this->connect(this->ui->diagnostic_keep_running, SIGNAL(toggled(bool)), this, SLOT(on_diagnostic_keep_running_toggled(bool)));
     this->connect(this->ui->diagnostic_vk_home_text, SIGNAL(returnPressed()), this, SLOT(on_diagnostic_vk_home_text_pressed()));
-    this->connect(this->ui->diagnostic_vk_home_browse, SIGNAL(pressed()), this, SLOT(on_diagnostic_vk_home_browse_pressed()));
+    this->connect(this->ui->diagnostic_vk_home_browse, SIGNAL(clicked()), this, SLOT(on_diagnostic_vk_home_browse_pressed()));
 
     Configurator &configurator = Configurator::Get();
 
@@ -39,16 +39,18 @@ TabDiagnostics::TabDiagnostics(MainWindow &window, std::shared_ptr<Ui::MainWindo
     this->ui->diagnostic_keep_running->blockSignals(false);
 
     this->ui->diagnostic_vk_home_text->blockSignals(true);
-    this->ui->diagnostic_vk_home_text->setText(configurator.GetHomeSDK().RelativePath().c_str());
-    this->ui->diagnostic_vk_home_text->setToolTip(configurator.GetHomeSDK().AbsolutePath().c_str());
+    this->ui->diagnostic_vk_home_text->setText(::Get(Path::HOME).RelativePath().c_str());
+    this->ui->diagnostic_vk_home_text->setToolTip(::Get(Path::HOME).AbsolutePath().c_str());
     this->ui->diagnostic_vk_home_text->blockSignals(false);
+
+    this->ui->diagnostic_status_text->document()->setMaximumBlockCount(65536);
 
     this->widget_refresh = new ResizeButton(this->ui->diagnostic_group_box_refresh, 0);
     this->widget_refresh->setMinimumSize(24, 24);
     this->widget_refresh->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     this->widget_refresh->adjustSize();
     this->ui->diagnostic_group_box_refresh->installEventFilter(this->widget_refresh);
-    this->connect(this->widget_refresh, SIGNAL(pressed()), this, SLOT(on_diagnostic_refresh_pressed()));
+    this->connect(this->widget_refresh, SIGNAL(clicked()), this, SLOT(on_diagnostic_refresh_pressed()));
 
     this->widget_export = new ResizeButton(this->ui->diagnostic_group_box_refresh, 1);
     this->widget_export->setMinimumSize(24, 24);
@@ -57,7 +59,7 @@ TabDiagnostics::TabDiagnostics(MainWindow &window, std::shared_ptr<Ui::MainWindo
     this->widget_export->setToolTip("Saving the 'Vulkan Development Status' to a file...");
     this->widget_export->adjustSize();
     this->ui->diagnostic_group_box_refresh->installEventFilter(this->widget_export);
-    this->connect(this->widget_export, SIGNAL(pressed()), this, SLOT(on_diagnostic_export_pressed()));
+    this->connect(this->widget_export, SIGNAL(clicked()), this, SLOT(on_diagnostic_export_pressed()));
 
     this->widget_reset_hard = new ResizeButton(this->ui->diagnostic_group_box_settings, 0);
     this->widget_reset_hard->setMinimumSize(24, 24);
@@ -66,7 +68,7 @@ TabDiagnostics::TabDiagnostics(MainWindow &window, std::shared_ptr<Ui::MainWindo
     this->widget_reset_hard->setToolTip("Resetting Vulkan Configurator to default...");
     this->widget_reset_hard->adjustSize();
     this->ui->diagnostic_group_box_settings->installEventFilter(this->widget_reset_hard);
-    this->connect(this->widget_reset_hard, SIGNAL(pressed()), this, SLOT(on_diagnostic_reset_hard_pressed()));
+    this->connect(this->widget_reset_hard, SIGNAL(clicked()), this, SLOT(on_diagnostic_reset_hard_pressed()));
 
     this->on_diagnostic_refresh_pressed();
 }
@@ -82,7 +84,12 @@ void TabDiagnostics::UpdateUI(UpdateUIMode mode) {
 
 void TabDiagnostics::CleanUI() {}
 
-bool TabDiagnostics::EventFilter(QObject *target, QEvent *event) { return false; }
+bool TabDiagnostics::EventFilter(QObject *target, QEvent *event) {
+    (void)target;
+    (void)event;
+
+    return false;
+}
 
 void TabDiagnostics::on_diagnostic_keep_running_toggled(bool checked) {
     Configurator &configurator = Configurator::Get();
@@ -94,7 +101,7 @@ void TabDiagnostics::on_diagnostic_vk_home_text_pressed() {
 
     Path path(this->ui->diagnostic_vk_home_text->text().toStdString());
     if (path.Exists()) {
-        configurator.SetHomeSDK(this->ui->diagnostic_vk_home_text->text().toStdString().c_str());
+        ::SetHomePath(this->ui->diagnostic_vk_home_text->text().toStdString());
     } else {
         QMessageBox message;
         message.setIcon(QMessageBox::Critical);
@@ -102,11 +109,10 @@ void TabDiagnostics::on_diagnostic_vk_home_text_pressed() {
         message.setText(
             format("'%s' is not a valid, it doesn't exist.", this->ui->diagnostic_vk_home_text->text().toStdString().c_str())
                 .c_str());
-        message.setInformativeText(
-            format("Restoring the previous path '%s'.", configurator.GetHomeSDK().AbsolutePath().c_str()).c_str());
+        message.setInformativeText(format("Restoring the previous path '%s'.", ::Get(Path::HOME).AbsolutePath().c_str()).c_str());
         message.exec();
 
-        this->ui->diagnostic_vk_home_text->setText(configurator.GetHomeSDK().AbsolutePath().c_str());
+        this->ui->diagnostic_vk_home_text->setText(::Get(Path::HOME).AbsolutePath().c_str());
     }
 }
 
@@ -114,12 +120,12 @@ void TabDiagnostics::on_diagnostic_vk_home_browse_pressed() {
     Configurator &configurator = Configurator::Get();
     const QString selected_path = QFileDialog::getExistingDirectory(
         this->ui->diagnostic_vk_home_browse, "Select the Vulkan Home Default Working Folder (Set ${VK_HOME} value)...",
-        configurator.GetHomeSDK().AbsolutePath().c_str());
+        ::Get(Path::HOME).AbsolutePath().c_str());
 
     if (!selected_path.isEmpty()) {
         this->ui->diagnostic_vk_home_text->setText(selected_path);
 
-        configurator.SetHomeSDK(selected_path.toStdString());
+        ::SetHomePath(selected_path.toStdString());
     }
 }
 

--- a/vkconfig_gui/tab_documentation.cpp
+++ b/vkconfig_gui/tab_documentation.cpp
@@ -25,8 +25,13 @@ TabDocumentation::TabDocumentation(MainWindow &window, std::shared_ptr<Ui::MainW
 
 TabDocumentation::~TabDocumentation() {}
 
-void TabDocumentation::UpdateUI(UpdateUIMode mode) {}
+void TabDocumentation::UpdateUI(UpdateUIMode mode) { (void)mode; }
 
 void TabDocumentation::CleanUI() {}
 
-bool TabDocumentation::EventFilter(QObject *target, QEvent *event) { return false; }
+bool TabDocumentation::EventFilter(QObject *target, QEvent *event) {
+    (void)target;
+    (void)event;
+
+    return false;
+}

--- a/vkconfig_gui/tab_layers.cpp
+++ b/vkconfig_gui/tab_layers.cpp
@@ -41,8 +41,8 @@ TabLayers::TabLayers(MainWindow &window, std::shared_ptr<Ui::MainWindow> ui) : T
     this->ui->layers_path_lineedit->setText(configurator.layers.last_layers_path.RelativePath().c_str());
     this->ui->layers_validate_checkBox->setChecked(configurator.layers.validate_manifests);
 
-    this->connect(this->ui->layers_browse_button, SIGNAL(pressed()), this, SLOT(on_layers_browse_pressed()));
-    this->connect(this->ui->layers_reload_button, SIGNAL(pressed()), this, SLOT(on_layers_reload_pressed()));
+    this->connect(this->ui->layers_browse_button, SIGNAL(clicked()), this, SLOT(on_layers_browse_pressed()));
+    this->connect(this->ui->layers_reload_button, SIGNAL(clicked()), this, SLOT(on_layers_reload_pressed()));
     this->connect(this->ui->layers_path_lineedit, SIGNAL(returnPressed()), this, SLOT(on_layers_append_pressed()));
     this->connect(this->ui->layers_validate_checkBox, SIGNAL(toggled(bool)), this, SLOT(on_layers_validate_checkBox_toggled(bool)));
 }
@@ -204,7 +204,7 @@ void TabLayers::LoadLayersManifest(const QString &selected_path) {
 
         this->on_layers_reload_pressed();
 
-        configurator.layers.UpdatePathEnabled(info);
+        configurator.layers.UpdatePathEnabled(info, LAYERS_PATHS_GUI);
         this->UpdateUI_LayersPaths(UPDATE_REBUILD_UI);
     }
 }

--- a/vkconfig_gui/vkconfig.pro
+++ b/vkconfig_gui/vkconfig.pro
@@ -7,6 +7,7 @@ CONFIG += sdk_no_version_check
 
 INCLUDEPATH += ../external/Vulkan-Headers/include
 INCLUDEPATH += ../Vulkan-Headers/include
+INCLUDEPATH += ../external/Debug/64/Vulkan-Headers/include
 
 # Ignore JSON validation
 DEFINES += JSON_VALIDATION_OFF

--- a/vkconfig_gui/widget_layer_version.cpp
+++ b/vkconfig_gui/widget_layer_version.cpp
@@ -24,15 +24,12 @@
 
 LayerVersionComboBox::LayerVersionComboBox(QWidget *parent) : QComboBox(parent), parent(parent) {
     this->setObjectName(QString::fromUtf8("layer_version_combobox"));
-    this->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    this->setMinimumHeight(24);
-    this->adjustSize();
     this->connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(on_layer_version_combobox_currentIndexChanged(int)));
 }
 
 void LayerVersionComboBox::Init(const Parameter &parameter, const std::vector<Path> &layer_versions) {
     const Configurator &configurator = Configurator::Get();
-    const Layer *layer_select = configurator.layers.Find(parameter.key, parameter.api_version);
+    const Layer *layer_select = configurator.layers.FindFromManifest(parameter.manifest);
     const Layer *layer_latest = configurator.layers.Find(parameter.key, Version::LATEST);
 
     this->blockSignals(true);
@@ -71,6 +68,8 @@ void LayerVersionComboBox::Init(const Parameter &parameter, const std::vector<Pa
         this->setToolTip(layer_select->manifest_path.AbsolutePath().c_str());
     }
 
+    this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
+    this->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     this->adjustSize();
 }
 

--- a/vkconfig_gui/widget_setting_list.cpp
+++ b/vkconfig_gui/widget_setting_list.cpp
@@ -70,7 +70,7 @@ WidgetSettingList::WidgetSettingList(QTreeWidget *tree, QTreeWidgetItem *item, c
     this->add_button->setText("+");
     this->add_button->setFont(this->tree->font());
 
-    this->connect(this->add_button, SIGNAL(pressed()), this, SLOT(OnElementAppended()), Qt::QueuedConnection);
+    this->connect(this->add_button, SIGNAL(clicked()), this, SLOT(OnElementAppended()), Qt::QueuedConnection);
 
     std::sort(value.begin(), value.end());
     this->data().value = value;

--- a/vkconfig_gui/widget_tab_configurations_layer.cpp
+++ b/vkconfig_gui/widget_tab_configurations_layer.cpp
@@ -33,7 +33,6 @@ ConfigurationLayerWidget::ConfigurationLayerWidget(TabConfigurations *tab, const
     const Layer *layer = configurator.layers.Find(parameter.key, parameter.api_version);
 
     this->layer_state = new ComboBox(this);
-    this->layer_state->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
     const int first = parameter.builtin == LAYER_BUILTIN_UNORDERED ? LAYER_CONTROL_UNORDERED_FIRST : LAYER_CONTROL_FIRST;
     const int last = parameter.builtin == LAYER_BUILTIN_UNORDERED ? LAYER_CONTROL_UNORDERED_LAST : LAYER_CONTROL_LAST;
@@ -94,6 +93,10 @@ ConfigurationLayerWidget::ConfigurationLayerWidget(TabConfigurations *tab, const
     } else if (!parameter.manifest.Empty()) {
         this->setToolTip(parameter.manifest.AbsolutePath().c_str());
     }
+
+    this->layer_state->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
+    this->layer_state->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    this->layer_state->adjustSize();
 }
 
 bool ConfigurationLayerWidget::eventFilter(QObject *target, QEvent *event) {

--- a/vkconfig_gui/widget_tab_configurations_layer.h
+++ b/vkconfig_gui/widget_tab_configurations_layer.h
@@ -43,7 +43,7 @@ class ConfigurationLayerWidget : public QLabel {
     std::string layer_name;
 
    protected:
-    bool eventFilter(QObject *target, QEvent *event);
+    bool eventFilter(QObject *target, QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
 
    public Q_SLOTS:

--- a/vkconfig_gui/widget_tab_layers_path.cpp
+++ b/vkconfig_gui/widget_tab_layers_path.cpp
@@ -25,7 +25,8 @@
 #include <QFileDialog>
 #include <QMessageBox>
 
-LayersPathWidget::LayersPathWidget(const LayersPathInfo& path_info, LayersPaths layers_path) : path_info(path_info) {
+LayersPathWidget::LayersPathWidget(const LayersPathInfo& path_info, LayersPaths layers_path)
+    : path_info(path_info), layers_path(layers_path) {
     this->setChecked(this->path_info.enabled);
 
     this->buttom_remove = new QPushButton(this);
@@ -35,8 +36,8 @@ LayersPathWidget::LayersPathWidget(const LayersPathInfo& path_info, LayersPaths 
     this->buttom_remove->setEnabled(layers_path == LAYERS_PATHS_GUI);
     this->buttom_remove->show();
 
-    this->setText(path_info.path.RelativePath().c_str());
-    this->setToolTip(GetLabel(layers_path));
+    this->setText(format("[%s] %s", GetLabel(layers_path), path_info.path.RelativePath().c_str()).c_str());
+    this->setToolTip(path_info.path.AbsolutePath().c_str());
 
     this->connect(this, SIGNAL(toggled(bool)), this, SLOT(on_toggled(bool)));
     this->connect(this->buttom_remove, SIGNAL(clicked(bool)), this, SLOT(on_buttom_remove_clicked(bool)));
@@ -53,6 +54,8 @@ void LayersPathWidget::resizeEvent(QResizeEvent* event) {
 }
 
 void LayersPathWidget::on_buttom_remove_clicked(bool checked) {
+    (void)checked;
+
     Configurator& configurator = Configurator::Get();
 
     std::vector<ReferencedLayer> referenced_layers;
@@ -111,7 +114,7 @@ void LayersPathWidget::on_toggled(bool checked) {
         this->path_info.enabled = checked;
 
         Configurator& configurator = Configurator::Get();
-        configurator.layers.UpdatePathEnabled(this->path_info);
+        configurator.layers.UpdatePathEnabled(this->path_info, this->layers_path);
 
         itemChanged();
     }

--- a/vkconfig_gui/widget_tab_layers_path.h
+++ b/vkconfig_gui/widget_tab_layers_path.h
@@ -44,6 +44,7 @@ class LayersPathWidget : public QCheckBox {
     void itemChanged();
 
    public:
+    LayersPaths layers_path;
     LayersPathInfo path_info;
     QPushButton *buttom_remove = nullptr;
 };


### PR DESCRIPTION
- Fix VK_HOME UI
- Fix rename executable
- Fix clicked event on buttons
- Fix layers paths checking when there are multiple time the same paths 
- Fix invalid manifest path that doesn't match the seelcted version
- Fix clear log at launch not saved
- Fix vkconfig layer --list and --list--verbose
- Increased UI log sizes
- Fix keep running on exit
- Fix command line override
- Fix unknown preset value crash
- Fix keep Vulkan Configurator running in system tray