### PR TITLE
vkconfig: Add layer setting deps to generated vk_layer_settings.txt

### DIFF
--- a/vkconfig_gui/CHANGELOG.md
+++ b/vkconfig_gui/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Add detailed description layer setting field
   - Add display of deprecated setting information in generated layer documentation
   - Add optional information about which setting replaced a deprecated setting
+  - Add layer setting dependences to generated vk_layer_settings.txt
 - Add theme mode control in preference tab
 
 ### Fixes:


### PR DESCRIPTION
Eg:
```
# Caching - check_shaders_caching
# ==========================================
# Creates an internal instance of VK_EXT_validation_cache and upon
# vkDestroyInstance, will cache the shader validation so sequential usage of the
# validation layers will be skipped.
# This setting requires ALL of the following values:
# - khronos_validation.validate_core = true
# - khronos_validation.check_shaders = true
khronos_validation.check_shaders_caching = true
```