### PR TITLE
cmake: Update jsoncpp to fix CMake 4.0 error

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -107,7 +107,7 @@
             "sub_dir": "jsoncpp",
             "build_dir": "jsoncpp/build",
             "install_dir": "jsoncpp/build/install",
-            "commit": "1.9.5",
+            "commit": "1.9.6",
             "cmake_options": [
                 "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
                 "-DJSONCPP_WITH_TESTS=OFF",

--- a/via/CMakeLists.txt
+++ b/via/CMakeLists.txt
@@ -66,9 +66,6 @@ elseif (MSVC)
     target_compile_definitions(vkvia PRIVATE _CRT_SECURE_NO_WARNINGS _USE_MATH_DEFINES)
 endif()
 
-# NOTE: jsoncpp hasn't had updates in a bit and isn't getting fixes.
-# may be worth using nlohmann/json in the future which gets more updates
-# and has better CMake support.
 find_package(jsoncpp CONFIG)
 if (TARGET jsoncpp_static)
     target_link_libraries(vkvia PRIVATE jsoncpp_static)


### PR DESCRIPTION
Compatibility with CMake < 3.5 has been removed from CMake 4.0

jsoncpp before version 1.9.6 will cause an error as a result

Link to release notes:
https://github.com/open-source-parsers/jsoncpp/releases/tag/1.9.6