### PR TITLE
vkconfig: Workaround loader message bug requiring layers override

### DIFF
--- a/vkconfig_gui/resources.qrc
+++ b/vkconfig_gui/resources.qrc
@@ -69,7 +69,6 @@
         <file alias="Crash Diagnostic.json">../vkconfig_core/configurations/3.0.0/Crash Diagnostic.json</file>
         <file alias="Disable All Vulkan Layers.json">../vkconfig_core/configurations/3.0.0/Disable All Vulkan Layers.json</file>
         <file alias="Frame Capture.json">../vkconfig_core/configurations/3.0.0/Frame Capture.json</file>
-        <file alias="Log Loader Messages.json">../vkconfig_core/configurations/3.0.0/Log Loader Messages.json</file>
         <file alias="Portability.json">../vkconfig_core/configurations/3.0.0/Portability.json</file>
         <file alias="Synchronization.json">../vkconfig_core/configurations/3.0.0/Synchronization.json</file>
         <file alias="Validation.json">../vkconfig_core/configurations/3.0.0/Validation.json</file>

--- a/vkconfig_gui/tab_configurations.cpp
+++ b/vkconfig_gui/tab_configurations.cpp
@@ -158,6 +158,16 @@ void TabConfigurations::UpdateUI_Configurations(UpdateUIMode mode) {
             ui->configurations_group_box_layers->blockSignals(false);
             ui->configurations_group_box_loader->blockSignals(true);
             ui->configurations_group_box_loader->setChecked(configuration.override_loader);
+            if (configurator.vulkan_system_info.loaderVersion <= Version(1, 4, 304)) {
+                ui->configurations_group_box_loader->setCheckable(configuration.override_layers);
+                ui->configurations_group_box_loader->setEnabled(configuration.override_layers);
+                if (configuration.override_layers) {
+                    ui->configurations_group_box_loader->setToolTip("Configure Loader Messages");
+                } else {
+                    ui->configurations_group_box_loader->setToolTip(
+                        "Due to a Vulkan Loader 304 bug, layers must be overridden for loader messages to be enabled.");
+                }
+            }
             ui->configurations_group_box_loader->blockSignals(false);
             current_row = static_cast<int>(i);
         } else if (has_missing_layer) {
@@ -207,23 +217,32 @@ void TabConfigurations::UpdateUI_LoaderMessages() {
 
     const Configuration *configuration = configurator.GetActiveConfiguration();
     if (configuration != nullptr) {
+        const bool enabled =
+            configurator.vulkan_system_info.loaderVersion <= Version(1, 4, 304) ? configuration->override_layers : true;
+
         ui->configuration_loader_errors->blockSignals(true);
         ui->configuration_loader_errors->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_ERROR));
+        ui->configuration_loader_errors->setEnabled(enabled);
         ui->configuration_loader_errors->blockSignals(false);
         ui->configuration_loader_warns->blockSignals(true);
         ui->configuration_loader_warns->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_WARN));
+        ui->configuration_loader_warns->setEnabled(enabled);
         ui->configuration_loader_warns->blockSignals(false);
         ui->configuration_loader_infos->blockSignals(true);
         ui->configuration_loader_infos->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_INFO));
+        ui->configuration_loader_infos->setEnabled(enabled);
         ui->configuration_loader_infos->blockSignals(false);
         ui->configuration_loader_debug->blockSignals(true);
         ui->configuration_loader_debug->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_DEBUG));
+        ui->configuration_loader_debug->setEnabled(enabled);
         ui->configuration_loader_debug->blockSignals(false);
         ui->configuration_loader_layers->blockSignals(true);
         ui->configuration_loader_layers->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_LAYER));
+        ui->configuration_loader_layers->setEnabled(enabled);
         ui->configuration_loader_layers->blockSignals(false);
         ui->configuration_loader_drivers->blockSignals(true);
         ui->configuration_loader_drivers->setChecked(configuration->loader_log_messages_flags & GetBit(LOG_DRIVER));
+        ui->configuration_loader_drivers->setEnabled(enabled);
         ui->configuration_loader_drivers->blockSignals(false);
     }
 


### PR DESCRIPTION
For SDK 1.4.304.1, the loader can't be updated so here is an ugly workaround.

The loader messages only configuration is removed and "Include Vulkan Loader Messages" can only be check if "Include Vulkan Layers" is checked. A tool tip is added to explain the workaround.

![loader_messages_wordaround](https://github.com/user-attachments/assets/6d7fd857-e300-4d63-a0c3-a8b0c111b3a6)
