### PR TITLE
api_dump: Fix array elements not printing addresses

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -1516,7 +1516,7 @@ void dump_pointer_array(const T *array, size_t len, const ApiDumpSettings &setti
         stream << "[" << i << "]";
         std::string indexName = stream.str();
         dump_element(array[i], settings, element_type, indexName.c_str(), indents + (Format == ApiDumpFormat::Json ? 2 : 1),
-                     nullptr);
+                     array + i);
         if constexpr (Format == ApiDumpFormat::Json) {
             if (i < len - 1) settings.stream() << ',';
             settings.stream() << "\n";
@@ -1541,7 +1541,7 @@ void dump_double_pointer_array(const T *const *array, size_t len, const ApiDumpS
         stream << "[" << i << "]";
         std::string indexName = stream.str();
         dump_pointer<Format>(array[i], settings, element_type, indexName.c_str(), indents + (Format == ApiDumpFormat::Json ? 2 : 1),
-                     dump_element);
+                             dump_element);
         if constexpr (Format == ApiDumpFormat::Json) {
             if (i < len - 1) settings.stream() << ',';
             settings.stream() << "\n";


### PR DESCRIPTION
Was always printing nullptr instead of the address of the element in the array.