### PR TITLE
build: Update dependencies to 1.4.316

### DIFF
--- a/layersvt/generated/api_dump.cpp
+++ b/layersvt/generated/api_dump.cpp
@@ -16811,32 +16811,32 @@ VKAPI_ATTR void VKAPI_CALL vkCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer
     }
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-VKAPI_ATTR void VKAPI_CALL vkCmdDispatchTileQCOM(VkCommandBuffer commandBuffer)
+VKAPI_ATTR void VKAPI_CALL vkCmdDispatchTileQCOM(VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo)
 {
     std::lock_guard<std::mutex> lg(ApiDumpInstance::current().outputMutex());
    if(ApiDumpInstance::current().settings().shouldPreDump() && ApiDumpInstance::current().settings().format() == ApiDumpFormat::Text) {
-        dump_function_head(ApiDumpInstance::current(), "vkCmdDispatchTileQCOM", "commandBuffer");
+        dump_function_head(ApiDumpInstance::current(), "vkCmdDispatchTileQCOM", "commandBuffer, pDispatchTileInfo");
         if (ApiDumpInstance::current().shouldDumpOutput()) {
-            dump_text_params_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer);
+            dump_text_params_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer, pDispatchTileInfo);
         }
         dump_return_preamble(ApiDumpInstance::current(), "void");
         
     } else {
-        dump_function_head(ApiDumpInstance::current(), "vkCmdDispatchTileQCOM", "commandBuffer", "void");
+        dump_function_head(ApiDumpInstance::current(), "vkCmdDispatchTileQCOM", "commandBuffer, pDispatchTileInfo", "void");
     }
-    device_dispatch_table(commandBuffer)->CmdDispatchTileQCOM(commandBuffer);
+    device_dispatch_table(commandBuffer)->CmdDispatchTileQCOM(commandBuffer, pDispatchTileInfo);
     
     if (ApiDumpInstance::current().shouldDumpOutput()) {
         switch(ApiDumpInstance::current().settings().format())
         {
             case ApiDumpFormat::Text:
-                dump_text_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer);
+                dump_text_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer, pDispatchTileInfo);
                 break;
             case ApiDumpFormat::Html:
-                dump_html_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer);
+                dump_html_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer, pDispatchTileInfo);
                 break;
             case ApiDumpFormat::Json:
-                dump_json_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer);
+                dump_json_vkCmdDispatchTileQCOM(ApiDumpInstance::current(), commandBuffer, pDispatchTileInfo);
                 break;
         }
     }

