### PR TITLE
dump: Use hex for VkDeviceAddress

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -1099,6 +1099,15 @@ void dump_value(const ApiDumpSettings &settings, T &&...values) {
     dump_value_end<Format>(settings);
 }
 
+template <ApiDumpFormat Format, typename... T>
+void dump_value_hex(const ApiDumpSettings &settings, T &&...values) {
+    dump_value_start<Format>(settings);
+    settings.stream() << "0x" << std::hex;
+    (settings.stream() << ... << values);
+    settings.stream() << std::dec;
+    dump_value_end<Format>(settings);
+}
+
 template <ApiDumpFormat Format>
 void dump_string(const ApiDumpSettings &settings, const char *name) {
     dump_value<Format>(settings, name);

--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -1370,6 +1370,14 @@ std::enable_if_t<std::is_pointer_v<T>> dump_type(const T &object, const ApiDumpS
 }
 
 template <ApiDumpFormat Format, typename T>
+std::enable_if_t<!std::is_pointer_v<T>> dump_type_hex(const T &object, const ApiDumpSettings &settings, const char *type_string,
+                                                      const char *name, int indents, const void *address = nullptr) {
+    dump_start<Format>(settings, OutputConstruct::value, type_string, name, indents, address);
+    dump_value_hex<Format>(settings, object);
+    dump_end<Format>(settings, OutputConstruct::value, indents);
+}
+
+template <ApiDumpFormat Format, typename T>
 void dump_fake_pointer(const T &object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents,
                        const void *address = nullptr) {
     dump_start<Format>(settings, OutputConstruct::pointer, type_string, name, indents, &object);

--- a/layersvt/generated/api_dump_dispatch.h
+++ b/layersvt/generated/api_dump_dispatch.h
@@ -4994,7 +4994,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetBufferDeviceAddress(VkDevice device, 
     }
     VkDeviceAddress result = device_dispatch_table(device)->GetBufferDeviceAddress(device, pInfo);
     if (ApiDumpInstance::current().shouldDumpOutput()) {
-        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result);
+        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result, dump_return_value_VkDeviceAddress<Format>);
         dump_pre_function_formatting<Format>(ApiDumpInstance::current().settings());
         dump_params_vkGetBufferDeviceAddress<Format>(ApiDumpInstance::current(), device, pInfo);
         dump_post_function_formatting<Format>(ApiDumpInstance::current().settings());
@@ -7451,7 +7451,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetBufferDeviceAddressKHR(VkDevice devic
     }
     VkDeviceAddress result = device_dispatch_table(device)->GetBufferDeviceAddressKHR(device, pInfo);
     if (ApiDumpInstance::current().shouldDumpOutput()) {
-        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result);
+        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result, dump_return_value_VkDeviceAddress<Format>);
         dump_pre_function_formatting<Format>(ApiDumpInstance::current().settings());
         dump_params_vkGetBufferDeviceAddressKHR<Format>(ApiDumpInstance::current(), device, pInfo);
         dump_post_function_formatting<Format>(ApiDumpInstance::current().settings());
@@ -10359,7 +10359,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetBufferDeviceAddressEXT(VkDevice devic
     }
     VkDeviceAddress result = device_dispatch_table(device)->GetBufferDeviceAddressEXT(device, pInfo);
     if (ApiDumpInstance::current().shouldDumpOutput()) {
-        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result);
+        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result, dump_return_value_VkDeviceAddress<Format>);
         dump_pre_function_formatting<Format>(ApiDumpInstance::current().settings());
         dump_params_vkGetBufferDeviceAddressEXT<Format>(ApiDumpInstance::current(), device, pInfo);
         dump_post_function_formatting<Format>(ApiDumpInstance::current().settings());
@@ -12457,7 +12457,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetPipelineIndirectDeviceAddressNV(VkDev
     }
     VkDeviceAddress result = device_dispatch_table(device)->GetPipelineIndirectDeviceAddressNV(device, pInfo);
     if (ApiDumpInstance::current().shouldDumpOutput()) {
-        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result);
+        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result, dump_return_value_VkDeviceAddress<Format>);
         dump_pre_function_formatting<Format>(ApiDumpInstance::current().settings());
         dump_params_vkGetPipelineIndirectDeviceAddressNV<Format>(ApiDumpInstance::current(), device, pInfo);
         dump_post_function_formatting<Format>(ApiDumpInstance::current().settings());
@@ -14358,7 +14358,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetAccelerationStructureDeviceAddressKHR
     }
     VkDeviceAddress result = device_dispatch_table(device)->GetAccelerationStructureDeviceAddressKHR(device, pInfo);
     if (ApiDumpInstance::current().shouldDumpOutput()) {
-        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result);
+        dump_return_value<Format>(ApiDumpInstance::current().settings(), "VkDeviceAddress", result, dump_return_value_VkDeviceAddress<Format>);
         dump_pre_function_formatting<Format>(ApiDumpInstance::current().settings());
         dump_params_vkGetAccelerationStructureDeviceAddressKHR<Format>(ApiDumpInstance::current(), device, pInfo);
         dump_post_function_formatting<Format>(ApiDumpInstance::current().settings());

--- a/scripts/generators/api_dump_generator.py
+++ b/scripts/generators/api_dump_generator.py
@@ -858,7 +858,6 @@ class ApiDumpGenerator(BaseGenerator):
         else:
             indent = 'indents + (Format == ApiDumpFormat::Json ? 2 : 1)'
 
-
         value = f'{object_access}{var.name}'
         if self.get_is_array(var):
             element_type = f'dump_type<Format, {custom_type}>'
@@ -911,6 +910,8 @@ class ApiDumpGenerator(BaseGenerator):
                     value_type = 'dump_pNext<Format>'
                 elif var.type == 'char':
                     value_type = 'dump_char<Format>'
+                elif var.fullType == 'VkDeviceAddress':
+                    value_type = f'dump_type_hex<Format, {var.fullType}>'
                 elif var.fullType == 'uint8_t': # ostream << treats uint8_t as char which we dont want
                     value_type = 'dump_type<Format, uint32_t>'
                 elif var.fullType == 'int8_t': # ostream << treats int8_t as char which we dont want


### PR DESCRIPTION
for https://github.com/LunarG/VulkanTools/issues/1967 (likely others, so maybe not close it completely)

This was 

1. Something I wanted before
2. A quick test how easy @charles-lunarg refactoring made this change.... it was really easy to add, so good job Charles! :confetti_ball:  

-----
Before

![Screenshot from 2025-06-30 12-15-35](https://github.com/user-attachments/assets/e4d1751a-a443-4fe4-ab4e-0bde1338266d)

After

![Screenshot from 2025-06-30 12-15-57](https://github.com/user-attachments/assets/6ed256dd-1407-427b-8239-4bb896a573e0)
