### PR TITLE
api_dump: Fix deadlock with blocking vkWaitSemaphoresKHR call

### DIFF
--- a/layersvt/generated/api_dump.cpp
+++ b/layersvt/generated/api_dump.cpp
@@ -10382,9 +10382,9 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreCounterValueKHR(VkDevice device, Vk
 }
 VKAPI_ATTR VkResult VKAPI_CALL vkWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout)
 {
+    VkResult result = device_dispatch_table(device)->WaitSemaphoresKHR(device, pWaitInfo, timeout);
     std::lock_guard<std::mutex> lg(ApiDumpInstance::current().outputMutex());
     dump_function_head(ApiDumpInstance::current(), "vkWaitSemaphoresKHR", "device, pWaitInfo, timeout", "VkResult");
-    VkResult result = device_dispatch_table(device)->WaitSemaphoresKHR(device, pWaitInfo, timeout);
     
     if (ApiDumpInstance::current().shouldDumpOutput()) {
         switch(ApiDumpInstance::current().settings().format())

--- a/scripts/api_dump_generator.py
+++ b/scripts/api_dump_generator.py
@@ -49,7 +49,7 @@ from common_codegen import *
 
 BLOCKING_API_CALLS = [
     'vkWaitForFences', 'vkWaitSemaphores', 'vkQueuePresentKHR', 'vkDeviceWaitIdle',
-    'vkQueueWaitIdle', 'vkAcquireNextImageKHR', 'vkGetQueryPoolResults',
+    'vkQueueWaitIdle', 'vkAcquireNextImageKHR', 'vkGetQueryPoolResults', 'vkWaitSemaphoresKHR'
 ]
 
 COMMON_CODEGEN = """


### PR DESCRIPTION
Fix deadlock with blocking vkWaitSemaphoresKHR call where api_dump is locking the outputMutex before the Wait call which results in a deadlock when another thread wants to signal the semaphore but can't because the outputMutex is locked.

vkWaitForFences is marked as blocking so the KHR version should be as-well.

Issue was found when running the CTS `dEQP-VK.synchronization.timeline_semaphore.device_host.write_copy_image_read_image_compute_indirect.image_128x128_r32g32b32a32_sfloat`