--- a/layersvt/generated/api_dump_html.cpp
+++ b/layersvt/generated/api_dump_html.cpp
@@ -3218,12 +3218,6 @@ void dump_html_VkStructureType(VkStructureType object, const ApiDumpSettings& se
     case 1000284002:
         settings.stream() << "VK_STRUCTURE_TYPE_DEVICE_MEMORY_REPORT_CALLBACK_DATA_EXT (";
         break;
-    case 1000286000:
-        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT (";
-        break;
-    case 1000286001:
-        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT (";
-        break;
     case 1000287000:
         settings.stream() << "VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT (";
         break;
@@ -4457,6 +4451,15 @@ void dump_html_VkStructureType(VkStructureType object, const ApiDumpSettings& se
     case 1000608000:
         settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT (";
         break;
+    case 1000609000:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FORMAT_PACK_FEATURES_ARM (";
+        break;
+    case 1000286000:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR (";
+        break;
+    case 1000286001:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_KHR (";
+        break;
     case 1000613000:
         settings.stream() << "VK_STRUCTURE_TYPE_SET_PRESENT_CONFIG_NV (";
         break;
@@ -4474,6 +4477,9 @@ void dump_html_VkStructureType(VkStructureType object, const ApiDumpSettings& se
         break;
     case 1000619003:
         settings.stream() << "VK_STRUCTURE_TYPE_RENDERING_END_INFO_EXT (";
+        break;
+    case 1000620000:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_DEVICE_MEMORY_FEATURES_EXT (";
         break;
     default:
         settings.stream() << "UNKNOWN (";
@@ -4587,6 +4593,9 @@ void dump_html_VkImageLayout(VkImageLayout object, const ApiDumpSettings& settin
         break;
     case 1000553000:
         settings.stream() << "VK_IMAGE_LAYOUT_VIDEO_ENCODE_QUANTIZATION_MAP_KHR (";
+        break;
+    case 1000620000:
+        settings.stream() << "VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT (";
         break;
     default:
         settings.stream() << "UNKNOWN (";
@@ -5687,6 +5696,48 @@ void dump_html_VkFormat(VkFormat object, const ApiDumpSettings& settings, int in
         break;
     case 1000464000:
         settings.stream() << "VK_FORMAT_R16G16_SFIXED5_NV (";
+        break;
+    case 1000609000:
+        settings.stream() << "VK_FORMAT_R10X6_UINT_PACK16_ARM (";
+        break;
+    case 1000609001:
+        settings.stream() << "VK_FORMAT_R10X6G10X6_UINT_2PACK16_ARM (";
+        break;
+    case 1000609002:
+        settings.stream() << "VK_FORMAT_R10X6G10X6B10X6A10X6_UINT_4PACK16_ARM (";
+        break;
+    case 1000609003:
+        settings.stream() << "VK_FORMAT_R12X4_UINT_PACK16_ARM (";
+        break;
+    case 1000609004:
+        settings.stream() << "VK_FORMAT_R12X4G12X4_UINT_2PACK16_ARM (";
+        break;
+    case 1000609005:
+        settings.stream() << "VK_FORMAT_R12X4G12X4B12X4A12X4_UINT_4PACK16_ARM (";
+        break;
+    case 1000609006:
+        settings.stream() << "VK_FORMAT_R14X2_UINT_PACK16_ARM (";
+        break;
+    case 1000609007:
+        settings.stream() << "VK_FORMAT_R14X2G14X2_UINT_2PACK16_ARM (";
+        break;
+    case 1000609008:
+        settings.stream() << "VK_FORMAT_R14X2G14X2B14X2A14X2_UINT_4PACK16_ARM (";
+        break;
+    case 1000609009:
+        settings.stream() << "VK_FORMAT_R14X2_UNORM_PACK16_ARM (";
+        break;
+    case 1000609010:
+        settings.stream() << "VK_FORMAT_R14X2G14X2_UNORM_2PACK16_ARM (";
+        break;
+    case 1000609011:
+        settings.stream() << "VK_FORMAT_R14X2G14X2B14X2A14X2_UNORM_4PACK16_ARM (";
+        break;
+    case 1000609012:
+        settings.stream() << "VK_FORMAT_G14X2_B14X2R14X2_2PLANE_420_UNORM_3PACK16_ARM (";
+        break;
+    case 1000609013:
+        settings.stream() << "VK_FORMAT_G14X2_B14X2R14X2_2PLANE_422_UNORM_3PACK16_ARM (";
         break;
     default:
         settings.stream() << "UNKNOWN (";
@@ -9807,7 +9858,7 @@ void dump_html_VkImageUsageFlagBits(VkImageUsageFlagBits object, const ApiDumpSe
         settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_RESERVED_23_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(object & 33554432) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"; is_first = false;
@@ -10296,7 +10347,7 @@ void dump_html_VkBufferUsageFlagBits(VkBufferUsageFlagBits object, const ApiDump
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -10965,7 +11016,7 @@ void dump_html_VkMemoryAllocateFlagBits(VkMemoryAllocateFlagBits object, const A
         settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT"; is_first = false;
     }
     if(object & 8) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_EXTENSION_621_BIT_EXT"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_ZERO_INITIALIZE_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -11194,6 +11245,9 @@ void dump_html_VkResolveModeFlagBits(VkResolveModeFlagBits object, const ApiDump
     }
     if(object & 16) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID"; is_first = false;
+    }
+    if(object & 32) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RESOLVE_MODE_RESERVED_5_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -11648,6 +11702,12 @@ void dump_html_VkRenderingFlagBits(VkRenderingFlagBits object, const ApiDumpSett
     if(object & 32) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_5_BIT_VALVE"; is_first = false;
     }
+    if(object & 64) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_6_BIT_EXT"; is_first = false;
+    }
+    if(object & 128) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_7_BIT_EXT"; is_first = false;
+    }
     if(!is_first)
         settings.stream() << ")";
     settings.stream() << "</div></summary>";
@@ -11966,6 +12026,9 @@ void dump_html_VkPipelineCreateFlagBits2(VkPipelineCreateFlagBits2 object, const
     if(object & 4398046511104) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_PIPELINE_CREATE_2_RESERVED_42_BIT_KHR"; is_first = false;
     }
+    if(object & 8796093022208) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_PIPELINE_CREATE_2_RESERVED_43_BIT_EXT"; is_first = false;
+    }
     if(!is_first)
         settings.stream() << ")";
     settings.stream() << "</div></summary>";
@@ -12057,7 +12120,7 @@ void dump_html_VkBufferUsageFlagBits2(VkBufferUsageFlagBits2 object, const ApiDu
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(object & 4294967296) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_RESERVED_32_BIT_NV"; is_first = false;
@@ -12160,6 +12223,9 @@ void dump_html_VkSwapchainCreateFlagBitsKHR(VkSwapchainCreateFlagBitsKHR object,
     }
     if(object & 16) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_SWAPCHAIN_CREATE_RESERVED_4_BIT_EXT"; is_first = false;
+    }
+    if(object & 32) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_SWAPCHAIN_CREATE_RESERVED_5_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -13616,6 +13682,9 @@ void dump_html_VkShaderCreateFlagBitsEXT(VkShaderCreateFlagBitsEXT object, const
     }
     if(object & 16384) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_SHADER_CREATE_RESERVED_14_BIT_EXT"; is_first = false;
+    }
+    if(object & 32768) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_SHADER_CREATE_RESERVED_15_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -28008,7 +28077,7 @@ void dump_html_VkDeviceDeviceMemoryReportCreateInfoEXT(const VkDeviceDeviceMemor
     dump_html_value<const PFN_vkDeviceMemoryReportCallbackEXT>(object.pfnUserCallback, settings, "PFN_vkDeviceMemoryReportCallbackEXT", "pfnUserCallback", indents + 1, dump_html_PFN_vkDeviceMemoryReportCallbackEXT);
     dump_html_value<const void*>(object.pUserData, settings, "void*", "pUserData", indents + 1, dump_html_void);
 }
-void dump_html_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobustness2FeaturesEXT& object, const ApiDumpSettings& settings, int indents)
+void dump_html_VkPhysicalDeviceRobustness2FeaturesKHR(const VkPhysicalDeviceRobustness2FeaturesKHR& object, const ApiDumpSettings& settings, int indents)
 {
     settings.stream() << "<div class='val'>";
     if(settings.showAddress())
@@ -28026,7 +28095,7 @@ void dump_html_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobu
     dump_html_value<const VkBool32>(object.robustImageAccess2, settings, "VkBool32", "robustImageAccess2", indents + 1, dump_html_VkBool32);
     dump_html_value<const VkBool32>(object.nullDescriptor, settings, "VkBool32", "nullDescriptor", indents + 1, dump_html_VkBool32);
 }
-void dump_html_VkPhysicalDeviceRobustness2PropertiesEXT(const VkPhysicalDeviceRobustness2PropertiesEXT& object, const ApiDumpSettings& settings, int indents)
+void dump_html_VkPhysicalDeviceRobustness2PropertiesKHR(const VkPhysicalDeviceRobustness2PropertiesKHR& object, const ApiDumpSettings& settings, int indents)
 {
     settings.stream() << "<div class='val'>";
     if(settings.showAddress())
@@ -35862,6 +35931,22 @@ void dump_html_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT(const VkPhys
     }
     dump_html_value<const VkBool32>(object.vertexAttributeRobustness, settings, "VkBool32", "vertexAttributeRobustness", indents + 1, dump_html_VkBool32);
 }
+void dump_html_VkPhysicalDeviceFormatPackFeaturesARM(const VkPhysicalDeviceFormatPackFeaturesARM& object, const ApiDumpSettings& settings, int indents)
+{
+    settings.stream() << "<div class='val'>";
+    if(settings.showAddress())
+        settings.stream() << &object << "\n";
+    else
+        settings.stream() << "address\n";
+    settings.stream() << "</div></summary>";
+    dump_html_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_html_VkStructureType);
+    if(object.pNext != nullptr){
+        dump_html_pNext_trampoline(object.pNext, settings, indents + 1);
+    } else {
+        dump_html_value<const void*>(object.pNext, settings, "void*", "pNext", indents + 1, dump_html_void);
+    }
+    dump_html_value<const VkBool32>(object.formatPack, settings, "VkBool32", "formatPack", indents + 1, dump_html_VkBool32);
+}
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_html_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const ApiDumpSettings& settings, int indents)
 {
@@ -35913,6 +35998,22 @@ void dump_html_VkRenderingEndInfoEXT(const VkRenderingEndInfoEXT& object, const 
     } else {
         dump_html_value<const void*>(object.pNext, settings, "const void*", "pNext", indents + 1, dump_html_void);
     }
+}
+void dump_html_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT(const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT& object, const ApiDumpSettings& settings, int indents)
+{
+    settings.stream() << "<div class='val'>";
+    if(settings.showAddress())
+        settings.stream() << &object << "\n";
+    else
+        settings.stream() << "address\n";
+    settings.stream() << "</div></summary>";
+    dump_html_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_html_VkStructureType);
+    if(object.pNext != nullptr){
+        dump_html_pNext_trampoline(object.pNext, settings, indents + 1);
+    } else {
+        dump_html_value<const void*>(object.pNext, settings, "void*", "pNext", indents + 1, dump_html_void);
+    }
+    dump_html_value<const VkBool32>(object.zeroInitializeDeviceMemory, settings, "VkBool32", "zeroInitializeDeviceMemory", indents + 1, dump_html_VkBool32);
 }
 
 //========================== Union Implementations ==========================//
@@ -38056,10 +38157,10 @@ void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         dump_html_pNext<const VkDeviceDeviceMemoryReportCreateInfoEXT>(static_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT*>(object), settings, "VkDeviceDeviceMemoryReportCreateInfoEXT", indents, dump_html_VkDeviceDeviceMemoryReportCreateInfoEXT);
         break;
     case 1000286000:
-        dump_html_pNext<const VkPhysicalDeviceRobustness2FeaturesEXT>(static_cast<const VkPhysicalDeviceRobustness2FeaturesEXT*>(object), settings, "VkPhysicalDeviceRobustness2FeaturesEXT", indents, dump_html_VkPhysicalDeviceRobustness2FeaturesEXT);
+        dump_html_pNext<const VkPhysicalDeviceRobustness2FeaturesKHR>(static_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(object), settings, "VkPhysicalDeviceRobustness2FeaturesKHR", indents, dump_html_VkPhysicalDeviceRobustness2FeaturesKHR);
         break;
     case 1000286001:
-        dump_html_pNext<const VkPhysicalDeviceRobustness2PropertiesEXT>(static_cast<const VkPhysicalDeviceRobustness2PropertiesEXT*>(object), settings, "VkPhysicalDeviceRobustness2PropertiesEXT", indents, dump_html_VkPhysicalDeviceRobustness2PropertiesEXT);
+        dump_html_pNext<const VkPhysicalDeviceRobustness2PropertiesKHR>(static_cast<const VkPhysicalDeviceRobustness2PropertiesKHR*>(object), settings, "VkPhysicalDeviceRobustness2PropertiesKHR", indents, dump_html_VkPhysicalDeviceRobustness2PropertiesKHR);
         break;
     case 1000287000:
         dump_html_pNext<const VkSamplerCustomBorderColorCreateInfoEXT>(static_cast<const VkSamplerCustomBorderColorCreateInfoEXT*>(object), settings, "VkSamplerCustomBorderColorCreateInfoEXT", indents, dump_html_VkSamplerCustomBorderColorCreateInfoEXT);
@@ -39351,6 +39452,9 @@ void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& setti
     case 1000608000:
         dump_html_pNext<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT>(static_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(object), settings, "VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT", indents, dump_html_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT);
         break;
+    case 1000609000:
+        dump_html_pNext<const VkPhysicalDeviceFormatPackFeaturesARM>(static_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(object), settings, "VkPhysicalDeviceFormatPackFeaturesARM", indents, dump_html_VkPhysicalDeviceFormatPackFeaturesARM);
+        break;
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
     case 1000613000:
         dump_html_pNext<const VkSetPresentConfigNV>(static_cast<const VkSetPresentConfigNV*>(object), settings, "VkSetPresentConfigNV", indents, dump_html_VkSetPresentConfigNV);
@@ -39363,6 +39467,9 @@ void dump_html_pNext_trampoline(const void* object, const ApiDumpSettings& setti
 #endif // VK_ENABLE_BETA_EXTENSIONS
     case 1000619003:
         dump_html_pNext<const VkRenderingEndInfoEXT>(static_cast<const VkRenderingEndInfoEXT*>(object), settings, "VkRenderingEndInfoEXT", indents, dump_html_VkRenderingEndInfoEXT);
+        break;
+    case 1000620000:
+        dump_html_pNext<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT>(static_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(object), settings, "VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT", indents, dump_html_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT);
         break;
     case VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO: // 47
     case VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO: // 48
@@ -46198,13 +46305,14 @@ void dump_html_params_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkComm
     settings.shouldFlush() ? settings.stream() << std::endl : settings.stream() << "\n";
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_html_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer)
+void dump_html_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo)
 {
     const ApiDumpSettings& settings(dump_inst.settings());
 
     if(settings.showParams())
     {
         dump_html_value<const VkCommandBuffer>(commandBuffer, settings, "VkCommandBuffer", "commandBuffer", 1, dump_html_VkCommandBuffer);
+        dump_html_pointer<const VkDispatchTileInfoQCOM>(pDispatchTileInfo, settings, "const VkDispatchTileInfoQCOM*", "pDispatchTileInfo", 1, dump_html_VkDispatchTileInfoQCOM);
     }
     settings.shouldFlush() ? settings.stream() << std::endl : settings.stream() << "\n";
 }
@@ -52670,10 +52778,10 @@ void dump_html_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuff
     settings.stream() << "</details>";
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_html_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer)
+void dump_html_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo)
 {
     const ApiDumpSettings& settings(dump_inst.settings());
-    dump_html_params_vkCmdDispatchTileQCOM(dump_inst, commandBuffer);
+    dump_html_params_vkCmdDispatchTileQCOM(dump_inst, commandBuffer, pDispatchTileInfo);
 
     settings.stream() << "</details>";
 }

--- a/layersvt/generated/api_dump_html.h
+++ b/layersvt/generated/api_dump_html.h
@@ -1613,8 +1613,8 @@ void dump_html_VkDepthBiasRepresentationInfoEXT(const VkDepthBiasRepresentationI
 void dump_html_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT(const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_html_VkDeviceMemoryReportCallbackDataEXT(const VkDeviceMemoryReportCallbackDataEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_html_VkDeviceDeviceMemoryReportCreateInfoEXT(const VkDeviceDeviceMemoryReportCreateInfoEXT& object, const ApiDumpSettings& settings, int indents);
-void dump_html_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobustness2FeaturesEXT& object, const ApiDumpSettings& settings, int indents);
-void dump_html_VkPhysicalDeviceRobustness2PropertiesEXT(const VkPhysicalDeviceRobustness2PropertiesEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_html_VkPhysicalDeviceRobustness2FeaturesKHR(const VkPhysicalDeviceRobustness2FeaturesKHR& object, const ApiDumpSettings& settings, int indents);
+void dump_html_VkPhysicalDeviceRobustness2PropertiesKHR(const VkPhysicalDeviceRobustness2PropertiesKHR& object, const ApiDumpSettings& settings, int indents);
 void dump_html_VkSamplerCustomBorderColorCreateInfoEXT(const VkSamplerCustomBorderColorCreateInfoEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_html_VkPhysicalDeviceCustomBorderColorPropertiesEXT(const VkPhysicalDeviceCustomBorderColorPropertiesEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_html_VkPhysicalDeviceCustomBorderColorFeaturesEXT(const VkPhysicalDeviceCustomBorderColorFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
@@ -2157,6 +2157,7 @@ void dump_html_VkMemoryMetalHandlePropertiesEXT(const VkMemoryMetalHandlePropert
 void dump_html_VkMemoryGetMetalHandleInfoEXT(const VkMemoryGetMetalHandleInfoEXT& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_USE_PLATFORM_METAL_EXT
 void dump_html_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT(const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_html_VkPhysicalDeviceFormatPackFeaturesARM(const VkPhysicalDeviceFormatPackFeaturesARM& object, const ApiDumpSettings& settings, int indents);
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_html_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -2164,6 +2165,7 @@ void dump_html_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const Ap
 void dump_html_VkPhysicalDevicePresentMeteringFeaturesNV(const VkPhysicalDevicePresentMeteringFeaturesNV& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_ENABLE_BETA_EXTENSIONS
 void dump_html_VkRenderingEndInfoEXT(const VkRenderingEndInfoEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_html_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT(const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
 
 //========================== Union Implementations ==========================//
 
@@ -2816,7 +2818,7 @@ void dump_html_params_vkDestroyCudaFunctionNV(ApiDumpInstance& dump_inst, VkDevi
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_html_params_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_html_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer);
+void dump_html_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo);
 void dump_html_params_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo);
 void dump_html_params_vkCmdEndPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo);
 #if defined(VK_USE_PLATFORM_METAL_EXT)
@@ -3674,7 +3676,7 @@ void dump_html_vkDestroyCudaFunctionNV(ApiDumpInstance& dump_inst, VkDevice devi
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_html_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_html_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer);
+void dump_html_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo);
 void dump_html_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo);
 void dump_html_vkCmdEndPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo);
 #if defined(VK_USE_PLATFORM_METAL_EXT)

--- a/layersvt/generated/api_dump_json.cpp
+++ b/layersvt/generated/api_dump_json.cpp
@@ -2818,12 +2818,6 @@ void dump_json_VkStructureType(VkStructureType object, const ApiDumpSettings& se
     case 1000284002:
         settings.stream() << "\"VK_STRUCTURE_TYPE_DEVICE_MEMORY_REPORT_CALLBACK_DATA_EXT\"";
         break;
-    case 1000286000:
-        settings.stream() << "\"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT\"";
-        break;
-    case 1000286001:
-        settings.stream() << "\"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT\"";
-        break;
     case 1000287000:
         settings.stream() << "\"VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT\"";
         break;
@@ -4057,6 +4051,15 @@ void dump_json_VkStructureType(VkStructureType object, const ApiDumpSettings& se
     case 1000608000:
         settings.stream() << "\"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT\"";
         break;
+    case 1000609000:
+        settings.stream() << "\"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FORMAT_PACK_FEATURES_ARM\"";
+        break;
+    case 1000286000:
+        settings.stream() << "\"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR\"";
+        break;
+    case 1000286001:
+        settings.stream() << "\"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_KHR\"";
+        break;
     case 1000613000:
         settings.stream() << "\"VK_STRUCTURE_TYPE_SET_PRESENT_CONFIG_NV\"";
         break;
@@ -4074,6 +4077,9 @@ void dump_json_VkStructureType(VkStructureType object, const ApiDumpSettings& se
         break;
     case 1000619003:
         settings.stream() << "\"VK_STRUCTURE_TYPE_RENDERING_END_INFO_EXT\"";
+        break;
+    case 1000620000:
+        settings.stream() << "\"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_DEVICE_MEMORY_FEATURES_EXT\"";
         break;
     default:
         settings.stream() << "\"UNKNOWN (" << object << ")\"";
@@ -4183,6 +4189,9 @@ void dump_json_VkImageLayout(VkImageLayout object, const ApiDumpSettings& settin
         break;
     case 1000553000:
         settings.stream() << "\"VK_IMAGE_LAYOUT_VIDEO_ENCODE_QUANTIZATION_MAP_KHR\"";
+        break;
+    case 1000620000:
+        settings.stream() << "\"VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT\"";
         break;
     default:
         settings.stream() << "\"UNKNOWN (" << object << ")\"";
@@ -5273,6 +5282,48 @@ void dump_json_VkFormat(VkFormat object, const ApiDumpSettings& settings, int in
         break;
     case 1000464000:
         settings.stream() << "\"VK_FORMAT_R16G16_SFIXED5_NV\"";
+        break;
+    case 1000609000:
+        settings.stream() << "\"VK_FORMAT_R10X6_UINT_PACK16_ARM\"";
+        break;
+    case 1000609001:
+        settings.stream() << "\"VK_FORMAT_R10X6G10X6_UINT_2PACK16_ARM\"";
+        break;
+    case 1000609002:
+        settings.stream() << "\"VK_FORMAT_R10X6G10X6B10X6A10X6_UINT_4PACK16_ARM\"";
+        break;
+    case 1000609003:
+        settings.stream() << "\"VK_FORMAT_R12X4_UINT_PACK16_ARM\"";
+        break;
+    case 1000609004:
+        settings.stream() << "\"VK_FORMAT_R12X4G12X4_UINT_2PACK16_ARM\"";
+        break;
+    case 1000609005:
+        settings.stream() << "\"VK_FORMAT_R12X4G12X4B12X4A12X4_UINT_4PACK16_ARM\"";
+        break;
+    case 1000609006:
+        settings.stream() << "\"VK_FORMAT_R14X2_UINT_PACK16_ARM\"";
+        break;
+    case 1000609007:
+        settings.stream() << "\"VK_FORMAT_R14X2G14X2_UINT_2PACK16_ARM\"";
+        break;
+    case 1000609008:
+        settings.stream() << "\"VK_FORMAT_R14X2G14X2B14X2A14X2_UINT_4PACK16_ARM\"";
+        break;
+    case 1000609009:
+        settings.stream() << "\"VK_FORMAT_R14X2_UNORM_PACK16_ARM\"";
+        break;
+    case 1000609010:
+        settings.stream() << "\"VK_FORMAT_R14X2G14X2_UNORM_2PACK16_ARM\"";
+        break;
+    case 1000609011:
+        settings.stream() << "\"VK_FORMAT_R14X2G14X2B14X2A14X2_UNORM_4PACK16_ARM\"";
+        break;
+    case 1000609012:
+        settings.stream() << "\"VK_FORMAT_G14X2_B14X2R14X2_2PLANE_420_UNORM_3PACK16_ARM\"";
+        break;
+    case 1000609013:
+        settings.stream() << "\"VK_FORMAT_G14X2_B14X2R14X2_2PLANE_422_UNORM_3PACK16_ARM\"";
         break;
     default:
         settings.stream() << "\"UNKNOWN (" << object << ")\"";
@@ -9122,7 +9173,7 @@ void dump_json_VkImageUsageFlagBits(VkImageUsageFlagBits object, const ApiDumpSe
         settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_RESERVED_23_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(object & 33554432) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"; is_first = false;
@@ -9596,7 +9647,7 @@ void dump_json_VkBufferUsageFlagBits(VkBufferUsageFlagBits object, const ApiDump
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ')';
@@ -10238,7 +10289,7 @@ void dump_json_VkMemoryAllocateFlagBits(VkMemoryAllocateFlagBits object, const A
         settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT"; is_first = false;
     }
     if(object & 8) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_EXTENSION_621_BIT_EXT"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_ZERO_INITIALIZE_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ')';
@@ -10458,6 +10509,9 @@ void dump_json_VkResolveModeFlagBits(VkResolveModeFlagBits object, const ApiDump
     }
     if(object & 16) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID"; is_first = false;
+    }
+    if(object & 32) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RESOLVE_MODE_RESERVED_5_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ')';
@@ -10904,6 +10958,12 @@ void dump_json_VkRenderingFlagBits(VkRenderingFlagBits object, const ApiDumpSett
     if(object & 32) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_5_BIT_VALVE"; is_first = false;
     }
+    if(object & 64) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_6_BIT_EXT"; is_first = false;
+    }
+    if(object & 128) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_7_BIT_EXT"; is_first = false;
+    }
     if(!is_first)
         settings.stream() << ')';
     settings.stream() << "\"";
@@ -11219,6 +11279,9 @@ void dump_json_VkPipelineCreateFlagBits2(VkPipelineCreateFlagBits2 object, const
     if(object & 4398046511104) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_PIPELINE_CREATE_2_RESERVED_42_BIT_KHR"; is_first = false;
     }
+    if(object & 8796093022208) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_PIPELINE_CREATE_2_RESERVED_43_BIT_EXT"; is_first = false;
+    }
     if(!is_first)
         settings.stream() << ')';
     settings.stream() << "\"";
@@ -11309,7 +11372,7 @@ void dump_json_VkBufferUsageFlagBits2(VkBufferUsageFlagBits2 object, const ApiDu
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(object & 4294967296) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_RESERVED_32_BIT_NV"; is_first = false;
@@ -11408,6 +11471,9 @@ void dump_json_VkSwapchainCreateFlagBitsKHR(VkSwapchainCreateFlagBitsKHR object,
     }
     if(object & 16) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_SWAPCHAIN_CREATE_RESERVED_4_BIT_EXT"; is_first = false;
+    }
+    if(object & 32) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_SWAPCHAIN_CREATE_RESERVED_5_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ')';
@@ -12801,6 +12867,9 @@ void dump_json_VkShaderCreateFlagBitsEXT(VkShaderCreateFlagBitsEXT object, const
     }
     if(object & 16384) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_SHADER_CREATE_RESERVED_14_BIT_EXT"; is_first = false;
+    }
+    if(object & 32768) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_SHADER_CREATE_RESERVED_15_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ')';
@@ -27528,7 +27597,7 @@ void dump_json_VkDeviceDeviceMemoryReportCreateInfoEXT(const VkDeviceDeviceMemor
     dump_json_value<const void*>(object.pUserData, NULL, settings, "void*", "pUserData", false, false, indents + 1, dump_json_void);
     settings.stream() << "\n" << settings.indentation(indents) << "]";
 }
-void dump_json_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobustness2FeaturesEXT& object, const ApiDumpSettings& settings, int indents)
+void dump_json_VkPhysicalDeviceRobustness2FeaturesKHR(const VkPhysicalDeviceRobustness2FeaturesKHR& object, const ApiDumpSettings& settings, int indents)
 {
     settings.stream() << settings.indentation(indents) << "[\n";
     dump_json_value<const VkStructureType>(object.sType, NULL, settings, "VkStructureType", "sType", false, false, indents + 1, dump_json_VkStructureType);
@@ -27546,7 +27615,7 @@ void dump_json_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobu
     dump_json_value<const VkBool32>(object.nullDescriptor, NULL, settings, "VkBool32", "nullDescriptor", false, false, indents + 1, dump_json_VkBool32);
     settings.stream() << "\n" << settings.indentation(indents) << "]";
 }
-void dump_json_VkPhysicalDeviceRobustness2PropertiesEXT(const VkPhysicalDeviceRobustness2PropertiesEXT& object, const ApiDumpSettings& settings, int indents)
+void dump_json_VkPhysicalDeviceRobustness2PropertiesKHR(const VkPhysicalDeviceRobustness2PropertiesKHR& object, const ApiDumpSettings& settings, int indents)
 {
     settings.stream() << settings.indentation(indents) << "[\n";
     dump_json_value<const VkStructureType>(object.sType, NULL, settings, "VkStructureType", "sType", false, false, indents + 1, dump_json_VkStructureType);
@@ -35269,6 +35338,20 @@ void dump_json_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT(const VkPhys
     dump_json_value<const VkBool32>(object.vertexAttributeRobustness, NULL, settings, "VkBool32", "vertexAttributeRobustness", false, false, indents + 1, dump_json_VkBool32);
     settings.stream() << "\n" << settings.indentation(indents) << "]";
 }
+void dump_json_VkPhysicalDeviceFormatPackFeaturesARM(const VkPhysicalDeviceFormatPackFeaturesARM& object, const ApiDumpSettings& settings, int indents)
+{
+    settings.stream() << settings.indentation(indents) << "[\n";
+    dump_json_value<const VkStructureType>(object.sType, NULL, settings, "VkStructureType", "sType", false, false, indents + 1, dump_json_VkStructureType);
+    settings.stream() << ",\n";
+    if(object.pNext != nullptr){
+        dump_json_pNext_trampoline(object.pNext, settings, indents + 1);
+    } else {
+        dump_json_value<const void*>(object.pNext, object.pNext, settings, "void*", "pNext", false, false, indents + 1, dump_json_void);
+    }
+    settings.stream() << ",\n";
+    dump_json_value<const VkBool32>(object.formatPack, NULL, settings, "VkBool32", "formatPack", false, false, indents + 1, dump_json_VkBool32);
+    settings.stream() << "\n" << settings.indentation(indents) << "]";
+}
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_json_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const ApiDumpSettings& settings, int indents)
 {
@@ -35313,6 +35396,20 @@ void dump_json_VkRenderingEndInfoEXT(const VkRenderingEndInfoEXT& object, const 
     } else {
         dump_json_value<const void*>(object.pNext, object.pNext, settings, "const void*", "pNext", false, false, indents + 1, dump_json_void);
     }
+    settings.stream() << "\n" << settings.indentation(indents) << "]";
+}
+void dump_json_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT(const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT& object, const ApiDumpSettings& settings, int indents)
+{
+    settings.stream() << settings.indentation(indents) << "[\n";
+    dump_json_value<const VkStructureType>(object.sType, NULL, settings, "VkStructureType", "sType", false, false, indents + 1, dump_json_VkStructureType);
+    settings.stream() << ",\n";
+    if(object.pNext != nullptr){
+        dump_json_pNext_trampoline(object.pNext, settings, indents + 1);
+    } else {
+        dump_json_value<const void*>(object.pNext, object.pNext, settings, "void*", "pNext", false, false, indents + 1, dump_json_void);
+    }
+    settings.stream() << ",\n";
+    dump_json_value<const VkBool32>(object.zeroInitializeDeviceMemory, NULL, settings, "VkBool32", "zeroInitializeDeviceMemory", false, false, indents + 1, dump_json_VkBool32);
     settings.stream() << "\n" << settings.indentation(indents) << "]";
 }
 
@@ -37425,10 +37522,10 @@ void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         dump_json_pNext<const VkDeviceDeviceMemoryReportCreateInfoEXT>(static_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT*>(object), settings, "VkDeviceDeviceMemoryReportCreateInfoEXT", indents, dump_json_VkDeviceDeviceMemoryReportCreateInfoEXT);
         break;
     case 1000286000:
-        dump_json_pNext<const VkPhysicalDeviceRobustness2FeaturesEXT>(static_cast<const VkPhysicalDeviceRobustness2FeaturesEXT*>(object), settings, "VkPhysicalDeviceRobustness2FeaturesEXT", indents, dump_json_VkPhysicalDeviceRobustness2FeaturesEXT);
+        dump_json_pNext<const VkPhysicalDeviceRobustness2FeaturesKHR>(static_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(object), settings, "VkPhysicalDeviceRobustness2FeaturesKHR", indents, dump_json_VkPhysicalDeviceRobustness2FeaturesKHR);
         break;
     case 1000286001:
-        dump_json_pNext<const VkPhysicalDeviceRobustness2PropertiesEXT>(static_cast<const VkPhysicalDeviceRobustness2PropertiesEXT*>(object), settings, "VkPhysicalDeviceRobustness2PropertiesEXT", indents, dump_json_VkPhysicalDeviceRobustness2PropertiesEXT);
+        dump_json_pNext<const VkPhysicalDeviceRobustness2PropertiesKHR>(static_cast<const VkPhysicalDeviceRobustness2PropertiesKHR*>(object), settings, "VkPhysicalDeviceRobustness2PropertiesKHR", indents, dump_json_VkPhysicalDeviceRobustness2PropertiesKHR);
         break;
     case 1000287000:
         dump_json_pNext<const VkSamplerCustomBorderColorCreateInfoEXT>(static_cast<const VkSamplerCustomBorderColorCreateInfoEXT*>(object), settings, "VkSamplerCustomBorderColorCreateInfoEXT", indents, dump_json_VkSamplerCustomBorderColorCreateInfoEXT);
@@ -38720,6 +38817,9 @@ void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& setti
     case 1000608000:
         dump_json_pNext<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT>(static_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(object), settings, "VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT", indents, dump_json_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT);
         break;
+    case 1000609000:
+        dump_json_pNext<const VkPhysicalDeviceFormatPackFeaturesARM>(static_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(object), settings, "VkPhysicalDeviceFormatPackFeaturesARM", indents, dump_json_VkPhysicalDeviceFormatPackFeaturesARM);
+        break;
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
     case 1000613000:
         dump_json_pNext<const VkSetPresentConfigNV>(static_cast<const VkSetPresentConfigNV*>(object), settings, "VkSetPresentConfigNV", indents, dump_json_VkSetPresentConfigNV);
@@ -38732,6 +38832,9 @@ void dump_json_pNext_trampoline(const void* object, const ApiDumpSettings& setti
 #endif // VK_ENABLE_BETA_EXTENSIONS
     case 1000619003:
         dump_json_pNext<const VkRenderingEndInfoEXT>(static_cast<const VkRenderingEndInfoEXT*>(object), settings, "VkRenderingEndInfoEXT", indents, dump_json_VkRenderingEndInfoEXT);
+        break;
+    case 1000620000:
+        dump_json_pNext<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT>(static_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(object), settings, "VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT", indents, dump_json_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT);
         break;
     case VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO: // 47
     case VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO: // 48
@@ -48524,7 +48627,7 @@ void dump_json_params_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkComm
     if (settings.shouldFlush()) settings.stream().flush();
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_json_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer)
+void dump_json_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo)
 {
     const ApiDumpSettings& settings(dump_inst.settings());
 
@@ -48533,6 +48636,8 @@ void dump_json_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkComman
         settings.stream() << settings.indentation(3) << "\"args\" :\n";
         settings.stream() << settings.indentation(3) << "[\n";
         dump_json_value<const VkCommandBuffer>(commandBuffer, NULL, settings, "VkCommandBuffer", "commandBuffer", false, false, 4, dump_json_VkCommandBuffer);
+        settings.stream() << ",\n";
+        dump_json_pointer<const VkDispatchTileInfoQCOM>(pDispatchTileInfo, settings, "const VkDispatchTileInfoQCOM*", "pDispatchTileInfo", true, false, 4, dump_json_VkDispatchTileInfoQCOM);
         settings.stream() << "\n" << settings.indentation(3) << "]\n";
     }
     if (settings.shouldFlush()) settings.stream().flush();
@@ -56428,10 +56533,10 @@ void dump_json_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuff
     settings.stream() << settings.indentation(2) << "}";
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_json_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer)
+void dump_json_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo)
 {
     const ApiDumpSettings& settings(dump_inst.settings());
-    dump_json_params_vkCmdDispatchTileQCOM(dump_inst, commandBuffer);
+    dump_json_params_vkCmdDispatchTileQCOM(dump_inst, commandBuffer, pDispatchTileInfo);
     settings.stream() << settings.indentation(2) << "}";
 }
 void dump_json_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo)

--- a/layersvt/generated/api_dump_json.h
+++ b/layersvt/generated/api_dump_json.h
@@ -1614,8 +1614,8 @@ void dump_json_VkDepthBiasRepresentationInfoEXT(const VkDepthBiasRepresentationI
 void dump_json_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT(const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_json_VkDeviceMemoryReportCallbackDataEXT(const VkDeviceMemoryReportCallbackDataEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_json_VkDeviceDeviceMemoryReportCreateInfoEXT(const VkDeviceDeviceMemoryReportCreateInfoEXT& object, const ApiDumpSettings& settings, int indents);
-void dump_json_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobustness2FeaturesEXT& object, const ApiDumpSettings& settings, int indents);
-void dump_json_VkPhysicalDeviceRobustness2PropertiesEXT(const VkPhysicalDeviceRobustness2PropertiesEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_json_VkPhysicalDeviceRobustness2FeaturesKHR(const VkPhysicalDeviceRobustness2FeaturesKHR& object, const ApiDumpSettings& settings, int indents);
+void dump_json_VkPhysicalDeviceRobustness2PropertiesKHR(const VkPhysicalDeviceRobustness2PropertiesKHR& object, const ApiDumpSettings& settings, int indents);
 void dump_json_VkSamplerCustomBorderColorCreateInfoEXT(const VkSamplerCustomBorderColorCreateInfoEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_json_VkPhysicalDeviceCustomBorderColorPropertiesEXT(const VkPhysicalDeviceCustomBorderColorPropertiesEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_json_VkPhysicalDeviceCustomBorderColorFeaturesEXT(const VkPhysicalDeviceCustomBorderColorFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
@@ -2158,6 +2158,7 @@ void dump_json_VkMemoryMetalHandlePropertiesEXT(const VkMemoryMetalHandlePropert
 void dump_json_VkMemoryGetMetalHandleInfoEXT(const VkMemoryGetMetalHandleInfoEXT& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_USE_PLATFORM_METAL_EXT
 void dump_json_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT(const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_json_VkPhysicalDeviceFormatPackFeaturesARM(const VkPhysicalDeviceFormatPackFeaturesARM& object, const ApiDumpSettings& settings, int indents);
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_json_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -2165,6 +2166,7 @@ void dump_json_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const Ap
 void dump_json_VkPhysicalDevicePresentMeteringFeaturesNV(const VkPhysicalDevicePresentMeteringFeaturesNV& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_ENABLE_BETA_EXTENSIONS
 void dump_json_VkRenderingEndInfoEXT(const VkRenderingEndInfoEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_json_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT(const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
 
 //========================== Union Implementations ==========================//
 
@@ -2817,7 +2819,7 @@ void dump_json_params_vkDestroyCudaFunctionNV(ApiDumpInstance& dump_inst, VkDevi
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_json_params_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_json_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer);
+void dump_json_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo);
 void dump_json_params_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo);
 void dump_json_params_vkCmdEndPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo);
 #if defined(VK_USE_PLATFORM_METAL_EXT)
@@ -3675,7 +3677,7 @@ void dump_json_vkDestroyCudaFunctionNV(ApiDumpInstance& dump_inst, VkDevice devi
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_json_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_json_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer);
+void dump_json_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo);
 void dump_json_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo);
 void dump_json_vkCmdEndPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo);
 #if defined(VK_USE_PLATFORM_METAL_EXT)

--- a/layersvt/generated/api_dump_text.cpp
+++ b/layersvt/generated/api_dump_text.cpp
@@ -3111,12 +3111,6 @@ void dump_text_VkStructureType(VkStructureType object, const ApiDumpSettings& se
     case 1000284002:
         settings.stream() << "VK_STRUCTURE_TYPE_DEVICE_MEMORY_REPORT_CALLBACK_DATA_EXT (";
         break;
-    case 1000286000:
-        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT (";
-        break;
-    case 1000286001:
-        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT (";
-        break;
     case 1000287000:
         settings.stream() << "VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT (";
         break;
@@ -4350,6 +4344,15 @@ void dump_text_VkStructureType(VkStructureType object, const ApiDumpSettings& se
     case 1000608000:
         settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT (";
         break;
+    case 1000609000:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FORMAT_PACK_FEATURES_ARM (";
+        break;
+    case 1000286000:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR (";
+        break;
+    case 1000286001:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_KHR (";
+        break;
     case 1000613000:
         settings.stream() << "VK_STRUCTURE_TYPE_SET_PRESENT_CONFIG_NV (";
         break;
@@ -4367,6 +4370,9 @@ void dump_text_VkStructureType(VkStructureType object, const ApiDumpSettings& se
         break;
     case 1000619003:
         settings.stream() << "VK_STRUCTURE_TYPE_RENDERING_END_INFO_EXT (";
+        break;
+    case 1000620000:
+        settings.stream() << "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_DEVICE_MEMORY_FEATURES_EXT (";
         break;
     default:
         settings.stream() << "UNKNOWN (";
@@ -4478,6 +4484,9 @@ void dump_text_VkImageLayout(VkImageLayout object, const ApiDumpSettings& settin
         break;
     case 1000553000:
         settings.stream() << "VK_IMAGE_LAYOUT_VIDEO_ENCODE_QUANTIZATION_MAP_KHR (";
+        break;
+    case 1000620000:
+        settings.stream() << "VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT (";
         break;
     default:
         settings.stream() << "UNKNOWN (";
@@ -5573,6 +5582,48 @@ void dump_text_VkFormat(VkFormat object, const ApiDumpSettings& settings, int in
         break;
     case 1000464000:
         settings.stream() << "VK_FORMAT_R16G16_SFIXED5_NV (";
+        break;
+    case 1000609000:
+        settings.stream() << "VK_FORMAT_R10X6_UINT_PACK16_ARM (";
+        break;
+    case 1000609001:
+        settings.stream() << "VK_FORMAT_R10X6G10X6_UINT_2PACK16_ARM (";
+        break;
+    case 1000609002:
+        settings.stream() << "VK_FORMAT_R10X6G10X6B10X6A10X6_UINT_4PACK16_ARM (";
+        break;
+    case 1000609003:
+        settings.stream() << "VK_FORMAT_R12X4_UINT_PACK16_ARM (";
+        break;
+    case 1000609004:
+        settings.stream() << "VK_FORMAT_R12X4G12X4_UINT_2PACK16_ARM (";
+        break;
+    case 1000609005:
+        settings.stream() << "VK_FORMAT_R12X4G12X4B12X4A12X4_UINT_4PACK16_ARM (";
+        break;
+    case 1000609006:
+        settings.stream() << "VK_FORMAT_R14X2_UINT_PACK16_ARM (";
+        break;
+    case 1000609007:
+        settings.stream() << "VK_FORMAT_R14X2G14X2_UINT_2PACK16_ARM (";
+        break;
+    case 1000609008:
+        settings.stream() << "VK_FORMAT_R14X2G14X2B14X2A14X2_UINT_4PACK16_ARM (";
+        break;
+    case 1000609009:
+        settings.stream() << "VK_FORMAT_R14X2_UNORM_PACK16_ARM (";
+        break;
+    case 1000609010:
+        settings.stream() << "VK_FORMAT_R14X2G14X2_UNORM_2PACK16_ARM (";
+        break;
+    case 1000609011:
+        settings.stream() << "VK_FORMAT_R14X2G14X2B14X2A14X2_UNORM_4PACK16_ARM (";
+        break;
+    case 1000609012:
+        settings.stream() << "VK_FORMAT_G14X2_B14X2R14X2_2PLANE_420_UNORM_3PACK16_ARM (";
+        break;
+    case 1000609013:
+        settings.stream() << "VK_FORMAT_G14X2_B14X2R14X2_2PLANE_422_UNORM_3PACK16_ARM (";
         break;
     default:
         settings.stream() << "UNKNOWN (";
@@ -9550,7 +9601,7 @@ void dump_text_VkImageUsageFlagBits(VkImageUsageFlagBits object, const ApiDumpSe
         settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_RESERVED_23_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(object & 33554432) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR"; is_first = false;
@@ -10009,7 +10060,7 @@ void dump_text_VkBufferUsageFlagBits(VkBufferUsageFlagBits object, const ApiDump
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -10624,7 +10675,7 @@ void dump_text_VkMemoryAllocateFlagBits(VkMemoryAllocateFlagBits object, const A
         settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT"; is_first = false;
     }
     if(object & 8) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_EXTENSION_621_BIT_EXT"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_MEMORY_ALLOCATE_ZERO_INITIALIZE_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -10835,6 +10886,9 @@ void dump_text_VkResolveModeFlagBits(VkResolveModeFlagBits object, const ApiDump
     }
     if(object & 16) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID"; is_first = false;
+    }
+    if(object & 32) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RESOLVE_MODE_RESERVED_5_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -11277,6 +11331,12 @@ void dump_text_VkRenderingFlagBits(VkRenderingFlagBits object, const ApiDumpSett
     if(object & 32) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_5_BIT_VALVE"; is_first = false;
     }
+    if(object & 64) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_6_BIT_EXT"; is_first = false;
+    }
+    if(object & 128) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_RENDERING_RESERVED_7_BIT_EXT"; is_first = false;
+    }
     if(!is_first)
         settings.stream() << ")";
 }
@@ -11593,6 +11653,9 @@ void dump_text_VkPipelineCreateFlagBits2(VkPipelineCreateFlagBits2 object, const
     if(object & 4398046511104) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_PIPELINE_CREATE_2_RESERVED_42_BIT_KHR"; is_first = false;
     }
+    if(object & 8796093022208) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_PIPELINE_CREATE_2_RESERVED_43_BIT_EXT"; is_first = false;
+    }
     if(!is_first)
         settings.stream() << ")";
 }
@@ -11684,7 +11747,7 @@ void dump_text_VkBufferUsageFlagBits2(VkBufferUsageFlagBits2 object, const ApiDu
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT"; is_first = false;
     }
     if(object & 134217728) {
-        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_TILE_MEMORY_QCOM"; is_first = false;
+        settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_TILE_MEMORY_BIT_QCOM"; is_first = false;
     }
     if(object & 4294967296) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_BUFFER_USAGE_2_RESERVED_32_BIT_NV"; is_first = false;
@@ -11779,6 +11842,9 @@ void dump_text_VkSwapchainCreateFlagBitsKHR(VkSwapchainCreateFlagBitsKHR object,
     }
     if(object & 16) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_SWAPCHAIN_CREATE_RESERVED_4_BIT_EXT"; is_first = false;
+    }
+    if(object & 32) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_SWAPCHAIN_CREATE_RESERVED_5_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -13113,6 +13179,9 @@ void dump_text_VkShaderCreateFlagBitsEXT(VkShaderCreateFlagBitsEXT object, const
     }
     if(object & 16384) {
         settings.stream() << (is_first ? " (" : " | ") << "VK_SHADER_CREATE_RESERVED_14_BIT_EXT"; is_first = false;
+    }
+    if(object & 32768) {
+        settings.stream() << (is_first ? " (" : " | ") << "VK_SHADER_CREATE_RESERVED_15_BIT_EXT"; is_first = false;
     }
     if(!is_first)
         settings.stream() << ")";
@@ -25343,7 +25412,7 @@ void dump_text_VkDeviceDeviceMemoryReportCreateInfoEXT(const VkDeviceDeviceMemor
         dump_text_pNext_trampoline(object.pNext, settings, indents < 2 ? indents + 1 : indents);
     }
 }
-void dump_text_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobustness2FeaturesEXT& object, const ApiDumpSettings& settings, int indents)
+void dump_text_VkPhysicalDeviceRobustness2FeaturesKHR(const VkPhysicalDeviceRobustness2FeaturesKHR& object, const ApiDumpSettings& settings, int indents)
 {
     if(settings.showAddress())
         settings.stream() << &object << ":\n";
@@ -25358,7 +25427,7 @@ void dump_text_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobu
         dump_text_pNext_trampoline(object.pNext, settings, indents < 2 ? indents + 1 : indents);
     }
 }
-void dump_text_VkPhysicalDeviceRobustness2PropertiesEXT(const VkPhysicalDeviceRobustness2PropertiesEXT& object, const ApiDumpSettings& settings, int indents)
+void dump_text_VkPhysicalDeviceRobustness2PropertiesKHR(const VkPhysicalDeviceRobustness2PropertiesKHR& object, const ApiDumpSettings& settings, int indents)
 {
     if(settings.showAddress())
         settings.stream() << &object << ":\n";
@@ -31901,6 +31970,19 @@ void dump_text_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT(const VkPhys
         dump_text_pNext_trampoline(object.pNext, settings, indents < 2 ? indents + 1 : indents);
     }
 }
+void dump_text_VkPhysicalDeviceFormatPackFeaturesARM(const VkPhysicalDeviceFormatPackFeaturesARM& object, const ApiDumpSettings& settings, int indents)
+{
+    if(settings.showAddress())
+        settings.stream() << &object << ":\n";
+    else
+        settings.stream() << "address:\n";
+    dump_text_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_text_VkStructureType);  // AET
+    dump_text_pNext_struct_name(object.pNext, settings, indents + 1, "void*");
+    dump_text_value<const VkBool32>(object.formatPack, settings, "VkBool32", "formatPack", indents + 1, dump_text_VkBool32);  // AET
+    if(object.pNext != nullptr){
+        dump_text_pNext_trampoline(object.pNext, settings, indents < 2 ? indents + 1 : indents);
+    }
+}
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_text_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const ApiDumpSettings& settings, int indents)
 {
@@ -31940,6 +32022,19 @@ void dump_text_VkRenderingEndInfoEXT(const VkRenderingEndInfoEXT& object, const 
         settings.stream() << "address:\n";
     dump_text_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_text_VkStructureType);  // AET
     dump_text_pNext_struct_name(object.pNext, settings, indents + 1, "const void*");
+    if(object.pNext != nullptr){
+        dump_text_pNext_trampoline(object.pNext, settings, indents < 2 ? indents + 1 : indents);
+    }
+}
+void dump_text_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT(const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT& object, const ApiDumpSettings& settings, int indents)
+{
+    if(settings.showAddress())
+        settings.stream() << &object << ":\n";
+    else
+        settings.stream() << "address:\n";
+    dump_text_value<const VkStructureType>(object.sType, settings, "VkStructureType", "sType", indents + 1, dump_text_VkStructureType);  // AET
+    dump_text_pNext_struct_name(object.pNext, settings, indents + 1, "void*");
+    dump_text_value<const VkBool32>(object.zeroInitializeDeviceMemory, settings, "VkBool32", "zeroInitializeDeviceMemory", indents + 1, dump_text_VkBool32);  // AET
     if(object.pNext != nullptr){
         dump_text_pNext_trampoline(object.pNext, settings, indents < 2 ? indents + 1 : indents);
     }
@@ -34064,10 +34159,10 @@ void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& sett
             settings.stream() << "VkDeviceDeviceMemoryReportCreateInfoEXT\n";
             break;
         case 1000286000:
-            settings.stream() << "VkPhysicalDeviceRobustness2FeaturesEXT\n";
+            settings.stream() << "VkPhysicalDeviceRobustness2FeaturesKHR\n";
             break;
         case 1000286001:
-            settings.stream() << "VkPhysicalDeviceRobustness2PropertiesEXT\n";
+            settings.stream() << "VkPhysicalDeviceRobustness2PropertiesKHR\n";
             break;
         case 1000287000:
             settings.stream() << "VkSamplerCustomBorderColorCreateInfoEXT\n";
@@ -35359,6 +35454,9 @@ void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& sett
         case 1000608000:
             settings.stream() << "VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT\n";
             break;
+        case 1000609000:
+            settings.stream() << "VkPhysicalDeviceFormatPackFeaturesARM\n";
+            break;
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
         case 1000613000:
             settings.stream() << "VkSetPresentConfigNV\n";
@@ -35371,6 +35469,9 @@ void dump_text_pNext_struct_name(const void* object, const ApiDumpSettings& sett
 #endif // VK_ENABLE_BETA_EXTENSIONS
         case 1000619003:
             settings.stream() << "VkRenderingEndInfoEXT\n";
+            break;
+        case 1000620000:
+            settings.stream() << "VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT\n";
             break;
         case VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO: // 47
         case VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO: // 48
@@ -37322,10 +37423,10 @@ void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& setti
         dump_text_pNext<const VkDeviceDeviceMemoryReportCreateInfoEXT>(reinterpret_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT*>(object), settings, "VkDeviceDeviceMemoryReportCreateInfoEXT", indents, dump_text_VkDeviceDeviceMemoryReportCreateInfoEXT);
         break;
     case 1000286000:
-        dump_text_pNext<const VkPhysicalDeviceRobustness2FeaturesEXT>(reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesEXT*>(object), settings, "VkPhysicalDeviceRobustness2FeaturesEXT", indents, dump_text_VkPhysicalDeviceRobustness2FeaturesEXT);
+        dump_text_pNext<const VkPhysicalDeviceRobustness2FeaturesKHR>(reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(object), settings, "VkPhysicalDeviceRobustness2FeaturesKHR", indents, dump_text_VkPhysicalDeviceRobustness2FeaturesKHR);
         break;
     case 1000286001:
-        dump_text_pNext<const VkPhysicalDeviceRobustness2PropertiesEXT>(reinterpret_cast<const VkPhysicalDeviceRobustness2PropertiesEXT*>(object), settings, "VkPhysicalDeviceRobustness2PropertiesEXT", indents, dump_text_VkPhysicalDeviceRobustness2PropertiesEXT);
+        dump_text_pNext<const VkPhysicalDeviceRobustness2PropertiesKHR>(reinterpret_cast<const VkPhysicalDeviceRobustness2PropertiesKHR*>(object), settings, "VkPhysicalDeviceRobustness2PropertiesKHR", indents, dump_text_VkPhysicalDeviceRobustness2PropertiesKHR);
         break;
     case 1000287000:
         dump_text_pNext<const VkSamplerCustomBorderColorCreateInfoEXT>(reinterpret_cast<const VkSamplerCustomBorderColorCreateInfoEXT*>(object), settings, "VkSamplerCustomBorderColorCreateInfoEXT", indents, dump_text_VkSamplerCustomBorderColorCreateInfoEXT);
@@ -38617,6 +38718,9 @@ void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& setti
     case 1000608000:
         dump_text_pNext<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT>(reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(object), settings, "VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT", indents, dump_text_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT);
         break;
+    case 1000609000:
+        dump_text_pNext<const VkPhysicalDeviceFormatPackFeaturesARM>(reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(object), settings, "VkPhysicalDeviceFormatPackFeaturesARM", indents, dump_text_VkPhysicalDeviceFormatPackFeaturesARM);
+        break;
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
     case 1000613000:
         dump_text_pNext<const VkSetPresentConfigNV>(reinterpret_cast<const VkSetPresentConfigNV*>(object), settings, "VkSetPresentConfigNV", indents, dump_text_VkSetPresentConfigNV);
@@ -38629,6 +38733,9 @@ void dump_text_pNext_trampoline(const void* object, const ApiDumpSettings& setti
 #endif // VK_ENABLE_BETA_EXTENSIONS
     case 1000619003:
         dump_text_pNext<const VkRenderingEndInfoEXT>(reinterpret_cast<const VkRenderingEndInfoEXT*>(object), settings, "VkRenderingEndInfoEXT", indents, dump_text_VkRenderingEndInfoEXT);
+        break;
+    case 1000620000:
+        dump_text_pNext<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT>(reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(object), settings, "VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT", indents, dump_text_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT);
         break;
     case VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO: // 47
     case VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO: // 48
@@ -45462,13 +45569,14 @@ void dump_text_params_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkComm
     }
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_text_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer)
+void dump_text_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo)
 {
     const ApiDumpSettings& settings(dump_inst.settings());
     if(settings.showParams())
     {
         settings.stream() << "\n";
         dump_text_value<const VkCommandBuffer>(commandBuffer, settings, "VkCommandBuffer", "commandBuffer", 1, dump_text_VkCommandBuffer); // MET
+        dump_text_pointer<const VkDispatchTileInfoQCOM>(pDispatchTileInfo, settings, "const VkDispatchTileInfoQCOM*", "pDispatchTileInfo", 1, dump_text_VkDispatchTileInfoQCOM);
         if (settings.shouldFlush()) settings.stream().flush();
     }
 }
@@ -51642,10 +51750,10 @@ void dump_text_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuff
     settings.shouldFlush() ? settings.stream() << std::endl : settings.stream() << "\n";
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_text_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer)
+void dump_text_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo)
 {
     const ApiDumpSettings& settings(dump_inst.settings());
-    dump_text_params_vkCmdDispatchTileQCOM(dump_inst, commandBuffer);
+    dump_text_params_vkCmdDispatchTileQCOM(dump_inst, commandBuffer, pDispatchTileInfo);
     settings.shouldFlush() ? settings.stream() << std::endl : settings.stream() << "\n";
 }
 void dump_text_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo)

--- a/layersvt/generated/api_dump_text.h
+++ b/layersvt/generated/api_dump_text.h
@@ -1629,8 +1629,8 @@ void dump_text_VkDepthBiasRepresentationInfoEXT(const VkDepthBiasRepresentationI
 void dump_text_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT(const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_text_VkDeviceMemoryReportCallbackDataEXT(const VkDeviceMemoryReportCallbackDataEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_text_VkDeviceDeviceMemoryReportCreateInfoEXT(const VkDeviceDeviceMemoryReportCreateInfoEXT& object, const ApiDumpSettings& settings, int indents);
-void dump_text_VkPhysicalDeviceRobustness2FeaturesEXT(const VkPhysicalDeviceRobustness2FeaturesEXT& object, const ApiDumpSettings& settings, int indents);
-void dump_text_VkPhysicalDeviceRobustness2PropertiesEXT(const VkPhysicalDeviceRobustness2PropertiesEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_text_VkPhysicalDeviceRobustness2FeaturesKHR(const VkPhysicalDeviceRobustness2FeaturesKHR& object, const ApiDumpSettings& settings, int indents);
+void dump_text_VkPhysicalDeviceRobustness2PropertiesKHR(const VkPhysicalDeviceRobustness2PropertiesKHR& object, const ApiDumpSettings& settings, int indents);
 void dump_text_VkSamplerCustomBorderColorCreateInfoEXT(const VkSamplerCustomBorderColorCreateInfoEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_text_VkPhysicalDeviceCustomBorderColorPropertiesEXT(const VkPhysicalDeviceCustomBorderColorPropertiesEXT& object, const ApiDumpSettings& settings, int indents);
 void dump_text_VkPhysicalDeviceCustomBorderColorFeaturesEXT(const VkPhysicalDeviceCustomBorderColorFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
@@ -2173,6 +2173,7 @@ void dump_text_VkMemoryMetalHandlePropertiesEXT(const VkMemoryMetalHandlePropert
 void dump_text_VkMemoryGetMetalHandleInfoEXT(const VkMemoryGetMetalHandleInfoEXT& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_USE_PLATFORM_METAL_EXT
 void dump_text_VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT(const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_text_VkPhysicalDeviceFormatPackFeaturesARM(const VkPhysicalDeviceFormatPackFeaturesARM& object, const ApiDumpSettings& settings, int indents);
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_text_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -2180,6 +2181,7 @@ void dump_text_VkSetPresentConfigNV(const VkSetPresentConfigNV& object, const Ap
 void dump_text_VkPhysicalDevicePresentMeteringFeaturesNV(const VkPhysicalDevicePresentMeteringFeaturesNV& object, const ApiDumpSettings& settings, int indents);
 #endif // VK_ENABLE_BETA_EXTENSIONS
 void dump_text_VkRenderingEndInfoEXT(const VkRenderingEndInfoEXT& object, const ApiDumpSettings& settings, int indents);
+void dump_text_VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT(const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT& object, const ApiDumpSettings& settings, int indents);
 
 //========================== Union Implementations ==========================//
 
@@ -2834,7 +2836,7 @@ void dump_text_params_vkDestroyCudaFunctionNV(ApiDumpInstance& dump_inst, VkDevi
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_text_params_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_text_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer);
+void dump_text_params_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo);
 void dump_text_params_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo);
 void dump_text_params_vkCmdEndPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo);
 #if defined(VK_USE_PLATFORM_METAL_EXT)
@@ -3692,7 +3694,7 @@ void dump_text_vkDestroyCudaFunctionNV(ApiDumpInstance& dump_inst, VkDevice devi
 #if defined(VK_ENABLE_BETA_EXTENSIONS)
 void dump_text_vkCmdCudaLaunchKernelNV(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
 #endif // VK_ENABLE_BETA_EXTENSIONS
-void dump_text_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer);
+void dump_text_vkCmdDispatchTileQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo);
 void dump_text_vkCmdBeginPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo);
 void dump_text_vkCmdEndPerTileExecutionQCOM(ApiDumpInstance& dump_inst, VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo);
 #if defined(VK_USE_PLATFORM_METAL_EXT)

--- a/layersvt/json/VkLayer_api_dump.json.in
+++ b/layersvt/json/VkLayer_api_dump.json.in
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_api_dump",
         "type": "GLOBAL",
         "library_path": "@JSON_LIBRARY_PATH@",
-        "api_version": "1.4.313",
+        "api_version": "1.4.316",
         "implementation_version": "2",
         "description": "LunarG API dump layer",
         "introduction": "The API Dump utility layer prints API calls, parameters, and values to the identified output stream.",

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
             "sub_dir": "Vulkan-Headers",
             "build_dir": "Vulkan-Headers/build",
             "install_dir": "Vulkan-Headers/build/install",
-            "commit": "v1.4.313",
+            "commit": "v1.4.316",
             "cmake_options": [
                 "-DVULKAN_HEADERS_ENABLE_MODULE=OFF"
             ]
@@ -17,7 +17,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "v1.4.313",
+            "commit": "v1.4.316",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",
@@ -31,7 +31,7 @@
             "sub_dir": "Vulkan-Loader",
             "build_dir": "Vulkan-Loader/build",
             "install_dir": "Vulkan-Loader/build/install",
-            "commit": "v1.4.313",
+            "commit": "v1.4.316",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",
@@ -50,7 +50,7 @@
             "sub_dir": "Vulkan-Tools",
             "build_dir": "Vulkan-Tools/build",
             "install_dir": "Vulkan-Tools/build/install",
-            "commit": "682e42f7ae70a8fadf374199c02de737daa5c70d",
+            "commit": "v1.4.316",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
This header update includes ABI incompatible changes to vkCmdDispatchTileQCOM which adds a new parameter.