### PR TITLE
Allow for building vkConfig against static versions of Qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(Qt6 COMPONENTS Core Gui Widgets Network QUIET)
 
 option(BUILD_TESTS "Build tests")
 option(RUN_ON_GITHUB "Build only tests that can run on Github" OFF)
+option(USE_STATIC_RT_VKCONFIG "Use static C runtime for VkConfig when linking against static Qt libraires")
 
 if(BUILD_TESTS)
     enable_testing()

--- a/vkconfig_cmd/CMakeLists.txt
+++ b/vkconfig_cmd/CMakeLists.txt
@@ -12,6 +12,12 @@ source_group("Docs Files" FILES ${FILES_DOCS})
 
 set(FILES_ALL ${FILES_UI} ${FILES_SOURCE} ${FILES_HEADER} ${FILES_DOCS})
 
+# Use the static runtime library?
+if(USE_STATIC_CRT_VKFG)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    message(STATUS "vkconfig-core will link against static runtime")
+endif()    
+
 if(NOT APPLE)
     if (NOT DEFINED CMAKE_INSTALL_BINDIR)
         include(GNUInstallDirs)

--- a/vkconfig_cmd/CMakeLists.txt
+++ b/vkconfig_cmd/CMakeLists.txt
@@ -12,11 +12,13 @@ source_group("Docs Files" FILES ${FILES_DOCS})
 
 set(FILES_ALL ${FILES_UI} ${FILES_SOURCE} ${FILES_HEADER} ${FILES_DOCS})
 
-# Use the static runtime library?
-if(USE_STATIC_CRT_VKFG)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    message(STATUS "vkconfig-core will link against static runtime")
-endif()    
+if(WIN32)
+    # Use the static runtime library? This is for special builds of Vulkan Configurator only
+    if(USE_STATIC_RT_VKCONFIG)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        message(STATUS "vkconfig-core will link against static runtime")
+    endif()    
+endif()
 
 if(NOT APPLE)
     if (NOT DEFINED CMAKE_INSTALL_BINDIR)

--- a/vkconfig_core/CMakeLists.txt
+++ b/vkconfig_core/CMakeLists.txt
@@ -16,6 +16,11 @@ set(FILES_RESOURCES
 
 set(FILES_ALL ${FILES_SOURCE} ${FILES_HEADER} ${FILES_RESOURCES})
 
+if(USE_STATIC_CRT_VKFG)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    message(STATUS "vkconfig-core will link against static runtime")
+endif()
+
 add_library(vkconfig-core STATIC ${FILES_ALL})
 target_compile_options(vkconfig-core PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/MP>)
 target_compile_definitions(vkconfig-core PRIVATE QT_NO_DEBUG_OUTPUT QT_NO_WARNING_OUTPUT)

--- a/vkconfig_core/CMakeLists.txt
+++ b/vkconfig_core/CMakeLists.txt
@@ -16,9 +16,12 @@ set(FILES_RESOURCES
 
 set(FILES_ALL ${FILES_SOURCE} ${FILES_HEADER} ${FILES_RESOURCES})
 
-if(USE_STATIC_CRT_VKFG)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    message(STATUS "vkconfig-core will link against static runtime")
+if(WIN32)
+    # Use the static runtime library? This is for special builds of Vulkan Configurator only
+    if(USE_STATIC_RT_VKCONFIG)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        message(STATUS "vkconfig-core will link against static runtime")
+    endif()    
 endif()
 
 add_library(vkconfig-core STATIC ${FILES_ALL})

--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -4,8 +4,14 @@ if (NOT DEFINED CMAKE_INSTALL_BINDIR)
     include(GNUInstallDirs)
 endif()
 
+# Use the static runtime library?
+if(USE_STATIC_CRT_VKFG)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    message(STATUS "vkconfig tests will link against static runtime")
+endif()
+
 function(vkConfigTest NAME)
-	set(TEST_FILE ./${NAME}.cpp)
+    set(TEST_FILE ./${NAME}.cpp)
     set(TEST_NAME vkconfig_${NAME})
 
     file(GLOB FILES_LAYER_JSON ./layers/*.json)
@@ -25,6 +31,12 @@ function(vkConfigTest NAME)
         Qt6::Network
     )
     if(WIN32)
+	# Use the static runtime library?
+	if(USE_STATIC_CRT_VKFG)
+ 	    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+	    message(STATUS "vkconfig tests will link against static runtime")
+	endif()
+
         target_link_libraries(${TEST_NAME} Cfgmgr32)
     endif()
     if (RUN_ON_GITHUB)

--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -4,10 +4,12 @@ if (NOT DEFINED CMAKE_INSTALL_BINDIR)
     include(GNUInstallDirs)
 endif()
 
-# Use the static runtime library?
-if(USE_STATIC_CRT_VKFG)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    message(STATUS "vkconfig tests will link against static runtime")
+if(WIN32)
+    # Use the static runtime library? This is for special builds of Vulkan Configurator only
+    if(USE_STATIC_RT_VKCONFIG)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        message(STATUS "vkconfig-core will link against static runtime")
+    endif()    
 endif()
 
 function(vkConfigTest NAME)

--- a/vkconfig_gui/CMakeLists.txt
+++ b/vkconfig_gui/CMakeLists.txt
@@ -16,6 +16,11 @@ source_group("Docs Files" FILES ${FILES_DOCS})
 
 set(FILES_ALL ${FILES_UI} ${FILES_SOURCE} ${FILES_HEADER} ${FILES_DOCS} resources.qrc)
 
+if(USE_STATIC_CRT_VKFG)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    message(STATUS "vkconfig-core will link against static runtime")
+endif()   
+
 if(NOT APPLE)
     if (NOT DEFINED CMAKE_INSTALL_BINDIR)
         include(GNUInstallDirs)

--- a/vkconfig_gui/CMakeLists.txt
+++ b/vkconfig_gui/CMakeLists.txt
@@ -16,10 +16,13 @@ source_group("Docs Files" FILES ${FILES_DOCS})
 
 set(FILES_ALL ${FILES_UI} ${FILES_SOURCE} ${FILES_HEADER} ${FILES_DOCS} resources.qrc)
 
-if(USE_STATIC_CRT_VKFG)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    message(STATUS "vkconfig-core will link against static runtime")
-endif()   
+if(WIN32)
+    # Use the static runtime library? This is for special builds of Vulkan Configurator only
+    if(USE_STATIC_RT_VKCONFIG)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        message(STATUS "vkconfig-core will link against static runtime")
+    endif()    
+endif()
 
 if(NOT APPLE)
     if (NOT DEFINED CMAKE_INSTALL_BINDIR)


### PR DESCRIPTION
Internally, we build the Vulkan Configurator against a static build of Qt (Qt6 now) that is also built using the static MSVC runtime (this is also used for the installer framework). This allows an executable to run without any additional DLL support.

We have the need to build Vulkan Configurator using our internal Qt6 build, but also to link against the static MSVC runtime, but we don't want the rest of VulkanTools to have this requirement. 

This change allows VulkanTools to pass:
-DUSE_STATIC_CRT_VKFG=ON

CMAKE_PREFIX_PATH can point to a version of Qt that uses the static runtime, and vkConfig only will be built with the static MSVC runtime.