### PR TITLE
vkconfig: Remove Windows ARM release notification workaround

### DIFF
--- a/vkconfig_gui/tab_preferences.cpp
+++ b/vkconfig_gui/tab_preferences.cpp
@@ -95,23 +95,14 @@ TabPreferences::TabPreferences(MainWindow &window, std::shared_ptr<Ui::MainWindo
     this->ui->preferences_download->setText("Searching Latest Vulkan SDK...");
     this->ui->preferences_validate_layer->setChecked(configurator.layers.validate_manifests);
 
-#if WORKAROUND_WINARM_RELEASE_NOTIFICATION_BUG
-    // Windows ARM crash, it looks like a Qt bug in 6.8.2...
-    if (VKC_PLATFORM == PLATFORM_WINDOWS_ARM) {
-        this->ui->preferences_group_box_releases->setVisible(false);
-    } else {
-#endif
         QUrl url(GetLatestReleaseSDK(VKC_PLATFORM));
         QNetworkRequest request(url);
         this->network_manager.get(request);
         this->connect(&this->network_manager, SIGNAL(finished(QNetworkReply *)), this,
                       SLOT(on_release_downloaded(QNetworkReply *)));
-#if WORKAROUND_WINARM_RELEASE_NOTIFICATION_BUG
-    }
-#endif
 
     this->UpdatePreferences(configurator.current_theme_mode);
-}
+} 
 
 TabPreferences::~TabPreferences() {}
 


### PR DESCRIPTION
Due to Qt update (>=6.9.3), the workaround for the Windows ARM release notification crash is no longer needed.

Fixes #2679 