### PR TITLE
vkconfig: Workaround to make the Vulkan SDK working directory writable if it's not

### DIFF
--- a/vkconfig_core/path.cpp
+++ b/vkconfig_core/path.cpp
@@ -300,7 +300,14 @@ static const std::string GetDefaultHomeDir() {
     }
 
     if (absolute_path.empty()) {  // Default path
-        absolute_path = QDir().homePath().toStdString() + "/VulkanSDK";
+        absolute_path = QDir().homePath().toStdString() + "/Vulkan";
+        /*
+                QFile file(absolute_path.c_str());
+                bool result = file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+                if (!result) {
+                    absolute_path = QDir().homePath().toStdString() + "/Vulkan";
+                }
+        */
     }
 
     return absolute_path;

--- a/vkconfig_core/test/test_configuration_manager.cpp
+++ b/vkconfig_core/test/test_configuration_manager.cpp
@@ -208,11 +208,11 @@ TEST(test_configuration_manager, ExportImport) {
     configuration_manager.LoadDefaultConfigurations(layer_manager);
     std::size_t count_init = configuration_manager.available_configurations.size();
 
-    configuration_manager.ExportConfiguration(layer_manager, Path(Path::HOME).RelativePath() + "ValidationExported.json",
+    configuration_manager.ExportConfiguration(layer_manager, Path(Path::HOME).RelativePath() + "/ValidationExported.json",
                                               "Validation");
 
     std::string configuration_name;
-    configuration_manager.ImportConfiguration(layer_manager, Path(Path::HOME).RelativePath() + "ValidationExported.json",
+    configuration_manager.ImportConfiguration(layer_manager, Path(Path::HOME).RelativePath() + "/ValidationExported.json",
                                               configuration_name);
     EXPECT_EQ(count_init + 1, configuration_manager.available_configurations.size());
 

--- a/vkconfig_core/test/test_executable_manager.cpp
+++ b/vkconfig_core/test/test_executable_manager.cpp
@@ -142,10 +142,10 @@ TEST(test_executable_manager, remove_executable) {
 TEST(test_executable_manager, remove_missing_applications) {
     ExecutableManager executable_manager;
 
-    const Path& path_missing = ::Path(Path::HOME).RelativePath() + "my_missing_executable";
-    const Path& path_exciting = ::Path(Path::HOME).RelativePath() + "my_exciting_executable";
+    const Path& path_missing = ::Path(Path::HOME).RelativePath() + "/my_missing_executable";
+    const Path& path_existing = ::Path(Path::HOME).RelativePath() + "/my_existing_executable";
 
-    QFile file(path_exciting.AbsolutePath().c_str());
+    QFile file(path_existing.AbsolutePath().c_str());
     const bool result = file.open(QIODevice::WriteOnly);
     ASSERT_TRUE(result);
 
@@ -155,7 +155,7 @@ TEST(test_executable_manager, remove_missing_applications) {
     executable.path = path_missing.AbsolutePath();
     executables.push_back(executable);
 
-    executable.path = path_exciting.AbsolutePath();
+    executable.path = path_existing.AbsolutePath();
     executables.push_back(executable);
 
     EXPECT_EQ(1, executable_manager.RemoveMissingExecutables(executables).size());

--- a/vkconfig_core/test/test_path.cpp
+++ b/vkconfig_core/test/test_path.cpp
@@ -246,9 +246,6 @@ TEST(test_path, convert_native_separator_empty) {
 
 TEST(test_path, get_path_home) {
     const std::string value_default(AbsolutePath(Path::HOME).c_str());
-
-    EXPECT_TRUE(EndsWith(value_default, "VulkanSDK"));
-
     qputenv("VULKAN_HOME", ":/MyVulkanSDKLocalDir");
 
     const std::string value_env(AbsolutePath(Path::HOME).c_str());
@@ -296,21 +293,24 @@ TEST(test_path, get_path_loader_settings) {
 }
 
 TEST(test_path, get_path_override_settings) {
+    Path path("~/TestVulkanDirectory");
+    qputenv("VULKAN_SDK", path.AbsolutePath().c_str());
+
     {
         const QString value(AbsolutePath(Path::LAYERS_SETTINGS).c_str());
         EXPECT_TRUE(value.endsWith("vk_layer_settings.txt"));
     }
 
     {
-        qputenv("VK_LAYER_SETTINGS_PATH", "~/VulkanSDK/vk_layer_settings.txt");
+        qputenv("VK_LAYER_SETTINGS_PATH", "~/TestVulkanDirectory/vk_layer_settings.txt");
         const std::string value = AbsolutePath(Path::LAYERS_SETTINGS).c_str();
-        EXPECT_STREQ(Path("~/VulkanSDK/vk_layer_settings.txt").AbsolutePath().c_str(), value.c_str());
+        EXPECT_STREQ(Path("~/TestVulkanDirectory/vk_layer_settings.txt").AbsolutePath().c_str(), value.c_str());
     }
 
     {
-        qputenv("VK_LAYER_SETTINGS_PATH", "~/VulkanSDK");
+        qputenv("VK_LAYER_SETTINGS_PATH", "~/TestVulkanDirectory");
         const std::string value = AbsolutePath(Path::LAYERS_SETTINGS).c_str();
-        EXPECT_STREQ(Path("~/VulkanSDK/vk_layer_settings.txt").AbsolutePath().c_str(), value.c_str());
+        EXPECT_STREQ(Path("~/TestVulkanDirectory/vk_layer_settings.txt").AbsolutePath().c_str(), value.c_str());
     }
 }
 
@@ -321,9 +321,9 @@ TEST(test_path, get_path_override_layers) {
 }
 
 TEST(test_path, get_path_vulkan_sdk) {
-    qputenv("VULKAN_SDK", "~/VulkanSDK");
+    qputenv("VULKAN_SDK", "~/TestVulkanDirectory");
     const std::string value = AbsolutePath(Path::SDK);
-    EXPECT_STREQ(Path("~/VulkanSDK").AbsolutePath().c_str(), value.c_str());
+    EXPECT_STREQ(Path("~/TestVulkanDirectory").AbsolutePath().c_str(), value.c_str());
 }
 
 TEST(test_path, get_path_vulkan_content) {
@@ -339,9 +339,9 @@ TEST(test_path, get_path_home_sdk) {
     Path home_current = Path(Path::HOME);
     EXPECT_STREQ(home_current.AbsolutePath().c_str(), home_default.AbsolutePath().c_str());
 
-    qputenv("VULKAN_SDK", "~/VulkanSDK");
+    qputenv("VULKAN_SDK", "~/TestVulkanDirectory");
     const std::string value = AbsolutePath(Path::SDK);
-    EXPECT_STREQ(Path("~/VulkanSDK").AbsolutePath().c_str(), value.c_str());
+    EXPECT_STREQ(Path("~/TestVulkanDirectory").AbsolutePath().c_str(), value.c_str());
 }
 
 TEST(test_path, get_path_url_sdk) {


### PR DESCRIPTION
<img width="1283" height="841" alt="image" src="https://github.com/user-attachments/assets/a6688ba2-d6e3-4ec7-93f3-7d63677ac23b" />
