### PR TITLE
apidump: Add missing calling convention attributes

### DIFF
--- a/layersvt/api_dump.h
+++ b/layersvt/api_dump.h
@@ -94,8 +94,8 @@
 
 extern "C" {
 // Forward declarations for dispatch
-PFN_vkVoidFunction layer_vkGetInstanceProcAddr(VkInstance instance, const char* pName);
-PFN_vkVoidFunction layer_vkGetDeviceProcAddr(VkDevice device, const char* pName);
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL layer_vkGetInstanceProcAddr(VkInstance instance, const char* pName);
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL layer_vkGetDeviceProcAddr(VkDevice device, const char* pName);
 }
 
 #define MAX_STRING_LENGTH 1024

--- a/layersvt/api_dump_handwritten_dispatch.cpp
+++ b/layersvt/api_dump_handwritten_dispatch.cpp
@@ -27,6 +27,8 @@
 
 #include "generated/api_dump_dispatch.h"
 
+extern "C" {
+
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL layer_vkGetInstanceProcAddr(VkInstance instance, const char* pName) {
     PFN_vkVoidFunction instance_func = nullptr;
     switch (ApiDumpInstance::current().settings().format()) {
@@ -83,8 +85,6 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL layer_vkGetDeviceProcAddr(VkDevice devi
     if (device_dispatch_table(device)->GetDeviceProcAddr == NULL) return nullptr;
     return device_dispatch_table(device)->GetDeviceProcAddr(device, pName);
 }
-
-extern "C" {
 
 EXPORT_FUNCTION VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
     return layer_vkGetInstanceProcAddr(instance, funcName);


### PR DESCRIPTION
And moves extern "C" to be consistent between the declaration and the definition.