### PR TITLE
vkconfig3: beta bugfixing

### DIFF
--- a/vkconfig_core/configurations/3.0.0/Portability.json
+++ b/vkconfig_core/configurations/3.0.0/Portability.json
@@ -31,7 +31,7 @@
                     {
                         "key": "profile_dirs",
                         "type": "LOAD_FOLDER",
-                        "value": "${VULKAN_CONTENT}/VK_LAYER_KHRONOS_profiles"
+                        "value": "${VULKAN_PROFILES}"
                     },
                     {
                         "key": "profile_name",

--- a/vkconfig_core/configurator.cpp
+++ b/vkconfig_core/configurator.cpp
@@ -574,7 +574,11 @@ std::string Configurator::Log() const {
     log += format("%s %s - %s:\n", VKCONFIG_NAME, Version::VKCONFIG.str().c_str(), GetBuildDate().c_str());
     log += format(" - Build: %s %s\n", GetLabel(VKC_PLATFORM), build.c_str());
     log += format(" - Vulkan API version: %s\n", Version::VKHEADER.str().c_str());
-    log += format(" - ${VULKAN_SDK}: %s\n", ::Get(Path::SDK).AbsolutePath().c_str());
+    if (::Get(Path::SDK).Empty()) {
+        log += " - ${VULKAN_SDK}: unset\n";
+    } else {
+        log += format(" - ${VULKAN_SDK}: %s\n", ::Get(Path::SDK).AbsolutePath().c_str());
+    }
     log += "\n";
 
     log += format("%s Settings:\n", VKCONFIG_NAME);
@@ -620,6 +624,8 @@ std::string Configurator::Log() const {
     }
 
     log += format(" - Use system tray: %s\n", this->use_system_tray ? "true" : "false");
+    log += format(" - ${VULKAN_BIN}: %s\n", ::Get(Path::BIN).AbsolutePath().c_str());
+    log += format(" - ${VULKAN_PROFILES}: %s\n", ::Get(Path::PROFILES).AbsolutePath().c_str());
     log += format(" - ${VK_HOME}: %s\n", ::Get(Path::HOME).AbsolutePath().c_str());
     log += "\n";
 

--- a/vkconfig_core/executable.cpp
+++ b/vkconfig_core/executable.cpp
@@ -102,7 +102,7 @@ DefaultPath GetDefaultExecutablePath(const std::string& executable_key) {
     DefaultPath default_path{"." + executable_name, "."};
 
     // Using VULKAN_SDK environement variable
-    const Path env = ::Get(Path::SDK_BIN);
+    const Path env = ::Get(Path::BIN);
     if (!env.Empty()) {
         const Path search_path(env + DEFAULT_PATH + executable_name.c_str());
         if (search_path.Exists()) {

--- a/vkconfig_core/executable_manager.cpp
+++ b/vkconfig_core/executable_manager.cpp
@@ -40,8 +40,14 @@ const char* GetExecutableFilter() {
 }
 
 static const DefaultExecutable defaults_executables[] = {
-    {"vkcube", "/vkcube", "--suppress_popups", "VkCube launcher options"},
-    {"vkcubepp", "/vkcubepp", "--suppress_popups", "VkCubepp launcher options"}};
+    {"vkcube", "/vkcube", "--suppress_popups", "vkcube launcher options"},
+    {"vkcubepp", "/vkcubepp", "--suppress_popups", "vkcubepp launcher options"},
+#if VKC_ENV == VKC_ENV_WIN32
+    {"vulkaninfoSDK", "/vulkaninfoSDK", "--json", "vulkaninfo launcher options"},
+#else
+    {"vulkaninfo", "/vulkaninfo", "--json", "vulkaninfo launcher options"},
+#endif
+};
 
 std::string ExecutableManager::Log() const {
     std::string log;

--- a/vkconfig_core/layer_manager.cpp
+++ b/vkconfig_core/layer_manager.cpp
@@ -58,24 +58,42 @@ std::vector<LayersPathInfo> GetImplicitLayerPaths() {
         LoadRegistrySystemLayers("HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Class\\...\\VulkanImplicitLayers");
     result.insert(result.begin(), drivers_registry_paths.begin(), drivers_registry_paths.end());
 #else
-    static const char *LAYERS_PATHS[] = {
-        "/usr/local/etc/vulkan/implicit_layer.d",  // Not used on macOS, okay to just ignore
-        "/usr/local/share/vulkan/implicit_layer.d",
-        "/etc/vulkan/implicit_layer.d",
-        "/usr/share/vulkan/implicit_layer.d",
-        ".local/share/vulkan/implicit_layer.d",
+    std::vector<std::string> paths;
+    if (VKC_PLATFORM == PLATFORM_MACOS) {
+        static const char *LAYERS_PATHS[] = {
+            "/usr/local/share/vulkan/implicit_layer.d",
+            ".local/share/vulkan/implicit_layer.d",
+        };
+
+        for (std::size_t i = 0, n = std::size(LAYERS_PATHS); i < n; ++i) {
+            paths.push_back(LAYERS_PATHS[i]);
+        }
+    } else {
+        static const char *LAYERS_PATHS[] = {
+            "/usr/local/etc/vulkan/implicit_layer.d",
+            "/usr/local/share/vulkan/implicit_layer.d",
+            "/etc/vulkan/implicit_layer.d",
+            "/usr/share/vulkan/implicit_layer.d",
+            ".local/share/vulkan/implicit_layer.d",
+#ifdef _DEBUG
 #ifdef INSTALL_FULL_DATAROOTDIR
-        INSTALL_FULL_DATAROOTDIR "/vulkan/implicit_layer.d",
+            INSTALL_FULL_DATAROOTDIR "/vulkan/implicit_layer.d",
 #endif
 #ifdef INSTALL_FULL_SYSCONFDIR
-        INSTALL_FULL_SYSCONFDIR "/vulkan/implicit_layer.d",
+            INSTALL_FULL_SYSCONFDIR "/vulkan/implicit_layer.d",
 #endif
-    };
+#endif  //_DEBUG
+        };
 
-    for (std::size_t i = 0, n = std::size(LAYERS_PATHS); i < n; ++i) {
+        for (std::size_t i = 0, n = std::size(LAYERS_PATHS); i < n; ++i) {
+            paths.push_back(LAYERS_PATHS[i]);
+        }
+    }
+
+    for (std::size_t i = 0, n = paths.size(); i < n; ++i) {
         LayersPathInfo info;
         info.type = LAYER_TYPE_IMPLICIT;
-        info.path = LAYERS_PATHS[i];
+        info.path = paths[i];
         result.push_back(info);
     }
 #endif
@@ -100,24 +118,42 @@ std::vector<LayersPathInfo> GetExplicitLayerPaths() {
         LoadRegistrySystemLayers("HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Class\\...\\VulkanExplicitLayers");
     result.insert(result.begin(), drivers_registry_paths.begin(), drivers_registry_paths.end());
 #else
-    static const char *LAYERS_PATHS[] = {
-        "/usr/local/etc/vulkan/explicit_layer.d",  // Not used on macOS, okay to just ignore
-        "/usr/local/share/vulkan/explicit_layer.d",
-        "/etc/vulkan/explicit_layer.d",
-        "/usr/share/vulkan/explicit_layer.d",
-        ".local/share/vulkan/explicit_layer.d",
+    std::vector<std::string> paths;
+    if (VKC_PLATFORM == PLATFORM_MACOS) {
+        static const char *LAYERS_PATHS[] = {
+            "/usr/local/share/vulkan/explicit_layer.d",
+            ".local/share/vulkan/explicit_layer.d",
+        };
+
+        for (std::size_t i = 0, n = std::size(LAYERS_PATHS); i < n; ++i) {
+            paths.push_back(LAYERS_PATHS[i]);
+        }
+    } else {
+        static const char *LAYERS_PATHS[] = {
+            "/usr/local/etc/vulkan/explicit_layer.d",
+            "/usr/local/share/vulkan/explicit_layer.d",
+            "/etc/vulkan/explicit_layer.d",
+            "/usr/share/vulkan/explicit_layer.d",
+            ".local/share/vulkan/explicit_layer.d",
+#ifdef _DEBUG
 #ifdef INSTALL_FULL_DATAROOTDIR
-        INSTALL_FULL_DATAROOTDIR "/vulkan/explicit_layer.d",
+            INSTALL_FULL_DATAROOTDIR "/vulkan/explicit_layer.d",
 #endif
 #ifdef INSTALL_FULL_SYSCONFDIR
-        INSTALL_FULL_SYSCONFDIR "/vulkan/explicit_layer.d",
+            INSTALL_FULL_SYSCONFDIR "/vulkan/explicit_layer.d",
 #endif
-    };
+#endif  //_DEBUG
+        };
 
-    for (std::size_t i = 0, n = std::size(LAYERS_PATHS); i < n; ++i) {
+        for (std::size_t i = 0, n = std::size(LAYERS_PATHS); i < n; ++i) {
+            paths.push_back(LAYERS_PATHS[i]);
+        }
+    }
+
+    for (std::size_t i = 0, n = paths.size(); i < n; ++i) {
         LayersPathInfo info;
         info.type = LAYER_TYPE_EXPLICIT;
-        info.path = LAYERS_PATHS[i];
+        info.path = paths[i];
         result.push_back(info);
     }
 #endif
@@ -293,7 +329,7 @@ void LayerManager::InitSystemPaths() {
     this->paths[LAYERS_PATHS_SDK].clear();
     {
         LayersPathInfo info;
-        info.path = ::Get(Path::SDK_BIN);
+        info.path = ::Get(Path::SDK_EXPLICIT_LAYERS);
         info.enabled = true;
         this->paths[LAYERS_PATHS_SDK].push_back(info);
     }

--- a/vkconfig_core/path.h
+++ b/vkconfig_core/path.h
@@ -34,10 +34,11 @@ class Path {
         CONFIGS,
         LAYERS_SETTINGS,
         LOADER_SETTINGS,
+        BIN,
         SDK,
-        SDK_BIN,
-        EXPLICIT_LAYERS,
-        CONTENT,
+        SDK_EXPLICIT_LAYERS,
+        PROFILES,
+        CONTENT
     };
 
     Path();

--- a/vkconfig_core/test/test_executable_manager.cpp
+++ b/vkconfig_core/test/test_executable_manager.cpp
@@ -33,20 +33,23 @@ TEST(test_executable_manager, reset_default_applications_sdk_found) {
     std::string result = qgetenv("VULKAN_SDK").toStdString();
 
     if (!result.empty()) {
-        EXPECT_EQ(2, executables.size());
+        EXPECT_EQ(3, executables.size());
 
         // Make sure the variable are not replaced
-        EXPECT_TRUE(executables[0].path.RelativePath().find("${VULKAN_SDK}") != std::string::npos);
-
+        EXPECT_TRUE(executables[0].path.RelativePath().find("${VULKAN_BIN}") != std::string::npos);
         const std::vector<ExecutableOptions>& options0 = executables[0].GetOptions();
-        EXPECT_TRUE(options0[0].working_folder.RelativePath().find("${VULKAN_SDK}") != std::string::npos);
+        EXPECT_TRUE(options0[0].working_folder.RelativePath().find("${VULKAN_BIN}") != std::string::npos);
         EXPECT_TRUE(options0[0].log_file.RelativePath().find("${VK_HOME}") != std::string::npos);
 
-        EXPECT_TRUE(executables[1].path.RelativePath().find("${VULKAN_SDK}") != std::string::npos);
-
+        EXPECT_TRUE(executables[1].path.RelativePath().find("${VULKAN_BIN}") != std::string::npos);
         const std::vector<ExecutableOptions>& options1 = executables[1].GetOptions();
-        EXPECT_TRUE(options1[0].working_folder.RelativePath().find("${VULKAN_SDK}") != std::string::npos);
+        EXPECT_TRUE(options1[0].working_folder.RelativePath().find("${VULKAN_BIN}") != std::string::npos);
         EXPECT_TRUE(options1[0].log_file.RelativePath().find("${VK_HOME}") != std::string::npos);
+
+        EXPECT_TRUE(executables[2].path.RelativePath().find("${VULKAN_BIN}") != std::string::npos);
+        const std::vector<ExecutableOptions>& options2 = executables[2].GetOptions();
+        EXPECT_TRUE(options2[0].working_folder.RelativePath().find("${VULKAN_BIN}") != std::string::npos);
+        EXPECT_TRUE(options2[0].log_file.RelativePath().find("${VK_HOME}") != std::string::npos);
     }
 }
 
@@ -58,20 +61,22 @@ TEST(test_executable_manager, reset_default_applications_no_sdk) {
 
     const std::vector<Executable>& executables = executable_manager.GetExecutables();
 
-    EXPECT_EQ(2, executables.size());
+    EXPECT_EQ(3, executables.size());
 
-    // Make sure the variable are not replaced
     EXPECT_TRUE(executables[0].path.RelativePath().find("vkcube") != std::string::npos);
-
     const std::vector<ExecutableOptions>& options0 = executables[0].GetOptions();
     EXPECT_TRUE(options0[0].working_folder.RelativePath().find(".") != std::string::npos);
     EXPECT_TRUE(options0[0].log_file.RelativePath().find("${VK_HOME}") != std::string::npos);
 
     EXPECT_TRUE(executables[1].path.RelativePath().find("vkcubepp") != std::string::npos);
-
     const std::vector<ExecutableOptions>& options1 = executables[1].GetOptions();
     EXPECT_TRUE(options1[0].working_folder.RelativePath().find(".") != std::string::npos);
     EXPECT_TRUE(options1[0].log_file.RelativePath().find("${VK_HOME}") != std::string::npos);
+
+    EXPECT_TRUE(executables[2].path.RelativePath().find("vulkaninfo") != std::string::npos);
+    const std::vector<ExecutableOptions>& options2 = executables[2].GetOptions();
+    EXPECT_TRUE(options2[0].working_folder.RelativePath().find(".") != std::string::npos);
+    EXPECT_TRUE(options2[0].log_file.RelativePath().find("${VK_HOME}") != std::string::npos);
 }
 
 TEST(test_executable_manager, remove_missing_applications) {

--- a/vkconfig_core/test/test_path.cpp
+++ b/vkconfig_core/test/test_path.cpp
@@ -245,17 +245,9 @@ TEST(test_path, get_path_override_layers) {
 }
 
 TEST(test_path, get_path_vulkan_sdk) {
-    {
-#ifdef __APPLE__
-        qputenv("VULKAN_SDK", "~/VulkanSDK");
-        const std::string value = AbsolutePath(Path::SDK);
-        EXPECT_STREQ(Path("~/VulkanSDK/share/vulkan").AbsolutePath().c_str(), value.c_str());
-#else
-        qputenv("VULKAN_SDK", "~/VulkanSDK");
-        const std::string value = AbsolutePath(Path::SDK);
-        EXPECT_STREQ(Path("~/VulkanSDK").AbsolutePath().c_str(), value.c_str());
-#endif
-    }
+    qputenv("VULKAN_SDK", "~/VulkanSDK");
+    const std::string value = AbsolutePath(Path::SDK);
+    EXPECT_STREQ(Path("~/VulkanSDK").AbsolutePath().c_str(), value.c_str());
 }
 
 TEST(test_path, get_path_vulkan_content) {

--- a/vkconfig_gui/CHANGELOG.md
+++ b/vkconfig_gui/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## Vulkan Configurator 3.0.0 - January 2025
 <a href="https://github.com/LunarG/VulkanTools/tree/vkconfig3-dev" target="_blank">https://github.com/LunarG/VulkanTools/tree/vkconfig3-dev</a>
 
-### TODO:
-- Fix preset label display
-
 ### Features:
 - Improve layers loading and selection:
   * Add loading of multiple versions of the same layer
@@ -25,6 +22,7 @@
   * Add *Vulkan Loader* selection of each logging message type
 - Split GUI and command line into two separated executables
 - Add system diagnostic
+- Improve ${VULKAN_SDK} applied on executable, profiles and layers path when set
 
 ### Improvements:
 - Almost all Vulkan Configurator data is stored in a `$HOME` directory JSON file

--- a/vkconfig_gui/mainwindow.ui
+++ b/vkconfig_gui/mainwindow.ui
@@ -83,7 +83,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>3</number>
+       <number>4</number>
       </property>
       <widget class="QWidget" name="tab_configurations">
        <attribute name="title">
@@ -1684,7 +1684,7 @@
             <number>5</number>
            </property>
            <item>
-            <widget class="QGroupBox" name="groupBox_2">
+            <widget class="QGroupBox" name="documentation_spec">
              <property name="font">
               <font>
                <family>Arial</family>
@@ -1710,7 +1710,7 @@
                <number>7</number>
               </property>
               <item>
-               <widget class="QLabel" name="label_12">
+               <widget class="QLabel" name="documentation_spec0">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1720,7 +1720,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vulkan 1.3 Core API + all published: &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3-extensions/html/index.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Chunked HTML&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3-extensions/pdf/vkspec.pdf&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;PDF&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Single-file HTML&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>Vulkan 1.3 Core API + all published: &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3-extensions/html/index.html&quot;&gt;Chunked HTML&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3-extensions/pdf/vkspec.pdf&quot;&gt;PDF&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html&quot;&gt;Single-file HTML&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1734,7 +1734,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_7">
+               <widget class="QLabel" name="documentation_spec1">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1744,7 +1744,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vulkan 1.3 Core API: &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3/html/index.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Chunked HTML&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3/pdf/vkspec.pdf&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;PDF&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Single-file HTML&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>Vulkan 1.3 Core API: &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3/html/index.html&quot;&gt;Chunked HTML&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3/pdf/vkspec.pdf&quot;&gt;PDF&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html&quot;&gt;Single-file HTML&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1758,7 +1758,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_19">
+               <widget class="QLabel" name="documentation_spec2">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1768,7 +1768,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vulkan 1.3 Core API + Ratified Extensions: &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/index.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Chunked HTML&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/pdf/vkspec.pdf&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;PDF&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/vkspec.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Single-file HTML&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>Vulkan 1.3 Core API + Ratified Extensions: &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/index.html&quot;&gt;Chunked HTML&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/pdf/vkspec.pdf&quot;&gt;PDF&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/specs/1.3-khr-extensions/html/vkspec.html&quot;&gt;Single-file HTML&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1785,7 +1785,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox_6">
+            <widget class="QGroupBox" name="documentation_doc">
              <property name="font">
               <font>
                <family>Arial</family>
@@ -1811,7 +1811,7 @@
                <number>7</number>
               </property>
               <item>
-               <widget class="QLabel" name="label_14">
+               <widget class="QLabel" name="documentation_doc0">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1821,7 +1821,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;a href=&quot;https://docs.vulkan.org/spec/latest/index.html&quot;&gt;Official Vulkan Documentation&lt;/a&gt;</string>
+                 <string>&lt;a style=&quot;color:%s;&quot; href=&quot;https://docs.vulkan.org/spec/latest/index.html&quot;&gt;Official Vulkan Documentation&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1835,7 +1835,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_20">
+               <widget class="QLabel" name="documentation_doc1">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1845,7 +1845,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;a href=&quot;https://registry.khronos.org/vulkan/&quot;&gt;Khronos Vulkan Registry&lt;/a&gt;</string>
+                 <string>&lt;a style=&quot;color:%s;&quot; href=&quot;https://registry.khronos.org/vulkan/&quot;&gt;Khronos Vulkan Registry&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1859,7 +1859,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_15">
+               <widget class="QLabel" name="documentation_doc2">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1869,7 +1869,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;a href=&quot;https://vulkan.gpuinfo.org/&quot;&gt;vulkan.gpuinfo.org&lt;/a&gt;</string>
+                 <string>&lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.gpuinfo.org/&quot;&gt;vulkan.gpuinfo.org&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1886,7 +1886,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox_4">
+            <widget class="QGroupBox" name="documentation_sdk">
              <property name="font">
               <font>
                <family>Arial</family>
@@ -1912,7 +1912,7 @@
                <number>7</number>
               </property>
               <item>
-               <widget class="QLabel" name="label_22">
+               <widget class="QLabel" name="documentation_sdk0">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1922,7 +1922,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Vulkan SDK: &lt;a href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/release_notes.html&quot;&gt;Release Notes&lt;/a&gt;, &lt;a href=&quot;https://vulkan.lunarg.com/sdk/home&quot;&gt;Download Page&lt;/a&gt;</string>
+                 <string>Vulkan SDK: &lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/release_notes.html&quot;&gt;Release Notes&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/sdk/home&quot;&gt;Download Page&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1936,7 +1936,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_16">
+               <widget class="QLabel" name="documentation_sdk1">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1946,7 +1946,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Vulkan Configurator: &lt;a href=&quot;https://github.com/LunarG/VulkanTools/blob/main/vkconfig_gui/README.md&quot;&gt;Readme&lt;/a&gt;, &lt;a href=&quot;https://github.com/LunarG/VulkanTools/blob/main/vkconfig_gui/CHANGELOG.md&quot;&gt;Changelog&lt;/a&gt;</string>
+                 <string>Vulkan Configurator: &lt;a style=&quot;color:%s;&quot; href=&quot;https://github.com/LunarG/VulkanTools/blob/main/vkconfig_gui/README.md&quot;&gt;Readme&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://github.com/LunarG/VulkanTools/blob/main/vkconfig_gui/CHANGELOG.md&quot;&gt;Changelog&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1960,7 +1960,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_4">
+               <widget class="QLabel" name="documentation_sdk2">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1970,7 +1970,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vulkan Loader: &lt;a href=&quot;https://vulkan.lunarg.com/doc/view/latest/windows/layer_configuration.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Layers Configuration&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderDebugging.md&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Loader Debugging Guide&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>Vulkan Loader: &lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/doc/view/latest/windows/layer_configuration.html&quot;&gt;Layers Configuration&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderDebugging.md&quot;&gt;Loader Debugging Guide&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -1984,7 +1984,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_13">
+               <widget class="QLabel" name="documentation_sdk3">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -1994,7 +1994,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Vulkan Validation Layer: &lt;a href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html&quot;&gt;Readme&lt;/a&gt;, &lt;a href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/validation_error_database.html&quot;&gt;Coverage&lt;/a&gt;</string>
+                 <string>Vulkan Validation Layer: &lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html&quot;&gt;Readme&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/validation_error_database.html&quot;&gt;Coverage&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -2008,7 +2008,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_17">
+               <widget class="QLabel" name="documentation_sdk4">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -2018,7 +2018,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vulkan API Capture and Replay - GFXReconstruct: &lt;a href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/capture_tools.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Usage&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>Vulkan API Capture and Replay - GFXReconstruct: &lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/doc/sdk/latest/windows/capture_tools.html&quot;&gt;Usage&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -2032,7 +2032,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_24">
+               <widget class="QLabel" name="documentation_sdk5">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -2042,7 +2042,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vulkan Profiles Tools: &lt;a href=&quot;https://github.com/KhronosGroup/Vulkan-Profiles/blob/main/OVERVIEW.md&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Overview&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://github.com/KhronosGroup/Vulkan-Profiles/blob/main/CHANGELOG.md&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Changelog&lt;/span&gt;&lt;/a&gt;, &lt;a href=&quot;https://www.lunarg.com/wp-content/uploads/2024/04/The-Vulkan-Profiles-Tools-LunarG-Christophe-Riccio-04-11-2024.pdf&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Whitepaper&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>Vulkan Profiles Tools: &lt;a style=&quot;color:%s;&quot; href=&quot;https://github.com/KhronosGroup/Vulkan-Profiles/blob/main/OVERVIEW.md&quot;&gt;Overview&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://github.com/KhronosGroup/Vulkan-Profiles/blob/main/CHANGELOG.md&quot;&gt;Changelog&lt;/a&gt;, &lt;a style=&quot;color:%s;&quot; href=&quot;https://www.lunarg.com/wp-content/uploads/2024/04/The-Vulkan-Profiles-Tools-LunarG-Christophe-Riccio-04-11-2024.pdf&quot;&gt;Whitepaper&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>
@@ -2059,7 +2059,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox_5">
+            <widget class="QGroupBox" name="documentation_community">
              <property name="font">
               <font>
                <family>Arial</family>
@@ -2085,7 +2085,7 @@
                <number>7</number>
               </property>
               <item>
-               <widget class="QLabel" name="label_23">
+               <widget class="QLabel" name="documentation_com0">
                 <property name="font">
                  <font>
                   <family>Arial</family>
@@ -2095,7 +2095,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://discord.com/invite/vulkan&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Vulkan Discord&lt;/span&gt;&lt;/a&gt; - &lt;a href=&quot;https://reddit.com/r/vulkan&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Reddit&lt;/span&gt;&lt;/a&gt; - &lt;a href=&quot;https://stackoverflow.com/questions/tagged/vulkan&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Stack Overflow&lt;/span&gt;&lt;/a&gt; - &lt;a href=&quot;https://fosstodon.org/@vulkan&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Mastodon&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;a style=&quot;color:%s;&quot; href=&quot;https://discord.com/invite/vulkan&quot;&gt;Vulkan Discord&lt;/a&gt; - &lt;a style=&quot;color:%s;&quot; href=&quot;https://reddit.com/r/vulkan&quot;&gt;Reddit&lt;/a&gt; - &lt;a style=&quot;color:%s;&quot; href=&quot;https://stackoverflow.com/questions/tagged/vulkan&quot;&gt;Stack Overflow&lt;/a&gt; - &lt;a style=&quot;color:%s;&quot; href=&quot;https://fosstodon.org/@vulkan&quot;&gt;Mastodon&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>

--- a/vkconfig_gui/settings_tree.cpp
+++ b/vkconfig_gui/settings_tree.cpp
@@ -23,6 +23,7 @@
 #include "item_tree.h"
 
 #include "widget_setting.h"
+#include "widget_setting_group.h"
 #include "widget_setting_int.h"
 #include "widget_setting_float.h"
 #include "widget_setting_frames.h"
@@ -210,11 +211,16 @@ void SettingsTreeManager::BuildTreeItem(QTreeWidgetItem *parent, const SettingMe
     }
     item->setExpanded(parameter->GetExpanded(meta_object.key.c_str()));
 
+    const SettingDependenceMode enabled = ::CheckDependence(meta_object, parameter->settings);
+    item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+
     switch (meta_object.type) {
         case SETTING_GROUP: {
-            item->setText(0, meta_object.label.c_str());
-            item->setToolTip(0, meta_object.description.c_str());
-            item->setFont(0, this->ui->configurations_settings->font());
+            const SettingMetaGroup &meta = static_cast<const SettingMetaGroup &>(meta_object);
+
+            WidgetSettingGroup *widget = new WidgetSettingGroup(this->ui->configurations_settings, item, meta, parameter->settings);
+            this->connect(widget, SIGNAL(itemChanged()), this, SLOT(OnSettingChanged()));
         } break;
         case SETTING_BOOL:
         case SETTING_BOOL_NUMERIC_DEPRECATED: {

--- a/vkconfig_gui/tab_applications.cpp
+++ b/vkconfig_gui/tab_applications.cpp
@@ -446,17 +446,17 @@ void TabApplications::on_launch_button_pressed() {
     Configuration *configuration = configurator.configurations.FindConfiguration(active_executable->configuration);
 
     QStringList env = QProcess::systemEnvironment();
-
     if (!options->envs.empty()) {
         const QStringList envs = ConvertString(options->envs);
         env << envs;
     }
     this->_launch_application->setEnvironment(env);
 
+    QStringList args;
     if (!options->args.empty()) {
-        const QStringList args = ConvertString(options->args);
-        this->_launch_application->setArguments(args);
+        args = ConvertString(options->args);
     }
+    this->_launch_application->setArguments(args);
 
     this->ui->launch_button->setText("Terminate");
     this->_launch_application->start(QIODevice::ReadOnly | QIODevice::Unbuffered);

--- a/vkconfig_gui/tab_configurations.cpp
+++ b/vkconfig_gui/tab_configurations.cpp
@@ -248,8 +248,9 @@ void TabConfigurations::UpdateUI_Layers(UpdateUIMode mode) {
                 }
             }
 
-            ListItem *item = new ListItem(parameter.key.c_str());
+            QListWidgetItem *item = new ListItem(parameter.key.c_str());
             item->setFlags(item->flags() | Qt::ItemIsSelectable);
+            item->setSizeHint(QSize(0, ITEM_HEIGHT));
             if (has_multiple_parameter) {
                 item->setIcon(QIcon(":/resourcefiles/drag.png"));
             }

--- a/vkconfig_gui/tab_documentation.cpp
+++ b/vkconfig_gui/tab_documentation.cpp
@@ -21,7 +21,55 @@
 #include "tab_documentation.h"
 #include "mainwindow.h"
 
-TabDocumentation::TabDocumentation(MainWindow &window, std::shared_ptr<Ui::MainWindow> ui) : Tab(TAB_DOCUMENTATION, window, ui) {}
+static void UpdateColor1(QLabel *label, const QColor &color) {
+    std::string ref = label->text().toStdString();
+    const std::string hex = color.name().toStdString();
+    std::string text = format(ref.c_str(), hex.c_str());
+    label->setText(text.c_str());
+}
+
+static void UpdateColor2(QLabel *label, const QColor &color) {
+    std::string ref = label->text().toStdString();
+    const std::string hex = color.name().toStdString();
+    std::string text = format(ref.c_str(), hex.c_str(), hex.c_str());
+    label->setText(text.c_str());
+}
+
+static void UpdateColor3(QLabel *label, const QColor &color) {
+    std::string ref = label->text().toStdString();
+    const std::string hex = color.name().toStdString();
+    std::string text = format(ref.c_str(), hex.c_str(), hex.c_str(), hex.c_str());
+    label->setText(text.c_str());
+}
+
+static void UpdateColor4(QLabel *label, const QColor &color) {
+    std::string ref = label->text().toStdString();
+    const std::string hex = color.name().toStdString();
+    std::string text = format(ref.c_str(), hex.c_str(), hex.c_str(), hex.c_str(), hex.c_str());
+    label->setText(text.c_str());
+}
+
+TabDocumentation::TabDocumentation(MainWindow &window, std::shared_ptr<Ui::MainWindow> ui) : Tab(TAB_DOCUMENTATION, window, ui) {
+    QPalette palette = this->ui->documentation_spec->palette();
+    QColor color = palette.color(QPalette::Text);
+
+    ::UpdateColor3(this->ui->documentation_spec0, color);
+    ::UpdateColor3(this->ui->documentation_spec1, color);
+    ::UpdateColor3(this->ui->documentation_spec2, color);
+
+    ::UpdateColor1(this->ui->documentation_doc0, color);
+    ::UpdateColor1(this->ui->documentation_doc1, color);
+    ::UpdateColor1(this->ui->documentation_doc2, color);
+
+    ::UpdateColor2(this->ui->documentation_sdk0, color);
+    ::UpdateColor2(this->ui->documentation_sdk1, color);
+    ::UpdateColor2(this->ui->documentation_sdk2, color);
+    ::UpdateColor2(this->ui->documentation_sdk3, color);
+    ::UpdateColor1(this->ui->documentation_sdk4, color);
+    ::UpdateColor3(this->ui->documentation_sdk5, color);
+
+    ::UpdateColor4(this->ui->documentation_com0, color);
+}
 
 TabDocumentation::~TabDocumentation() {}
 

--- a/vkconfig_gui/tab_layers.cpp
+++ b/vkconfig_gui/tab_layers.cpp
@@ -62,7 +62,7 @@ void TabLayers::UpdateUI_LayersPaths(UpdateUIMode ui_update_mode) {
         for (std::size_t i = 0, n = paths_group.size(); i < n; ++i) {
             QTreeWidgetItem *item_state = new QTreeWidgetItem;
             item_state->setFlags(item_state->flags() | Qt::ItemIsSelectable);
-            item_state->setSizeHint(0, QSize(0, 32));
+            item_state->setSizeHint(0, QSize(0, ITEM_HEIGHT));
             LayersPathWidget *layer_path_widget = new LayersPathWidget(paths_group[i], group_path);
             this->connect(layer_path_widget, SIGNAL(itemChanged()), this, SLOT(on_check_box_paths_changed()));
 

--- a/vkconfig_gui/vkconfig.pro
+++ b/vkconfig_gui/vkconfig.pro
@@ -81,6 +81,7 @@ SOURCES += \
     widget_tab_configurations_layer.cpp \
     widget_tab_layers_path.cpp \
     widget_setting.cpp \
+    widget_setting_group.cpp \
     widget_setting_bool.cpp \
     widget_setting_enum.cpp \
     widget_setting_filesystem.cpp \
@@ -160,6 +161,7 @@ HEADERS += \
     widget_tab_configurations_layer.h \
     widget_tab_layers_path.h \
     widget_setting.h \
+    widget_setting_group.h \
     widget_setting_bool.h \
     widget_setting_enum.h \
     widget_setting_filesystem.h \

--- a/vkconfig_gui/widget_setting_group.cpp
+++ b/vkconfig_gui/widget_setting_group.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors:
+ * - Christophe Riccio <christophe@lunarg.com>
+ */
+
+#include "widget_setting_group.h"
+
+#include <cassert>
+
+WidgetSettingGroup::WidgetSettingGroup(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaGroup& meta,
+                                       SettingDataSet& data_set)
+    : WidgetSettingBase(tree, item), meta(meta), data_set(data_set) {
+    this->item->setText(0, meta.label.c_str());
+    this->item->setToolTip(0, meta.description.c_str());
+    this->item->setFont(0, tree->font());
+
+    this->item->setSizeHint(0, QSize(0, ITEM_HEIGHT));
+    this->tree->setItemWidget(this->item, 0, this);
+
+    this->Refresh(REFRESH_ENABLE_AND_STATE);
+}
+
+void WidgetSettingGroup::Refresh(RefreshAreas refresh_areas) {
+    const SettingDependenceMode enabled = ::CheckDependence(this->meta, this->data_set);
+
+    this->item->setHidden(enabled == SETTING_DEPENDENCE_HIDE);
+    this->item->setDisabled(enabled != SETTING_DEPENDENCE_ENABLE);
+    this->setEnabled(enabled == SETTING_DEPENDENCE_ENABLE);
+}

--- a/vkconfig_gui/widget_setting_group.h
+++ b/vkconfig_gui/widget_setting_group.h
@@ -15,44 +15,26 @@
  * limitations under the License.
  *
  * Authors:
- * - Richard S. Wright Jr. <richard@lunarg.com>
  * - Christophe Riccio <christophe@lunarg.com>
  */
 
 #pragma once
 
+#include "../vkconfig_core/setting_group.h"
+
 #include "widget_setting.h"
-#include "combo_box.h"
 
-#include "../vkconfig_core/setting_flags.h"
+#include <QCheckBox>
 
-#include <QResizeEvent>
-
-class WidgetSettingEnum : public WidgetSettingBase {
+class WidgetSettingGroup : public WidgetSettingBase {
     Q_OBJECT
 
    public:
-    explicit WidgetSettingEnum(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaEnum& meta, SettingDataSet& data_set);
+    explicit WidgetSettingGroup(QTreeWidget* tree, QTreeWidgetItem* item, const SettingMetaGroup& meta, SettingDataSet& data_set);
 
     void Refresh(RefreshAreas refresh_areas) override;
 
-   public Q_SLOTS:
-    void OnIndexChanged(int index);
-
-   Q_SIGNALS:
-    void itemChanged();
-
    private:
-    void resizeEvent(QResizeEvent* event) override;
-
-    void Resize();
-
-    SettingDataEnum& data();
-
-    const SettingMetaEnum& meta;
+    const SettingMetaGroup& meta;
     SettingDataSet& data_set;
-
-    ComboBox* field;
-    std::vector<std::size_t> enum_indexes;
-    QSize last_resize;
 };

--- a/vkconfig_gui/widget_tab_configurations_layer.cpp
+++ b/vkconfig_gui/widget_tab_configurations_layer.cpp
@@ -93,10 +93,6 @@ ConfigurationLayerWidget::ConfigurationLayerWidget(TabConfigurations *tab, const
     } else if (!parameter.manifest.Empty()) {
         this->setToolTip(parameter.manifest.AbsolutePath().c_str());
     }
-
-    this->layer_state->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
-    this->layer_state->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    this->layer_state->adjustSize();
 }
 
 bool ConfigurationLayerWidget::eventFilter(QObject *target, QEvent *event) {
@@ -123,8 +119,9 @@ void ConfigurationLayerWidget::resizeEvent(QResizeEvent *event) {
         this->layer_state->adjustSize();
 
         const int width_state = this->layer_state->width();
+        const int height_state = this->layer_state->height();
 
-        const QRect state_button_rect = QRect(size.width() - width_state, 0, width_state, size.height());
+        const QRect state_button_rect = QRect(size.width() - width_state, 0, width_state, height_state);
         this->layer_state->setGeometry(state_button_rect);
     }
 }


### PR DESCRIPTION
- Fix `${VULKAN_SDK}` path in logging
- Fix `${VULKAN_SDK}` overriding system path when set
- Add `vulkaninfo` to default executable
- Add `${VULKAN_PROFILES}`
- Fix group settings visibility which depends on enum value
- Clean up layer paths on macOS
- Improve layer control UI combobox on macOS
- Resolve dark theme difficult link to read