### PR TITLE
vkconfig: Improved generated layer documentation

### DIFF
--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -452,6 +452,8 @@ void Layer::AddSettingsSet(SettingMetaSet& settings, const SettingMeta* parent, 
         SettingView view = SETTING_VIEW_STANDARD;
         if (json_setting.value("view") != QJsonValue::Undefined) {
             view = GetSettingView(ReadStringValue(json_setting, "view").c_str());
+        } else if (parent != nullptr) {
+            view = parent->view;
         }
         if (view == SETTING_VIEW_HIDDEN) {
             continue;
@@ -460,9 +462,7 @@ void Layer::AddSettingsSet(SettingMetaSet& settings, const SettingMeta* parent, 
         SettingMeta* setting_meta = Instantiate(settings, key, type);
         setting_meta->platform_flags = parent == nullptr ? this->platforms : parent->platform_flags;
         setting_meta->status = parent == nullptr ? STATUS_STABLE : parent->status;
-        if (parent != nullptr) {
-            setting_meta->view = parent->view;
-        }
+        setting_meta->view = view;
 
         LoadMetaHeader(*setting_meta, json_setting);
         if (json_setting.value("env") != QJsonValue::Undefined) {

--- a/vkconfig_core/vulkan_util.cpp
+++ b/vkconfig_core/vulkan_util.cpp
@@ -275,7 +275,7 @@ enum TrimMode {
     TRIM_LAST = TRIM_NAMESPACE,
 };
 
-static std::string TrimPrefix(const std::string &layer_key) {
+std::string TrimPrefix(const std::string &layer_key) {
     std::string key{};
     if (layer_key.find("VK_LAYER_") == 0) {
         std::size_t prefix = std::strlen("VK_LAYER_");

--- a/vkconfig_core/vulkan_util.h
+++ b/vkconfig_core/vulkan_util.h
@@ -61,6 +61,7 @@ struct VulkanSystemInfo {
 
 VulkanSystemInfo BuildVulkanSystemInfo();
 
+std::string TrimPrefix(const std::string &layer_key);
 std::vector<std::string> BuildEnvVariablesList(const char *layer_key, const char *setting_key);
 
 const char *GetLabel(VkPhysicalDeviceType deviceType);

--- a/vkconfig_gui/CHANGELOG.md
+++ b/vkconfig_gui/CHANGELOG.md
@@ -11,10 +11,13 @@
 - Refactor layer version combobox
 - Clean up UI layout
 - Add button to remove missing layers
+- Clarify VK_EXT_layer_settings variable names in generated layer documentation
+- Hide `advanced` settings from generated layer documentation, used only by layer developers
 
 ### Fixes:
 - Fix layer settings all display with the layer development status
 - Fix reset to default when stay in system tray is checked
+- Fix broken generated layer doc links
 
 ## Vulkan Configurator 3.1.0 - March 2025
 [Vulkan SDK 1.4.309.0](https://github.com/LunarG/VulkanTools/tree/vulkan-sdk-1.4.309)


### PR DESCRIPTION
### Improvements:
- Clarify VK_EXT_layer_settings variable names in generated layer documentation
- Hide `advanced` settings from generated layer documentation, used only by layer developers

### Fixes:
- Fix broken generated layer doc links

![image](https://github.com/user-attachments/assets/196973ca-59cc-47ba-9957-68bb4c118144)
- When we click on the layer setting label, it jumps to the details layer setting below.
- When we click on `Variables Key`, it opens the general layer settings documentation https://vulkan.lunarg.com/doc/sdk/1.4.309.0/windows/layer_configuration.html

![image](https://github.com/user-attachments/assets/0276b58b-71f2-4b6c-98ff-8e45d1ffa6b1)
When we click on `Setting Variables`, it opens the general layer settings documentation https://vulkan.lunarg.com/doc/sdk/1.4.309.0/windows/layer_configuration.html
