### PR TITLE
vkconfig: optimize compiling of tests to fix link crashes

### DIFF
--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -32,12 +32,11 @@ function(vkConfigTest NAME)
     file(GLOB FILES_TEXT ./*.txt)
     source_group("Test Files" FILES ${FILES_JSON} ${FILES_TEXT} ${FILES_LAYER_JSON})
 
-    # Link the pre-compiled resource object instead of passing the raw .qrc file
-    add_executable(${TEST_NAME} ${TEST_FILE} ${FILES_JSON} ${FILES_TEXT} $<TARGET_OBJECTS:vkconfig_test_resources>)
+    add_executable(${TEST_NAME} ${TEST_FILE} ${FILES_JSON} ${FILES_TEXT})
     set_target_properties(${TEST_NAME} PROPERTIES FOLDER "vkconfig/tests")
 
     if(Qt6_FOUND)
-      target_link_libraries(${TEST_NAME} vkconfig-core Vulkan::LayerSettings GTest::gtest_main Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network)
+      target_link_libraries(${TEST_NAME} vkconfig_test_resources vkconfig-core Vulkan::LayerSettings GTest::gtest_main Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network)
     endif()
 
     target_compile_definitions(${TEST_NAME} PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -34,6 +34,7 @@ function(vkConfigTest NAME)
 
     add_executable(${TEST_NAME} ${TEST_FILE} ${FILES_JSON} ${FILES_TEXT})
     set_target_properties(${TEST_NAME} PROPERTIES FOLDER "vkconfig/tests")
+    add_dependencies(${TEST_NAME} vkconfig_test_resources)
 
     if(Qt6_FOUND)
       target_link_libraries(${TEST_NAME} vkconfig_test_resources vkconfig-core Vulkan::LayerSettings GTest::gtest_main Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network)

--- a/vkconfig_core/test/CMakeLists.txt
+++ b/vkconfig_core/test/CMakeLists.txt
@@ -20,6 +20,9 @@ if (NOT DEFINED CMAKE_INSTALL_BINDIR)
     include(GNUInstallDirs)
 endif()
 
+# Compile the Qt resources exactly once to prevent rcc contention across parallel builds
+add_library(vkconfig_test_resources OBJECT resources.qrc)
+
 function(vkConfigTest NAME)
     set(TEST_FILE ./${NAME}.cpp)
     set(TEST_NAME vkconfig_${NAME})
@@ -29,10 +32,12 @@ function(vkConfigTest NAME)
     file(GLOB FILES_TEXT ./*.txt)
     source_group("Test Files" FILES ${FILES_JSON} ${FILES_TEXT} ${FILES_LAYER_JSON})
 
-    add_executable(${TEST_NAME} ${TEST_FILE} ${FILES_JSON} ${FILES_TEXT} resources.qrc)
+    # Link the pre-compiled resource object instead of passing the raw .qrc file
+    add_executable(${TEST_NAME} ${TEST_FILE} ${FILES_JSON} ${FILES_TEXT} $<TARGET_OBJECTS:vkconfig_test_resources>)
     set_target_properties(${TEST_NAME} PROPERTIES FOLDER "vkconfig/tests")
+
     if(Qt6_FOUND)
-      target_link_libraries(${TEST_NAME} vkconfig-core Vulkan::LayerSettings GTest::gtest GTest::gtest_main Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network)
+      target_link_libraries(${TEST_NAME} vkconfig-core Vulkan::LayerSettings GTest::gtest_main Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network)
     endif()
 
     target_compile_definitions(${TEST_NAME} PRIVATE CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
@@ -92,6 +97,3 @@ vkConfigTest(test_type_status)
 vkConfigTest(test_type_tab)
 vkConfigTest(test_ui)
 vkConfigTest(test_vulkan)
-
-
-


### PR DESCRIPTION
We've seen situations where Linux and Mac test builds crash while linking tests.  The large number of Qt-based test executables (43) all trying to link at the same time can provoke out-of-memory conditions on Linux, triggering the OOM killer and build errors like:

    collect2: fatal error: ld terminated with signal 9 [Killed]

On Mac, the simultaneous Qt loads can provoke a linker crash with symptoms like:

    c++: c++: error: unable to execute command: Bus error: 10
    c++c++: error: linker command failed due to signal (use -v to see invocation)

Also, there appears to be a multiple load of GoogleTest, because the existing code references both GTest::gtest and GTest::gtest_main; provoking messages like:

    ld: warning: ignoring duplicate libraries: '/Users/lunarg/.jenkins/vt0/Debug64/VulkanTools/external/googletest/build/install/lib/libgtest.a'

Removing the reference to GTest::gtest removes the redundant reference.