### PR TITLE
cmake: Run codegen on demand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,16 +64,24 @@ endif()
 # So this target needs to be off by default to avoid obtuse build errors or patches.
 option(VT_CODEGEN "Enable vulkantools code generation")
 if (VT_CODEGEN)
-    file(GLOB VT_GENERATED_FILES "${CMAKE_SOURCE_DIR}/layersvt/generated/*.cpp" "${CMAKE_SOURCE_DIR}/layersvt/generated/*.h")
     find_package(Python3 REQUIRED)
+    add_custom_target(vt_codegen
+        COMMAND Python3::Interpreter "${CMAKE_SOURCE_DIR}/scripts/generate_source.py"
+            "${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry"
+            --incremental --generated-version ${VulkanHeaders_VERSION}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/layersvt/generated
+    )
+
+    file(GLOB VT_GENERATED_FILES "${CMAKE_SOURCE_DIR}/layersvt/generated/*.cpp" "${CMAKE_SOURCE_DIR}/layersvt/generated/*.h")
     add_custom_command(OUTPUT ${VT_GENERATED_FILES}
         COMMAND Python3::Interpreter "${CMAKE_SOURCE_DIR}/scripts/generate_source.py"
             "${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry"
             --incremental --generated-version ${VulkanHeaders_VERSION}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/layersvt/generated
-        MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/scripts/api_dump_generator.py
+        DEPENDS ${CMAKE_SOURCE_DIR}/scripts/api_dump_generator.py ${VULKAN_HEADERS_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/vulkan/registry/vk.xml
     )
-    add_custom_target(vt_codegen DEPENDS ${VT_GENERATED_FILES})
+
+    add_custom_target(vt_codegen_as_needed DEPENDS ${VT_GENERATED_FILES})
 endif()
 
 if (MSVC)

--- a/layersvt/CMakeLists.txt
+++ b/layersvt/CMakeLists.txt
@@ -90,7 +90,7 @@ if(BUILD_APIDUMP)
     target_compile_definitions(VkLayer_api_dump PRIVATE VK_ENABLE_BETA_EXTENSIONS)
 
     if (VT_CODEGEN)
-        add_dependencies(VkLayer_api_dump vt_codegen)
+        add_dependencies(VkLayer_api_dump vt_codegen_as_needed)
     endif()
 endif ()
 


### PR DESCRIPTION
Creates a new target that is run on-demand with the vt_codegen target. A new target vt_codegen_as_needed creates the necessary file dependencies to allow the build tool to know when to rerun codegen.

This separationg of on-demand and as-needed is so that tools using the codegen can have it run automatically as changes are made while the vt_codegen target can be used to *force* codegen to run in case the file level dependencies aren't accurate.