### PR TITLE
Use static RT when static QT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if(BUILD_LAYERMGR)
         add_subdirectory(vkconfig_cmd)
         add_subdirectory(vkconfig_gui)
 
-        if(WIN32 AND BUILD_TESTS AND (QT_TARGET_TYPE STREQUAL STATIC_LIBRARY))
+        if(WIN32 AND (QT_TARGET_TYPE STREQUAL STATIC_LIBRARY))
             set_property(TARGET vkconfig-gui vkconfig-cmd vkconfig-core PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
             message(STATUS "INFO: vkconfig will link against static runtime")
         endif()


### PR DESCRIPTION
When building using our local version of Qt, we need to ensure we use the static runtime library for vkConfig builds. This was working, but recent changes caused a regression when tests are built. This small change restores using the static runtime when tests are not built as well.