### PR TITLE
Add ability to append pid to the filename of the log dumping in ApiDump

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -76,6 +76,13 @@
 #pragma warning(disable : 4554)
 #endif
 
+#ifdef _WIN32
+#include <processthreadsapi.h>
+#elif defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNX__) || defined(__FreeBSD__) || \
+    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__GNU__) || defined(__ANDROID__)
+#include <unistd.h>
+#endif
+
 #define MAX_STRING_LENGTH 1024
 
 // Defines for utilized environment variables.
@@ -798,12 +805,10 @@ class ApiDumpSettings {
     std::string getCurrentPidString() {
         std::stringstream ss;
 #ifdef _WIN32
-#include <processthreadsapi.h>
         DWORD pid = GetCurrentProcessId();
         ss << pid;
 #elif defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNX__) || defined(__FreeBSD__) || \
     defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__GNU__) || defined(__ANDROID__)
-#include <unistd.h>
         pid_t pid = getpid();
         ss << pid;
 #else

--- a/layersvt/json/VkLayer_api_dump.json.in
+++ b/layersvt/json/VkLayer_api_dump.json.in
@@ -191,6 +191,23 @@
                                     }
                                 ]
                             }
+                        },
+                        {
+                            "key": "append_pid",
+                            "env": "VK_APIDUMP_APPEND_LOG_FILENAME_WITH_PID",
+                            "label": "Append log filename with pid.",
+                            "description": "If set, appends the log filename with pid.",
+                            "type": "BOOL",
+                            "default": "false",
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "file",
+                                        "value": true
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
Proposed solution for issue #2406.

Tested on Windows. Still to be tested on other OSes, but sending for the early review.

@charles-lunarg please have a look!