### PR TITLE
build: only look for valijson dep when building vkconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ add_subdirectory(scripts)
 find_package(VulkanHeaders ${PROJECT_VERSION} REQUIRED CONFIG)
 find_package(VulkanLoader CONFIG)
 find_package(VulkanUtilityLibraries REQUIRED CONFIG)
-find_package(valijson REQUIRED CONFIG)
 
 find_package(Qt6 COMPONENTS Core Gui Widgets Network QUIET)
 if(Qt6_FOUND)

--- a/vkconfig_core/CMakeLists.txt
+++ b/vkconfig_core/CMakeLists.txt
@@ -17,6 +17,8 @@
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+find_package(valijson REQUIRED CONFIG)
+
 file(GLOB FILES_SOURCE ./*.cpp)
 file(GLOB FILES_HEADER ./*.h)
 


### PR DESCRIPTION
The valijson dependency is only required for the layer manager utility. When limited to only that configuration, it allows building other tools in build setups that don't rely on update_deps.py.