### PR TITLE
Fix skipped std video h265 hrd parameters

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -969,6 +969,16 @@ class ApiDumpInstance {
     VkIndirectExecutionSetInfoTypeEXT getIndirectExecutionSetInfoType() { return this->indirectExecutionSetInfoType; }
     void setIndirectCommandsLayoutToken(VkIndirectCommandsTokenTypeEXT type) { this->indirectCommandsLayoutToken = type; }
     VkIndirectCommandsTokenTypeEXT getIndirectCommandsLayoutToken() { return this->indirectCommandsLayoutToken; }
+    void setSpsMaxSubLayersMinus1(uint8_t sps_max_sub_layers_minus1) {
+        this->sps_max_sub_layers_minus1 = sps_max_sub_layers_minus1;
+    }
+    uint8_t getSpsMaxSubLayersMinus1() { return sps_max_sub_layers_minus1; }
+    void setVpsMaxSubLayersMinus1(uint8_t vps_max_sub_layers_minus1) {
+        this->vps_max_sub_layers_minus1 = vps_max_sub_layers_minus1;
+    }
+    uint8_t getVpsMaxSubLayersMinus1() { return vps_max_sub_layers_minus1; }
+    void setIsInVps(bool is_in_vps) { this->is_in_vps = is_in_vps; }
+    bool getIsInVps() { return is_in_vps; }
 
     std::chrono::microseconds current_time_since_start() {
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
@@ -1050,6 +1060,15 @@ class ApiDumpInstance {
 
     // Storage for the VkIndirectCommandsTokenDataEXT union to know which is the active element
     VkIndirectCommandsTokenTypeEXT indirectCommandsLayoutToken;
+
+    // Storage for StdVideoH265HrdParameters's array length for pSubLayerHrdParametersNal and pSubLayerHrdParametersVcl
+    uint8_t sps_max_sub_layers_minus1;
+    uint8_t vps_max_sub_layers_minus1;
+
+    // True if StdVideoH265HrdParameters is currently in StdVideoH265VideoParameterSet, false if it is in
+    // StdVideoH265SequenceParameterSetVui. Needed to determine whether to use vps_max_sub_layers_minus1 or
+    // sps_max_sub_layers_minus1
+    bool is_in_vps;
 };
 
 enum class OutputConstruct {

--- a/layersvt/generated/api_dump_video_implementation.h
+++ b/layersvt/generated/api_dump_video_implementation.h
@@ -1855,6 +1855,26 @@ void dump_StdVideoH265HrdParameters(const StdVideoH265HrdParameters& object, con
     dump_single_array<Format>(object.elemental_duration_in_tc_minus1, STD_VIDEO_H265_SUBLAYERS_LIST_SIZE, settings, "uint16_t[STD_VIDEO_H265_SUBLAYERS_LIST_SIZE]", "elemental_duration_in_tc_minus1", "uint16_t", indents + (Format == ApiDumpFormat::Json ? 2 : 1), dump_type<Format, uint16_t>);
     dump_separate_members<Format>(settings);
     dump_single_array<Format>(object.reserved, 3, settings, "uint16_t[3]", "reserved", "uint16_t", indents + (Format == ApiDumpFormat::Json ? 2 : 1), dump_type<Format, uint16_t>);
+    dump_separate_members<Format>(settings);
+    if (object.flags.nal_hrd_parameters_present_flag == 1) {
+        dump_pointer_array<Format>(object.pSubLayerHrdParametersNal, ApiDumpInstance::current().getIsInVps() ? ApiDumpInstance::current().getVpsMaxSubLayersMinus1() : ApiDumpInstance::current().getSpsMaxSubLayersMinus1(), settings, "const StdVideoH265SubLayerHrdParameters*", "pSubLayerHrdParametersNal", "const StdVideoH265SubLayerHrdParameters", indents + (Format == ApiDumpFormat::Json ? 2 : 1), dump_StdVideoH265SubLayerHrdParameters<Format>);
+    } else {
+        if constexpr (Format == ApiDumpFormat::Text || Format == ApiDumpFormat::Html) {
+            dump_special<Format>("UNUSED", settings, "const StdVideoH265SubLayerHrdParameters*", "pSubLayerHrdParametersNal", indents + 1);
+        } else if constexpr (Format == ApiDumpFormat::Json) {
+            dump_json_UNUSED(settings, "const StdVideoH265SubLayerHrdParameters*", "pSubLayerHrdParametersNal", indents + 2);
+        }
+    }
+    dump_separate_members<Format>(settings);
+    if (object.flags.vcl_hrd_parameters_present_flag == 1) {
+        dump_pointer_array<Format>(object.pSubLayerHrdParametersVcl, ApiDumpInstance::current().getIsInVps() ? ApiDumpInstance::current().getVpsMaxSubLayersMinus1() : ApiDumpInstance::current().getSpsMaxSubLayersMinus1(), settings, "const StdVideoH265SubLayerHrdParameters*", "pSubLayerHrdParametersVcl", "const StdVideoH265SubLayerHrdParameters", indents + (Format == ApiDumpFormat::Json ? 2 : 1), dump_StdVideoH265SubLayerHrdParameters<Format>);
+    } else {
+        if constexpr (Format == ApiDumpFormat::Text || Format == ApiDumpFormat::Html) {
+            dump_special<Format>("UNUSED", settings, "const StdVideoH265SubLayerHrdParameters*", "pSubLayerHrdParametersVcl", indents + 1);
+        } else if constexpr (Format == ApiDumpFormat::Json) {
+            dump_json_UNUSED(settings, "const StdVideoH265SubLayerHrdParameters*", "pSubLayerHrdParametersVcl", indents + 2);
+        }
+    }
     dump_end<Format>(settings, OutputConstruct::api_struct, indents);
 }
 template <ApiDumpFormat Format>
@@ -1896,6 +1916,8 @@ void dump_StdVideoH265ProfileTierLevel(const StdVideoH265ProfileTierLevel& objec
 template <ApiDumpFormat Format>
 void dump_StdVideoH265VideoParameterSet(const StdVideoH265VideoParameterSet& object, const ApiDumpSettings& settings, const char* type_name, const char* var_name, int indents, const void* address = nullptr) {
     dump_start<Format>(settings, OutputConstruct::api_struct, type_name, var_name, indents, address);
+    ApiDumpInstance::current().setVpsMaxSubLayersMinus1(object.vps_max_sub_layers_minus1);
+    ApiDumpInstance::current().setIsInVps(true);
     dump_StdVideoH265VpsFlags<Format>(object.flags, settings, "StdVideoH265VpsFlags", "flags", indents + (Format == ApiDumpFormat::Json ? 2 : 1));
     dump_separate_members<Format>(settings);
     dump_type<Format, uint32_t>(object.vps_video_parameter_set_id, settings, "uint8_t", "vps_video_parameter_set_id", indents + (Format == ApiDumpFormat::Json ? 2 : 1));
@@ -2154,6 +2176,8 @@ void dump_StdVideoH265LongTermRefPicsSps(const StdVideoH265LongTermRefPicsSps& o
 template <ApiDumpFormat Format>
 void dump_StdVideoH265SequenceParameterSet(const StdVideoH265SequenceParameterSet& object, const ApiDumpSettings& settings, const char* type_name, const char* var_name, int indents, const void* address = nullptr) {
     dump_start<Format>(settings, OutputConstruct::api_struct, type_name, var_name, indents, address);
+    ApiDumpInstance::current().setSpsMaxSubLayersMinus1(object.sps_max_sub_layers_minus1);
+    ApiDumpInstance::current().setIsInVps(false);
     dump_StdVideoH265SpsFlags<Format>(object.flags, settings, "StdVideoH265SpsFlags", "flags", indents + (Format == ApiDumpFormat::Json ? 2 : 1));
     dump_separate_members<Format>(settings);
     dump_StdVideoH265ChromaFormatIdc<Format>(object.chroma_format_idc, settings, "StdVideoH265ChromaFormatIdc", "chroma_format_idc", indents + (Format == ApiDumpFormat::Json ? 2 : 1));

--- a/scripts/generators/api_dump_generator.py
+++ b/scripts/generators/api_dump_generator.py
@@ -38,7 +38,7 @@ TRACKED_STATE = {
 }
 
 PARAMETER_STATE = {
-    'VkPipelineViewportStateCreateInfo': {
+    'pDynamicState': {
         'VkGraphicsPipelineCreateInfo':
             'ApiDumpInstance::current().setIsDynamicViewport('
             'object.pDynamicState && '
@@ -56,23 +56,19 @@ PARAMETER_STATE = {
             '));'
             'ApiDumpInstance::current().setIsGPLPreRasterOrFragmentShader(checkForGPLPreRasterOrFragmentShader(object));',
     },
-    'VkCommandBufferBeginInfo': {
+    'commandBuffer': {
         'vkBeginCommandBuffer':
             'ApiDumpInstance::current().setCmdBuffer(commandBuffer);',
     },
-    'VkPhysicalDeviceMemoryProperties': {
+    'memoryProperties': {
         'VkPhysicalDeviceMemoryProperties2':
             'ApiDumpInstance::current().setMemoryHeapCount(object.memoryProperties.memoryHeapCount);',
     },
-    'VkDescriptorDataEXT': {
+    'type': {
         'VkDescriptorGetInfoEXT':
             'ApiDumpInstance::current().setDescriptorType(object.type);',
-    },
-    'VkIndirectExecutionSetInfoEXT':{
         'VkIndirectExecutionSetInfoEXT':
             'ApiDumpInstance::current().setIndirectExecutionSetInfoType(object.type);',
-    },
-    'VkIndirectCommandsTokenDataEXT':{
         'VkIndirectCommandsLayoutTokenEXT':
             'ApiDumpInstance::current().setIndirectCommandsLayoutToken(object.type);',
     }
@@ -816,9 +812,8 @@ class ApiDumpGenerator(BaseGenerator):
         return type_to_check
 
     def get_parameter_state(self, var, parent):
-        typeID = self.get_unaliased_type(var.type)
-        if typeID in PARAMETER_STATE and parent.name in PARAMETER_STATE[typeID]:
-            return PARAMETER_STATE[typeID][parent.name]
+        if var.name in PARAMETER_STATE and parent.name in PARAMETER_STATE[var.name]:
+            return PARAMETER_STATE[var.name][parent.name]
         return None
 
     def get_validity_check(self, var, parent):

--- a/scripts/generators/api_dump_generator.py
+++ b/scripts/generators/api_dump_generator.py
@@ -818,7 +818,7 @@ class ApiDumpGenerator(BaseGenerator):
 
     def get_validity_check(self, var, parent):
         if parent.name in VALIDITY_CHECKS and var.name in VALIDITY_CHECKS[parent.name]:
-            if var.noAutoValidity or (isinstance(parent, Struct) and parent.union):
+            if var.noAutoValidity or (isinstance(parent, Struct)):
                 return VALIDITY_CHECKS[parent.name][var.name]
         return None
 


### PR DESCRIPTION
Adding the necessary special cases turned out to be a bit more work than I originally thought. This was because there was a bug in the get_validity_check generator logic, as well as the complex validity requirements that the previously skipped struct members had.