### PR TITLE
vkconfig: Fix QT_QPA_PLATFORM crashes

### DIFF
--- a/vkconfig_gui/CHANGELOG.md
+++ b/vkconfig_gui/CHANGELOG.md
@@ -11,6 +11,9 @@
   - Add display of deprecated setting information in generated layer documentation
   - Add optional information about which setting replaced a deprecated setting
 
+### Fixes:
+  - Fix crashes when `QT_QPA_PLATFORM` is set
+
 ## Vulkan Configurator 3.2.0 - May 2025
 [Vulkan SDK 1.4.313.0](https://github.com/LunarG/VulkanTools/tree/vulkan-sdk-1.4.313)
 

--- a/vkconfig_gui/main.cpp
+++ b/vkconfig_gui/main.cpp
@@ -75,6 +75,7 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
     qputenv("QT_QPA_PLATFORMTHEME", "");
+    qputenv("QT_QPA_PLATFORM", "");  // SDK build using static Qt which doesn't include plugins
 
     qInstallMessageHandler(log_handler);
 


### PR DESCRIPTION
QT_QPA_PLATFORM can be used to for manually setting the underlying display driver on Linux : wayland, xcb, xwayland. 

The SDK build use static Qt which doesn't containt the Qt plugins causing Qt the crash at inilialization.