### PR TITLE
scripts: Remove unused custom changes to vulkan_object.py

### DIFF
--- a/scripts/base_generator.py
+++ b/scripts/base_generator.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 import copy
 from vulkan_object import (VulkanObject,
-    Extension, Version, Deprecate, Handle, BaseType, PlatformType, FuncPointerParam, FuncPointer, Param, Queues, CommandScope, Command,
+    Extension, Version, Deprecate, Handle, FuncPointerParam, FuncPointer, Param, Queues, CommandScope, Command,
     EnumField, Enum, Flag, Bitmask, ExternSync, Flags, Member, Struct,
     Constant, FormatComponent, FormatPlane, Format, FeatureRequirement,
     SyncSupport, SyncEquivalent, SyncStage, SyncAccess, SyncPipelineStage, SyncPipeline,
@@ -971,13 +971,6 @@ class BaseGenerator(OutputGenerator):
                 params.append(FuncPointerParam(paramSplit[-1], paramTypes[0], ' '.join(paramSplit[0:-1]), paramsText))
 
             self.vk.funcPointers[typeName] = FuncPointer(typeName, protect, returnType, requires,  params, self.makeCParamDecl(typeElem, 0))
-
-        elif category == 'basetype':
-            self.vk.baseTypes[typeName] = BaseType(typeName, '*' in typeElem.text, self.makeCParamDecl(typeElem, 0), protect)
-
-        elif category is None:
-            self.vk.platformTypes[typeName] = PlatformType(typeName, typeElem.get('requires'), protect)
-
 
         else:
             # not all categories are used

--- a/scripts/vulkan_object.py
+++ b/scripts/vulkan_object.py
@@ -94,14 +94,6 @@ class Handle:
 
 
 @dataclass
-class BaseType:
-    """<basetype>"""
-    name: str  # ex) MTLDevice_id
-    pointer: bool # If the underlying type is a pointer type, ex) void* MTLDevice_id
-    cDeclaration: str # C string of param, ex) struct ANativeWindow;
-    protect: (str | None) # ex) 'VK_ENABLE_BETA_EXTENSIONS'
-
-@dataclass
 class FuncPointerParam:
     """<funcpointer/param>"""
     name: str
@@ -116,12 +108,6 @@ class FuncPointerParam:
     # C string of param, ex) void* pUserData
     cDeclaration: str
 
-@dataclass
-class PlatformType:
-    """<type> which represents a platform defined type"""
-    name: str # ex) HINSTANCE
-    requires: (str | None) # ex) "windows.h"
-    protect: (str | None) # ex) 'VK_USE_PLATFORM_WIN32_KHR'
 
 @dataclass
 class FuncPointer:
@@ -619,8 +605,6 @@ class VulkanObject():
     constants: dict[str, Constant]   = field(default_factory=dict, init=False)
     formats:   dict[str, Format]     = field(default_factory=dict, init=False)
 
-    baseTypes:     dict[str, BaseType]     = field(default_factory=dict, init=False)
-    platformTypes: dict[str, PlatformType] = field(default_factory=dict, init=False)
     funcPointers:  dict[str, FuncPointer]  = field(default_factory=dict, init=False)
 
     syncStage:    list[SyncStage]    = field(default_factory=list, init=False)


### PR DESCRIPTION
basetypes and platform types are no longer used by API Dump, so they can safely be removed from the local copy of vulkan_object.py & base_generator.py.