### PR TITLE
vkconfig3: Redesign reset to default

### DIFF
--- a/vkconfig_cmd/main.cpp
+++ b/vkconfig_cmd/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
         return -1;
     }
 
-    InitSignals();
+    ::InitSignals();
 
     switch (command_line.command) {
         case COMMAND_SHOW_USAGE: {

--- a/vkconfig_cmd/main_doc.cpp
+++ b/vkconfig_cmd/main_doc.cpp
@@ -82,7 +82,7 @@ int run_doc(const CommandLine& command_line) {
     assert(command_line.error == ERROR_NONE);
 
     Configurator& configurator = Configurator::Get();
-    configurator.Init(Configurator::CMD);
+    configurator.Init();
 
     switch (command_line.command_doc_arg) {
         case COMMAND_DOC_HTML: {

--- a/vkconfig_cmd/main_layers.cpp
+++ b/vkconfig_cmd/main_layers.cpp
@@ -100,7 +100,7 @@ int run_layers(const CommandLine& command_line) {
     assert(command_line.error == ERROR_NONE);
 
     Configurator& configurator = Configurator::Get();
-    configurator.Init(Configurator::CMD);
+    configurator.Init();
 
     switch (command_line.command_layers_arg) {
         case COMMAND_LAYERS_OVERRIDE: {

--- a/vkconfig_cmd/main_reset.cpp
+++ b/vkconfig_cmd/main_reset.cpp
@@ -26,7 +26,7 @@
 
 static int RunReset(int argc, char* argv[], bool hard) {
     Configurator& configurator = Configurator::Get();
-    configurator.Init(Configurator::CMD);
+    configurator.Init();
     configurator.Reset(hard);
 
     return 0;

--- a/vkconfig_core/configuration_manager.cpp
+++ b/vkconfig_core/configuration_manager.cpp
@@ -55,8 +55,6 @@ bool ConfigurationManager::Load(const QJsonObject &json_root_object) {
         }
     }
 
-    this->LoadAllConfigurations(Configurator::Get().layers);
-
     return true;
 }
 
@@ -77,17 +75,6 @@ bool ConfigurationManager::Save(QJsonObject &json_root_object) const {
     json_root_object.insert("configurations", json_configurations_object);
 
     return true;
-}
-
-void ConfigurationManager::Reset() {
-    this->removed_built_in_configuration.clear();
-    this->available_configurations.clear();
-    this->last_path_import_config = Get(Path::HOME);
-    this->last_path_export_config = Get(Path::HOME);
-    this->last_path_export_settings = Get(Path::HOME) + "/vK_layer_settings.txt";
-
-    this->LoadDefaultConfigurations(Configurator::Get().layers);
-    this->SortConfigurations();
 }
 
 std::string ConfigurationManager::Log() const {
@@ -239,14 +226,14 @@ bool ConfigurationManager::HasFile(const Configuration &configuration) const {
 }
 
 void ConfigurationManager::RemoveConfigurationFiles() {
-    const std::vector<Path> &configuration_files = CollectFilePaths(Get(Path::CONFIGS));
+    const std::vector<Path> &configuration_files = ::CollectFilePaths(Get(Path::CONFIGS));
     for (std::size_t i = 0, n = configuration_files.size(); i < n; ++i) {
         configuration_files[i].Remove();
     }
 }
 
 void ConfigurationManager::RemoveConfigurationFile(const std::string &key) {
-    const std::vector<Path> &configuration_files = CollectFilePaths(Get(Path::CONFIGS));
+    const std::vector<Path> &configuration_files = ::CollectFilePaths(Get(Path::CONFIGS));
     for (std::size_t j = 0, o = configuration_files.size(); j < o; ++j) {
         if (configuration_files[j].Basename() == key) {
             configuration_files[j].Remove();
@@ -257,7 +244,7 @@ void ConfigurationManager::RemoveConfigurationFile(const std::string &key) {
 void ConfigurationManager::RemoveConfiguration(const std::string &configuration_name) {
     assert(!configuration_name.empty());
 
-    RemoveConfigurationFile(configuration_name.c_str());
+    this->RemoveConfigurationFile(configuration_name.c_str());
 
     // Update the configuration in the list
     std::vector<Configuration> updated_configurations;

--- a/vkconfig_core/configuration_manager.h
+++ b/vkconfig_core/configuration_manager.h
@@ -39,7 +39,6 @@ class ConfigurationManager : public Serialize {
 
     bool Load(const QJsonObject& json_root_object) override;
     bool Save(QJsonObject& json_root_object) const override;
-    void Reset() override;
     std::string Log() const override;
 
     void LoadAllConfigurations(const LayerManager& layers);

--- a/vkconfig_core/configurator.h
+++ b/vkconfig_core/configurator.h
@@ -41,10 +41,8 @@ enum EnabledUI {
     ENABLE_UI_SETTINGS,
 };
 
-class Configurator : public Serialize {
+class Configurator {
    public:
-    enum Mode { CMD, GUI };
-
     struct LayersSettings {
         std::string configuration_name;
         Path executable_path;
@@ -68,13 +66,12 @@ class Configurator : public Serialize {
     };
 
     static Configurator& Get();
-    bool Init(Mode mode = GUI);
+    bool Init();
 
    public:
-    bool Load(const QJsonObject& json_root_object) override;
-    bool Save(QJsonObject& json_root_object) const override;
-    void Reset() override;
-    std::string Log() const override;
+    bool Load();
+    bool Save() const;
+    std::string Log() const;
     std::string LogConfiguration(const std::string& configuration_key) const;
 
     bool Surrender(OverrideArea override_area);
@@ -124,12 +121,12 @@ class Configurator : public Serialize {
                              std::vector<LoaderSettings>& loader_settings_array) const;
 
    public:
-    Mode mode;
     LayerManager layers;
     ConfigurationManager configurations;
     ExecutableManager executables;
     VulkanSystemInfo vulkan_system_info;
 
+    bool reset_hard = false;
     bool has_crashed = false;
     TabType active_tab = TAB_CONFIGURATIONS;
     bool advanced = true;

--- a/vkconfig_core/configurator_signal.cpp
+++ b/vkconfig_core/configurator_signal.cpp
@@ -27,13 +27,8 @@
 void SurrenderConfiguration(int signal) {
     (void)signal;
 
-    Configurator& configurator = Configurator::Get();
-
-    // Indicate that Vulkan Configurator crashed to handle it on next run
-    configurator.has_crashed = true;
-
     // Delete the layers configurations files
-    configurator.Surrender(OVERRIDE_AREA_ALL);
+    Configurator::Get().Surrender(OVERRIDE_AREA_ALL);
 }
 
 void InitSignals() {

--- a/vkconfig_core/executable_manager.cpp
+++ b/vkconfig_core/executable_manager.cpp
@@ -43,19 +43,9 @@ static const DefaultExecutable defaults_executables[] = {
     {"vkcube", "/vkcube", "--suppress_popups", "VkCube launcher options"},
     {"vkcubepp", "/vkcubepp", "--suppress_popups", "VkCubepp launcher options"}};
 
-void ExecutableManager::Reset() {
-    this->data = this->CreateDefaultExecutables();
-    this->active_executable = this->data[0].path;
-}
-
 std::string ExecutableManager::Log() const {
     std::string log;
     return log;
-}
-
-void ExecutableManager::Clear() {
-    this->data.clear();
-    this->active_executable.Clear();
 }
 
 bool ExecutableManager::Empty() const { return this->data.empty(); }
@@ -128,6 +118,11 @@ bool ExecutableManager::Load(const QJsonObject& json_root_object) {
     }
 
     return true;
+}
+
+void ExecutableManager::Reset() {
+    this->data = this->CreateDefaultExecutables();
+    this->active_executable = this->data[0].path;
 }
 
 bool ExecutableManager::Save(QJsonObject& json_root_object) const {

--- a/vkconfig_core/executable_manager.h
+++ b/vkconfig_core/executable_manager.h
@@ -30,12 +30,11 @@ class ExecutableManager : public Serialize {
    public:
     bool Load(const QJsonObject& json_root_object) override;
     bool Save(QJsonObject& json_root_object) const override;
-    void Reset() override;
     std::string Log() const override;
 
-    void Clear();
     bool Empty() const;
     std::size_t Size() const;
+    void Reset();
 
     void SetActiveExecutable(int executable_index);
     int GetActiveExecutableIndex() const;

--- a/vkconfig_core/layer_manager.cpp
+++ b/vkconfig_core/layer_manager.cpp
@@ -137,9 +137,9 @@ static LayersPathInfo *FindPathInfo(std::array<std::vector<LayersPathInfo>, LAYE
     return nullptr;
 }
 
-bool LayerManager::Load(const QJsonObject &json_root_object) {
-    this->InitSystemPaths();
+LayerManager::LayerManager() { this->InitSystemPaths(); }
 
+bool LayerManager::Load(const QJsonObject &json_root_object) {
     // LAYERS_PATHS_GUI
     if (json_root_object.value("layers") != QJsonValue::Undefined) {
         const QJsonObject &json_layers_object = json_root_object.value("layers").toObject();
@@ -208,13 +208,6 @@ bool LayerManager::Save(QJsonObject &json_root_object) const {
     json_root_object.insert("layers", json_layers_object);
 
     return true;
-}
-
-void LayerManager::Reset() {
-    this->InitSystemPaths();
-    this->LoadAllInstalledLayers();
-    this->last_layers_path = Get(Path::HOME);
-    this->validate_manifests = false;
 }
 
 std::string LayerManager::Log() const {
@@ -292,6 +285,9 @@ void LayerManager::InitSystemPaths() {
 
     // LAYERS_PATHS_EXPLICIT_ENV_ADD: VK_ADD_LAYER_PATH env variables
     this->paths[LAYERS_PATHS_EXPLICIT_ENV_ADD] = GetEnvVariablePaths("VK_ADD_LAYER_PATH", LAYER_TYPE_EXPLICIT);
+
+    // LAYERS_PATHS_GUI
+    this->paths[LAYERS_PATHS_GUI].clear();
 
     // LAYERS_PATHS_SDK
     this->paths[LAYERS_PATHS_SDK].clear();

--- a/vkconfig_core/layer_manager.h
+++ b/vkconfig_core/layer_manager.h
@@ -31,9 +31,10 @@
 
 class LayerManager : public Serialize {
    public:
+    LayerManager();
+
     bool Load(const QJsonObject& json_root_object) override;
     bool Save(QJsonObject& json_root_object) const override;
-    void Reset() override;
     std::string Log() const override;
 
     void Clear();

--- a/vkconfig_core/path.cpp
+++ b/vkconfig_core/path.cpp
@@ -221,15 +221,30 @@ Path operator+(const Path& path, const std::string& extend) { return Path(path.d
 
 bool operator<(const Path& a, const Path& b) { return a.RelativePath() < b.RelativePath(); }
 
-static Path VK_HOME_PATH = QDir().homePath().toStdString() + "/VulkanSDK";
+static Path VK_DEFAULT_HOME_PATH = QDir().homePath().toStdString() + "/VulkanSDK";
+static Path VK_CURRENT_HOME_PATH = VK_DEFAULT_HOME_PATH;
 
-void SetHomePath(const Path& path) { ::VK_HOME_PATH = path; }
+void SetHomePath(const Path& path) { ::VK_CURRENT_HOME_PATH = path; }
 
 static const Path GetHomePath() {
     Path path = qgetenv("VK_HOME").toStdString();
 
     if (path.Empty()) {  // Default path
-        path = VK_HOME_PATH;
+        path = VK_CURRENT_HOME_PATH;
+    }
+
+    if (!path.Exists()) {
+        path.Create();
+    }
+
+    return path;
+}
+
+static const Path GetDefaultHomePath() {
+    Path path = qgetenv("VK_HOME").toStdString();
+
+    if (path.Empty()) {  // Default path
+        path = VK_DEFAULT_HOME_PATH;
     }
 
     if (!path.Exists()) {
@@ -403,6 +418,8 @@ Path Get(Path::Builtin path) {
             return "";
         case Path::HOME:
             return ::GetHomePath();
+        case Path::DEFAULT_HOME:
+            return ::GetDefaultHomePath();
         case Path::APPDATA:
             return ::GetAppDataPath();
         case Path::INIT:

--- a/vkconfig_core/path.h
+++ b/vkconfig_core/path.h
@@ -28,6 +28,7 @@ class Path {
    public:
     enum Builtin {
         HOME,  // Vulkan SDK user directory
+        DEFAULT_HOME,
         APPDATA,
         INIT,
         CONFIGS,

--- a/vkconfig_core/serialization.h
+++ b/vkconfig_core/serialization.h
@@ -25,6 +25,5 @@
 struct Serialize {
     virtual bool Load(const QJsonObject& json_root_object) = 0;
     virtual bool Save(QJsonObject& json_root_object) const = 0;
-    virtual void Reset() = 0;
     virtual std::string Log() const = 0;
 };

--- a/vkconfig_core/test/test_layer_manager.cpp
+++ b/vkconfig_core/test/test_layer_manager.cpp
@@ -105,9 +105,6 @@ TEST(test_layer_manager, reset) {
 
     layer_manager.Clear();
     EXPECT_TRUE(layer_manager.Empty());
-
-    layer_manager.Reset();
-    EXPECT_TRUE(layer_manager.Size() < Count);
 }
 
 TEST(test_layer_manager, find_single) {

--- a/vkconfig_gui/main.cpp
+++ b/vkconfig_gui/main.cpp
@@ -75,13 +75,22 @@ int main(int argc, char* argv[]) {
         return -1;
     }
 
-    if (!configurator.Init()) {
-        return -1;
+    const bool init = configurator.Init();
+    int result = 0;
+
+    if (init) {
+        // The main GUI is driven here
+        MainWindow main_window;
+        main_window.show();
+
+        result = app.exec();
     }
 
-    // The main GUI is driven here
-    MainWindow main_window;
-    main_window.show();
+    if (configurator.reset_hard) {
+        singleton.ReleaseInstance();
 
-    return app.exec();
+        QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
+    }
+
+    return result;
 }

--- a/vkconfig_gui/mainwindow.cpp
+++ b/vkconfig_gui/mainwindow.cpp
@@ -245,8 +245,6 @@ void MainWindow::toolsResetToDefault(bool checked) {
 
     Configurator &configurator = Configurator::Get();
     configurator.Reset(true);
-
-    this->UpdateUI(UPDATE_REBUILD_UI);
 }
 
 void MainWindow::StartTool(Tool tool) {

--- a/vkconfig_gui/tab_configurations.cpp
+++ b/vkconfig_gui/tab_configurations.cpp
@@ -351,7 +351,10 @@ void TabConfigurations::UpdateUI(UpdateUIMode ui_update_mode) {
     this->ui->configurations_group_box_list->blockSignals(true);
     this->ui->configurations_group_box_list->setEnabled(scope != EXECUTABLE_NONE);
     this->ui->configurations_group_box_list->setCheckable(enabled_executable);
-    this->ui->configurations_group_box_list->setChecked(configurator.executables.GetActiveExecutable()->enabled);
+    const Executable *executable = configurator.executables.GetActiveExecutable();
+    if (executable != nullptr) {
+        this->ui->configurations_group_box_list->setChecked(executable->enabled);
+    }
     this->ui->configurations_group_box_list->blockSignals(false);
 }
 

--- a/vkconfig_gui/tab_diagnostics.cpp
+++ b/vkconfig_gui/tab_diagnostics.cpp
@@ -34,15 +34,6 @@ TabDiagnostics::TabDiagnostics(MainWindow &window, std::shared_ptr<Ui::MainWindo
 
     Configurator &configurator = Configurator::Get();
 
-    this->ui->diagnostic_keep_running->blockSignals(true);
-    this->ui->diagnostic_keep_running->setChecked(configurator.GetUseSystemTray());
-    this->ui->diagnostic_keep_running->blockSignals(false);
-
-    this->ui->diagnostic_vk_home_text->blockSignals(true);
-    this->ui->diagnostic_vk_home_text->setText(::Get(Path::HOME).RelativePath().c_str());
-    this->ui->diagnostic_vk_home_text->setToolTip(::Get(Path::HOME).AbsolutePath().c_str());
-    this->ui->diagnostic_vk_home_text->blockSignals(false);
-
     this->ui->diagnostic_status_text->document()->setMaximumBlockCount(65536);
 
     this->widget_refresh = new ResizeButton(this->ui->diagnostic_group_box_refresh, 0);
@@ -80,6 +71,17 @@ void TabDiagnostics::UpdateUI(UpdateUIMode mode) {
 
     this->status.clear();
     this->on_diagnostic_refresh_pressed();
+
+    Configurator &configurator = Configurator::Get();
+
+    this->ui->diagnostic_keep_running->blockSignals(true);
+    this->ui->diagnostic_keep_running->setChecked(configurator.GetUseSystemTray());
+    this->ui->diagnostic_keep_running->blockSignals(false);
+
+    this->ui->diagnostic_vk_home_text->blockSignals(true);
+    this->ui->diagnostic_vk_home_text->setText(::Get(Path::HOME).RelativePath().c_str());
+    this->ui->diagnostic_vk_home_text->setToolTip(::Get(Path::HOME).AbsolutePath().c_str());
+    this->ui->diagnostic_vk_home_text->blockSignals(false);
 }
 
 void TabDiagnostics::CleanUI() {}
@@ -140,8 +142,8 @@ void TabDiagnostics::on_diagnostic_reset_hard_pressed() {
     message.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     message.setDefaultButton(QMessageBox::No);
     if (message.exec() == QMessageBox::Yes) {
-        Configurator &configurator = Configurator::Get();
-        configurator.Reset(true);
+        Configurator::Get().Reset(true);
+        qApp->quit();
     }
 }
 


### PR DESCRIPTION
The new approach, delete all the saved files and registry entries and restart vkconfig3 that will setup up itself like on first install.