### PR TITLE
vkconfig: Fix malformed JSON schema

### DIFF
--- a/vkconfig_core/layers/layers_schema.json
+++ b/vkconfig_core/layers/layers_schema.json
@@ -99,7 +99,7 @@
                                 "operator": {
                                     "type": "string",
                                     "enum": [ "NONE", "NOT" ]
-                                },
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
Removes an illegal trailing comma in the JSON schema, preventing it being loaded by some clients (e.g. LSPs).