### PR TITLE
layers: Harden against debug CRT popups

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -64,6 +64,10 @@
 #include <unordered_set>
 #include <utility>
 
+#if defined(_WIN32) && !defined(NDEBUG)
+#include <crtdbg.h>
+#endif
+
 #ifdef ANDROID
 #include <memory>
 #include <string_view>
@@ -1399,8 +1403,10 @@ std::enable_if_t<!std::is_pointer_v<T>> dump_type_hex(const T &object, const Api
 }
 
 template <ApiDumpFormat Format>
-void dump_uint64_t_as_pointer(const uint64_t object, const ApiDumpSettings &settings, const char *type_string, const char *name, int indents) {
-    dump_start<Format>(settings, OutputConstruct::pointer, type_string, name, indents, reinterpret_cast<const void*>(static_cast<uintptr_t>(object)));
+void dump_uint64_t_as_pointer(const uint64_t object, const ApiDumpSettings &settings, const char *type_string, const char *name,
+                              int indents) {
+    dump_start<Format>(settings, OutputConstruct::pointer, type_string, name, indents,
+                       reinterpret_cast<const void *>(static_cast<uintptr_t>(object)));
     dump_end<Format>(settings, OutputConstruct::pointer, indents);
 }
 

--- a/layersvt/api_dump_handwritten_functions.h
+++ b/layersvt/api_dump_handwritten_functions.h
@@ -31,6 +31,18 @@ extern "C" {
 
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                                 VkInstance* pInstance) {
+#if defined(_WIN32) && defined(_CRTDBG_MODE_FILE)
+#if !defined(NDEBUG)
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+    // Avoid "Abort, Retry, Ignore" dialog boxes
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+
     std::lock_guard<std::mutex> lg(ApiDumpInstance::current().outputMutex());
     ApiDumpInstance::current().initLayerSettings(pCreateInfo, pAllocator);
     dump_function_head(ApiDumpInstance::current(), "vkCreateInstance", "pCreateInfo, pAllocator, pInstance", "VkResult");
@@ -87,7 +99,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCre
 
     return result;
 }
-
 }
 
 template <ApiDumpFormat Format>
@@ -165,5 +176,4 @@ EXPORT_FUNCTION VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(
 
     return util_GetLayerProperties(ARRAY_SIZE(layerProperties), layerProperties, pPropertyCount, pProperties);
 }
-
 }

--- a/layersvt/monitor.cpp
+++ b/layersvt/monitor.cpp
@@ -38,6 +38,10 @@
 #warning "Monitor layer only has code for XCB and Windows at this time"
 #endif
 
+#if defined(_WIN32) && !defined(NDEBUG)
+#include <crtdbg.h>
+#endif
+
 #define TITLE_LENGTH 1000
 #define FPS_LENGTH 24
 struct monitor_layer_data {
@@ -182,6 +186,18 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const VkAllocationCa
 
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
                                                 VkInstance *pInstance) {
+#if defined(_WIN32) && defined(_CRTDBG_MODE_FILE)
+#if !defined(NDEBUG)
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+    // Avoid "Abort, Retry, Ignore" dialog boxes
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+
     VkLayerInstanceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
     assert(chain_info->u.pLayerInfo);

--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -33,6 +33,10 @@
 #include <mutex>
 #include <fstream>
 
+#if defined(_WIN32) && !defined(NDEBUG)
+#include <crtdbg.h>
+#endif
+
 using namespace std;
 
 #include <vulkan/layer/vk_layer_settings.hpp>
@@ -1009,6 +1013,18 @@ static bool writePPM(const char *filename, VkImage image1) {
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
                                               VkInstance *pInstance) {
+#if defined(_WIN32) && defined(_CRTDBG_MODE_FILE)
+#if !defined(NDEBUG)
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+    // Avoid "Abort, Retry, Ignore" dialog boxes
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+
     VkLayerInstanceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
     assert(chain_info->u.pLayerInfo);


### PR DESCRIPTION
A consequence of using the static CRT on windows is the need to call debug CRT configuration functions on each instance of the CRT, which means adding code to disable debug popups in the screenshot, monitor, and api dump layer code. This code is necessary to prevent CI jobs from timing out waiting for someone to log into the machine and click 'abort' when the debug CRT generates a dialog box.