### PR TITLE
vkconfig3: Add more unit tests

### DIFF
--- a/vkconfig_cmd/main.cpp
+++ b/vkconfig_cmd/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     // This has to go after the construction of QApplication in
     // order to use a QMessageBox and avoid some QThread warnings.
     ApplicationSingleton singleton("vkconfig_single_instance");
-    if (!singleton.IsFirstInstance()) {
+    if (singleton.IsLocked()) {
         fprintf(stderr, "%s: [ERROR] %s GUI is running which is incompatible with %s command line.", VKCONFIG_SHORT_NAME,
                 VKCONFIG_NAME, VKCONFIG_NAME);
         return -1;
@@ -94,7 +94,7 @@ int main(int argc, char* argv[]) {
             return 0;
         }
         case COMMAND_GUI: {
-            singleton.ReleaseInstance();
+            singleton.Release();
 
             QProcess* gui = new QProcess(&app);
 

--- a/vkconfig_core/application_singleton.cpp
+++ b/vkconfig_core/application_singleton.cpp
@@ -32,28 +32,28 @@
 ApplicationSingleton::ApplicationSingleton(const std::string& application_name, int timeout)
     : _application_name(application_name), _timeout(timeout) {}
 
-ApplicationSingleton::~ApplicationSingleton() { this->ReleaseInstance(); }
+ApplicationSingleton::~ApplicationSingleton() { this->Release(); }
 
-bool ApplicationSingleton::IsFirstInstance() {
+bool ApplicationSingleton::IsLocked() {
     // If we can connect to the server, it means there is another copy running
     QLocalSocket localSocket;
-    localSocket.connectToServer(_application_name.c_str());
+    localSocket.connectToServer(this->_application_name.c_str());
 
     // The default timeout is 5 seconds, which should be enough under
     // the most extreme circumstances. Note, that it will actually
     // only time out if the server exists and for some reason it can't
     // connect. Too small a timeout on the other hand can give false
     // assurance that another copy is not running.
-    if (localSocket.waitForConnected(_timeout)) {
+    if (localSocket.waitForConnected(this->_timeout)) {
         localSocket.close();
-        return false;
+        return true;
     }
 
     // Not connected, OR timed out
     // We are the first, start a server
-    _local_server.listen(_application_name.c_str());
+    this->_local_server.listen(this->_application_name.c_str());
 
-    return true;
+    return false;
 }
 
-void ApplicationSingleton::ReleaseInstance() { _local_server.close(); }
+void ApplicationSingleton::Release() { this->_local_server.close(); }

--- a/vkconfig_core/application_singleton.h
+++ b/vkconfig_core/application_singleton.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@ class ApplicationSingleton {
     ApplicationSingleton(const std::string &application_name, int timeout = 5000);
     ~ApplicationSingleton();
 
-    bool IsFirstInstance();
-    void ReleaseInstance();
+    bool IsLocked();
+    void Release();
 
    private:
     QLocalServer _local_server;

--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -75,7 +75,6 @@ Layer::Layer(const std::string& key, const Version& file_format_version, const V
       status(STATUS_STABLE),
       platforms(PLATFORM_DESKTOP_BIT) {}
 
-// Todo: Load the layer with Vulkan API
 bool Layer::IsValid() const {
     return file_format_version != Version::NONE && !key.empty() && !binary_path.Empty() && api_version != Version::NONE &&
            !implementation_version.empty();
@@ -260,7 +259,8 @@ LayerLoadStatus Layer::Load(const Path& full_path_to_file, LayerType type, bool 
     if (it != layers_validated.end()) {
         cached_last_modified = it->second;
     }
-    const bool should_validate = request_validate_manifest && last_modified != cached_last_modified && !this->manifest_path.IsBuiltIn();
+    const bool should_validate =
+        request_validate_manifest && last_modified != cached_last_modified && !this->manifest_path.IsBuiltIn();
     const bool is_valid = should_validate ? validator.Check(json_text) : true;
 
     if (!is_valid) {

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -92,7 +92,7 @@ class Layer {
     std::string description;
     std::string introduction;
     std::string url;
-    int platforms;
+    int platforms = PLATFORM_DESKTOP_BIT;
     Path manifest_path;
     LayerType type = LAYER_TYPE_EXPLICIT;
     QJsonDocument profile;

--- a/vkconfig_core/layer.h
+++ b/vkconfig_core/layer.h
@@ -61,7 +61,7 @@ enum { LAYER_LOAD_COUNT = LAYER_LOAD_LAST - LAYER_LOAD_FIRST + 1 };
 
 class Layer {
    public:
-    static const int NO_PRESET = -1;
+    enum { NO_PRESET = -1 };
 
     Layer();
     Layer(const std::string& key);

--- a/vkconfig_core/layer_preset.cpp
+++ b/vkconfig_core/layer_preset.cpp
@@ -24,26 +24,13 @@
 
 #include <cstring>
 
-const LayerPreset* GetPreset(const std::vector<LayerPreset>& presets, const char* preset_label) {
-    assert(preset_label);
-    assert(std::strcmp(preset_label, "") != 0);
-
-    for (std::size_t i = 0, n = presets.size(); i < n; ++i) {
-        if (presets[i].label == preset_label) {
-            return &presets[i];
-        }
-    }
-
-    return nullptr;
-}
-
 bool HasPreset(const SettingDataSet& layer_settings, const SettingDataSetConst& preset_settings) {
     if (preset_settings.empty()) {
         return false;
     }
 
     for (std::size_t preset_index = 0, preset_count = preset_settings.size(); preset_index < preset_count; ++preset_index) {
-        const SettingData* layer_setting = FindSetting(layer_settings, preset_settings[preset_index]->key.c_str());
+        const SettingData* layer_setting = ::FindSetting(layer_settings, preset_settings[preset_index]->key.c_str());
         if (layer_setting == nullptr) {
             return false;
         }

--- a/vkconfig_core/layer_preset.h
+++ b/vkconfig_core/layer_preset.h
@@ -29,8 +29,6 @@ struct LayerPreset : public Header {
     SettingDataSetConst settings;
 };
 
-const LayerPreset* GetPreset(const std::vector<LayerPreset>& presets, const char* preset_label);
-
 // Check whether "layer_settings" has all the settings set in "preset_settings"
 // "layer_settings" may have more settings then "preset_settings" and return true
 bool HasPreset(const SettingDataSet& layer_settings, const SettingDataSetConst& preset_settings);

--- a/vkconfig_core/parameter.cpp
+++ b/vkconfig_core/parameter.cpp
@@ -100,15 +100,15 @@ ParameterRank GetParameterOrdering(const LayerManager& layers, const Parameter& 
         return PARAMETER_RANK_UNORDERED_LAYER;
     } else if (layer == nullptr) {
         return PARAMETER_RANK_MISSING_LAYER;
-    } else if (IsValidationLayer(layer->key)) {
-        return PARAMETER_RANK_VALIDATION_LAYER;
-    } else if (IsProfilesLayer(layer->key)) {
-        return PARAMETER_RANK_PROFILES_LAYER;
-    } else if (IsExtensionLayer(layer->key)) {
-        return PARAMETER_RANK_EXTENSION_LAYER;
-    } else if (layer->type == LAYER_TYPE_IMPLICIT) {
+    } else if (parameter.type == LAYER_TYPE_IMPLICIT) {
         return PARAMETER_RANK_IMPLICIT_LAYER;
-    } else if (layer->type == LAYER_TYPE_EXPLICIT) {
+    } else if (IsValidationLayer(parameter.key)) {
+        return PARAMETER_RANK_VALIDATION_LAYER;
+    } else if (IsProfilesLayer(parameter.key)) {
+        return PARAMETER_RANK_PROFILES_LAYER;
+    } else if (IsExtensionLayer(parameter.key)) {
+        return PARAMETER_RANK_EXTENSION_LAYER;
+    } else if (parameter.type == LAYER_TYPE_EXPLICIT) {
         return PARAMETER_RANK_EXPLICIT_LAYER;
     } else {
         assert(0);  // Unknown ordering
@@ -128,10 +128,10 @@ void OrderParameter(std::vector<Parameter>& parameters, const LayerManager& laye
 
             if (both_overridden)
                 return a.overridden_rank < b.overridden_rank;
-            else if (rankA == rankB)
-                return a.key < b.key;
-            else
+            else if (rankA != rankB)
                 return rankA < rankB;
+            else
+                return a.key < b.key;
         }
 
         const LayerManager& layers;
@@ -140,10 +140,13 @@ void OrderParameter(std::vector<Parameter>& parameters, const LayerManager& laye
     std::sort(parameters.begin(), parameters.end(), ParameterCompare(layers));
 
     for (std::size_t i = 0, n = parameters.size(); i < n; ++i) {
+        parameters[i].overridden_rank = static_cast<int>(i);
+        /*
         if (parameters[i].control == LAYER_CONTROL_ON)
             parameters[i].overridden_rank = static_cast<int>(i);
         else
             parameters[i].overridden_rank = Parameter::NO_RANK;
+        */
     }
 }
 

--- a/vkconfig_core/parameter.h
+++ b/vkconfig_core/parameter.h
@@ -38,7 +38,7 @@ enum ParameterRank {
 };
 
 struct Parameter {
-    static const int NO_RANK = -1;
+    enum { NO_RANK = -1 };
 
     Parameter() : control(LAYER_CONTROL_AUTO) {}
 

--- a/vkconfig_core/registry.cpp
+++ b/vkconfig_core/registry.cpp
@@ -214,7 +214,7 @@ std::vector<LayersPathInfo> LoadRegistrySoftwareLayers(const char *path, LayerTy
         info.type = type;
         info.path = path.IsFile() ? path.AbsoluteDir() : path.AbsolutePath();
 
-        if (Found(result, info.path)) {
+        if (::Found(result, info.path)) {
             continue;
         }
 

--- a/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_04.json
+++ b/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_04.json
@@ -28,7 +28,7 @@
                     "settings": [
                         {
                             "key": "int_required_only",
-                            "value": 75
+                            "value": 76
                         }
                     ]
                 }

--- a/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_07.json
+++ b/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_07.json
@@ -31,7 +31,7 @@
                     "type": "INT",
                     "label": "Integer",
                     "description": "Integer Description",
-                    "default": 82
+                    "default": 75
                 }
             ]
         }

--- a/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_08.json
+++ b/vkconfig_core/test/layers/VK_LAYER_LUNARG_test_08.json
@@ -1,0 +1,28 @@
+{
+    "file_format_version" : "1.2.0",
+    "layer": {
+        "name": "VK_LAYER_LUNARG_test_08",
+        "library_path": ".\\VkLayer_test.dll",
+        "api_version": "1.2.170",
+        "implementation_version": "Build 76",
+        "description": "test layer",
+        "platforms": [ "WINDOWS", "MACOS" ],
+        "status": "BETA",
+        "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html",
+        "device_extensions": [
+            {
+                "name": "VK_EXT_tooling_info",
+                "spec_version": "1",
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ]
+            }
+        ],
+        "enable_environment": {
+            "VK_LAYER_TEST08_ENABLE": "1"
+        },
+        "disable_environment": {
+            "VK_LAYER_TEST08_DISABLE": "1"
+        }
+    }
+}

--- a/vkconfig_core/test/resources.qrc
+++ b/vkconfig_core/test/resources.qrc
@@ -35,6 +35,7 @@
         <file alias="VK_LAYER_LUNARG_test_05.json">./layers/VK_LAYER_LUNARG_test_05.json</file>
         <file alias="VK_LAYER_LUNARG_test_06.json">./layers/VK_LAYER_LUNARG_test_06.json</file>
         <file alias="VK_LAYER_LUNARG_test_07.json">./layers/VK_LAYER_LUNARG_test_07.json</file>
+        <file alias="VK_LAYER_LUNARG_test_08.json">./layers/VK_LAYER_LUNARG_test_08.json</file>
 
         <file alias="VK_LAYER_LUNARG_version_135.json">./layers/VK_LAYER_LUNARG_version_135.json</file>
         <file alias="VK_LAYER_LUNARG_version_193.json">./layers/VK_LAYER_LUNARG_version_193.json</file>

--- a/vkconfig_core/test/test_application_singleton.cpp
+++ b/vkconfig_core/test/test_application_singleton.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,16 +27,19 @@ TEST(test_application_singleton, single_server) {
     ApplicationSingleton a("test_application_singleton_single_server");
     ApplicationSingleton b("test_application_singleton_single_server");
 
-    EXPECT_EQ(true, a.IsFirstInstance());
-    EXPECT_EQ(false, b.IsFirstInstance());
+    EXPECT_EQ(false, a.IsLocked());
+    EXPECT_EQ(true, b.IsLocked());
+
+    EXPECT_EQ(true, a.IsLocked());  // IsLocked was call once already
+    EXPECT_EQ(true, b.IsLocked());
 }
 
 TEST(test_application_singleton, two_servers) {
     ApplicationSingleton a("test_application_singleton_0");
     ApplicationSingleton b("test_application_singleton_1");
 
-    EXPECT_EQ(true, a.IsFirstInstance());
-    EXPECT_EQ(true, b.IsFirstInstance());
+    EXPECT_EQ(false, a.IsLocked());
+    EXPECT_EQ(false, b.IsLocked());
 }
 
 TEST(test_application_singleton, multi_instance) {
@@ -46,9 +49,33 @@ TEST(test_application_singleton, multi_instance) {
     ApplicationSingleton d("test_application_singleton_multi_instance");
     ApplicationSingleton e("test_application_singleton_multi_instance");
 
-    EXPECT_EQ(true, a.IsFirstInstance());
-    EXPECT_EQ(false, b.IsFirstInstance());
-    EXPECT_EQ(false, c.IsFirstInstance());
-    EXPECT_EQ(false, d.IsFirstInstance());
-    EXPECT_EQ(false, e.IsFirstInstance());
+    EXPECT_EQ(false, a.IsLocked());
+    EXPECT_EQ(true, b.IsLocked());
+    EXPECT_EQ(true, c.IsLocked());
+    EXPECT_EQ(true, d.IsLocked());
+    EXPECT_EQ(true, e.IsLocked());
+}
+
+TEST(test_application_singleton, release_instance) {
+    ApplicationSingleton a("test_application_singleton_release");
+    ApplicationSingleton b("test_application_singleton_release");
+
+    a.Release();
+
+    EXPECT_EQ(false, a.IsLocked());
+    EXPECT_EQ(true, b.IsLocked());
+
+    a.Release();
+
+    EXPECT_EQ(false, b.IsLocked());
+    EXPECT_EQ(true, a.IsLocked());
+
+    b.Release();
+
+    EXPECT_EQ(false, a.IsLocked());
+    EXPECT_EQ(true, b.IsLocked());
+
+    b.Release();
+
+    EXPECT_EQ(true, a.IsLocked());
 }

--- a/vkconfig_core/test/test_configuration.cpp
+++ b/vkconfig_core/test/test_configuration.cpp
@@ -333,24 +333,23 @@ TEST(test_configuration, gather_parameters_missing) {
     configuration.GatherParameters(layer_manager);
 
     // Missing layer are reordred first
-    EXPECT_STREQ(configuration.parameters[0].key.c_str(), "VK_LAYER_LUNARG_reference_1_1_0");
-    EXPECT_STREQ(configuration.parameters[1].key.c_str(), "VK_LAYER_LUNARG_reference_1_2_0");
-    EXPECT_STREQ(configuration.parameters[2].key.c_str(), "VK_LAYER_LUNARG_reference_1_2_1");
+    EXPECT_STREQ(configuration.parameters[0].key.c_str(), ::GetLabel(LAYER_BUILTIN_UNORDERED));
 
-    EXPECT_STREQ(configuration.parameters[3].key.c_str(), "VK_LAYER_LUNARG_test_00");
-    EXPECT_STREQ(configuration.parameters[4].key.c_str(), "VK_LAYER_LUNARG_test_01");
-    EXPECT_STREQ(configuration.parameters[5].key.c_str(), "VK_LAYER_LUNARG_test_02");
-    EXPECT_STREQ(configuration.parameters[6].key.c_str(), "VK_LAYER_LUNARG_test_03");
-    EXPECT_STREQ(configuration.parameters[7].key.c_str(), "VK_LAYER_LUNARG_test_04");
-    EXPECT_STREQ(configuration.parameters[8].key.c_str(), "VK_LAYER_LUNARG_test_05");
-    EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_06");
-    EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_07");
-    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_test_08");
+    EXPECT_STREQ(configuration.parameters[1].key.c_str(), "VK_LAYER_LUNARG_reference_1_1_0");
+    EXPECT_STREQ(configuration.parameters[2].key.c_str(), "VK_LAYER_LUNARG_reference_1_2_0");
+    EXPECT_STREQ(configuration.parameters[3].key.c_str(), "VK_LAYER_LUNARG_reference_1_2_1");
 
-    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_version");
+    EXPECT_STREQ(configuration.parameters[4].key.c_str(), "VK_LAYER_LUNARG_test_00");
+    EXPECT_STREQ(configuration.parameters[5].key.c_str(), "VK_LAYER_LUNARG_test_01");
+    EXPECT_STREQ(configuration.parameters[6].key.c_str(), "VK_LAYER_LUNARG_test_02");
+    EXPECT_STREQ(configuration.parameters[7].key.c_str(), "VK_LAYER_LUNARG_test_03");
+    EXPECT_STREQ(configuration.parameters[8].key.c_str(), "VK_LAYER_LUNARG_test_04");
+    EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_05");
+    EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_06");
+    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_test_07");
+    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_test_08");
 
-    // Unordered are never missing so end up last
-    EXPECT_STREQ(configuration.parameters[13].key.c_str(), ::GetLabel(LAYER_BUILTIN_UNORDERED));
+    EXPECT_STREQ(configuration.parameters[13].key.c_str(), "VK_LAYER_LUNARG_version");
 
     std::string missing_layer;
     EXPECT_TRUE(HasMissingLayer(configuration.parameters, layer_manager, missing_layer));

--- a/vkconfig_core/test/test_configuration.cpp
+++ b/vkconfig_core/test/test_configuration.cpp
@@ -282,8 +282,9 @@ TEST(test_configuration, gather_parameters_exist) {
     EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_05");
     EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_06");
     EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_test_07");
+    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_test_08");
 
-    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_version");
+    EXPECT_STREQ(configuration.parameters[13].key.c_str(), "VK_LAYER_LUNARG_version");
 
     std::string missing_layer;
     EXPECT_FALSE(HasMissingLayer(configuration.parameters, layer_manager, missing_layer));
@@ -314,8 +315,9 @@ TEST(test_configuration, gather_parameters_repeat) {
     EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_05");
     EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_06");
     EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_test_07");
+    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_test_08");
 
-    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_version");
+    EXPECT_STREQ(configuration.parameters[13].key.c_str(), "VK_LAYER_LUNARG_version");
 }
 
 TEST(test_configuration, gather_parameters_missing) {
@@ -343,11 +345,12 @@ TEST(test_configuration, gather_parameters_missing) {
     EXPECT_STREQ(configuration.parameters[8].key.c_str(), "VK_LAYER_LUNARG_test_05");
     EXPECT_STREQ(configuration.parameters[9].key.c_str(), "VK_LAYER_LUNARG_test_06");
     EXPECT_STREQ(configuration.parameters[10].key.c_str(), "VK_LAYER_LUNARG_test_07");
+    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_test_08");
 
-    EXPECT_STREQ(configuration.parameters[11].key.c_str(), "VK_LAYER_LUNARG_version");
+    EXPECT_STREQ(configuration.parameters[12].key.c_str(), "VK_LAYER_LUNARG_version");
 
     // Unordered are never missing so end up last
-    EXPECT_STREQ(configuration.parameters[12].key.c_str(), ::GetLabel(LAYER_BUILTIN_UNORDERED));
+    EXPECT_STREQ(configuration.parameters[13].key.c_str(), ::GetLabel(LAYER_BUILTIN_UNORDERED));
 
     std::string missing_layer;
     EXPECT_TRUE(HasMissingLayer(configuration.parameters, layer_manager, missing_layer));

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,11 @@ TEST(test_layer, load_header_overridden) {
     EXPECT_STREQ("test layer", layer.description.c_str());
     EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_MACOS_BIT, layer.platforms);
     EXPECT_EQ(STATUS_BETA, layer.status);
+    EXPECT_EQ(true, layer.disable_env.empty());
+    EXPECT_EQ(true, layer.enable_env.empty());
+    EXPECT_EQ(true, layer.enable_value.empty());
+    EXPECT_EQ(false, layer.is_32bits);
+    EXPECT_EQ(true, layer.enabled);
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html", layer.url.c_str());
     EXPECT_TRUE(layer.settings.empty());
     EXPECT_TRUE(layer.presets.empty());
@@ -223,6 +228,29 @@ TEST(test_layer, load_setting_missing) {
     EXPECT_EQ(STATUS_BETA, layer.status);
     EXPECT_EQ(1, layer.settings.size());
     EXPECT_EQ(1, layer.presets.size());
+}
+
+TEST(test_layer, load_env_variable) {
+    Layer layer;
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_08.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
+
+    EXPECT_EQ(Version(1, 2, 0), layer.file_format_version);
+    EXPECT_STREQ("VK_LAYER_LUNARG_test_08", layer.key.c_str());
+    EXPECT_STREQ(Path(".\\VkLayer_test.dll").RelativePath().c_str(), layer.binary_path.RelativePath().c_str());
+    EXPECT_EQ(Version(1, 2, 170), layer.api_version);
+    EXPECT_STREQ("Build 76", layer.implementation_version.c_str());
+    EXPECT_STREQ("test layer", layer.description.c_str());
+    EXPECT_EQ(PLATFORM_WINDOWS_BIT | PLATFORM_MACOS_BIT, layer.platforms);
+    EXPECT_EQ(STATUS_BETA, layer.status);
+    EXPECT_STREQ("VK_LAYER_TEST08_DISABLE", layer.disable_env.c_str());
+    EXPECT_STREQ("VK_LAYER_TEST08_ENABLE", layer.enable_env.c_str());
+    EXPECT_STREQ("1", layer.enable_value.c_str());
+    EXPECT_EQ(false, layer.is_32bits);
+    EXPECT_EQ(true, layer.enabled);
+    EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html", layer.url.c_str());
+    EXPECT_TRUE(layer.settings.empty());
+    EXPECT_TRUE(layer.presets.empty());
 }
 
 TEST(test_layer, load_1_1_0_header) {

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -220,7 +220,7 @@ TEST(test_layer, load_setting_enum_interit) {
 
 TEST(test_layer, load_setting_missing) {
     Layer layer;
-    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_07.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_07.json", LAYER_TYPE_IMPLICIT, false, Dummy());
     EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
 
     EXPECT_EQ(Version(1, 2, 0), layer.file_format_version);
@@ -228,11 +228,14 @@ TEST(test_layer, load_setting_missing) {
     EXPECT_EQ(STATUS_BETA, layer.status);
     EXPECT_EQ(1, layer.settings.size());
     EXPECT_EQ(1, layer.presets.size());
+
+    LayerControl layer_controlA = layer.GetActualControl();
+    EXPECT_EQ(layer_controlA, LAYER_CONTROL_ON);
 }
 
 TEST(test_layer, load_env_variable) {
     Layer layer;
-    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_08.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_08.json", LAYER_TYPE_IMPLICIT, false, Dummy());
     EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
 
     EXPECT_EQ(Version(1, 2, 0), layer.file_format_version);
@@ -251,6 +254,31 @@ TEST(test_layer, load_env_variable) {
     EXPECT_STREQ("https://vulkan.lunarg.com/doc/sdk/latest/windows/layer_dummy.html", layer.url.c_str());
     EXPECT_TRUE(layer.settings.empty());
     EXPECT_TRUE(layer.presets.empty());
+
+    LayerControl layer_controlA = layer.GetActualControl();
+    EXPECT_EQ(layer_controlA, LAYER_CONTROL_OFF);
+
+    qputenv("VK_LAYER_TEST08_DISABLE", "1");
+    LayerControl layer_controlB = layer.GetActualControl();
+    EXPECT_EQ(layer_controlB, LAYER_CONTROL_OFF);
+    qunsetenv("VK_LAYER_TEST08_DISABLE");
+
+    qputenv("VK_LAYER_TEST08_ENABLE", "0");
+    LayerControl layer_controlC = layer.GetActualControl();
+    EXPECT_EQ(layer_controlC, LAYER_CONTROL_OFF);
+    qunsetenv("VK_LAYER_TEST08_ENABLE");
+
+    qputenv("VK_LAYER_TEST08_ENABLE", "1");
+    LayerControl layer_controlD = layer.GetActualControl();
+    EXPECT_EQ(layer_controlD, LAYER_CONTROL_ON);
+    qunsetenv("VK_LAYER_TEST08_ENABLE");
+
+    qputenv("VK_LAYER_TEST08_DISABLE", "1");
+    qputenv("VK_LAYER_TEST08_ENABLE", "1");
+    LayerControl layer_controlE = layer.GetActualControl();
+    EXPECT_EQ(layer_controlE, LAYER_CONTROL_OFF);
+    qunsetenv("VK_LAYER_TEST08_DISABLE");
+    qunsetenv("VK_LAYER_TEST08_ENABLE");
 }
 
 TEST(test_layer, load_1_1_0_header) {

--- a/vkconfig_core/test/test_layer.cpp
+++ b/vkconfig_core/test/test_layer.cpp
@@ -32,11 +32,11 @@
 
 #include <regex>
 
-inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
+static SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
     return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
 }
 
-std::map<Path, std::string> Dummy() { return std::map<Path, std::string>(); }
+static std::map<Path, std::string> Dummy() { return std::map<Path, std::string>(); }
 
 TEST(test_layer, collect_settings) {
     Layer layer;

--- a/vkconfig_core/test/test_layer_manager.cpp
+++ b/vkconfig_core/test/test_layer_manager.cpp
@@ -60,7 +60,7 @@ TEST(test_layer_manager, load_all) {
     LayerManager layer_manager;
     layer_manager.LoadLayersFromPath(":/layers");
 
-    EXPECT_EQ(15, layer_manager.Size());
+    EXPECT_EQ(16, layer_manager.Size());
     EXPECT_TRUE(!layer_manager.Empty());
 
     layer_manager.Clear();
@@ -201,7 +201,7 @@ TEST(test_layer_manager, BuildLayerNameList) {
     LayerManager layer_manager;
     layer_manager.LoadLayersFromPath(":/layers");
 
-    EXPECT_EQ(layer_manager.GatherLayerNames().size(), 12);
+    EXPECT_EQ(layer_manager.GatherLayerNames().size(), 13);
 }
 
 TEST(test_layer_manager, avoid_duplicate) {

--- a/vkconfig_core/test/test_layer_preset.cpp
+++ b/vkconfig_core/test/test_layer_preset.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,21 +27,6 @@
 
 inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
     return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
-}
-
-TEST(test_layer_preset, get_preset) {
-    LayerPreset layer_preset_a;
-    layer_preset_a.label = "1";
-
-    LayerPreset layer_preset_b;
-    layer_preset_b.label = "2";
-
-    std::vector<LayerPreset> presets;
-    presets.push_back(layer_preset_a);
-    presets.push_back(layer_preset_b);
-
-    EXPECT_STREQ("1", GetPreset(presets, "1")->label.c_str());
-    EXPECT_EQ(nullptr, GetPreset(presets, "3"));
 }
 
 TEST(test_layer_preset, has_preset) {

--- a/vkconfig_core/test/test_layer_preset.cpp
+++ b/vkconfig_core/test/test_layer_preset.cpp
@@ -21,11 +21,14 @@
 #include "../layer.h"
 #include "../layer_preset.h"
 #include "../setting_string.h"
+#include "../setting_int.h"
 #include "../util.h"
 
 #include <gtest/gtest.h>
 
-inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
+static std::map<Path, std::string> Dummy() { return std::map<Path, std::string>(); }
+
+static SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
     return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
 }
 
@@ -39,25 +42,84 @@ TEST(test_layer_preset, has_preset) {
     SettingMetaString* metaB = InstantiateString(layer, "KeyB");
     SettingMetaString* metaC = InstantiateString(layer, "KeyC");
 
-    EXPECT_EQ(false, HasPreset(layer_settings, preset_settings));
+    EXPECT_EQ(false, ::HasPreset(layer_settings, preset_settings));
 
     SettingDataString* presetA = Instantiate<SettingDataString>(metaA);
     presetA->value = "ValueA";
     preset_settings.push_back(presetA);
-    EXPECT_EQ(false, HasPreset(layer_settings, preset_settings));
+    EXPECT_EQ(false, ::HasPreset(layer_settings, preset_settings));
 
     SettingDataString* layerA = Instantiate<SettingDataString>(metaA);
     layerA->value = "ValueA";
     layer_settings.push_back(layerA);
-    EXPECT_EQ(true, HasPreset(layer_settings, preset_settings));
+    EXPECT_EQ(true, ::HasPreset(layer_settings, preset_settings));
 
     SettingDataString* layerB = Instantiate<SettingDataString>(metaB);
     layerB->value = "ValueB";
     layer_settings.push_back(layerB);
-    EXPECT_EQ(true, HasPreset(layer_settings, preset_settings));
+    EXPECT_EQ(true, ::HasPreset(layer_settings, preset_settings));
 
     SettingDataString* presetC = Instantiate<SettingDataString>(metaC);
     presetA->value = "ValueC";
     preset_settings.push_back(presetC);
-    EXPECT_EQ(false, HasPreset(layer_settings, preset_settings));
+    EXPECT_EQ(false, ::HasPreset(layer_settings, preset_settings));
+}
+
+TEST(test_layer_preset, find_preset_index_no_preset) {
+    Layer layer;
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_03.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
+
+    SettingDataSet layer_settings;
+    ::CollectDefaultSettingData(layer.settings, layer_settings);
+
+    int index = layer.FindPresetIndex(layer_settings);
+    EXPECT_EQ(index, Layer::NO_PRESET);
+}
+
+TEST(test_layer_preset, find_preset_index_empty) {
+    Layer layer;
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_04.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
+
+    SettingDataSet layer_settings;
+    int index = layer.FindPresetIndex(layer_settings);
+    EXPECT_EQ(index, Layer::NO_PRESET);
+}
+
+TEST(test_layer_preset, find_preset_index_found) {
+    Layer layer;
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_04.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
+
+    SettingDataSet layer_settings;
+    ::CollectDefaultSettingData(layer.settings, layer_settings);
+    SettingDataInt& setting = static_cast<SettingDataInt&>(*layer_settings[0]);
+
+    int indexDefault = layer.FindPresetIndex(layer_settings);
+    EXPECT_EQ(indexDefault, Layer::NO_PRESET);
+
+    setting.value = 75;
+    int index75 = layer.FindPresetIndex(layer_settings);
+    EXPECT_EQ(index75, 0);
+
+    setting.value = 76;
+    int index76 = layer.FindPresetIndex(layer_settings);
+    EXPECT_EQ(index76, 1);
+
+    setting.value = 99;
+    int index99 = layer.FindPresetIndex(layer_settings);
+    EXPECT_EQ(index99, Layer::NO_PRESET);
+}
+
+TEST(test_layer_preset, find_preset_index_missing_value) {
+    Layer layer;
+    const LayerLoadStatus load_loaded = layer.Load(":/layers/VK_LAYER_LUNARG_test_07.json", LAYER_TYPE_EXPLICIT, false, Dummy());
+    EXPECT_EQ(load_loaded, LAYER_LOAD_ADDED);
+
+    SettingDataSet layer_settings;
+    ::CollectDefaultSettingData(layer.settings, layer_settings);
+
+    int index = layer.FindPresetIndex(layer_settings);  // missing preset values are ignored
+    EXPECT_EQ(index, 0);
 }

--- a/vkconfig_core/test/test_parameter.cpp
+++ b/vkconfig_core/test/test_parameter.cpp
@@ -28,70 +28,6 @@
 inline SettingMetaString* InstantiateString(Layer& layer, const std::string& key) {
     return static_cast<SettingMetaString*>(layer.Instantiate(layer.settings, key, SETTING_STRING));
 }
-/*
-static std::vector<Layer> GenerateTestLayers() {
-    std::vector<Layer> layers;
-    layers.push_back(Layer("Layer E0", LAYER_TYPE_EXPLICIT, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer E1", LAYER_TYPE_EXPLICIT, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer E2", LAYER_TYPE_EXPLICIT, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer I0", LAYER_TYPE_IMPLICIT, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer I1", LAYER_TYPE_IMPLICIT, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer I2", LAYER_TYPE_IMPLICIT, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer C0", LAYER_TYPE_USER_DEFINED, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer C1", LAYER_TYPE_USER_DEFINED, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    layers.push_back(Layer("Layer C2", LAYER_TYPE_USER_DEFINED, Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
-    return layers;
-}
-*/
-static std::vector<Parameter> GenerateTestParametersExist() {
-    std::vector<Parameter> parameters;
-    parameters.push_back(Parameter("Layer E0", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer E1", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer C1", LAYER_CONTROL_AUTO));
-    return parameters;
-}
-
-static std::vector<Parameter> GenerateTestParametersImplicitOrdering() {
-    std::vector<Parameter> parameters;
-    parameters.push_back(Parameter("Layer I0", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer I1", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer E0", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer E1", LAYER_CONTROL_ON));
-    return parameters;
-}
-
-static std::vector<Parameter> GenerateTestParametersMissing() {
-    std::vector<Parameter> parameters;
-    parameters.push_back(Parameter("Layer E3", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer E1", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer C1", LAYER_CONTROL_AUTO));
-    return parameters;
-}
-
-static std::vector<Parameter> GenerateTestParametersAll() {
-    std::vector<Parameter> parameters;
-    parameters.push_back(Parameter("Layer E0", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer E1", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer E2", LAYER_CONTROL_AUTO));
-    parameters.push_back(Parameter("Layer E3", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer E4", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer E5", LAYER_CONTROL_AUTO));
-
-    parameters.push_back(Parameter("Layer I0", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer I1", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer I2", LAYER_CONTROL_AUTO));
-    parameters.push_back(Parameter("Layer I3", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer I4", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer I5", LAYER_CONTROL_AUTO));
-
-    parameters.push_back(Parameter("Layer C0", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer C1", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer C2", LAYER_CONTROL_AUTO));
-    parameters.push_back(Parameter("Layer C3", LAYER_CONTROL_ON));
-    parameters.push_back(Parameter("Layer C4", LAYER_CONTROL_OFF));
-    parameters.push_back(Parameter("Layer C5", LAYER_CONTROL_AUTO));
-    return parameters;
-}
 
 TEST(test_parameter, apply_settings) {
     Layer layer;
@@ -127,139 +63,66 @@ TEST(test_parameter, apply_settings) {
     EXPECT_STREQ("setting value", static_cast<SettingDataString*>(FindSetting(parameter.settings, "B"))->value.c_str());
 }
 
-TEST(test_parameter, ordering_no_layers) {
-    LayerManager layer_manager;
+TEST(test_parameter, ordering_found_parameter_rank) {
+    LayerManager layers;
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_implicit", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_explicit", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_validation", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_profiles", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(
+        Layer("VK_LAYER_KHRONOS_timeline_semaphore", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(
+        Layer("VK_LAYER_KHRONOS_synchronization2", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(
+        Layer("VK_LAYER_KHRONOS_shader_object", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(
+        Layer("VK_LAYER_KHRONOS_memory_decompression", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
 
-    EXPECT_EQ(PARAMETER_RANK_MISSING_LAYER, GetParameterOrdering(layer_manager, Parameter("Layer", LAYER_CONTROL_AUTO)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING_LAYER, GetParameterOrdering(layer_manager, Parameter("Layer", LAYER_CONTROL_ON)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING_LAYER, GetParameterOrdering(layer_manager, Parameter("Layer", LAYER_CONTROL_OFF)));
-}
-/*
-TEST(test_parameter, ordering_found_custom_layers) {
-    const std::vector<Layer>& layers = GenerateTestLayers();
+    layers.selected_layers[0].type = LAYER_TYPE_IMPLICIT;
 
-    EXPECT_EQ(PARAMETER_RANK_EXPLICIT_AVAILABLE, GetParameterOrdering(layers, Parameter("Layer C0", LAYER_CONTROL_AUTO)));
-    EXPECT_EQ(PARAMETER_RANK_EXPLICIT_OVERRIDDEN, GetParameterOrdering(layers, Parameter("Layer C1", LAYER_CONTROL_ON)));
-    EXPECT_EQ(PARAMETER_RANK_EXCLUDED, GetParameterOrdering(layers, Parameter("Layer C1", LAYER_CONTROL_OFF)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING, GetParameterOrdering(layers, Parameter("Layer C3", LAYER_CONTROL_ON)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING, GetParameterOrdering(layers, Parameter("Layer C4", LAYER_CONTROL_OFF)));
-}
-
-TEST(test_parameter, ordering_found_explicit_layers) {
-    const std::vector<Layer>& layers = GenerateTestLayers();
-
-    EXPECT_EQ(PARAMETER_RANK_EXPLICIT_AVAILABLE, GetParameterOrdering(layers, Parameter("Layer E0", LAYER_CONTROL_AUTO)));
-    EXPECT_EQ(PARAMETER_RANK_EXPLICIT_OVERRIDDEN, GetParameterOrdering(layers, Parameter("Layer E1", LAYER_CONTROL_ON)));
-    EXPECT_EQ(PARAMETER_RANK_EXCLUDED, GetParameterOrdering(layers, Parameter("Layer E1", LAYER_CONTROL_OFF)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING, GetParameterOrdering(layers, Parameter("Layer E3", LAYER_CONTROL_ON)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING, GetParameterOrdering(layers, Parameter("Layer E4", LAYER_CONTROL_OFF)));
-}
-
-TEST(test_parameter, ordering_found_implicit_layers) {
-    const std::vector<Layer>& layers = GenerateTestLayers();
-
-    EXPECT_EQ(PARAMETER_RANK_IMPLICIT_AVAILABLE, GetParameterOrdering(layers, Parameter("Layer I0", LAYER_CONTROL_AUTO)));
-    EXPECT_EQ(PARAMETER_RANK_IMPLICIT_OVERRIDDEN, GetParameterOrdering(layers, Parameter("Layer I1", LAYER_CONTROL_ON)));
-    EXPECT_EQ(PARAMETER_RANK_EXCLUDED, GetParameterOrdering(layers, Parameter("Layer I1", LAYER_CONTROL_OFF)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING, GetParameterOrdering(layers, Parameter("Layer I3", LAYER_CONTROL_ON)));
-    EXPECT_EQ(PARAMETER_RANK_MISSING, GetParameterOrdering(layers, Parameter("Layer I4", LAYER_CONTROL_OFF)));
+    EXPECT_EQ(PARAMETER_RANK_VALIDATION_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_validation", LAYER_CONTROL_AUTO)));
+    EXPECT_EQ(PARAMETER_RANK_PROFILES_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_profiles", LAYER_CONTROL_ON)));
+    EXPECT_EQ(PARAMETER_RANK_EXTENSION_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_timeline_semaphore", LAYER_CONTROL_OFF)));
+    EXPECT_EQ(PARAMETER_RANK_EXTENSION_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_synchronization2", LAYER_CONTROL_AUTO)));
+    EXPECT_EQ(PARAMETER_RANK_EXTENSION_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_shader_object", LAYER_CONTROL_ON)));
+    EXPECT_EQ(PARAMETER_RANK_EXTENSION_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_memory_decompression", LAYER_CONTROL_OFF)));
+    EXPECT_EQ(PARAMETER_RANK_EXPLICIT_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_explicit", LAYER_CONTROL_ON)));
+    EXPECT_EQ(PARAMETER_RANK_IMPLICIT_LAYER,
+              GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_implicit", LAYER_CONTROL_OFF)));
+    EXPECT_EQ(PARAMETER_RANK_MISSING_LAYER, GetParameterOrdering(layers, Parameter("VK_LAYER_KHRONOS_missing", LAYER_CONTROL_OFF)));
 }
 
-TEST(test_parameter, order_automatic) {
-    std::vector<Layer> layers = GenerateTestLayers();
-    std::vector<Parameter> parameters = GenerateTestParametersAll();
+TEST(test_parameter, has_missing_layer) {
+    LayerManager layers;
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_implicit", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_explicit", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
 
-    OrderParameter(parameters, layers);
+    std::vector<Parameter> parameters;
+    parameters.push_back(Parameter("VK_LAYER_KHRONOS_implicit", LAYER_CONTROL_AUTO));
+    parameters.push_back(Parameter("VK_LAYER_KHRONOS_missing", LAYER_CONTROL_AUTO));
 
-    // Missing
-    EXPECT_STREQ("Layer C3", parameters[0].key.c_str());
-    EXPECT_STREQ("Layer C4", parameters[1].key.c_str());
-    EXPECT_STREQ("Layer C5", parameters[2].key.c_str());
-    EXPECT_STREQ("Layer E3", parameters[3].key.c_str());
-    EXPECT_STREQ("Layer E4", parameters[4].key.c_str());
-    EXPECT_STREQ("Layer E5", parameters[5].key.c_str());
-    EXPECT_STREQ("Layer I3", parameters[6].key.c_str());
-    EXPECT_STREQ("Layer I4", parameters[7].key.c_str());
-    EXPECT_STREQ("Layer I5", parameters[8].key.c_str());
-
-    // Exclude
-    EXPECT_STREQ("Layer C1", parameters[9].key.c_str());
-    EXPECT_STREQ("Layer E1", parameters[10].key.c_str());
-    EXPECT_STREQ("Layer I1", parameters[11].key.c_str());
-
-    // Implicit application controlled
-    EXPECT_STREQ("Layer I2", parameters[12].key.c_str());
-
-    // Implicit overriden
-    EXPECT_STREQ("Layer I0", parameters[13].key.c_str());
-
-    // Explicit overriden
-    EXPECT_STREQ("Layer C0", parameters[14].key.c_str());
-    EXPECT_STREQ("Layer E0", parameters[15].key.c_str());
-
-    // Explicit application controlled
-    EXPECT_STREQ("Layer C2", parameters[16].key.c_str());
-    EXPECT_STREQ("Layer E2", parameters[17].key.c_str());
+    std::string missing_layer;
+    EXPECT_EQ(::HasMissingLayer(parameters, layers, missing_layer), true);
+    EXPECT_STREQ(missing_layer.c_str(), "VK_LAYER_KHRONOS_missing");
 }
 
-TEST(test_parameter, order_manual) {
-    std::vector<Layer> layers = GenerateTestLayers();
-    std::vector<Parameter> parameters = GenerateTestParametersAll();
+TEST(test_parameter, no_missing_layer) {
+    LayerManager layers;
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_implicit", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
+    layers.selected_layers.push_back(Layer("VK_LAYER_KHRONOS_explicit", Version(1, 0, 0), Version(1, 2, 148), "1", "layer.json"));
 
-    Parameter* layer_e0 = FindByKey(parameters, "Layer E0");
-    layer_e0->overridden_rank = 14;
+    std::vector<Parameter> parameters;
+    parameters.push_back(Parameter("VK_LAYER_KHRONOS_implicit", LAYER_CONTROL_AUTO));
+    parameters.push_back(Parameter("VK_LAYER_KHRONOS_explicit", LAYER_CONTROL_AUTO));
 
-    Parameter* layer_c0 = FindByKey(parameters, "Layer C0");
-    layer_c0->overridden_rank = 15;
-
-    OrderParameter(parameters, layers);
-
-    // Missing
-    EXPECT_STREQ("Layer C3", parameters[0].key.c_str());
-    EXPECT_STREQ("Layer C4", parameters[1].key.c_str());
-    EXPECT_STREQ("Layer C5", parameters[2].key.c_str());
-    EXPECT_STREQ("Layer E3", parameters[3].key.c_str());
-    EXPECT_STREQ("Layer E4", parameters[4].key.c_str());
-    EXPECT_STREQ("Layer E5", parameters[5].key.c_str());
-    EXPECT_STREQ("Layer I3", parameters[6].key.c_str());
-    EXPECT_STREQ("Layer I4", parameters[7].key.c_str());
-    EXPECT_STREQ("Layer I5", parameters[8].key.c_str());
-
-    // Exclude
-    EXPECT_STREQ("Layer C1", parameters[9].key.c_str());
-    EXPECT_STREQ("Layer E1", parameters[10].key.c_str());
-    EXPECT_STREQ("Layer I1", parameters[11].key.c_str());
-
-    // Implicit application controlled
-    EXPECT_STREQ("Layer I2", parameters[12].key.c_str());
-
-    // Implicit overriden
-    EXPECT_STREQ("Layer I0", parameters[13].key.c_str());
-
-    // Explicit overriden with manual override!
-    EXPECT_STREQ("Layer E0", parameters[14].key.c_str());
-    EXPECT_STREQ("Layer C0", parameters[15].key.c_str());
-
-    // Explicit application controlled
-    EXPECT_STREQ("Layer C2", parameters[16].key.c_str());
-    EXPECT_STREQ("Layer E2", parameters[17].key.c_str());
+    std::string missing_layer;
+    EXPECT_EQ(::HasMissingLayer(parameters, layers, missing_layer), false);
+    EXPECT_TRUE(missing_layer.empty());
 }
-
-TEST(test_parameter, OrderParameter_ImplicitLayer) {
-    std::vector<Layer> layers = GenerateTestLayers();
-    std::vector<Parameter> sources = GenerateTestParametersImplicitOrdering();
-    std::vector<Parameter> parameters = sources;
-
-    parameters[0].overridden_rank = 3;
-    parameters[1].overridden_rank = 1;
-    parameters[2].overridden_rank = 2;
-    parameters[3].overridden_rank = 0;
-
-    OrderParameter(parameters, layers);
-
-    EXPECT_STREQ(parameters[0].key.c_str(), "Layer E1");
-    EXPECT_STREQ(parameters[1].key.c_str(), "Layer I1");
-    EXPECT_STREQ(parameters[2].key.c_str(), "Layer E0");
-    EXPECT_STREQ(parameters[3].key.c_str(), "Layer I0");
-}
-*/

--- a/vkconfig_core/test/test_path.cpp
+++ b/vkconfig_core/test/test_path.cpp
@@ -268,7 +268,7 @@ TEST(test_path, collect_file_paths_success_set1) {
 TEST(test_path, collect_file_paths_success_set2) {
     const std::vector<Path>& paths = CollectFilePaths(":/layers/");
 
-    EXPECT_EQ(paths.size(), 15);
+    EXPECT_EQ(paths.size(), 16);
     EXPECT_STREQ(Path(":/layers/VK_LAYER_LUNARG_reference_1_1_0.json").AbsolutePath().c_str(), paths[0].AbsolutePath().c_str());
 }
 

--- a/vkconfig_core/test/test_path.cpp
+++ b/vkconfig_core/test/test_path.cpp
@@ -258,6 +258,16 @@ TEST(test_path, get_path_vulkan_content) {
     EXPECT_TRUE(value.toLower().endsWith("config"));
 }
 
+TEST(test_path, get_path_home_sdk) {
+    Path home_default = Get(Path::DEFAULT_HOME);
+    Path home_current = Get(Path::HOME);
+    EXPECT_STREQ(home_current.AbsolutePath().c_str(), home_default.AbsolutePath().c_str());
+
+    qputenv("VULKAN_SDK", "~/VulkanSDK");
+    const std::string value = AbsolutePath(Path::SDK);
+    EXPECT_STREQ(Path("~/VulkanSDK").AbsolutePath().c_str(), value.c_str());
+}
+
 TEST(test_path, collect_file_paths_success_set1) {
     const std::vector<Path>& paths = CollectFilePaths(":/configurations/");
 
@@ -273,20 +283,20 @@ TEST(test_path, collect_file_paths_success_set2) {
 }
 
 TEST(test_path, collect_file_paths_success_set3) {
-    const std::vector<Path>& paths = CollectFilePaths(":/profiles/");
+    const std::vector<Path>& paths = ::CollectFilePaths(":/profiles/");
 
     EXPECT_EQ(paths.size(), 4);
     EXPECT_STREQ(Path(":/profiles/VP_KHR_roadmap.json").AbsolutePath().c_str(), paths[0].AbsolutePath().c_str());
 }
 
 TEST(test_path, collect_file_paths_not_found) {
-    const std::vector<Path>& result = CollectFilePaths(":/configurations_not_found/");
+    const std::vector<Path>& result = ::CollectFilePaths(":/configurations_not_found/");
 
     EXPECT_EQ(result.empty(), true);
 }
 
 TEST(test_path, collect_profiles_from_file) {
-    const std::vector<std::string>& result = CollectProfileNamesFromFile(":/profiles/VP_KHR_roadmap.json");
+    const std::vector<std::string>& result = ::CollectProfileNamesFromFile(":/profiles/VP_KHR_roadmap.json");
 
     EXPECT_EQ(result.size(), 2);
     EXPECT_STREQ("VP_KHR_roadmap_2022", result[0].c_str());
@@ -294,7 +304,7 @@ TEST(test_path, collect_profiles_from_file) {
 }
 
 TEST(test_path, collect_profiles_from_dir) {
-    const std::vector<std::string>& result = CollectProfileNamesFromDir(":/profiles/");
+    const std::vector<std::string>& result = ::CollectProfileNamesFromDir(":/profiles/");
 
     EXPECT_EQ(result.size(), 9);
     EXPECT_STREQ("VP_KHR_roadmap_2022", result[0].c_str());

--- a/vkconfig_gui/main.cpp
+++ b/vkconfig_gui/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
     // This has to go after the construction of QApplication in
     // order to use a QMessageBox and avoid some QThread warnings.
     ApplicationSingleton singleton("vkconfig_single_instance");
-    while (!singleton.IsFirstInstance()) {
+    while (singleton.IsLocked()) {
         if (Alert::StartSingleton() == QMessageBox::Cancel) {
             return -1;
         }
@@ -87,7 +87,7 @@ int main(int argc, char* argv[]) {
     }
 
     if (configurator.reset_hard) {
-        singleton.ReleaseInstance();
+        singleton.Release();
 
         QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
     }


### PR DESCRIPTION
- Add layers env vars load unit tests
- Add single instance unit tests
- Add `Layer::FindPresetIndex` tests
- Add `Layer::GetActualControl` tests
- Add `HasMissingLayer` test
- Add `OrderParameter` test