### PR TITLE
api_dump: Fix destroy instance dispatch table

### DIFF
--- a/layersvt/generated/api_dump.cpp
+++ b/layersvt/generated/api_dump.cpp
@@ -161,9 +161,10 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, const VkAlloca
 {
     std::lock_guard<std::mutex> lg(ApiDumpInstance::current().outputMutex());
     dump_function_head(ApiDumpInstance::current(), "vkDestroyInstance", "instance, pAllocator", "void");
+    auto dispatch_key = get_dispatch_key(instance);
     instance_dispatch_table(instance)->DestroyInstance(instance, pAllocator);
     
-    destroy_instance_dispatch_table(get_dispatch_key(instance));
+    destroy_instance_dispatch_table(dispatch_key);
     if (ApiDumpInstance::current().shouldDumpOutput()) {
         switch(ApiDumpInstance::current().settings().format())
         {

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -237,6 +237,9 @@ VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     }}
     @end if
 
+    @if('{funcName}' == 'vkDestroyInstance')
+    auto dispatch_key = get_dispatch_key(instance);
+    @end if
     @if('{funcReturn}' != 'void')
     {funcReturn} result = instance_dispatch_table({funcDispatchParam})->{funcShortName}({funcNamedParams});
     @end if
@@ -256,7 +259,7 @@ VKAPI_ATTR {funcReturn} VKAPI_CALL {funcName}({funcTypedParams})
     }}
     @end if
     @if('{funcName}' == 'vkDestroyInstance')
-    destroy_instance_dispatch_table(get_dispatch_key(instance));
+    destroy_instance_dispatch_table(dispatch_key);
     @end if
 
     @if('{funcName}' == 'vkGetPhysicalDeviceToolPropertiesEXT')


### PR DESCRIPTION
Make sure to get the dispatch key before destroying the instance as it
might not be valid anymore after calling `DestroyInstance`.