### PR TITLE
vkconfig: Use table to display detail setting methods doc

### DIFF
--- a/vkconfig_core/layer.cpp
+++ b/vkconfig_core/layer.cpp
@@ -516,7 +516,7 @@ void Layer::AddSettingData(SettingDataSet& settings_data, const QJsonValue& json
 
     const std::string& key = ReadStringValue(json_setting_object, "key");
 
-    SettingMeta* setting_meta = FindSetting(this->settings, key.c_str());
+    SettingMeta* setting_meta = ::FindSetting(this->settings, key.c_str());
     if (setting_meta == nullptr) {
         return;
     }

--- a/vkconfig_core/setting.cpp
+++ b/vkconfig_core/setting.cpp
@@ -246,8 +246,20 @@ const SettingData* FindSetting(const SettingDataSet& settings, const char* key) 
     return nullptr;
 }
 
-std::size_t CountSettings(const SettingMetaSet& settings) {
-    std::size_t count = settings.size();
+static std::size_t CountStandardSettings(const SettingMetaSet& settings) {
+    std::size_t count = 0;
+
+    for (std::size_t i = 0, n = settings.size(); i < n; ++i) {
+        if (settings[i]->view == SETTING_VIEW_STANDARD) {
+            ++count;
+        }
+    }
+
+    return count;
+}
+
+std::size_t CountSettings(const SettingMetaSet& settings, bool only_standard) {
+    std::size_t count = only_standard ? ::CountStandardSettings(settings) : settings.size();
 
     for (std::size_t i = 0, n = settings.size(); i < n; ++i) {
         count += CountSettings(settings[i]->children);

--- a/vkconfig_core/setting.h
+++ b/vkconfig_core/setting.h
@@ -193,7 +193,7 @@ const T* FindSetting(const SettingDataSet& settings, const char* key) {
     return static_cast<const T*>(FindSetting(settings, key));
 }
 
-std::size_t CountSettings(const SettingMetaSet& settings);
+std::size_t CountSettings(const SettingMetaSet& settings, bool only_standard = false);
 
 bool CheckSettingOverridden(const SettingMeta& meta);
 

--- a/vkconfig_gui/CHANGELOG.md
+++ b/vkconfig_gui/CHANGELOG.md
@@ -11,8 +11,11 @@
 - Refactor layer version combobox
 - Clean up UI layout
 - Add button to remove missing layers
-- Clarify VK_EXT_layer_settings variable names in generated layer documentation
-- Hide `advanced` settings from generated layer documentation, used only by layer developers
+- Improved generated layer documentation
+  - Add links within the documentation to reach detailed part of a setting documentation
+  - Clarify VK_EXT_layer_settings variable names
+  - Hide `advanced` settings, used only by layer developers
+  - Add setting dependences section
 
 ### Fixes:
 - Fix layer settings all display with the layer development status


### PR DESCRIPTION
Here is what it looks like:

![image](https://github.com/user-attachments/assets/0ef7e8b0-d128-4eb6-87f7-4dbd8b7cc1ef)

Also show the layer settings hierarchy:
![image](https://github.com/user-attachments/assets/169515e6-97ff-48c1-a45b-77557b117c38)


