### PR TITLE
[screenshots] Remove VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT 

### DIFF
--- a/layersvt/screenshot.cpp
+++ b/layersvt/screenshot.cpp
@@ -1004,7 +1004,7 @@ bool prepareScreenshotData(ScreenshotQueueData &data, VkImage image1) {
     const VkCommandBufferBeginInfo commandBufferBeginInfo = {
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         NULL,
-        VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+        0,
     };
     err = pTableCommandBuffer->BeginCommandBuffer(data.commandBuffer, &commandBufferBeginInfo);
     assert(!err);


### PR DESCRIPTION
Remove VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT from command buffer begin info as we reuse recorded buffer multiple time.

Fixes Vulkan Validation layer warnings.