### PR TITLE
vkconfig: Enabled passing SDK version to vkconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows|Linux|BSD")
     option(BUILD_MONITOR "Build monitor layer" ON)
     option(BUILD_SCREENSHOT "Build screenshot layer" ON)
     option(BUILD_LAYERMGR "Build Vulkan Configurator" ON)
+    set(SDK_VERSION "" CACHE STRING "Vulkan SDK version")
 
 elseif(ANDROID)
 

--- a/vkconfig_core/CMakeLists.txt
+++ b/vkconfig_core/CMakeLists.txt
@@ -37,6 +37,8 @@ target_compile_options(vkconfig-core PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/MP>)
 target_compile_definitions(vkconfig-core PRIVATE QT_NO_DEBUG_OUTPUT QT_NO_WARNING_OUTPUT)
 target_compile_definitions(vkconfig-core PRIVATE INSTALL_FULL_SYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
 target_compile_definitions(vkconfig-core PRIVATE INSTALL_FULL_DATAROOTDIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}")
+target_compile_definitions(vkconfig-core PRIVATE SDK_VERSION="${SDK_VERSION}")
+add_definitions( -DVERSION_LIBINTERFACE=${LIBINTERFACE_VERSION} )
 set_target_properties(vkconfig-core PROPERTIES FOLDER "vkconfig")
 
 if(WIN32)

--- a/vkconfig_core/configurator.cpp
+++ b/vkconfig_core/configurator.cpp
@@ -1213,9 +1213,8 @@ bool Configurator::Load() {
             if (json_object.value("latest_sdk_version") != QJsonValue::Undefined) {
                 this->latest_sdk_version = Version(json_object.value("latest_sdk_version").toString().toStdString().c_str());
             }
-
-            if (json_object.value("last_vkconfig_version") != QJsonValue::Undefined) {
-                this->last_vkconfig_version = Version(json_object.value("last_vkconfig_version").toString().toStdString().c_str());
+            if (this->latest_sdk_version < this->current_sdk_version) {
+                this->latest_sdk_version = this->current_sdk_version;
             }
 
             if (json_object.value("use_system_tray") != QJsonValue::Undefined) {
@@ -1292,7 +1291,6 @@ bool Configurator::Save() const {
         json_object.insert("theme_dark_alternate_color", this->theme_dark_alternate_color.name());
         json_object.insert("use_notify_releases", this->use_notify_releases);
         json_object.insert("latest_sdk_version", this->latest_sdk_version.str().c_str());
-        json_object.insert("last_vkconfig_version", Version::VKCONFIG.str().c_str());
         json_object.insert("show_external_layers_settings", this->show_external_layers_settings);
         json_object.insert("VULKAN_HOME", ::Path(Path::HOME).RelativePath().c_str());
         json_object.insert("VULKAN_DOWNLOAD", ::Path(Path::DOWNLOAD).RelativePath().c_str());
@@ -1386,12 +1384,17 @@ bool Configurator::IsExternalLayersSettingsUsed(bool icon_mode) const {
 }
 
 bool Configurator::ShouldNotify() const {
-    // Notify if
-    return this->latest_sdk_version < this->online_sdk_version  // There is an online SDK version newer than the latest SDK version
-           && this->online_sdk_version != Version::NONE;        // We could query the online SDK version
-    //        && Version::VKCONFIG < this->last_vkconfig_version // The Vulkan Configurator version
-    //&& Version::VKHEADER < this->online_sdk_version;  // The Vulkan Header version used to build Vulkan Configurator is older
-    // than the online version
+    return this->latest_sdk_version < this->online_sdk_version && this->online_sdk_version != Version::NONE;
+
+    /*
+        // Notify if
+        return this->latest_sdk_version < this->online_sdk_version  // There is an online SDK version newer than the latest SDK
+       version
+               && this->online_sdk_version != Version::NONE;        // We could query the online SDK version
+        //        && Version::VKCONFIG < this->last_vkconfig_version // The Vulkan Configurator version
+        //&& Version::VKHEADER < this->online_sdk_version;  // The Vulkan Header version used to build Vulkan Configurator is older
+        // than the online version
+    */
 }
 
 bool Configurator::HasActiveSettings() const {

--- a/vkconfig_core/configurator.h
+++ b/vkconfig_core/configurator.h
@@ -158,9 +158,14 @@ class Configurator {
     TabType active_tab = TAB_CONFIGURATIONS;
     bool advanced = true;
     Path last_path_status = Path(Path::HOME).AbsolutePath() + "/diagnostics";
-    Version latest_sdk_version = Version::NONE;
     Version online_sdk_version = Version::NONE;
-    Version last_vkconfig_version = Version::NONE;
+    Version latest_sdk_version = Version::NONE;
+#ifdef SDK_VERSION
+    Version current_sdk_version = Version(SDK_VERSION);
+#else
+    Version current_sdk_version = Version::VKHEADER;
+#endif
+
     QByteArray window_geometry;
     QByteArray window_state;
     ThemeMode current_theme_mode = THEME_MODE_AUTO;

--- a/vkconfig_gui/CHANGELOG.md
+++ b/vkconfig_gui/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixes:
   - Fix crashes when `QT_QPA_PLATFORM` is set
+  - Fix invalid new SDK notifications on patch releases
 
 ## Vulkan Configurator 3.2.0 - May 2025
 [Vulkan SDK 1.4.313.0](https://github.com/LunarG/VulkanTools/tree/vulkan-sdk-1.4.313)

--- a/vkconfig_gui/mainwindow.ui
+++ b/vkconfig_gui/mainwindow.ui
@@ -3191,7 +3191,7 @@
                 <property name="spacing">
                  <number>0</number>
                 </property>
-                <item row="1" column="0">
+                <item row="2" column="0">
                  <layout class="QHBoxLayout" name="horizontalLayout_8">
                   <property name="spacing">
                    <number>0</number>
@@ -3209,7 +3209,7 @@
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QLabel" name="label_4">
+                   <widget class="QLabel" name="preferences_vk_download_label">
                     <property name="maximumSize">
                      <size>
                       <width>16777215</width>
@@ -3305,6 +3305,32 @@
                   </item>
                  </layout>
                 </item>
+                <item row="0" column="1">
+                 <widget class="QPushButton" name="preferences_open_page">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>24</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>24</height>
+                   </size>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <family>Arial</family>
+                    <pointsize>10</pointsize>
+                    <bold>false</bold>
+                   </font>
+                  </property>
+                  <property name="text">
+                   <string>Open Vulkan SDK download web page...</string>
+                  </property>
+                 </widget>
+                </item>
                 <item row="0" column="0">
                  <layout class="QHBoxLayout" name="horizontalLayout_11">
                   <property name="spacing">
@@ -3360,57 +3386,73 @@
                   </item>
                  </layout>
                 </item>
-                <item row="1" column="1">
-                 <widget class="QPushButton" name="preferences_download">
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>24</height>
-                   </size>
+                <item row="2" column="1">
+                 <layout class="QHBoxLayout" name="horizontalLayout_16">
+                  <property name="spacing">
+                   <number>0</number>
                   </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>24</height>
-                   </size>
+                  <property name="topMargin">
+                   <number>0</number>
                   </property>
-                  <property name="font">
-                   <font>
-                    <family>Arial</family>
-                    <pointsize>10</pointsize>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QPushButton" name="preferences_open_page">
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>24</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>24</height>
-                   </size>
-                  </property>
-                  <property name="font">
-                   <font>
-                    <family>Arial</family>
-                    <pointsize>10</pointsize>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string>Open Vulkan SDK download web page...</string>
-                  </property>
-                 </widget>
+                  <item>
+                   <widget class="QPushButton" name="preferences_download">
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>24</height>
+                     </size>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>24</height>
+                     </size>
+                    </property>
+                    <property name="font">
+                     <font>
+                      <family>Arial</family>
+                      <pointsize>10</pointsize>
+                      <bold>false</bold>
+                     </font>
+                    </property>
+                    <property name="toolTip">
+                     <string>Download last Vulkan SDK</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="preferences_vk_download_open">
+                    <property name="minimumSize">
+                     <size>
+                      <width>24</width>
+                      <height>24</height>
+                     </size>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>24</width>
+                      <height>24</height>
+                     </size>
+                    </property>
+                    <property name="font">
+                     <font>
+                      <family>Arial</family>
+                      <pointsize>10</pointsize>
+                      <bold>false</bold>
+                     </font>
+                    </property>
+                    <property name="toolTip">
+                     <string>Open Vulkan SDK download folder</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                </layout>
               </item>

--- a/vkconfig_gui/tab_preferences.h
+++ b/vkconfig_gui/tab_preferences.h
@@ -41,6 +41,7 @@ class TabPreferences : public Tab {
     void on_vk_home_text_pressed();
     void on_vk_home_browse_pressed();
     void on_vk_download_browse_pressed();
+    void on_vk_download_open_pressed();
     void on_reset_hard_pressed();
     void on_layer_dev_mode_toggled(bool checked);
     void on_show_override_settings_toggled(bool checked);


### PR DESCRIPTION
Fixed .X SDK release invalid notifications by setting `SDK_VERSION` cmake variable to a SDK version