### PR TITLE
Use deviceName + driverName + driverVersion to distinguish drivers

### DIFF
--- a/vkconfig_core/vulkan_util.h
+++ b/vkconfig_core/vulkan_util.h
@@ -41,7 +41,9 @@ enum VendorID {
 };
 
 struct VulkanPhysicalDeviceInfo {
+    std::string fullName;
     std::string deviceName;
+    std::string driverName;
     uint8_t deviceUUID[VK_UUID_SIZE];
     std::string driverUUID;
     std::string deviceLUID;

--- a/vkconfig_gui/tab_diagnostics.cpp
+++ b/vkconfig_gui/tab_diagnostics.cpp
@@ -152,7 +152,7 @@ std::string TabDiagnostics::BuildStatus(DiagnosticMode selected_mode, std::size_
                 args += filename.c_str();
             }
             if (selected_mode == DIAGNOSTIC_VULKAN_PROFILE) {
-                filename = format("%s.json", configurator.vulkan_system_info.physicalDevices[mode_index].deviceName.c_str());
+                filename = format("%s.json", configurator.vulkan_system_info.physicalDevices[mode_index].fullName.c_str());
 
                 args += format("--json=%d", mode_index).c_str();
                 args += "-o";
@@ -362,7 +362,7 @@ void TabDiagnostics::on_mode_changed(int index) {
         this->ui->diagnostic_mode_options->clear();
         if (profile_mode) {
             for (std::size_t i = 0, n = configurator.vulkan_system_info.physicalDevices.size(); i < n; ++i) {
-                this->ui->diagnostic_mode_options->addItem(configurator.vulkan_system_info.physicalDevices[i].deviceName.c_str());
+                this->ui->diagnostic_mode_options->addItem(configurator.vulkan_system_info.physicalDevices[i].fullName.c_str());
             }
         } else {
             const std::vector<Executable> &executables = configurator.executables.GetExecutables();
@@ -437,7 +437,7 @@ void TabDiagnostics::on_export_folder() {
                 case DIAGNOSTIC_VULKAN_PROFILE: {
                     export_path =
                         export_dir.RelativePath() +
-                        format("/%s.json", configurator.vulkan_system_info.physicalDevices[options_index].deviceName.c_str());
+                        format("/%s.json", configurator.vulkan_system_info.physicalDevices[options_index].fullName.c_str());
                 } break;
                 case DIAGNOSTIC_VULKAN_LOADER_CONFIGURATION:
                 case DIAGNOSTIC_VULKAN_LAYERS_SETTINGS: {
@@ -488,7 +488,7 @@ void TabDiagnostics::on_export_file() {
             std::size_t index = this->ui->diagnostic_mode_options->currentIndex();
 
             export_path = export_path.RelativePath() +
-                          format("/%s.json", configurator.vulkan_system_info.physicalDevices[index].deviceName.c_str());
+                          format("/%s.json", configurator.vulkan_system_info.physicalDevices[index].fullName.c_str());
         } break;
         case DIAGNOSTIC_VULKAN_LOADER_CONFIGURATION:
         case DIAGNOSTIC_VULKAN_LAYERS_SETTINGS: {

--- a/vkconfig_gui/tab_drivers.cpp
+++ b/vkconfig_gui/tab_drivers.cpp
@@ -61,7 +61,7 @@ void TabDrivers::UpdateUI(UpdateUIMode ui_update_mode) {
 
     if (configurator.driver_override_list.empty()) {
         for (std::size_t i = 0, n = configurator.vulkan_system_info.physicalDevices.size(); i < n; ++i) {
-            configurator.driver_override_list.push_back(configurator.vulkan_system_info.physicalDevices[i].deviceName.c_str());
+            configurator.driver_override_list.push_back(configurator.vulkan_system_info.physicalDevices[i].fullName.c_str());
         }
     }
 
@@ -81,8 +81,7 @@ void TabDrivers::UpdateUI(UpdateUIMode ui_update_mode) {
                     this->ui->driver_forced_name->blockSignals(true);
                     this->ui->driver_forced_name->clear();
                     for (std::size_t i = 0, n = configurator.vulkan_system_info.physicalDevices.size(); i < n; ++i) {
-                        this->ui->driver_forced_name->addItem(
-                            configurator.vulkan_system_info.physicalDevices[i].deviceName.c_str());
+                        this->ui->driver_forced_name->addItem(configurator.vulkan_system_info.physicalDevices[i].fullName.c_str());
                     }
                     this->ui->driver_forced_name->setCurrentIndex(configurator.GetActiveDeviceIndex());
                     this->ui->driver_forced_name->blockSignals(false);

--- a/vkconfig_gui/widget_setting_enum.cpp
+++ b/vkconfig_gui/widget_setting_enum.cpp
@@ -112,9 +112,9 @@ void WidgetSettingEnum::Refresh(RefreshAreas refresh_areas) {
         int selection = 0;
         const std::string value = this->data().GetValue();
         for (std::size_t i = 0, n = physical_device_infos.size(); i < n; ++i) {
-            this->field->addItem(physical_device_infos[i].deviceName.c_str());
-            if (physical_device_infos[i].deviceName == value || "${VP_PHYSICAL_DEVICES}" == value) {
-                this->data().SetValue(physical_device_infos[i].deviceName.c_str());
+            this->field->addItem(physical_device_infos[i].fullName.c_str());
+            if (physical_device_infos[i].fullName == value || "${VP_PHYSICAL_DEVICES}" == value) {
+                this->data().SetValue(physical_device_infos[i].fullName.c_str());
                 selection = static_cast<int>(this->enum_indexes.size());
             }
             this->enum_indexes.push_back(i);
@@ -170,7 +170,7 @@ void WidgetSettingEnum::Resize() {
     } else if (meta.default_value == "${VP_PHYSICAL_DEVICES}") {
         const std::vector<VulkanPhysicalDeviceInfo>& physical_device_infos = Configurator::Get().vulkan_system_info.physicalDevices;
         for (std::size_t i = 0, n = physical_device_infos.size(); i < n; ++i) {
-            width = std::max(width, HorizontalAdvance(fm, (physical_device_infos[i].deviceName + std::string("000")).c_str()));
+            width = std::max(width, HorizontalAdvance(fm, (physical_device_infos[i].fullName + std::string("000")).c_str()));
         }
     } else {
         for (std::size_t i = 0, n = this->meta.enum_values.size(); i < n; ++i) {
@@ -203,8 +203,8 @@ void WidgetSettingEnum::OnIndexChanged(int index) {
         const std::vector<VulkanPhysicalDeviceInfo>& physical_device_infos = Configurator::Get().vulkan_system_info.physicalDevices;
         assert(index >= 0 && index < static_cast<int>(physical_device_infos.size()));
 
-        this->data().SetValue(physical_device_infos[index].deviceName.c_str());
-        this->setToolTip(physical_device_infos[index].deviceName.c_str());
+        this->data().SetValue(physical_device_infos[index].fullName.c_str());
+        this->setToolTip(physical_device_infos[index].fullName.c_str());
     } else {
         assert(index >= 0 && index < static_cast<int>(this->meta.enum_values.size()));
 


### PR DESCRIPTION
There may be multiple drivers that are for the same device, so add the driver name and driver version to the displayed name.

Add the driverUUID, driverVersion, and driverName fields to the loader settings json file, so that the loader picks out the correct VkPhysicalDevice.