### PR TITLE
cmake: Fix bad GLOB for generated files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,14 +64,14 @@ endif()
 # So this target needs to be off by default to avoid obtuse build errors or patches.
 option(VT_CODEGEN "Enable vulkantools code generation")
 if (VT_CODEGEN)
-    file(GLOB VT_GENERATED_FILES ${VULKAN_TOOLS_SOURCE_DIR}/layersvt/generated *)
+    file(GLOB VT_GENERATED_FILES "${CMAKE_SOURCE_DIR}/layersvt/generated/*.cpp" "${CMAKE_SOURCE_DIR}/layersvt/generated/*.h")
     find_package(Python3 REQUIRED)
     add_custom_command(OUTPUT ${VT_GENERATED_FILES}
-        COMMAND Python3::Interpreter "${VULKAN_TOOLS_SOURCE_DIR}/scripts/generate_source.py"
+        COMMAND Python3::Interpreter "${CMAKE_SOURCE_DIR}/scripts/generate_source.py"
             "${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry"
             --incremental --generated-version ${VulkanHeaders_VERSION}
-        WORKING_DIRECTORY ${VULKAN_TOOLS_SOURCE_DIR}/layersvt/generated
-        MAIN_DEPENDENCY ${VULKAN_TOOLS_SOURCE_DIR}/scripts/api_dump_generator.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/layersvt/generated
+        MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/scripts/api_dump_generator.py
     )
     add_custom_target(vt_codegen DEPENDS ${VT_GENERATED_FILES})
 endif()

--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -46,7 +46,6 @@ endif()
 if(BUILD_APIDUMP)
     find_package(Python3 REQUIRED)
 
-    set(VULKANTOOLS_SCRIPTS_DIR "${VULKAN_TOOLS_SOURCE_DIR}/scripts")
     set(VULKAN_REGISTRY "${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry")
 
     if(IOS)


### PR DESCRIPTION
The file(GLOB) command works differently than I thought, causing the glob to match the WHOLE PROJECT.
Is not a hard fix, but only was found after trying to clean my build and accidentally deleted everything.