### PR TITLE
vkconfig: update url to point to LunarG's latest public antora spec

### DIFF
--- a/vkconfig_gui/mainwindow.ui
+++ b/vkconfig_gui/mainwindow.ui
@@ -1673,7 +1673,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>&lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/doc/view/master/windows/antora/spec/latest/chapters/introduction.html&quot;&gt;Latest HTML&lt;/a&gt;</string>
+                 <string>&lt;a style=&quot;color:%s;&quot; href=&quot;https://vulkan.lunarg.com/doc/view/latest/windows/antora/spec/latest/chapters/introduction.html&quot;&gt;Latest HTML&lt;/a&gt;</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::RichText</enum>


### PR DESCRIPTION
The previous URL won't work for people outside LunarG. This URL should point to the latest public spec.